### PR TITLE
Optional include of mandatory elements to the list of provided elements during serialization

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
@@ -595,7 +595,7 @@ namespace Hl7.Fhir.Tests.Serialization
         }
 
         [TestMethod]
-        public void IncludeMandatoryToElementsTest()
+        public void IncludeMandatoryInElementsSummaryTest()
         {
             Observation obs = new()
             {
@@ -610,7 +610,7 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.IsFalse(json.ContainsKey("status"));
 
             // Adding mandatory elements to the set of elements
-            json = new FhirJsonSerializer(new SerializerSettings() { IncludeMandatoryToElements = true })
+            json = new FhirJsonSerializer(new SerializerSettings() { IncludeMandatoryInElementsSummary = true })
                 .SerializeToDocument(obs, elements: new[] { "issued" });
 
             Assert.IsTrue(json.ContainsKey("issued"));

--- a/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
@@ -6,18 +6,17 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Utility;
-using Hl7.Fhir.Introspection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
-using Hl7.Fhir.ElementModel;
 
 namespace Hl7.Fhir.Tests.Serialization
 {
@@ -57,9 +56,9 @@ namespace Hl7.Fhir.Tests.Serialization
         public void ParsePatientXmlNullType()
         {
             string xmlPacientTest = TestDataHelper.ReadTestData("TestPatient.xml");
-            
+
             var poco = new FhirXmlParser().Parse(xmlPacientTest);
-            
+
             Assert.AreEqual(((Patient)poco).Id, "pat1");
             Assert.AreEqual(((Patient)poco).Contained.First().Id, "1");
             Assert.AreEqual(((Patient)poco).Name.First().Family, "Donald");
@@ -195,7 +194,7 @@ namespace Hl7.Fhir.Tests.Serialization
             var ext = new FhirDecimal(dec6);
             var obs = new Observation();
             obs.AddExtension("http://example.org/DecimalPrecision", ext);
-            
+
             var json = FhirJsonSerializer.SerializeToString(obs);
             var obs2 = FhirJsonParser.Parse<Observation>(json);
 
@@ -230,7 +229,7 @@ namespace Hl7.Fhir.Tests.Serialization
         {
             var dec6 = 6m;
             var ext = new FhirDecimal(dec6);
-            var obs = new Observation{ Value = new FhirDecimal(dec6) };
+            var obs = new Observation { Value = new FhirDecimal(dec6) };
             var json = FhirJsonSerializer.SerializeToString(obs);
             try
             {
@@ -275,7 +274,7 @@ namespace Hl7.Fhir.Tests.Serialization
 
             var xml = FhirXmlSerializer.SerializeToString(x);
             Assert.IsFalse(xml.Contains("<script"));
-        }       
+        }
 
 
         [TestMethod]
@@ -368,7 +367,7 @@ namespace Hl7.Fhir.Tests.Serialization
 
             string json = TestDataHelper.ReadTestData(@"valueset-v2-0717.json");
             Assert.IsNotNull(json);
-            var parser = new FhirJsonParser { Settings = { PermissiveParsing = true} };
+            var parser = new FhirJsonParser { Settings = { PermissiveParsing = true } };
             var vs = parser.Parse<ValueSet>(json);
             Assert.IsNotNull(vs);
 
@@ -556,7 +555,7 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.IsTrue(patient.IsExactly(res), "1");
 
             // Is the parsing still correct without milliseconds?
-            patient = new Patient { Meta = new Meta { LastUpdated = new DateTimeOffset(2018, 8, 13, 13, 41, 56, TimeSpan.Zero)} };
+            patient = new Patient { Meta = new Meta { LastUpdated = new DateTimeOffset(2018, 8, 13, 13, 41, 56, TimeSpan.Zero) } };
             json = "{\"resourceType\":\"Patient\",\"meta\":{\"lastUpdated\":\"2018-08-13T13:41:56+00:00\"}}";
             res = new FhirJsonParser().Parse<Patient>(json);
             Assert.IsTrue(patient.IsExactly(res), "2");
@@ -593,6 +592,29 @@ namespace Hl7.Fhir.Tests.Serialization
             var newPoco = fhirJsonParser.Parse<Patient>(reserialized);
 
             Assert.AreEqual(1, newPoco.Name.Count);
+        }
+
+        [TestMethod]
+        public void IncludeMandatoryToElementsTest()
+        {
+            Observation obs = new()
+            {
+                Status = ObservationStatus.Final,
+                Issued = DateTimeOffset.Now
+            };
+
+            // default behavior
+            var json = new FhirJsonSerializer().SerializeToDocument(obs, elements: new[] { "issued" });
+
+            Assert.IsTrue(json.ContainsKey("issued"));
+            Assert.IsFalse(json.ContainsKey("status"));
+
+            // Adding mandatory elements to the set of elements
+            json = new FhirJsonSerializer(new SerializerSettings() { IncludeMandatoryToElements = true })
+                .SerializeToDocument(obs, elements: new[] { "issued" });
+
+            Assert.IsTrue(json.ContainsKey("issued"));
+            Assert.IsTrue(json.ContainsKey("status"));
         }
     }
 }

--- a/src/Hl7.Fhir.Core/Serialization/BaseFhirSerializer.cs
+++ b/src/Hl7.Fhir.Core/Serialization/BaseFhirSerializer.cs
@@ -6,11 +6,11 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
-using Hl7.Fhir.ElementModel;
-using System.Linq;
 using Hl7.Fhir.Utility;
+using System.Linq;
 
 namespace Hl7.Fhir.Serialization
 {
@@ -24,6 +24,9 @@ namespace Hl7.Fhir.Serialization
         }
 
         protected static ITypedElement MakeElementStack(Base instance, SummaryType summary, string[] elements)
+            => MakeElementStack(instance, summary, elements, false);
+
+        protected static ITypedElement MakeElementStack(Base instance, SummaryType summary, string[] elements, bool includeMandatoryToElements)
         {
             if (summary == SummaryType.False && elements == null) return instance.ToTypedElement();
 
@@ -47,7 +50,7 @@ namespace Hl7.Fhir.Serialization
                 case SummaryType.Count:
                     return MaskingNode.ForCount(baseNav);
                 case SummaryType.False:
-                    return MaskingNode.ForElements(baseNav, elements);
+                    return MaskingNode.ForElements(baseNav, elements, includeMandatoryToElements);
                 default:
                     return baseNav;
             }

--- a/src/Hl7.Fhir.Core/Serialization/BaseFhirSerializer.cs
+++ b/src/Hl7.Fhir.Core/Serialization/BaseFhirSerializer.cs
@@ -26,7 +26,7 @@ namespace Hl7.Fhir.Serialization
         protected static ITypedElement MakeElementStack(Base instance, SummaryType summary, string[] elements)
             => MakeElementStack(instance, summary, elements, false);
 
-        protected static ITypedElement MakeElementStack(Base instance, SummaryType summary, string[] elements, bool includeMandatoryToElements)
+        protected static ITypedElement MakeElementStack(Base instance, SummaryType summary, string[] elements, bool includeMandatoryInElementsSummary)
         {
             if (summary == SummaryType.False && elements == null) return instance.ToTypedElement();
 
@@ -50,7 +50,7 @@ namespace Hl7.Fhir.Serialization
                 case SummaryType.Count:
                     return MaskingNode.ForCount(baseNav);
                 case SummaryType.False:
-                    return MaskingNode.ForElements(baseNav, elements, includeMandatoryToElements);
+                    return MaskingNode.ForElements(baseNav, elements, includeMandatoryInElementsSummary);
                 default:
                     return baseNav;
             }

--- a/src/Hl7.Fhir.Core/Serialization/FhirJsonSerializer.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirJsonSerializer.cs
@@ -23,15 +23,15 @@ namespace Hl7.Fhir.Serialization
             new FhirJsonSerializationSettings { Pretty = Settings.Pretty, AppendNewLine = Settings.AppendNewLine };
 
         public string SerializeToString(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) =>
-            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryToElements ?? false).ToJson(buildFhirJsonWriterSettings());
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).ToJson(buildFhirJsonWriterSettings());
 
         public byte[] SerializeToBytes(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) =>
