### PR TITLE
R4: FhirPath 'as time' fails in a Select 

### DIFF
--- a/src/Hl7.Fhir.Core/FhirPath/ElementNavFhirExtensions.cs
+++ b/src/Hl7.Fhir.Core/FhirPath/ElementNavFhirExtensions.cs
@@ -113,7 +113,7 @@ namespace Hl7.Fhir.FhirPath
                     decimal _ => new FhirDecimal((decimal)result),
                     string _ => new FhirString((string)result),
                     P.Date d => new Date(d.ToString()),
-                    P.Time t => new Date(t.ToString()),
+                    P.Time t => new Time(t.ToString()),
                     P.DateTime dt => new FhirDateTime(dt.ToDateTimeOffset(TimeSpan.Zero).ToUniversalTime()),
                     _ => (Base)result
                 };

--- a/src/Hl7.Fhir.Core/FhirPath/ElementNavFhirExtensions.cs
+++ b/src/Hl7.Fhir.Core/FhirPath/ElementNavFhirExtensions.cs
@@ -113,6 +113,7 @@ namespace Hl7.Fhir.FhirPath
                     decimal _ => new FhirDecimal((decimal)result),
                     string _ => new FhirString((string)result),
                     P.Date d => new Date(d.ToString()),
+                    P.Time t => new Date(t.ToString()),
                     P.DateTime dt => new FhirDateTime(dt.ToDateTimeOffset(TimeSpan.Zero).ToUniversalTime()),
                     _ => (Base)result
                 };

--- a/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathExtensionsTest.cs
+++ b/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathExtensionsTest.cs
@@ -6,13 +6,13 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Hl7.Fhir.Model;
 using Hl7.Fhir.ElementModel;
-using System.IO;
-using Hl7.Fhir.Serialization;
 using Hl7.Fhir.FhirPath;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
 using Hl7.FhirPath;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
 using System.Linq;
 
 namespace Hl7.Fhir.Tests.Introspection
@@ -62,18 +62,6 @@ namespace Hl7.Fhir.Tests.Introspection
                 called = true;
                 return null;
             }
-        }
-
-        [TestMethod]
-        public void TestSelectDate()
-        {
-            var goal = new Goal {Start = new Date(2000, 1, 1)};
-            var result = goal.Select("(Goal.start as date)");
-            Assert.IsNotNull(result);
-
-            var date = result.FirstOrDefault();
-            Assert.IsNotNull(date);
-            Assert.AreEqual(new Date(2000, 1, 1), date);
         }
     }
 }


### PR DESCRIPTION
Fixes #1580. 

This R4 variant also includes unittests
