### PR TITLE
Fix issue with FhirPath "as date" expression .

### DIFF
--- a/src/Hl7.Fhir.Core/FhirPath/ElementNavFhirExtensions.cs
+++ b/src/Hl7.Fhir.Core/FhirPath/ElementNavFhirExtensions.cs
@@ -112,6 +112,7 @@ namespace Hl7.Fhir.FhirPath
                     long _ => new Integer((int)(long)result),
                     decimal _ => new FhirDecimal((decimal)result),
                     string _ => new FhirString((string)result),
+                    P.Date d => new Date(d.ToString()),
                     P.DateTime dt => new FhirDateTime(dt.ToDateTimeOffset(TimeSpan.Zero).ToUniversalTime()),
                     _ => (Base)result
                 };

--- a/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathExtensionsTest.cs
+++ b/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathExtensionsTest.cs
@@ -63,5 +63,17 @@ namespace Hl7.Fhir.Tests.Introspection
                 return null;
             }
         }
+
+        [TestMethod]
+        public void TestSelectDate()
+        {
+            var goal = new Goal {Start = new Date(2000, 1, 1)};
+            var result = goal.Select("(Goal.start as date)");
+            Assert.IsNotNull(result);
+
+            var date = result.FirstOrDefault();
+            Assert.IsNotNull(date);
+            Assert.AreEqual(new Date(2000, 1, 1), date);
+        }
     }
 }


### PR DESCRIPTION
It was throwing this exception:
```
System.InvalidCastException: Unable to cast object of type 'Hl7.Fhir.ElementModel.Types.Date' to type 'Hl7.Fhir.Model.Base'.
    at Hl7.Fhir.FhirPath.ElementNavFhirExtensions.<>c.<ToFhirValues>b__6_0(ITypedElement r) in ...\firely-net-sdk\src\Hl7.Fhir.Core\FhirPath\ElementNavFhirExtensions.cs:line 117
   at System.Linq.Utilities.<>c__DisplayClass2_0`3.<CombineSelectors>b__0(TSource x)
   at System.Linq.Enumerable.SelectArrayIterator`2.TryGetFirst(Boolean& found)
   at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Boolean& found)
   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source)
```

Unit test provided.