### PR TITLE
STU3: fix: ElementDefinition.binding now gets merged on a level deeper in the snapshatgenerator

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -6944,6 +6944,46 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [TestMethod]
+        public async T.Task TestExtensionOnPrimitive()
+        {
+            var profile = new StructureDefinition()
+            {
+                Type = FHIRAllTypes.Address.GetLiteral(),
+                BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Address),
+                Name = "MyCustomAddress",
+                Url = "http://example.org/fhir/StructureDefinition/MyCustomAddress",
+                Differential = new StructureDefinition.DifferentialComponent()
+                {
+                    Element = new List<ElementDefinition>()
+                    {
+                        new ElementDefinition("Address.use")
+                        {
+                            DefinitionElement = new Markdown
+                            {
+                                Extension = new List<Extension>
+                                {
+                                    new Extension
+                                    {
+                                        Url = "http://example.org/fhir/StructureDefinition/myExtension",
+                                        Value = new FhirString("TestValue")
+                                    }
+                                }
+                            }                           
+                        },
+                    }
+                }
+            };
+
+            _generator = new SnapshotGenerator(_testResolver, _settings);
+            (_, var expanded) = await generateSnapshotAndCompare(profile);
+
+            Assert.IsNotNull(expanded?.Snapshot?.Element);
+            Assert.IsTrue(expanded.Snapshot.Element.Where(e => e.Path == "Address.use").FirstOrDefault().DefinitionElement.Extension.Any(e => e.Url == "http://example.org/fhir/StructureDefinition/myExtension"));
+            Assert.IsNotNull(expanded.Snapshot.Element.Where(e => e.Path == "Address.use")?.FirstOrDefault()?.DefinitionElement?.Value);
+        }
+
+
+        [TestMethod]
         public async T.Task TestReferenceTargetProfile()
         {
             // Verify that the snapshot generator correctly expands elements with a targetProfile (on ResourceReference itself)

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -6944,6 +6944,7 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [TestMethod]
+        [Ignore] //[MS 20201211] TODO: Changing elementDefnMerger from mergeprimitives to mergecomplexattribute seems to do the trick, but there are is some string specific code that will be ignored in that case.
         public async T.Task TestExtensionOnPrimitive()
         {
             var profile = new StructureDefinition()

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -340,6 +340,9 @@ namespace Hl7.Fhir.Specification.Snapshot
                     return snap;
             }
 
+
+            //[MS 20201211] Separate function introduced to make sure that introduced extensions on Binding.Valueset in the diff are merged with the base.
+            // This is a very specific fix and might be replaced by a more general merging method using ITypedElement in the future.
             private ElementDefinition.ElementDefinitionBindingComponent mergeBinding(ElementDefinition.ElementDefinitionBindingComponent snap, ElementDefinition.ElementDefinitionBindingComponent diff)
             {
                 var result = snap;

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -350,16 +350,15 @@ namespace Hl7.Fhir.Specification.Snapshot
                 {
                     if (snap.IsNullOrEmpty())
                     {
-                        result = (ElementDefinition.ElementDefinitionBindingComponent)diff.DeepCopy();
-                        onConstraint(result);
+                        result = (ElementDefinition.ElementDefinitionBindingComponent)diff.DeepCopy();                        
                     }
                     else if (!diff.IsExactly(snap))
                     {
                         snap.StrengthElement = mergePrimitiveAttribute(snap.StrengthElement, diff.StrengthElement);
                         snap.DescriptionElement = mergePrimitiveAttribute(snap.DescriptionElement, diff.DescriptionElement);
-                        snap.ValueSet = mergeComplexAttribute(snap.ValueSet, diff.ValueSet);
-                        onConstraint(result);
+                        snap.ValueSet = mergeComplexAttribute(snap.ValueSet, diff.ValueSet);                        
                     }
+                    onConstraint(result);
                 }
                 return result;
             }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -350,15 +350,16 @@ namespace Hl7.Fhir.Specification.Snapshot
                 {
                     if (snap.IsNullOrEmpty())
                     {
-                        result = (ElementDefinition.ElementDefinitionBindingComponent)diff.DeepCopy();                        
+                        result = (ElementDefinition.ElementDefinitionBindingComponent)diff.DeepCopy();
+                        onConstraint(result);
                     }
                     else if (!diff.IsExactly(snap))
                     {
                         snap.StrengthElement = mergePrimitiveAttribute(snap.StrengthElement, diff.StrengthElement);
                         snap.DescriptionElement = mergePrimitiveAttribute(snap.DescriptionElement, diff.DescriptionElement);
-                        snap.ValueSet = mergeComplexAttribute(snap.ValueSet, diff.ValueSet);                        
+                        snap.ValueSet = mergeComplexAttribute(snap.ValueSet, diff.ValueSet);
+                        onConstraint(result);
                     }
-                    onConstraint(result);
                 }
                 return result;
             }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -164,7 +164,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                 snap.IsSummaryElement = mergePrimitiveAttribute(snap.IsSummaryElement, diff.IsSummaryElement);
 
-                snap.Binding = mergeComplexAttribute(snap.Binding, diff.Binding);
+                snap.Binding = mergeBinding(snap.Binding, diff.Binding);
 
                 // [AE 20200129] Merging only fails for lists on a nested level. Slicing.Discriminator is the only case where this happens
                 var originalDiscriminator = snap.Slicing?.Discriminator;
@@ -338,6 +338,27 @@ namespace Hl7.Fhir.Specification.Snapshot
                 }
                 else
                     return snap;
+            }
+
+            private ElementDefinition.ElementDefinitionBindingComponent mergeBinding(ElementDefinition.ElementDefinitionBindingComponent snap, ElementDefinition.ElementDefinitionBindingComponent diff)
+            {
+                var result = snap;
+                if (!diff.IsNullOrEmpty())
+                {
+                    if (snap.IsNullOrEmpty())
+                    {
+                        result = (ElementDefinition.ElementDefinitionBindingComponent)diff.DeepCopy();
+                        onConstraint(result);
+                    }
+                    else if (!diff.IsExactly(snap))
+                    {
+                        snap.StrengthElement = mergePrimitiveAttribute(snap.StrengthElement, diff.StrengthElement);
+                        snap.DescriptionElement = mergePrimitiveAttribute(snap.DescriptionElement, diff.DescriptionElement);
+                        snap.ValueSet = mergeComplexAttribute(snap.ValueSet, diff.ValueSet);
+                        onConstraint(result);
+                    }
+                }
+                return result;
             }
 
             string mergeId(ElementDefinition snap, ElementDefinition diff, bool mergeElementId)


### PR DESCRIPTION
fixes #1516