### PR TITLE
STU3: FhirPath 'as time' fails in a Select

### DIFF
--- a/src/Hl7.Fhir.Core/FhirPath/ElementNavFhirExtensions.cs
+++ b/src/Hl7.Fhir.Core/FhirPath/ElementNavFhirExtensions.cs
@@ -113,7 +113,7 @@ namespace Hl7.Fhir.FhirPath
                     decimal _ => new FhirDecimal((decimal)result),
                     string _ => new FhirString((string)result),
                     P.Date d => new Date(d.ToString()),
-                    P.Time t => new Date(t.ToString()),
+                    P.Time t => new Time(t.ToString()),
                     P.DateTime dt => new FhirDateTime(dt.ToDateTimeOffset(TimeSpan.Zero).ToUniversalTime()),
                     _ => (Base)result
                 };

--- a/src/Hl7.Fhir.Core/FhirPath/ElementNavFhirExtensions.cs
+++ b/src/Hl7.Fhir.Core/FhirPath/ElementNavFhirExtensions.cs
@@ -113,6 +113,7 @@ namespace Hl7.Fhir.FhirPath
                     decimal _ => new FhirDecimal((decimal)result),
                     string _ => new FhirString((string)result),
                     P.Date d => new Date(d.ToString()),
+                    P.Time t => new Date(t.ToString()),
                     P.DateTime dt => new FhirDateTime(dt.ToDateTimeOffset(TimeSpan.Zero).ToUniversalTime()),
                     _ => (Base)result
                 };


### PR DESCRIPTION
Fixes #1580 . 

To complete the whole casting, we should also add the type 'time', not only 'date'. 
The unittest for this will be in the PR for R4