-            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryToElements ?? false).ToJsonBytes(buildFhirJsonWriterSettings());
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).ToJsonBytes(buildFhirJsonWriterSettings());
 
         public JObject SerializeToDocument(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) =>
-            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryToElements ?? false).ToJObject(buildFhirJsonWriterSettings());
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).ToJObject(buildFhirJsonWriterSettings());
 
         public void Serialize(Base instance, JsonWriter writer, SummaryType summary = SummaryType.False, string[] elements = null) =>
-            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryToElements ?? false).WriteTo(writer, buildFhirJsonWriterSettings());
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).WriteTo(writer, buildFhirJsonWriterSettings());
     }
 }

--- a/src/Hl7.Fhir.Core/Serialization/FhirJsonSerializer.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirJsonSerializer.cs
@@ -6,7 +6,6 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
-using System;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Newtonsoft.Json;
@@ -23,16 +22,16 @@ namespace Hl7.Fhir.Serialization
         private FhirJsonSerializationSettings buildFhirJsonWriterSettings() =>
             new FhirJsonSerializationSettings { Pretty = Settings.Pretty, AppendNewLine = Settings.AppendNewLine };
 
-        public string SerializeToString(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) => 
-            MakeElementStack(instance, summary, elements).ToJson(buildFhirJsonWriterSettings());
+        public string SerializeToString(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) =>
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryToElements ?? false).ToJson(buildFhirJsonWriterSettings());
 
