### PR TITLE
Add support for exists slicing

### DIFF
--- a/src/Hl7.Fhir.Specification/Validation/Slicing/DiscriminatorBucket.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/DiscriminatorBucket.cs
@@ -6,12 +6,12 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Support;
-using System.Linq;
-using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Utility;
+using System.Linq;
 
 namespace Hl7.Fhir.Validation
 {
@@ -26,9 +26,8 @@ namespace Hl7.Fhir.Validation
         /// <param name="discriminators">A set of discriminators that determine whether or not an instance is part of this bucket.</param>
         public DiscriminatorBucket(ElementDefinitionNavigator sliceConstraints, Validator validator, IDiscriminator[] discriminators) : base(sliceConstraints.Current)
         {
-            //TODO: discriminator-less validation?
             if (discriminators == null || discriminators.Length == 0)
-                throw Error.NotImplemented($"Discriminator-less slicing is not implemented. Must pass at least one discriminator - none found at '{sliceConstraints.CanonicalPath()}'");
+                throw Error.InvalidOperation($"Discriminator bucket requires at least one discriminator. Otherwise, use the ConstraintsBucket instead.");
 
             // Keep a copy of the constraints for this slice, so we can use them to validate the instances against later.
             SliceConstraints = sliceConstraints.ShallowCopy();
@@ -36,7 +35,7 @@ namespace Hl7.Fhir.Validation
             Validator = validator;
             Discriminators = discriminators;
         }
-    
+
         public ElementDefinitionNavigator SliceConstraints { get; private set; }
 
         public Validator Validator { get; private set; }

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/ExistsDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/ExistsDiscriminator.cs
@@ -1,0 +1,34 @@
+﻿/* 
+ * Copyright (c) 2019, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+using Hl7.Fhir.ElementModel;
+using Hl7.FhirPath;
+using System.Linq;
+
+namespace Hl7.Fhir.Validation
+{
+    internal class ExistsDiscriminator : IDiscriminator
+    {
+        public bool ExistsMode { get; private set; }
+
+        public ExistsDiscriminator(bool existsMode, string path)
+        {
+            Path = path;
+            ExistsMode = existsMode;
+        }
+
+        public string Path { get; }
+
+        public bool Matches(ITypedElement candidate)
+        {
+            ITypedElement[] values = candidate.Select(Path).ToArray();
+
+            return ExistsMode == values.Any();
+        }
+    }
+}


### PR DESCRIPTION
Adds support for `exists` slicing + added a unit test to verify.

Fixes #1578.

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes