### PR TITLE
ScopedNode: AtResource can also be determined from IResourceTypeSupplier

### DIFF
--- a/src/Hl7.Fhir.ElementModel.Tests/ScopedNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Tests/ScopedNodeTests.cs
@@ -8,15 +8,16 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using T=System.Threading.Tasks;
+using T = System.Threading.Tasks;
+
+#nullable enable
 
 namespace Hl7.Fhir.ElementModel.Tests
 {
     [TestClass]
     public class ScopedNodeTests
     {
-        ScopedNode _bundleNode;
+        ScopedNode? _bundleNode;
 
         [TestInitialize]
         public void SetupSource()
@@ -31,7 +32,7 @@ namespace Hl7.Fhir.ElementModel.Tests
         [TestMethod]
         public void KeepScopes()
         {
-            Assert.IsNull(_bundleNode.ParentResource);
+            Assert.IsNull(_bundleNode!.ParentResource);
             Assert.AreEqual("Bundle", _bundleNode.InstanceType);
             Assert.AreEqual("Bundle", _bundleNode.NearestResourceType);
 
@@ -39,7 +40,7 @@ namespace Hl7.Fhir.ElementModel.Tests
             Assert.IsNotNull(entry);
             Assert.AreEqual("Bundle.entry[0]", entry.Location);
             Assert.AreEqual("Bundle.entry[0]", entry.LocalLocation);
-            Assert.AreEqual("Bundle", entry.ParentResource.Location);
+            Assert.AreEqual("Bundle", entry.ParentResource!.Location);
             Assert.AreEqual("Bundle", entry.ParentResource.LocalLocation);
             Assert.AreNotEqual("Bundle", entry.InstanceType);
             Assert.IsFalse(entry.AtResource);
@@ -48,7 +49,7 @@ namespace Hl7.Fhir.ElementModel.Tests
             Assert.IsNotNull(resource);
             Assert.AreEqual("Bundle.entry[0].resource[0]", resource.Location);
             Assert.AreEqual("Bundle.entry[0].resource[0]", resource.LocalLocation);
-            Assert.AreEqual("Bundle", resource.ParentResource.Location);
+            Assert.AreEqual("Bundle", resource.ParentResource!.Location);
             Assert.AreNotEqual("Bundle", resource.InstanceType);
             Assert.IsTrue(resource.AtResource);
 
@@ -57,8 +58,8 @@ namespace Hl7.Fhir.ElementModel.Tests
             Assert.AreEqual("Bundle.entry[0].resource[0].active[0]", active.Location);
             Assert.AreEqual("Organization", active.NearestResourceType);
             Assert.AreEqual("Organization.active[0]", active.LocalLocation);
-            Assert.AreEqual("Bundle.entry[0].resource[0]", active.ParentResource.Location);
-            Assert.AreEqual("Bundle", active.ParentResource.ParentResource.Location);
+            Assert.AreEqual("Bundle.entry[0].resource[0]", active.ParentResource!.Location);
+            Assert.AreEqual("Bundle", active.ParentResource.ParentResource!.Location);
             Assert.AreNotEqual("Bundle", active.InstanceType);
             Assert.IsFalse(active.AtResource);
         }
@@ -66,30 +67,30 @@ namespace Hl7.Fhir.ElementModel.Tests
         [TestMethod]
         public void KeepScopesContained()
         {
-            var entry = (ScopedNode)_bundleNode.Children("entry").Skip(6).First();
+            var entry = (ScopedNode)_bundleNode!.Children("entry").Skip(6).First();
             Assert.AreEqual("Bundle.entry[6]", entry.Location);
-            Assert.AreEqual("Bundle", entry.ParentResource.Location);
+            Assert.AreEqual("Bundle", entry.ParentResource!.Location);
 
-            entry = (ScopedNode)entry.Children("resource").FirstOrDefault();
+            entry = entry.Children("resource").FirstOrDefault() as ScopedNode;
             Assert.IsNotNull(entry);
-            entry = (ScopedNode)entry.Children("contained").FirstOrDefault();
+            entry = entry!.Children("contained").FirstOrDefault() as ScopedNode;
             Assert.IsNotNull(entry);
-            Assert.AreNotEqual("Bundle", entry.InstanceType);
+            Assert.AreNotEqual("Bundle", entry!.InstanceType);
 
             Assert.IsTrue(entry.AtResource);
             Assert.AreEqual("Bundle.entry[6].resource[0].contained[0]", entry.Location);
-            Assert.AreEqual("Bundle.entry[6].resource[0]", entry.ParentResource.Location);
-            Assert.AreEqual("Bundle", entry.ParentResource.ParentResource.Location);
+            Assert.AreEqual("Bundle.entry[6].resource[0]", entry.ParentResource!.Location);
+            Assert.AreEqual("Bundle", entry.ParentResource.ParentResource!.Location);
 
-            entry = (ScopedNode)entry.Children("id").FirstOrDefault();
+            entry = entry.Children("id").FirstOrDefault() as ScopedNode;
             Assert.IsNotNull(entry);
-            Assert.AreNotEqual("Bundle", entry.InstanceType);
+            Assert.AreNotEqual("Bundle", entry!.InstanceType);
 
             Assert.IsFalse(entry.AtResource);
             Assert.AreEqual("Bundle.entry[6].resource[0].contained[0].id[0]", entry.Location);
-            Assert.AreEqual("Bundle.entry[6].resource[0].contained[0]", entry.ParentResource.Location);
-            Assert.AreEqual("Bundle.entry[6].resource[0]", entry.ParentResource.ParentResource.Location);
-            Assert.AreEqual("Bundle", entry.ParentResource.ParentResource.ParentResource.Location);
+            Assert.AreEqual("Bundle.entry[6].resource[0].contained[0]", entry.ParentResource!.Location);
+            Assert.AreEqual("Bundle.entry[6].resource[0]", entry.ParentResource.ParentResource!.Location);
+            Assert.AreEqual("Bundle", entry.ParentResource.ParentResource.ParentResource!.Location);
             Assert.AreEqual(3, entry.ParentResources().Count());
 
         }
@@ -97,7 +98,7 @@ namespace Hl7.Fhir.ElementModel.Tests
         [TestMethod]
         public void GetChildResources()
         {
-            Assert.AreEqual(0, _bundleNode.ContainedResources().Count());
+            Assert.AreEqual(0, _bundleNode!.ContainedResources().Count());
 
             var entries = _bundleNode.BundledResources().ToList();
             Assert.AreEqual(7, entries.Count);
@@ -105,13 +106,13 @@ namespace Hl7.Fhir.ElementModel.Tests
             Assert.AreEqual("urn:uuid:04121321-4af5-424c-a0e1-ed3aab1c349d", entries[1].FullUrl);
             Assert.AreEqual("http://example.org/fhir/Patient/b", entries[3].FullUrl);
 
-            Assert.IsFalse(entries[1].Resource.ContainedResources().Any());
-            Assert.IsNotNull(entries[1].Resource.Children("active").First());
+            Assert.IsFalse(entries[1].Resource!.ContainedResources().Any());
+            Assert.IsNotNull(entries[1].Resource!.Children("active").First());
 
-            Assert.AreEqual("#a", entries[2].Resource.Id());
+            Assert.AreEqual("#a", entries[2].Resource!.Id());
 
             var entry6 = entries[6].Resource;
-            Assert.AreEqual(2, entry6.ContainedResources().Count());
+            Assert.AreEqual(2, entry6!.ContainedResources().Count());
             Assert.IsFalse(entry6.BundledResources().Any());
             Assert.AreEqual("#orgY", entry6.ContainedResources().Skip(1).First().Id());
         }
@@ -119,37 +120,37 @@ namespace Hl7.Fhir.ElementModel.Tests
         [TestMethod]
         public void GetFullUrl()
         {
-            var entries = _bundleNode.BundledResources().ToList();
+            var entries = _bundleNode!.BundledResources().ToList();
 
             Assert.AreEqual("http://example.org/fhir/Patient/b", entries[3].FullUrl);
 
             var entry3 = entries[3].Resource;
-            entry3 = (ScopedNode)entry3.Children("managingOrganization").FirstOrDefault();
+            entry3 = entry3!.Children("managingOrganization").FirstOrDefault() as ScopedNode;
             Assert.IsNotNull(entry3);
-            entry3 = (ScopedNode)entry3.Children("reference").FirstOrDefault();
+            entry3 = entry3!.Children("reference").FirstOrDefault() as ScopedNode;
             Assert.IsNotNull(entry3);
-            Assert.AreEqual(entries[3].FullUrl, entry3.FullUrl());
-            Assert.AreEqual(entry3.ParentResource.FullUrl(), entry3.FullUrl());
+            Assert.AreEqual(entries[3].FullUrl, entry3!.FullUrl());
+            Assert.AreEqual(entry3!.ParentResource!.FullUrl(), entry3.FullUrl());
 
             var entry6 = entries[6].Resource;
-            entry6 = (ScopedNode)entry6.Children("contained").Skip(1).FirstOrDefault();
+            entry6 = entry6!.Children("contained").Skip(1).FirstOrDefault() as ScopedNode;
             Assert.IsNotNull(entry6);
-            Assert.AreEqual("#orgY", entry6.Id());
+            Assert.AreEqual("#orgY", entry6!.Id());
             Assert.AreEqual(entries[6].FullUrl, entry6.FullUrl());
-            Assert.AreEqual(entry6.ParentResource.FullUrl(), entry6.FullUrl());
+            Assert.AreEqual(entry6.ParentResource!.FullUrl(), entry6.FullUrl());
         }
 
         [TestMethod]
         public void TestMakeAbsolute()
         {
-            var inner0 = (ScopedNode)_bundleNode.Children("entry").First().Children("resource").Children("active").SingleOrDefault();
+            var inner0 = _bundleNode!.Children("entry").First().Children("resource").Children("active").SingleOrDefault() as ScopedNode;
             Assert.IsNotNull(inner0);
 
             Assert.AreEqual("http://example.org/fhir/Patient/3", inner0.MakeAbsolute("Patient/3"));
             Assert.AreEqual("http://nu.nl/myPat/3x", inner0.MakeAbsolute("http://nu.nl/myPat/3x"));
             Assert.AreEqual("http://example.org/fhir/Organization/5", inner0.MakeAbsolute("http://example.org/fhir/Organization/5"));
 
-            var inner1 = (ScopedNode)_bundleNode.Children("entry").Skip(1).First().Children("resource").Children("active").SingleOrDefault();
+            var inner1 = _bundleNode.Children("entry").Skip(1).First().Children("resource").Children("active").SingleOrDefault() as ScopedNode;
 
             Assert.AreEqual("urn:uuid:04121321-4af5-424c-a0e1-ed3aab1c349d/3", inner1.MakeAbsolute("Patient/3"));
             Assert.AreEqual("http://nu.nl/myPat/3x", inner1.MakeAbsolute("http://nu.nl/myPat/3x"));
@@ -159,19 +160,19 @@ namespace Hl7.Fhir.ElementModel.Tests
         [TestMethod]
         public void TestResolve()
         {
-            var inner7 = (ScopedNode)_bundleNode.Children("entry").Skip(6).First().Children("resource").Children("managingOrganization").SingleOrDefault();
+            var inner7 = _bundleNode!.Children("entry").Skip(6).First().Children("resource").Children("managingOrganization").SingleOrDefault() as ScopedNode;
 
-            Assert.AreEqual("Bundle.entry[6].resource[0]", inner7.Resolve("http://example.org/fhir/Patient/e").Location);
-            Assert.AreEqual("Bundle.entry[6].resource[0].contained[1]", inner7.Resolve("#orgY").Location);
-            Assert.AreEqual("Bundle.entry[6].resource[0]", inner7.Resolve("#e").Location);
-            Assert.AreEqual("Bundle.entry[5].resource[0]", inner7.Resolve("http://example.org/fhir/Patient/d").Location);
-            Assert.AreEqual("Bundle.entry[5].resource[0]", inner7.Resolve("Patient/d").Location);
-            Assert.AreEqual("Bundle.entry[1].resource[0]", inner7.Resolve("urn:uuid:04121321-4af5-424c-a0e1-ed3aab1c349d").Location);
+            Assert.AreEqual("Bundle.entry[6].resource[0]", inner7!.Resolve("http://example.org/fhir/Patient/e").Location);
+            Assert.AreEqual("Bundle.entry[6].resource[0].contained[1]", inner7!.Resolve("#orgY").Location);
+            Assert.AreEqual("Bundle.entry[6].resource[0]", inner7!.Resolve("#e").Location);
+            Assert.AreEqual("Bundle.entry[5].resource[0]", inner7!.Resolve("http://example.org/fhir/Patient/d").Location);
+            Assert.AreEqual("Bundle.entry[5].resource[0]", inner7!.Resolve("Patient/d").Location);
+            Assert.AreEqual("Bundle.entry[1].resource[0]", inner7!.Resolve("urn:uuid:04121321-4af5-424c-a0e1-ed3aab1c349d").Location);
             Assert.IsNull(inner7.Resolve("#d"));
             Assert.IsNull(inner7.Resolve("http://nu.nl/3"));
 
-            Assert.AreEqual("Bundle.entry[6].resource[0].contained[1]", inner7.Resolve().Location);
-            Assert.IsTrue(inner7.Children("reference").Any());
+            Assert.AreEqual("Bundle.entry[6].resource[0].contained[1]", inner7!.Resolve().Location);
+            Assert.IsTrue(inner7!.Children("reference").Any());
             Assert.AreEqual("Bundle.entry[6].resource[0].contained[1]", inner7.Children("reference").First().Resolve().Location);
 
             string lastUrlResolved = "";
@@ -181,11 +182,24 @@ namespace Hl7.Fhir.ElementModel.Tests
             Assert.IsNull(inner7.Resolve("http://nu.nl/3", externalResolve));
             Assert.AreEqual("http://nu.nl/3", lastUrlResolved);
 
-            ITypedElement externalResolve(string url)
+            ITypedElement? externalResolve(string url)
             {
                 lastUrlResolved = url;
                 return null;
             }
+        }
+
+        [TestMethod]
+        public void AtResourceWithoutDefinition()
+        {
+            var elementNode = ElementNodeAdapter.Root("Patient");
+            elementNode.Add("active", true, "boolean");
+
+            var node = new ScopedNode(elementNode);
+
+            Assert.IsTrue(node.AtResource);
+            var inner = (ScopedNode)node.Children().First();
+            Assert.IsFalse(inner.AtResource);
         }
 
         [TestMethod]
@@ -240,7 +254,7 @@ namespace Hl7.Fhir.ElementModel.Tests
 
             public async T.Task<Resource> ResolveByCanonicalUriAsync(string uri)
             {
-                if (_cache.TryGetValue(uri, out StructureDefinition sd))
+                if (_cache.TryGetValue(uri, out StructureDefinition? sd))
                     return sd;
 
                 sd = await _coreResolver.FindStructureDefinitionAsync(uri);
@@ -255,6 +269,60 @@ namespace Hl7.Fhir.ElementModel.Tests
             }
 
             public T.Task<Resource> ResolveByUriAsync(string uri) => throw new NotImplementedException();
+        }
+
+        private class ElementNodeAdapter : ITypedElement, IResourceTypeSupplier
+        {
+            private ElementNode _elementNodeInstance;
+            private IStructureDefinitionSummaryProvider _structureDefinitionSummaryProvider;
+
+            public string Name => _elementNodeInstance.Name;
+
+            public string InstanceType => _elementNodeInstance.InstanceType;
+
+            public object Value => _elementNodeInstance.Value;
+
+            public string Location => _elementNodeInstance.Location;
+
+            public IElementDefinitionSummary Definition => _elementNodeInstance.Definition;
+
+            public string? ResourceType => !string.IsNullOrEmpty(InstanceType) && char.IsUpper(InstanceType, 0) ? InstanceType : null;
+
+            public static ElementNodeAdapter Root(string type, string? name = null, object? value = null)
+            {
+                var def = new NoTypeProvider();
+                var instance = ElementNode.Root(def, type, name, value);
+                return new ElementNodeAdapter(instance, def);
+
+            }
+            private ElementNodeAdapter(ElementNode elementNode, IStructureDefinitionSummaryProvider structureDefinitionSummaryProvider)
+            {
+                _elementNodeInstance = elementNode;
+                _structureDefinitionSummaryProvider = structureDefinitionSummaryProvider;
+            }
+
+            public IEnumerable<ITypedElement> Children(string? name = null) => _elementNodeInstance.Children(name);
+
+            internal void Add(string name, object? value = null, string? instanceType = null)
+                => _elementNodeInstance.Add(_structureDefinitionSummaryProvider, name, value, instanceType);
+
+
+            internal void Add(ITypedElement child, string name)
+            {
+                switch (child)
+                {
+                    case ElementNodeAdapter node:
+                        _elementNodeInstance.Add(_structureDefinitionSummaryProvider, node._elementNodeInstance, name);
+                        break;
+                    default:
+                        throw new ArgumentException($"{nameof(child)} is not of type {nameof(ElementNodeAdapter)}");
+                }
+            }
+
+            private class NoTypeProvider : IStructureDefinitionSummaryProvider
+            {
+                public IStructureDefinitionSummary? Provide(string canonical) => null;
+            }
         }
 
     }


### PR DESCRIPTION
## Description
In class `ScopedNode` the property `AtResource` can now also be determined from IResourceTypeSupplier when there is no `Definition` present.

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes