### PR TITLE
R4: fix: ElementDefinition.binding now gets merged on a level deeper in the snapshotgenerator

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -7444,9 +7444,8 @@ namespace Hl7.Fhir.Specification.Tests
                         new ElementDefinition("Address.use")
                         {
                             Binding = new ElementDefinition.ElementDefinitionBindingComponent
-                            {
-                                Strength = BindingStrength.Required,
-                                ValueSet = new Canonical
+                            {                               
+                                ValueSetElement = new Canonical
                                 {
                                     Extension = new List<Extension>{new Extension
                                         {

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -344,16 +344,15 @@ namespace Hl7.Fhir.Specification.Snapshot
                 {
                     if (snap.IsNullOrEmpty())
                     {
-                        result = (ElementDefinition.ElementDefinitionBindingComponent)diff.DeepCopy();
-                        onConstraint(result);
+                        result = (ElementDefinition.ElementDefinitionBindingComponent)diff.DeepCopy();                       
                     }
                     else if (!diff.IsExactly(snap))
                     {
                         snap.StrengthElement = mergePrimitiveElement(snap.StrengthElement, diff.StrengthElement);
                         snap.DescriptionElement = mergePrimitiveElement(snap.DescriptionElement, diff.DescriptionElement);
-                        snap.ValueSetElement = mergeComplexAttribute(snap.ValueSetElement, diff.ValueSetElement);
-                        onConstraint(result);
+                        snap.ValueSetElement = mergeComplexAttribute(snap.ValueSetElement, diff.ValueSetElement);                       
                     }
+                    onConstraint(result);
                 }
                 return result;
             }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -169,7 +169,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                 snap.IsSummaryElement = mergePrimitiveElement(snap.IsSummaryElement, diff.IsSummaryElement);
 
-                snap.Binding = mergeComplexAttribute(snap.Binding, diff.Binding);
+                snap.Binding = mergeBinding(snap.Binding, diff.Binding);
 
                 // Mappings are cumulative, but keep unique on full contents
                 snap.Mapping = mergeCollection(snap.Mapping, diff.Mapping, matchExactly);
@@ -330,6 +330,27 @@ namespace Hl7.Fhir.Specification.Snapshot
                             }
                             onConstraint(mergedItem);
                         }
+                    }
+                }
+                return result;
+            }
+
+            private ElementDefinition.ElementDefinitionBindingComponent mergeBinding(ElementDefinition.ElementDefinitionBindingComponent snap, ElementDefinition.ElementDefinitionBindingComponent diff)
+            {
+                var result = snap;
+                if (!diff.IsNullOrEmpty())
+                {
+                    if (snap.IsNullOrEmpty())
+                    {
+                        result = (ElementDefinition.ElementDefinitionBindingComponent)diff.DeepCopy();
+                        onConstraint(result);
+                    }
+                    else if (!diff.IsExactly(snap))
+                    {
+                        snap.StrengthElement = mergePrimitiveElement(snap.StrengthElement, diff.StrengthElement);
+                        snap.DescriptionElement = mergePrimitiveElement(snap.DescriptionElement, diff.DescriptionElement);
+                        snap.ValueSetElement = mergeComplexAttribute(snap.ValueSetElement, diff.ValueSetElement);
+                        onConstraint(result);
                     }
                 }
                 return result;

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -335,6 +335,8 @@ namespace Hl7.Fhir.Specification.Snapshot
                 return result;
             }
 
+            //[MS 20201211] Separate function introduced to make sure that introduced extensions on Binding.Valueset in the diff are merged with the base.
+            // This is a very specific fix and might be replaced by a more general merging method using ITypedElement in the future.
             private ElementDefinition.ElementDefinitionBindingComponent mergeBinding(ElementDefinition.ElementDefinitionBindingComponent snap, ElementDefinition.ElementDefinitionBindingComponent diff)
             {
                 var result = snap;

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -344,15 +344,16 @@ namespace Hl7.Fhir.Specification.Snapshot
                 {
                     if (snap.IsNullOrEmpty())
                     {
-                        result = (ElementDefinition.ElementDefinitionBindingComponent)diff.DeepCopy();                       
+                        result = (ElementDefinition.ElementDefinitionBindingComponent)diff.DeepCopy();
+                        onConstraint(result);
                     }
                     else if (!diff.IsExactly(snap))
                     {
                         snap.StrengthElement = mergePrimitiveElement(snap.StrengthElement, diff.StrengthElement);
                         snap.DescriptionElement = mergePrimitiveElement(snap.DescriptionElement, diff.DescriptionElement);
-                        snap.ValueSetElement = mergeComplexAttribute(snap.ValueSetElement, diff.ValueSetElement);                       
+                        snap.ValueSetElement = mergeComplexAttribute(snap.ValueSetElement, diff.ValueSetElement);
+                        onConstraint(result);
                     }
-                    onConstraint(result);
                 }
                 return result;
             }


### PR DESCRIPTION
fixes #1516