-        public byte[] SerializeToBytes(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) => 
-            MakeElementStack(instance, summary, elements).ToJsonBytes(buildFhirJsonWriterSettings());
+        public byte[] SerializeToBytes(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) =>
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryToElements ?? false).ToJsonBytes(buildFhirJsonWriterSettings());
 
-        public JObject SerializeToDocument(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) => 
-            MakeElementStack(instance, summary, elements).ToJObject(buildFhirJsonWriterSettings());
+        public JObject SerializeToDocument(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) =>
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryToElements ?? false).ToJObject(buildFhirJsonWriterSettings());
 
         public void Serialize(Base instance, JsonWriter writer, SummaryType summary = SummaryType.False, string[] elements = null) =>
-            MakeElementStack(instance, summary, elements).WriteTo(writer, buildFhirJsonWriterSettings());
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryToElements ?? false).WriteTo(writer, buildFhirJsonWriterSettings());
     }
 }

--- a/src/Hl7.Fhir.Core/Serialization/FhirXmlSerializer.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirXmlSerializer.cs
@@ -9,7 +9,6 @@
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Utility;
-using System;
 using System.Xml;
 using System.Xml.Linq;
 
@@ -17,30 +16,30 @@ namespace Hl7.Fhir.Serialization
 {
     public class FhirXmlSerializer : BaseFhirSerializer
     {
-        public FhirXmlSerializer(SerializerSettings settings=null) : base(settings)
+        public FhirXmlSerializer(SerializerSettings settings = null) : base(settings)
         {
         }
 
         private FhirXmlSerializationSettings buildFhirXmlWriterSettings() =>
             new FhirXmlSerializationSettings { Pretty = Settings.Pretty, AppendNewLine = Settings.AppendNewLine, TrimWhitespaces = Settings.TrimWhiteSpacesInXml };
 
-        public string SerializeToString(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) => 
-            MakeElementStack(instance, summary, elements)
+        public string SerializeToString(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryToElements ?? false)
             .Rename(root)
             .ToXml(settings: buildFhirXmlWriterSettings());
 
-        public byte[] SerializeToBytes(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) => 
-            MakeElementStack(instance, summary, elements)
+        public byte[] SerializeToBytes(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryToElements ?? false)
             .Rename(root)
             .ToXmlBytes(settings: buildFhirXmlWriterSettings());
 
         public XDocument SerializeToDocument(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
-           MakeElementStack(instance, summary, elements)
+           MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryToElements ?? false)
             .Rename(root)
             .ToXDocument(buildFhirXmlWriterSettings()).Rename(root);
 
         public void Serialize(Base instance, XmlWriter writer, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
-            MakeElementStack(instance, summary, elements)
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryToElements ?? false)
             .Rename(root)
             .WriteTo(writer, settings: buildFhirXmlWriterSettings());
     }

--- a/src/Hl7.Fhir.Core/Serialization/FhirXmlSerializer.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirXmlSerializer.cs
@@ -24,22 +24,22 @@ namespace Hl7.Fhir.Serialization
             new FhirXmlSerializationSettings { Pretty = Settings.Pretty, AppendNewLine = Settings.AppendNewLine, TrimWhitespaces = Settings.TrimWhiteSpacesInXml };
 
         public string SerializeToString(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
-            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryToElements ?? false)
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
             .Rename(root)
             .ToXml(settings: buildFhirXmlWriterSettings());
 
         public byte[] SerializeToBytes(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
-            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryToElements ?? false)
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
             .Rename(root)
             .ToXmlBytes(settings: buildFhirXmlWriterSettings());
 
         public XDocument SerializeToDocument(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
-           MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryToElements ?? false)
+           MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
             .Rename(root)
             .ToXDocument(buildFhirXmlWriterSettings()).Rename(root);
 
         public void Serialize(Base instance, XmlWriter writer, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
-            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryToElements ?? false)
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
             .Rename(root)
             .WriteTo(writer, settings: buildFhirXmlWriterSettings());
     }


### PR DESCRIPTION
## Description
Adding an extra setting `IncludeMandatoryToElements` to `SerializeSetting` . This is used during serialization with a set of elements:

```c#
var json = new FhirJsonSerializer(new SerializerSettings() { IncludeMandatoryToElements = true })
                .SerializeToDocument(obs, elements: new[] { "issued" });
```
In above case, not only the element `issued` is serialized but also the mandatory elements. For `Observation` is that `status`. So 2 elements are serialized here. 

## Related issues
Resolves #1653.

## Testing
Unit test `SerializationTests.IncludeMandatoryToElementsTest`

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes