### PR TITLE
R4: Use a better validation regex for strings

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -1259,7 +1259,13 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
-
+        [Fact]
+        public void ValidateNonBreakingWhitespaceInString()
+        {
+            var value = new FhirString("Non-breaking" + '\u00A0' + "space");
+            var result = _validator.Validate(value);
+            Assert.True(result.Success);
+        }
 
         private class ClearSnapshotResolver : IResourceResolver
         {

--- a/src/Hl7.Fhir.Specification/Validation/Validator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Validator.cs
@@ -259,6 +259,12 @@ namespace Hl7.Fhir.Validation
             var pattern = elementDef.GetStringExtension(uri);
             if (pattern != null)
             {
+                // See issue https://github.com/FirelyTeam/firely-net-sdk/issues/1563 and https://hl7.org/fhir/datatypes.html#string 
+                // the regex provided by the Fhir standard is not sufficient enough. The regex [\r\n\t\u0020-\uFFFF]* is more recommended 
+                if (instance?.InstanceType == FHIRAllTypes.String.GetLiteral() && pattern == @"[ \r\n\t\S]+")
+                {
+                    pattern = @"[\r\n\t\u0020-\uFFFF]*";
+                }
                 var regex = new Regex(pattern);
                 var value = toStringRepresentation(instance);
                 var success = Regex.Match(value, "^" + regex + "$").Success;


### PR DESCRIPTION
fixes #1563 

Uses a better regex for string validation: `[\r\n\t\u0020-\uFFFF]*`
