### PR TITLE
Made some extensions of ElementDefinitionNavigator public (for R3)

### DIFF
--- a/src/Hl7.Fhir.Specification/Validation/ElementDefinitionNavigatorExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/ElementDefinitionNavigatorExtensions.cs
@@ -12,10 +12,9 @@ using System.Linq;
 
 namespace Hl7.Fhir.Validation
 {
-
-    internal static class ElementDefinitionNavigatorExtensions
+    public static class ElementDefinitionNavigatorExtensions
     {
-        public static string GetFhirPathConstraint(this ElementDefinition.ConstraintComponent cc)
+        internal static string GetFhirPathConstraint(this ElementDefinition.ConstraintComponent cc)
         {
             // This was required for 3.0.0, but was rectified in the 3.0.1 technical update
             //if (cc.Key == "ele-1")
@@ -37,7 +36,7 @@ namespace Hl7.Fhir.Validation
 
         public static bool IsSlicing(this ElementDefinitionNavigator nav) => nav.Current.Slicing != null;
 
-        public static string ConstraintDescription(this ElementDefinition.ConstraintComponent cc)
+        internal static string ConstraintDescription(this ElementDefinition.ConstraintComponent cc)
         {
             var desc = cc.Key;
 


### PR DESCRIPTION
## Description
Made some extensions on `ElementDefinitionNavigator` public since there is potential for re-use

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes