### PR TITLE
Terminology unit tests are not run in Devops anymore 

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Source/TerminologyTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/TerminologyTests.cs
@@ -14,7 +14,7 @@ namespace Hl7.Fhir.Specification.Tests
     public class TerminologyTests : IClassFixture<ValidationFixture>
     {
         private readonly IAsyncResourceResolver _resolver;
-
+        private static Uri _externalTerminologyServerEndpoint = new("https://ontoserver.csiro.au/stu3-latest");
 
         public TerminologyTests(ValidationFixture fixture, Xunit.Abstractions.ITestOutputHelper _)
         {
@@ -320,10 +320,10 @@ namespace Hl7.Fhir.Specification.Tests
             await Assert.ThrowsAsync<ValueSetExpansionTooComplexException>(() => svc.ValueSetValidateCode(inParams));
         }
 
-        [Fact]
+        [Fact(), Trait("TestCategory", "IntegrationTest")]
         public async void ExternalServiceTranslateSimpleTranslate()
         {
-            var client = new FhirClient("https://ontoserver.csiro.au/stu3-latest");
+            var client = new FhirClient(_externalTerminologyServerEndpoint);
             var svc = new ExternalTerminologyService(client);
 
             var parameters = new TranslateParameters()
@@ -368,10 +368,10 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
-        [Fact]
+        [Fac(), Trait("TestCategory", "IntegrationTest")]
         public async void ExternalServiceTranslateSimpleAutomap()
         {
-            var client = new FhirClient("https://ontoserver.csiro.au/stu3-latest");
+            var client = new FhirClient(_externalTerminologyServerEndpoint);
             var svc = new ExternalTerminologyService(client);
 
             var parameters = new TranslateParameters()
@@ -386,10 +386,10 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.Equal("result", param1.Name);
         }
 
-        [Fact]
+        [Fact(), Trait("TestCategory", "IntegrationTest")]
         public async void ExternalServiceLookupPropertiesDisplayAndInactiveStatus()
         {
-            var client = new FhirClient("https://ontoserver.csiro.au/stu3-latest");
+            var client = new FhirClient(_externalTerminologyServerEndpoint);
             var svc = new ExternalTerminologyService(client);
 
             var parameters = new LookupParameters()
@@ -422,10 +422,10 @@ namespace Hl7.Fhir.Specification.Tests
                 });
         }
 
-        [Fact]
+        [Fact(), Trait("TestCategory", "IntegrationTest")]
         public async void ExternalServiceLookupInactiveStatus()
         {
-            var client = new FhirClient("https://ontoserver.csiro.au/stu3-latest");
+            var client = new FhirClient(_externalTerminologyServerEndpoint);
             var svc = new ExternalTerminologyService(client);
 
             var parameters = new LookupParameters()
@@ -454,10 +454,10 @@ namespace Hl7.Fhir.Specification.Tests
                 });
         }
 
-        [Fact]
+        [Fact(), Trait("TestCategory", "IntegrationTest")]
         public async void ExternalServiceLookupSNOMEDCode()
         {
-            var client = new FhirClient("https://ontoserver.csiro.au/stu3-latest");
+            var client = new FhirClient(_externalTerminologyServerEndpoint);
             var svc = new ExternalTerminologyService(client);
 
             var parameters = new LookupParameters()
@@ -469,10 +469,10 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.True(result.Parameter.Count > 0);
         }
 
-        [Fact]
+        [Fact(), Trait("TestCategory", "IntegrationTest")]
         public async void ExternalServiceExpandExplicitValueSet()
         {
-            var client = new FhirClient("https://ontoserver.csiro.au/stu3-latest");
+            var client = new FhirClient(_externalTerminologyServerEndpoint);
             var svc = new ExternalTerminologyService(client);
 
             var result = await svc.Expand(null, "education-levels") as ValueSet;
@@ -480,10 +480,10 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.True(result.Expansion.Contains.Count > 0, "Expected more than 0 items.");
         }
 
-        [Fact]
+        [Fact(), Trait("TestCategory", "IntegrationTest")]
         public async void ExternalServiceExpandImplicitValueSetWithFilter()
         {
-            var client = new FhirClient("https://ontoserver.csiro.au/stu3-latest");
+            var client = new FhirClient(_externalTerminologyServerEndpoint);
             var svc = new ExternalTerminologyService(client);
 
             var parameters = new ExpandParameters()
@@ -538,10 +538,10 @@ namespace Hl7.Fhir.Specification.Tests
                 });
         }
 
-        [Fact]
+        [Fact(), Trait("TestCategory", "IntegrationTest")]
         public async void ExternalServiceSubsumesConceptASubsumesConceptB()
         {
-            var client = new FhirClient("https://ontoserver.csiro.au/stu3-latest");
+            var client = new FhirClient(_externalTerminologyServerEndpoint);
             var svc = new ExternalTerminologyService(client);
 
             var parameters = new SubsumesParameters()
@@ -557,10 +557,10 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.Equal("subsumes", ((Code)paramOutcome.Value).Value);
         }
 
-        [Fact]
+        [Fact(), Trait("TestCategory", "IntegrationTest")]
         public async void ExternalServiceClosureExample()
         {
-            var client = new FhirClient("https://ontoserver.csiro.au/stu3-latest");
+            var client = new FhirClient(_externalTerminologyServerEndpoint);
             var svc = new ExternalTerminologyService(client);
 
             // Step 1
@@ -800,7 +800,7 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact(Skip = "Don't want to run these kind of integration tests anymore"), Trait("TestCategory", "IntegrationTest")]
         public async void ExternalServiceValidateCodeTest()
         {
-            var client = new FhirClient("https://ontoserver.csiro.au/stu3-latest");
+            var client = new FhirClient(_externalTerminologyServerEndpoint);
             var svc = new ExternalTerminologyService(client);
 
             var parameters = new ValidateCodeParameters()
@@ -816,7 +816,7 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact(Skip = "Don't want to run these kind of integration tests anymore"), Trait("TestCategory", "IntegrationTest")]
         public void FallbackServiceValidateCodeTest()
         {
-            var client = new FhirClient("https://ontoserver.csiro.au/stu3-latest");
+            var client = new FhirClient(_externalTerminologyServerEndpoint);
             var external = new ExternalTerminologyService(client);
             var local = new LocalTerminologyService(_resolver);
             var svc = new FallbackTerminologyService(local, external);
@@ -833,7 +833,7 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact(Skip = "Don't want to run these kind of integration tests anymore"), Trait("TestCategory", "IntegrationTest")]
         public async void FallbackServiceValidateCodeWithParamsTest()
         {
-            var client = new FhirClient("https://ontoserver.csiro.au/stu3-latest");
+            var client = new FhirClient(_externalTerminologyServerEndpoint);
             var external = new ExternalTerminologyService(client);
             var local = new LocalTerminologyService(_resolver);
             var svc = new FallbackTerminologyService(local, external);
@@ -850,7 +850,7 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact(Skip = "Don't want to run these kind of integration tests anymore"), Trait("TestCategory", "IntegrationTest")]
         public async T.Task FallbackServiceValidateCodeTestWithVS()
         {
-            var client = new FhirClient("https://ontoserver.csiro.au/stu3-latest");
+            var client = new FhirClient(_externalTerminologyServerEndpoint);
             var service = new ExternalTerminologyService(client);
             var vs = await _resolver.FindValueSetAsync("http://hl7.org/fhir/ValueSet/substance-code");
             Assert.NotNull(vs);

--- a/src/Hl7.Fhir.Specification.Tests/Source/TerminologyTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/TerminologyTests.cs
@@ -368,7 +368,7 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
-        [Fac(), Trait("TestCategory", "IntegrationTest")]
+        [Fact(), Trait("TestCategory", "IntegrationTest")]
         public async void ExternalServiceTranslateSimpleAutomap()
         {
             var client = new FhirClient(_externalTerminologyServerEndpoint);


### PR DESCRIPTION
## Description
Created a static for ontoserver and placed all referring unit tests in the category IntegrationTest (= not run by Devops)

## Related issues
None

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes