### PR TITLE
fix: throws error on _sort search param value that consists of just a single dash

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Rest/SearchParamsTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/SearchParamsTests.cs
@@ -393,6 +393,15 @@ namespace Hl7.Fhir.Test.Rest
             Assert.AreEqual("Invalid _elements value: it cannot be empty", formatException.Message);
         }
 
+        [TestMethod]
+        public void FormatExceptionOnSingleDashSortParam()
+        {
+            var q = new SearchParams();
+            var formatException = AssertThrows<FormatException>(() => q.Add("_sort", "-"));
+            Assert.AreEqual("Invalid _sort: one of the values is just a single '-', an element name must be provided", formatException.Message);            
+        }
+
+
         private void FormatExceptionOnDuplicateOrEmptyParam(string paramName)
         {
             var q = new SearchParams();


### PR DESCRIPTION
fixes #1531 