### PR TITLE
Async support Json/Xml Parsers + Serializers

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/ElementModel/PocoTypedElementTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/ElementModel/PocoTypedElementTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using Tasks = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Core.Tests.ElementModel
 {
@@ -86,13 +87,14 @@ namespace Hl7.Fhir.Core.Tests.ElementModel
         }
 
         [TestMethod]
-        public void CompareToOtherElementNavigator()
+        public async Tasks.Task CompareToOtherElementNavigator()
         {
             var json = TestDataHelper.ReadTestData("TestPatient.json");
             var xml = TestDataHelper.ReadTestData("TestPatient.xml");
 
-            var pocoP = (new FhirJsonParser()).Parse<Patient>(json).ToTypedElement();
-            var jsonP = FhirJsonNode.Parse(json, settings: new FhirJsonParsingSettings { AllowJsonComments = true })
+            var poco = await (new FhirJsonParser()).ParseAsync<Patient>(json);
+            var pocoP = poco.ToTypedElement();
+            var jsonP = (await FhirJsonNode.ParseAsync(json, settings: new FhirJsonParsingSettings { AllowJsonComments = true }))
                 .ToTypedElement(new PocoStructureDefinitionSummaryProvider());
             var xmlP = FhirXmlNode.Parse(xml).ToTypedElement(new PocoStructureDefinitionSummaryProvider());
 

--- a/src/Hl7.Fhir.Core.Tests/ElementModel/PocoTypedElementTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/ElementModel/PocoTypedElementTests.cs
@@ -96,7 +96,7 @@ namespace Hl7.Fhir.Core.Tests.ElementModel
             var pocoP = poco.ToTypedElement();
             var jsonP = (await FhirJsonNode.ParseAsync(json, settings: new FhirJsonParsingSettings { AllowJsonComments = true }))
                 .ToTypedElement(new PocoStructureDefinitionSummaryProvider());
-            var xmlP = FhirXmlNode.Parse(xml).ToTypedElement(new PocoStructureDefinitionSummaryProvider());
+            var xmlP = (await FhirXmlNode.ParseAsync(xml)).ToTypedElement(new PocoStructureDefinitionSummaryProvider());
 
             doCompare(pocoP, jsonP, "poco<->json");
             doCompare(pocoP, xmlP, "poco<->xml");

--- a/src/Hl7.Fhir.Core.Tests/Model/DeepCopyTest.cs
+++ b/src/Hl7.Fhir.Core.Tests/Model/DeepCopyTest.cs
@@ -12,12 +12,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using System.IO;
 using Hl7.Fhir.Serialization;
 using System.Xml;
 using static Hl7.Fhir.Tests.TestDataHelper;
 using System.Diagnostics;
+using Task = System.Threading.Tasks.Task;
 
 namespace Hl7.Fhir.Tests.Model
 {
@@ -25,24 +25,24 @@ namespace Hl7.Fhir.Tests.Model
     public class DeepCopyTest
     {
         [TestMethod]
-        public void CheckCopyAllFields()
+        public async Task CheckCopyAllFields()
         {
             string xml = ReadTestData("TestPatient.xml");
 
             var p = new FhirXmlParser().Parse<Patient>(xml);
             var p2 = (Patient)p.DeepCopy();
-            var xml2 = new FhirXmlSerializer().SerializeToString(p2);
+            var xml2 = await new FhirXmlSerializer().SerializeToStringAsync(p2);
             XmlAssert.AreSame("TestPatient.xml", xml, xml2);
         }
 
         [TestMethod]
-        public void CheckCopyCarePlan()
+        public async Task CheckCopyCarePlan()
         {
             string xml = ReadTestData(@"careplan-example-f201-renal.xml");
 
             var p = new FhirXmlParser().Parse<CarePlan>(xml);
             var p2 = (CarePlan)p.DeepCopy();
-            var xml2 = new FhirXmlSerializer().SerializeToString(p2);
+            var xml2 = await new FhirXmlSerializer().SerializeToStringAsync(p2);
             XmlAssert.AreSame("careplan-example-f201-renal.xml", xml, xml2);
         }
 

--- a/src/Hl7.Fhir.Core.Tests/Model/DeepCopyTest.cs
+++ b/src/Hl7.Fhir.Core.Tests/Model/DeepCopyTest.cs
@@ -29,7 +29,7 @@ namespace Hl7.Fhir.Tests.Model
         {
             string xml = ReadTestData("TestPatient.xml");
 
-            var p = new FhirXmlParser().Parse<Patient>(xml);
+            var p = await new FhirXmlParser().ParseAsync<Patient>(xml);
             var p2 = (Patient)p.DeepCopy();
             var xml2 = await new FhirXmlSerializer().SerializeToStringAsync(p2);
             XmlAssert.AreSame("TestPatient.xml", xml, xml2);
@@ -40,7 +40,7 @@ namespace Hl7.Fhir.Tests.Model
         {
             string xml = ReadTestData(@"careplan-example-f201-renal.xml");
 
-            var p = new FhirXmlParser().Parse<CarePlan>(xml);
+            var p = await new FhirXmlParser().ParseAsync<CarePlan>(xml);
             var p2 = (CarePlan)p.DeepCopy();
             var xml2 = await new FhirXmlSerializer().SerializeToStringAsync(p2);
             XmlAssert.AreSame("careplan-example-f201-renal.xml", xml, xml2);

--- a/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
@@ -21,7 +21,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
+using T = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Tests.Rest
 {
@@ -301,22 +301,22 @@ namespace Hl7.Fhir.Tests.Rest
         }
 
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest")]
-        public void Read()
+        public async T.Task Read()
         {
             LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
-            testReadClient(client);
+            await testReadClientAsync(client);
         }
 
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest")]
-        public void ReadHttpClient()
+        public async T.Task ReadHttpClient()
         {
             using (FhirClient client = new FhirClient(testEndpoint))
             {
-                testReadClient(client);
+                await testReadClientAsync(client);
             }
         }
-
-        private void testReadClient(BaseFhirClient client)
+        
+        private async T.Task testReadClientAsync(BaseFhirClient client)
         {
             var loc = client.Read<Location>("Location/" + locationId);
             Assert.IsNotNull(loc);
@@ -344,15 +344,14 @@ namespace Hl7.Fhir.Tests.Rest
             var loc3 = client.Read<Location>(ResourceIdentity.Build("Location", locationId, loc.Meta.VersionId));
             Assert.IsNotNull(loc3);
             var jsonSer = new FhirJsonSerializer();
-            Assert.AreEqual(jsonSer.SerializeToString(loc),
-                            jsonSer.SerializeToString(loc3));
+            Assert.AreEqual(await jsonSer.SerializeToStringAsync(loc),
+                await jsonSer.SerializeToStringAsync(loc3));
 
             var loc4 = client.Read<Location>(loc.ResourceIdentity());
             Assert.IsNotNull(loc4);
-            Assert.AreEqual(jsonSer.SerializeToString(loc),
-                            jsonSer.SerializeToString(loc4));
+            Assert.AreEqual(await jsonSer.SerializeToStringAsync(loc),
+                await jsonSer.SerializeToStringAsync(loc4));
         }
-
 
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest")]
         public void ReadRelative()
@@ -765,24 +764,24 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
-        public void CreateEditDelete()
+        public async T.Task CreateEditDelete()
         {
             LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
             client.OnBeforeRequest += Compression_OnBeforeWebRequestZipOrDeflate;
-            testCreateEditDelete(client);
+            await testCreateEditDeleteAsync(client);
         }
 
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
-        public void CreateEditDeleteHttpClient()
+        public async T.Task CreateEditDeleteHttpClient()
         {
             using (var handler = new HttpClientHandler())
             using (FhirClient client = new FhirClient(testEndpoint, messageHandler: handler))
             {
                 handler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
                 // client.CompressRequestBody = true;
-                testCreateEditDelete(client);
+                await testCreateEditDeleteAsync(client);
             }
         }
 
@@ -792,7 +791,7 @@ namespace Hl7.Fhir.Tests.Rest
         /// This test is also used as a "setup" test for the History test.
         /// If you change the number of operations in here, this will make the History test fail.
         /// </summary>
-        private void testCreateEditDelete(BaseFhirClient client)
+        private async T.Task testCreateEditDeleteAsync(BaseFhirClient client)
         {
             // client.CompressRequestBody = true;
 
@@ -801,7 +800,7 @@ namespace Hl7.Fhir.Tests.Rest
             pat.Identifier.Clear();
             pat.Identifier.Add(new Identifier("http://hl7.org/test/2", "99999"));
 
-            System.Diagnostics.Trace.WriteLine(new FhirXmlSerializer().SerializeToString(pat));
+            System.Diagnostics.Trace.WriteLine(await new FhirXmlSerializer().SerializeToStringAsync(pat));
 
             var fe = client.Create(pat); // Create as we are not providing the ID to be used.
             Assert.IsNotNull(fe);
@@ -957,10 +956,10 @@ namespace Hl7.Fhir.Tests.Rest
         /// and counts them in the WholeSystemHistory
         /// </summary>
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest"), Ignore]     // Keeps on failing periodically. Grahames server?
-        public void History()
+        public async T.Task History()
         {
             LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
-            testHistory(client);
+            await testHistoryAsync(client);
         }
 
 
@@ -969,17 +968,17 @@ namespace Hl7.Fhir.Tests.Rest
         /// and counts them in the WholeSystemHistory
         /// </summary>
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest"), Ignore]     // Keeps on failing periodically. Grahames server?
-        public void HistoryHttpClient()
+        public async T.Task HistoryHttpClient()
         {
             FhirClient client = new FhirClient(testEndpoint);
-            testHistory(client);
+            await testHistoryAsync(client);
         }
 
-        private void testHistory(BaseFhirClient client)
+        private async T.Task testHistoryAsync(BaseFhirClient client)
         {
             System.Threading.Thread.Sleep(500);
             DateTimeOffset timestampBeforeCreationAndDeletions = DateTimeOffset.Now;
-            testCreateEditDelete(client); // this test does a create, update, update, delete (4 operations)
+            await testCreateEditDeleteAsync(client); // this test does a create, update, update, delete (4 operations)
 
             System.Diagnostics.Trace.WriteLine("History of this specific patient since just before the create, update, update, delete (4 operations)");
 
@@ -1268,23 +1267,23 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
-        public void CreateDynamic()
+        public async T.Task CreateDynamic()
         {
             LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
-            testCreateDynamicHttpClient(client);
+            await testCreateDynamicHttpClientAsync(client);
         }
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
-        public void CreateDynamicHttpClient()
+        public async T.Task CreateDynamicHttpClient()
         {
             using (FhirClient client = new FhirClient(testEndpoint))
             {
-                testCreateDynamicHttpClient(client);
+                await testCreateDynamicHttpClientAsync(client);
             }
         }
 
-        private static void testCreateDynamicHttpClient(BaseFhirClient client)
+        private static async T.Task testCreateDynamicHttpClientAsync(BaseFhirClient client)
         {
             Resource furore = new Organization
             {
@@ -1296,7 +1295,7 @@ namespace Hl7.Fhir.Tests.Rest
                 }
             };
 
-            System.Diagnostics.Trace.WriteLine(new FhirXmlSerializer().SerializeToString(furore));
+            System.Diagnostics.Trace.WriteLine(await new FhirXmlSerializer().SerializeToStringAsync(furore));
             var fe = client.Create(furore);
             Assert.IsNotNull(fe);
         }

--- a/src/Hl7.Fhir.Core.Tests/Rest/RequesterTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/RequesterTests.cs
@@ -258,7 +258,7 @@ namespace Hl7.Fhir.Test
         #region Bundle.EntryComponent To EntryRequest
 
         [TestMethod]
-        public void TestBundleToEntryRequest()
+        public async Tasks.Task TestBundleToEntryRequest()
         {
             var bundleComponent = new Bundle.EntryComponent
             {
@@ -274,7 +274,7 @@ namespace Hl7.Fhir.Test
             };
             bundleComponent.AddAnnotation(InteractionType.Search);
 
-            var entryRequest = bundleComponent.ToEntryRequest(_Settings);
+            var entryRequest = await bundleComponent.ToEntryRequestAsync(_Settings);
 
             Assert.IsNotNull(entryRequest);
             Assert.AreEqual(bundleComponent.Request.Url, entryRequest.Url);
@@ -288,7 +288,7 @@ namespace Hl7.Fhir.Test
         }
 
         [TestMethod]
-        public void TestPatchBundleToEntryRequest()
+        public async Tasks.Task TestPatchBundleToEntryRequest()
         {
             var bundleComponent = new Bundle.EntryComponent
             {
@@ -304,7 +304,7 @@ namespace Hl7.Fhir.Test
             };
             bundleComponent.AddAnnotation(InteractionType.Patch);
 
-            var entryRequest = bundleComponent.ToEntryRequest(_Settings);
+            var entryRequest = await bundleComponent.ToEntryRequestAsync(_Settings);
 
             Assert.IsNotNull(entryRequest);
             Assert.AreEqual(bundleComponent.Request.Url, entryRequest.Url);
@@ -318,7 +318,7 @@ namespace Hl7.Fhir.Test
         }
 
         [TestMethod]
-        public void TestBundleToEntryRequestBody()
+        public async Tasks.Task TestBundleToEntryRequestBody()
         {
             var bundleComponent = new Bundle.EntryComponent
             {
@@ -334,7 +334,7 @@ namespace Hl7.Fhir.Test
             };
             bundleComponent.AddAnnotation(InteractionType.Search);
 
-            var entryRequest = bundleComponent.ToEntryRequest(_Settings);
+            var entryRequest = await bundleComponent.ToEntryRequestAsync(_Settings);
             Assert.IsNotNull(entryRequest);
             Assert.IsNotNull(entryRequest.RequestBodyContent);
             Assert.AreEqual("test content type", entryRequest.ContentType);
@@ -363,7 +363,7 @@ namespace Hl7.Fhir.Test
 
             var result = await response.ToTypedEntryResponseAsync(new PocoStructureDefinitionSummaryProvider());
 
-            var typedElementXml = result.TypedElement.ToXml();
+            var typedElementXml = await result.TypedElement.ToXmlAsync();
             Assert.AreEqual(xml, typedElementXml);
             Assert.AreEqual(response.ContentType, result.ContentType);
             Assert.AreEqual(response.Etag, result.Etag);

--- a/src/Hl7.Fhir.Core.Tests/Rest/RequesterTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/RequesterTests.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Tasks = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Test
 {
@@ -345,7 +346,7 @@ namespace Hl7.Fhir.Test
         #region EntryResponse To TypedEntryResponse
 
         [TestMethod]
-        public void TestToTypedEntryResponse()
+        public async Tasks.Task TestToTypedEntryResponse()
         {
             var xml = "<Patient xmlns=\"http://hl7.org/fhi\"><active value=\"true\" /></Patient>";
             var response = new EntryResponse
@@ -360,7 +361,7 @@ namespace Hl7.Fhir.Test
                 Body = Encoding.UTF8.GetBytes(xml),
             };
 
-            var result = response.ToTypedEntryResponse(new PocoStructureDefinitionSummaryProvider());
+            var result = await response.ToTypedEntryResponseAsync(new PocoStructureDefinitionSummaryProvider());
 
             var typedElementXml = result.TypedElement.ToXml();
             Assert.AreEqual(xml, typedElementXml);
@@ -379,7 +380,7 @@ namespace Hl7.Fhir.Test
         #region TypedEntryResponse To BundleEntryResponse
 
         [TestMethod]
-        public void TestTypedEntryResponseToBundle()
+        public async Tasks.Task TestTypedEntryResponseToBundle()
         {
             var xml = "<Patient xmlns=\"http://hl7.org/fhi\"><active value=\"true\" /></Patient>";
             var response = new EntryResponse
@@ -393,7 +394,7 @@ namespace Hl7.Fhir.Test
                 Headers = new Dictionary<string, string>() { { "Test-key", "Test-value" } },
                 Body = Encoding.UTF8.GetBytes(xml),
             };
-            var typedresponse = response.ToTypedEntryResponse(new PocoStructureDefinitionSummaryProvider());
+            var typedresponse = await response.ToTypedEntryResponseAsync(new PocoStructureDefinitionSummaryProvider());
 
             var settings = new ParserSettings
             {

--- a/src/Hl7.Fhir.Core.Tests/Serialization/ResourceParsingTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/ResourceParsingTests.cs
@@ -145,7 +145,7 @@ namespace Hl7.Fhir.Tests.Serialization
         {
             var xml = "<Basic xmlns='http://hl7.org/fhir'><extension url='http://blabla.nl'><valueString value='Daar gaat ie dan" + "&#xA;" + "verdwijnt dit?' /></extension></Basic>";
 
-            var basic = FhirXmlParser.Parse<DomainResource>(xml);
+            var basic = await FhirXmlParser.ParseAsync<DomainResource>(xml);
 
             Assert.IsTrue(basic.GetStringExtension("http://blabla.nl").Contains("\n"));
 
@@ -251,7 +251,7 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.IsNotNull(xml);
             await File.WriteAllTextAsync(Path.Combine(tempPath, "edgecase.xml"), xml);
 
-            poco = FhirXmlParser.Parse<Resource>(xml);
+            poco = await FhirXmlParser.ParseAsync<Resource>(xml);
             Assert.IsNotNull(poco);
             var json2 = await FhirJsonSerializer.SerializeToStringAsync(poco);
             Assert.IsNotNull(json2);
@@ -274,7 +274,7 @@ namespace Hl7.Fhir.Tests.Serialization
             var xml = await FhirXmlSerializer.SerializeToStringAsync(o);
             Assert.IsTrue(xml.Contains("value=\"#jaap\""));
 
-            var o2 = FhirXmlParser.Parse<Observation>(xml);
+            var o2 = await FhirXmlParser.ParseAsync<Observation>(xml);
             o2.ResourceBase = new Uri("http://nu.nl/fhir");
             xml = await FhirXmlSerializer.SerializeToStringAsync(o2);
             Assert.IsTrue(xml.Contains("value=\"#jaap\""));
@@ -313,7 +313,7 @@ namespace Hl7.Fhir.Tests.Serialization
             }
 
             var xml = await FhirXmlSerializer.SerializeToStringAsync(patient);
-            parsedPatient = FhirXmlParser.Parse<Patient>(xml);
+            parsedPatient = await FhirXmlParser.ParseAsync<Patient>(xml);
 
             Assert.AreEqual(patient.Identifier.Count, parsedPatient.Identifier.Count);
             for (var i = 0; i < patient.Identifier.Count; i++)
@@ -340,7 +340,7 @@ namespace Hl7.Fhir.Tests.Serialization
             };
 
             var xml = await FhirXmlSerializer.SerializeToStringAsync(p);
-            Assert.IsNotNull(FhirXmlParser.Parse<Resource>(xml));
+            Assert.IsNotNull(await FhirXmlParser.ParseAsync<Resource>(xml));
             var json = await FhirJsonSerializer.SerializeToStringAsync(p);
             Assert.IsNotNull(await FhirJsonParser.ParseAsync<Resource>(json));
         }

--- a/src/Hl7.Fhir.Core.Tests/Serialization/ResourceParsingTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/ResourceParsingTests.cs
@@ -141,7 +141,7 @@ namespace Hl7.Fhir.Tests.Serialization
 
 
         [TestMethod]
-        public void RetainSpacesInAttribute()
+        public async Tasks.Task RetainSpacesInAttribute()
         {
             var xml = "<Basic xmlns='http://hl7.org/fhir'><extension url='http://blabla.nl'><valueString value='Daar gaat ie dan" + "&#xA;" + "verdwijnt dit?' /></extension></Basic>";
 
@@ -149,7 +149,7 @@ namespace Hl7.Fhir.Tests.Serialization
 
             Assert.IsTrue(basic.GetStringExtension("http://blabla.nl").Contains("\n"));
 
-            var outp = FhirXmlSerializer.SerializeToString(basic);
+            var outp = await FhirXmlSerializer.SerializeToStringAsync(basic);
             Assert.IsTrue(outp.Contains("&#xA;"));
         }
 
@@ -247,13 +247,13 @@ namespace Hl7.Fhir.Tests.Serialization
 
             var poco = await FhirJsonParser.ParseAsync<Resource>(json);
             Assert.IsNotNull(poco);
-            var xml = FhirXmlSerializer.SerializeToString(poco);
+            var xml = await FhirXmlSerializer.SerializeToStringAsync(poco);
             Assert.IsNotNull(xml);
             await File.WriteAllTextAsync(Path.Combine(tempPath, "edgecase.xml"), xml);
 
             poco = FhirXmlParser.Parse<Resource>(xml);
             Assert.IsNotNull(poco);
-            var json2 = FhirJsonSerializer.SerializeToString(poco);
+            var json2 = await FhirJsonSerializer.SerializeToStringAsync(poco);
             Assert.IsNotNull(json2);
             await File.WriteAllTextAsync(Path.Combine(tempPath, "edgecase.json"), json2);
 
@@ -264,19 +264,19 @@ namespace Hl7.Fhir.Tests.Serialization
         }
 
         [TestMethod]
-        public void ContainedBaseIsNotAddedToId()
+        public async Tasks.Task ContainedBaseIsNotAddedToId()
         {
             var p = new Patient() { Id = "jaap" };
             var o = new Observation() { Subject = new ResourceReference() { Reference = "#" + p.Id } };
             o.Contained.Add(p);
             o.ResourceBase = new Uri("http://nu.nl/fhir");
 
-            var xml = FhirXmlSerializer.SerializeToString(o);
+            var xml = await FhirXmlSerializer.SerializeToStringAsync(o);
             Assert.IsTrue(xml.Contains("value=\"#jaap\""));
 
             var o2 = FhirXmlParser.Parse<Observation>(xml);
             o2.ResourceBase = new Uri("http://nu.nl/fhir");
-            xml = FhirXmlSerializer.SerializeToString(o2);
+            xml = await FhirXmlSerializer.SerializeToStringAsync(o2);
             Assert.IsTrue(xml.Contains("value=\"#jaap\""));
         }
 
@@ -295,7 +295,7 @@ namespace Hl7.Fhir.Tests.Serialization
                 }
             };
 
-            var json = FhirJsonSerializer.SerializeToString(patient);
+            var json = await FhirJsonSerializer.SerializeToStringAsync(patient);
             var parsedPatient = await FhirJsonParser.ParseAsync<Patient>(json);
 
             Assert.AreEqual(patient.Identifier.Count, parsedPatient.Identifier.Count);
@@ -312,7 +312,7 @@ namespace Hl7.Fhir.Tests.Serialization
                 }
             }
 
-            var xml = FhirXmlSerializer.SerializeToString(patient);
+            var xml = await FhirXmlSerializer.SerializeToStringAsync(patient);
             parsedPatient = FhirXmlParser.Parse<Patient>(xml);
 
             Assert.AreEqual(patient.Identifier.Count, parsedPatient.Identifier.Count);
@@ -339,9 +339,9 @@ namespace Hl7.Fhir.Tests.Serialization
                 Text = new Narrative() { Div = "<div xmlns=\"http://www.w3.org/1999/xhtml\">Nasty, a text with both \"double\" quotes and 'single' quotes</div>" }
             };
 
-            var xml = FhirXmlSerializer.SerializeToString(p);
+            var xml = await FhirXmlSerializer.SerializeToStringAsync(p);
             Assert.IsNotNull(FhirXmlParser.Parse<Resource>(xml));
-            var json = FhirJsonSerializer.SerializeToString(p);
+            var json = await FhirJsonSerializer.SerializeToStringAsync(p);
             Assert.IsNotNull(await FhirJsonParser.ParseAsync<Resource>(json));
         }
 

--- a/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
@@ -29,25 +29,25 @@ namespace Hl7.Fhir.Tests.Serialization
         private readonly Meta metaPoco = new Meta { LastUpdated = new DateTimeOffset(2014, 12, 24, 16, 30, 56, 31, new TimeSpan(1, 0, 0)), VersionId = "3141" };
 
         [TestMethod]
-        public void SerializeMetaXml()
+        public async Tasks.Task SerializeMetaXml()
         {
-            var xml = new FhirXmlSerializer().SerializeToString(metaPoco, root: "meta");
+            var xml = await new FhirXmlSerializer().SerializeToStringAsync(metaPoco, root: "meta");
             Assert.AreEqual(metaXml, xml);
         }
 
 
         [TestMethod]
-        public void SerializeMetaJson()
+        public async Tasks.Task SerializeMetaJson()
         {
-            var json = new FhirJsonSerializer().SerializeToString(metaPoco);
+            var json = await new FhirJsonSerializer().SerializeToStringAsync(metaPoco);
             Assert.AreEqual(metaJson, json);
         }
 
         [TestMethod]
-        public void ParseMetaXml()
+        public async Tasks.Task ParseMetaXml()
         {
             var poco = (Meta)(new FhirXmlParser().Parse(metaXml, typeof(Meta)));
-            var xml = new FhirXmlSerializer().SerializeToString(poco, root: "meta");
+            var xml = await new FhirXmlSerializer().SerializeToStringAsync(poco, root: "meta");
 
             Assert.IsTrue(poco.IsExactly(metaPoco));
             Assert.AreEqual(metaXml, xml);
@@ -73,7 +73,7 @@ namespace Hl7.Fhir.Tests.Serialization
         public async Tasks.Task ParseMetaJson()
         {
             var poco = (Meta)await (new FhirJsonParser().ParseAsync(metaJson, typeof(Meta)));
-            var json = FhirJsonSerializer.SerializeToString(poco);
+            var json = await FhirJsonSerializer.SerializeToStringAsync(poco);
 
             Assert.IsTrue(poco.IsExactly(metaPoco));
             Assert.AreEqual(metaJson, json);
@@ -93,22 +93,22 @@ namespace Hl7.Fhir.Tests.Serialization
         }
 
         [TestMethod]
-        public void AvoidBOMUse()
+        public async Tasks.Task AvoidBOMUse()
         {
             Bundle b = new Bundle() { Total = 1000 };
 
-            var data = FhirJsonSerializer.SerializeToBytes(b);
+            var data = await FhirJsonSerializer.SerializeToBytesAsync(b);
             Assert.IsFalse(data[0] == Encoding.UTF8.GetPreamble()[0]);
 
-            data = FhirXmlSerializer.SerializeToBytes(b);
+            data = await FhirXmlSerializer.SerializeToBytesAsync(b);
             Assert.IsFalse(data[0] == Encoding.UTF8.GetPreamble()[0]);
 
             Patient p = new Patient() { Active = true };
 
-            data = FhirJsonSerializer.SerializeToBytes(p);
+            data = await FhirJsonSerializer.SerializeToBytesAsync(p);
             Assert.IsFalse(data[0] == Encoding.UTF8.GetPreamble()[0]);
 
-            data = FhirXmlSerializer.SerializeToBytes(p);
+            data = await FhirXmlSerializer.SerializeToBytesAsync(p);
             Assert.IsFalse(data[0] == Encoding.UTF8.GetPreamble()[0]);
         }
 
@@ -173,14 +173,14 @@ namespace Hl7.Fhir.Tests.Serialization
 
 
         [TestMethod]
-        public void BundleLinksUnaltered()
+        public async Tasks.Task BundleLinksUnaltered()
         {
             var b = new Bundle
             {
                 NextLink = new Uri("Organization/123456/_history/123456", UriKind.Relative)
             };
 
-            var xml = new FhirXmlSerializer().SerializeToString(b);
+            var xml = await new FhirXmlSerializer().SerializeToStringAsync(b);
 
             b = FhirXmlParser.Parse<Bundle>(xml);
 
@@ -196,7 +196,7 @@ namespace Hl7.Fhir.Tests.Serialization
             var obs = new Observation();
             obs.AddExtension("http://example.org/DecimalPrecision", ext);
 
-            var json = FhirJsonSerializer.SerializeToString(obs);
+            var json = await FhirJsonSerializer.SerializeToStringAsync(obs);
             var obs2 = await FhirJsonParser.ParseAsync<Observation>(json);
 
             Assert.AreEqual("6", ((FhirDecimal)obs2.GetExtension("http://example.org/DecimalPrecision").Value).Value.Value.ToString(CultureInfo.InvariantCulture));
@@ -205,7 +205,7 @@ namespace Hl7.Fhir.Tests.Serialization
             obs = new Observation();
             obs.AddExtension("http://example.org/DecimalPrecision", ext);
 
-            json = FhirJsonSerializer.SerializeToString(obs);
+            json = await FhirJsonSerializer.SerializeToStringAsync(obs);
             obs2 = await FhirJsonParser.ParseAsync<Observation>(json);
 
             Assert.AreEqual("6.0", ((FhirDecimal)obs2.GetExtension("http://example.org/DecimalPrecision").Value).Value.Value.ToString(CultureInfo.InvariantCulture));
@@ -219,7 +219,7 @@ namespace Hl7.Fhir.Tests.Serialization
             var obs = new Observation();
             obs.AddExtension("http://example.org/DecimalPrecision", ext);
 
-            var json = FhirJsonSerializer.SerializeToString(obs);
+            var json = await FhirJsonSerializer.SerializeToStringAsync(obs);
             var obs2 = await FhirJsonParser.ParseAsync<Observation>(json);
 
             Assert.AreEqual(dec.ToString(CultureInfo.InvariantCulture), ((FhirDecimal)obs2.GetExtension("http://example.org/DecimalPrecision").Value).Value.Value.ToString(CultureInfo.InvariantCulture));
@@ -231,7 +231,7 @@ namespace Hl7.Fhir.Tests.Serialization
             var dec6 = 6m;
             var ext = new FhirDecimal(dec6);
             var obs = new Observation { Value = new FhirDecimal(dec6) };
-            var json = FhirJsonSerializer.SerializeToString(obs);
+            var json = await FhirJsonSerializer.SerializeToStringAsync(obs);
             try
             {
                 var obs2 = await FhirJsonParser.ParseAsync<Observation>(json);
@@ -244,7 +244,7 @@ namespace Hl7.Fhir.Tests.Serialization
         }
 
         [TestMethod]
-        public void TestSerializeWhitespacesInXml()
+        public async Tasks.Task TestSerializeWhitespacesInXml()
         {
             var patient = new Patient
             {
@@ -254,12 +254,12 @@ namespace Hl7.Fhir.Tests.Serialization
                 }
             };
 
-            var trimmed = FhirXmlSerializer.SerializeToString(patient);
+            var trimmed = await FhirXmlSerializer.SerializeToStringAsync(patient);
             Assert.IsFalse(trimmed.Contains(" Smith"));
             Assert.IsFalse(trimmed.Contains("Smith&#xD;&#xA;&#x9;"));
             Assert.IsTrue(trimmed.Contains("\"Smith\""));
 
-            var notTrimmed = new FhirXmlSerializer(new SerializerSettings { TrimWhiteSpacesInXml = false }).SerializeToString(patient);
+            var notTrimmed = await new FhirXmlSerializer(new SerializerSettings { TrimWhiteSpacesInXml = false }).SerializeToStringAsync(patient);
             Assert.IsTrue(notTrimmed.Contains(" Smith"));
             Assert.IsTrue(notTrimmed.Contains("Smith&#xD;&#xA;&#x9;"));
             Assert.IsFalse(notTrimmed.Contains("\"Smith\""));
@@ -267,13 +267,13 @@ namespace Hl7.Fhir.Tests.Serialization
         }
 
         [TestMethod]
-        public void TryScriptInject()
+        public async Tasks.Task TryScriptInject()
         {
             var x = new Patient();
 
             x.Name.Add(HumanName.ForFamily("<script language='javascript'></script>"));
 
-            var xml = FhirXmlSerializer.SerializeToString(x);
+            var xml = await FhirXmlSerializer.SerializeToStringAsync(x);
             Assert.IsFalse(xml.Contains("<script"));
         }
 
@@ -308,25 +308,25 @@ namespace Hl7.Fhir.Tests.Serialization
         }
 
         [TestMethod]
-        public void SerializeUnknownEnums()
+        public async Tasks.Task SerializeUnknownEnums()
         {
             string xml = TestDataHelper.ReadTestData("TestPatient.xml");
             var pser = new FhirXmlParser();
             var p = pser.Parse<Patient>(xml);
-            string outp = FhirXmlSerializer.SerializeToString(p);
+            string outp = await FhirXmlSerializer.SerializeToStringAsync(p);
             Assert.IsTrue(outp.Contains("\"male\""));
 
             // Pollute the data with an incorrect administrative gender
             p.GenderElement.ObjectValue = "superman";
 
-            outp = FhirXmlSerializer.SerializeToString(p);
+            outp = await FhirXmlSerializer.SerializeToStringAsync(p);
             Assert.IsFalse(outp.Contains("\"male\""));
             Assert.IsTrue(outp.Contains("\"superman\""));
         }
 
 
         [TestMethod]
-        public void TestNullExtensionRemoval()
+        public async Tasks.Task  TestNullExtensionRemoval()
         {
             var p = new Patient
             {
@@ -343,7 +343,7 @@ namespace Hl7.Fhir.Tests.Serialization
                 }
             };
 
-            var xml = FhirXmlSerializer.SerializeToString(p);
+            var xml = await FhirXmlSerializer.SerializeToStringAsync(p);
 
             var p2 = (new FhirXmlParser()).Parse<Patient>(xml);
             Assert.AreEqual(1, p2.Extension.Count);
@@ -372,7 +372,7 @@ namespace Hl7.Fhir.Tests.Serialization
             var vs = await parser.ParseAsync<ValueSet>(json);
             Assert.IsNotNull(vs);
 
-            var xml = FhirXmlSerializer.SerializeToString(vs);
+            var xml = await FhirXmlSerializer.SerializeToStringAsync(vs);
             Assert.IsNotNull(xml);
         }
 
@@ -385,7 +385,7 @@ namespace Hl7.Fhir.Tests.Serialization
             c.Payee.ResourceType = new Coding(null, "test2");
             c.Payee.Party = new ResourceReference("Practitioner/example", "Example, Dr John");
 
-            string json = FhirJsonSerializer.SerializeToString(c);
+            string json = await FhirJsonSerializer.SerializeToStringAsync(c);
             var c2 = await new FhirJsonParser().ParseAsync<Claim>(json);
             Assert.AreEqual("test", c2.Payee.Type.Coding[0].Code);
             Assert.AreEqual("test2", c2.Payee.ResourceType.Code);
@@ -402,7 +402,7 @@ namespace Hl7.Fhir.Tests.Serialization
         // [WMR 20170825] Richard Kavanagh: runtime exception while serializating derived PoCo classes
         // Workaround: add the FhirType attribute to derived class
         [TestMethod]
-        public void TestDerivedPoCoSerialization()
+        public async Tasks.Task TestDerivedPoCoSerialization()
         {
             ModelInfo.ModelInspector.ImportType(typeof(CustomBundle));
 
@@ -412,10 +412,10 @@ namespace Hl7.Fhir.Tests.Serialization
                 Id = "MyBundle"
             };
 
-            var xml = FhirXmlSerializer.SerializeToString(bundle);
+            var xml = await FhirXmlSerializer.SerializeToStringAsync(bundle);
             Assert.IsNotNull(xml);
 
-            var json = FhirJsonSerializer.SerializeToString(bundle);
+            var json = await FhirJsonSerializer.SerializeToStringAsync(bundle);
             Assert.IsNotNull(json);
         }
 
@@ -450,7 +450,7 @@ namespace Hl7.Fhir.Tests.Serialization
 
         // [WMR 20180409] NEW: Serialize to JObject
         [TestMethod]
-        public void TestSerializeToJsonDocument()
+        public async Tasks.Task TestSerializeToJsonDocument()
         {
             // Note: output order is defined by core resource/datatype definitions!
 
@@ -466,7 +466,7 @@ namespace Hl7.Fhir.Tests.Serialization
             };
 
             var serializer = new FhirJsonSerializer();
-            var jsonText = serializer.SerializeToString(patientOne);
+            var jsonText = await serializer.SerializeToStringAsync(patientOne);
             Assert.IsNotNull(jsonText);
 
             var doc = JObject.Parse(jsonText);
@@ -529,18 +529,18 @@ namespace Hl7.Fhir.Tests.Serialization
         /// This test proves issue 583: https://github.com/FirelyTeam/firely-net-sdk/issues/583
         /// </summary>
         [TestMethod]
-        public void SummarizeSerializingTest()
+        public async Tasks.Task SummarizeSerializingTest()
         {
             var patient = new Patient();
             var telecom = new ContactPoint(ContactPoint.ContactPointSystem.Phone, ContactPoint.ContactPointUse.Work, "0471 144 099");
             telecom.AddExtension("http://healthconnex.com.au/hcxd/Phone/IsMain", new FhirBoolean(true));
             patient.Telecom.Add(telecom);
 
-            var doc = FhirXmlSerializer.SerializeToString(patient, Fhir.Rest.SummaryType.True);
+            var doc = await FhirXmlSerializer.SerializeToStringAsync(patient, Fhir.Rest.SummaryType.True);
 
             Assert.IsFalse(doc.Contains("<extension"), "In the summary there must be no extension section.");
 
-            doc = FhirXmlSerializer.SerializeToString(patient, Fhir.Rest.SummaryType.False);
+            doc = await FhirXmlSerializer.SerializeToStringAsync(patient, Fhir.Rest.SummaryType.False);
             Assert.IsTrue(doc.Contains("<extension"), "Extension exists when Summary = false");
         }
 
@@ -551,7 +551,7 @@ namespace Hl7.Fhir.Tests.Serialization
         public async Tasks.Task DateTimeOffsetAccuracyTest()
         {
             var patient = new Patient { Meta = new Meta { LastUpdated = DateTimeOffset.UtcNow } };
-            var json = new FhirJsonSerializer().SerializeToString(patient);
+            var json = await new FhirJsonSerializer().SerializeToStringAsync(patient);
             var res = await new FhirJsonParser().ParseAsync<Patient>(json);
             Assert.IsTrue(patient.IsExactly(res), "1");
 
@@ -562,7 +562,7 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.IsTrue(patient.IsExactly(res), "2");
 
             // Is the serialization still correct without milliseconds?
-            var json2 = new FhirJsonSerializer().SerializeToString(patient);
+            var json2 = await new FhirJsonSerializer().SerializeToStringAsync(patient);
             Assert.AreEqual(json, json2, "3");
 
             // Is the parsing still correct with a few milliseconds and TimeZone?
@@ -572,7 +572,7 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.IsTrue(patient.IsExactly(res), "4");
 
             // Is the serialization still correct with a few milliseconds?
-            json2 = new FhirJsonSerializer().SerializeToString(patient);
+            json2 = await new FhirJsonSerializer().SerializeToStringAsync(patient);
             Assert.AreEqual(json, json2, "5");
         }
 
@@ -588,7 +588,7 @@ namespace Hl7.Fhir.Tests.Serialization
 
             poco.Meta = new Meta();
 
-            var reserialized = poco.ToJson();
+            var reserialized = await poco.ToJsonAsync();
 
             var newPoco = await fhirJsonParser.ParseAsync<Patient>(reserialized);
 

--- a/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
@@ -46,7 +46,7 @@ namespace Hl7.Fhir.Tests.Serialization
         [TestMethod]
         public async Tasks.Task ParseMetaXml()
         {
-            var poco = (Meta)(new FhirXmlParser().Parse(metaXml, typeof(Meta)));
+            var poco = (Meta)(await new FhirXmlParser().ParseAsync(metaXml, typeof(Meta)));
             var xml = await new FhirXmlSerializer().SerializeToStringAsync(poco, root: "meta");
 
             Assert.IsTrue(poco.IsExactly(metaPoco));
@@ -312,7 +312,7 @@ namespace Hl7.Fhir.Tests.Serialization
         {
             string xml = TestDataHelper.ReadTestData("TestPatient.xml");
             var pser = new FhirXmlParser();
-            var p = pser.Parse<Patient>(xml);
+            var p = await pser.ParseAsync<Patient>(xml);
             string outp = await FhirXmlSerializer.SerializeToStringAsync(p);
             Assert.IsTrue(outp.Contains("\"male\""));
 
@@ -345,7 +345,7 @@ namespace Hl7.Fhir.Tests.Serialization
 
             var xml = await FhirXmlSerializer.SerializeToStringAsync(p);
 
-            var p2 = (new FhirXmlParser()).Parse<Patient>(xml);
+            var p2 = await (new FhirXmlParser()).ParseAsync<Patient>(xml);
             Assert.AreEqual(1, p2.Extension.Count);
             Assert.AreEqual(1, p2.Contact.Count);
         }

--- a/src/Hl7.Fhir.Core.Tests/Serialization/SummarySerializationTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/SummarySerializationTests.cs
@@ -20,6 +20,7 @@ using System.Text;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Rest;
 using System.IO;
+using T = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Tests.Serialization
 {
@@ -31,7 +32,7 @@ namespace Hl7.Fhir.Tests.Serialization
         private readonly FhirXmlParser FhirXmlParser = new FhirXmlParser();
 
         [TestMethod] // Old tests, I'm note sure we need them anymore
-        public void TestSummary()
+        public async T.Task TestSummary()
         {
             var p = new Patient
             {
@@ -39,12 +40,12 @@ namespace Hl7.Fhir.Tests.Serialization
                 Photo = new List<Attachment>() { new Attachment() { ContentType = "text/plain" } }
             };
 
-            var full = FhirXmlSerializer.SerializeToString(p);
+            var full = await FhirXmlSerializer.SerializeToStringAsync(p);
             Assert.IsTrue(full.Contains("<birthDate"));
             Assert.IsTrue(full.Contains("<photo"));
             Assert.IsNull(p.Meta, "Meta element should not be introduced here.");
 
-            var summ = FhirXmlSerializer.SerializeToString(p, summary: Fhir.Rest.SummaryType.True);
+            var summ = await FhirXmlSerializer.SerializeToStringAsync(p, summary: Fhir.Rest.SummaryType.True);
             Assert.IsTrue(summ.Contains("<birthDate"));
             Assert.IsFalse(summ.Contains("<photo"));
             Assert.IsNull(p.Meta, "Meta element should not be introduced here.");
@@ -62,7 +63,7 @@ namespace Hl7.Fhir.Tests.Serialization
             });
             
             Assert.IsNull(q.Meta, "Meta element has not been created.");
-            var qfull = FhirXmlSerializer.SerializeToString(q);
+            var qfull = await FhirXmlSerializer.SerializeToStringAsync(q);
             Assert.IsNull(q.Meta, "Meta element should not be introduced here.");
             Console.WriteLine("summary: Fhir.Rest.SummaryType.False");
             Console.WriteLine(qfull);
@@ -73,7 +74,7 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.IsTrue(qfull.Contains("<text value=\"TEXT\""));
             Assert.IsTrue(qfull.Contains("<linkId value=\"linkid\""));
 
-            var qSum = FhirXmlSerializer.SerializeToString(q, summary: Fhir.Rest.SummaryType.True);
+            var qSum = await FhirXmlSerializer.SerializeToStringAsync(q, summary: Fhir.Rest.SummaryType.True);
             Console.WriteLine("summary: Fhir.Rest.SummaryType.True");
             Console.WriteLine(qSum);
             Assert.IsFalse(qSum.Contains("Test Questionnaire"));
@@ -83,7 +84,7 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.IsFalse(qSum.Contains("<text value=\"TEXT\""));
             Assert.IsFalse(qSum.Contains("<linkId value=\"linkid\""));
 
-            var qData = FhirXmlSerializer.SerializeToString(q, summary: Fhir.Rest.SummaryType.Data);
+            var qData = await FhirXmlSerializer.SerializeToStringAsync(q, summary: Fhir.Rest.SummaryType.Data);
             Console.WriteLine("summary: Fhir.Rest.SummaryType.Data");
             Console.WriteLine(qData);
             Assert.IsFalse(qData.Contains("Test Questionnaire"));
@@ -95,7 +96,7 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.IsTrue(qData.Contains("<linkId value=\"linkid\""));
 
             q.Meta = new Meta { VersionId = "v2" };
-            var qText = FhirXmlSerializer.SerializeToString(q, summary: Fhir.Rest.SummaryType.Text);
+            var qText = await FhirXmlSerializer.SerializeToStringAsync(q, summary: Fhir.Rest.SummaryType.Text);
             Console.WriteLine("summary: Fhir.Rest.SummaryType.Text");
             Console.WriteLine(qText);
             Assert.IsTrue(qText.Contains("Test Questionnaire"));
@@ -116,13 +117,13 @@ namespace Hl7.Fhir.Tests.Serialization
         }
 
         [TestMethod]
-        public void TestIncludeMandatory()
+        public async T.Task TestIncludeMandatory()
         {
             var l = new Library();
             l.Type = new CodeableConcept { TextElement = new FhirString("testMandatoryComplexType") };
             l.Id = "testId";
             l.Language = "testLang";
-            var summaryElements = FhirXmlSerializer.SerializeToString(l, Fhir.Rest.SummaryType.Count);
+            var summaryElements = await FhirXmlSerializer.SerializeToStringAsync(l, Fhir.Rest.SummaryType.Count);
             
             Assert.IsFalse(summaryElements.Contains("<language"));
             Assert.IsTrue(summaryElements.Contains("<type>"));
@@ -134,7 +135,7 @@ namespace Hl7.Fhir.Tests.Serialization
                 PreserveBundle = MaskingNodeSettings.PreserveBundleMode.All
             });
 
-            var result = customMaskingNode.ToXml(settings: new FhirXmlSerializationSettings());
+            var result = await customMaskingNode.ToXmlAsync(settings: new FhirXmlSerializationSettings());
 
             Assert.IsFalse(result.Contains("<language>"));
             Assert.IsTrue(result.Contains("<type>"));
@@ -156,14 +157,14 @@ namespace Hl7.Fhir.Tests.Serialization
                 PreserveBundle = MaskingNodeSettings.PreserveBundleMode.None
             });
 
-            result = customMaskingNodeForBundle.ToXml(settings: new FhirXmlSerializationSettings());
+            result = await customMaskingNodeForBundle.ToXmlAsync(settings: new FhirXmlSerializationSettings());
             
             Assert.IsTrue(result.Contains("<type value=\"collection\""));
             Assert.IsFalse(result.Contains("<id value=\"bundle-id\""));
         }
 
         [TestMethod]
-        public void TestElements()
+        public async T.Task TestElements()
         {
             var p = new Patient
             {
@@ -172,41 +173,41 @@ namespace Hl7.Fhir.Tests.Serialization
             };
             var elements = new[] { "photo" };
             
-            var summaryElements = FhirXmlSerializer.SerializeToString(p, Fhir.Rest.SummaryType.False, elements: elements);
+            var summaryElements = await FhirXmlSerializer.SerializeToStringAsync(p, Fhir.Rest.SummaryType.False, elements: elements);
             Assert.IsFalse(summaryElements.Contains("<birthDate"));
             Assert.IsTrue(summaryElements.Contains("<photo"));
 
-            var noSummarySpecified = FhirXmlSerializer.SerializeToString(p, elements: elements);
+            var noSummarySpecified = await FhirXmlSerializer.SerializeToStringAsync(p, elements: elements);
             Assert.IsFalse(noSummarySpecified.Contains("<birthDate"));
             Assert.IsTrue(noSummarySpecified.Contains("<photo"));
 
-            ExceptionAssert.Throws<ArgumentException>(() => FhirXmlSerializer.SerializeToString(p, Fhir.Rest.SummaryType.True, elements: elements));
-            ExceptionAssert.Throws<ArgumentException>(() => FhirXmlSerializer.SerializeToString(p, Fhir.Rest.SummaryType.Count, elements: elements));
-            ExceptionAssert.Throws<ArgumentException>(() => FhirXmlSerializer.SerializeToString(p, Fhir.Rest.SummaryType.Data, elements: elements));
-            ExceptionAssert.Throws<ArgumentException>(() => FhirXmlSerializer.SerializeToString(p, Fhir.Rest.SummaryType.Text, elements: elements));
+            await ExceptionAssert.Throws<ArgumentException>(async () => await FhirXmlSerializer.SerializeToStringAsync(p, Fhir.Rest.SummaryType.True, elements: elements));
+            await ExceptionAssert.Throws<ArgumentException>(async () => await FhirXmlSerializer.SerializeToStringAsync(p, Fhir.Rest.SummaryType.Count, elements: elements));
+            await ExceptionAssert.Throws<ArgumentException>(async () => await FhirXmlSerializer.SerializeToStringAsync(p, Fhir.Rest.SummaryType.Data, elements: elements));
+            await ExceptionAssert.Throws<ArgumentException>(async () => await FhirXmlSerializer.SerializeToStringAsync(p, Fhir.Rest.SummaryType.Text, elements: elements));
         }
 
         [TestMethod]
-        public void TestWithMetadata()
+        public async T.Task TestWithMetadata()
         {
             var p = new Patient
             {
                 BirthDate = "1972-11-30"
             };
 
-            var pSum = FhirXmlSerializer.SerializeToString(p, summary: Fhir.Rest.SummaryType.True);
+            var pSum = await FhirXmlSerializer.SerializeToStringAsync(p, summary: Fhir.Rest.SummaryType.True);
             Assert.IsNull(p.Meta, "Meta should not be there");
 
             p.Meta = new Meta { VersionId = "v2" }; // introducing meta data ourselves. 
 
-            pSum = FhirXmlSerializer.SerializeToString(p, summary: Fhir.Rest.SummaryType.True);
+            pSum = await FhirXmlSerializer.SerializeToStringAsync(p, summary: Fhir.Rest.SummaryType.True);
             Assert.IsNotNull(p.Meta, "Meta should still be there");
             Assert.AreEqual(0, p.Meta.Tag.Where(t => t.System == "http://hl7.org/fhir/v3/ObservationValue" && t.Code == "SUBSETTED").Count(), "Subsetted Tag should not still be there.");
         }
 
 
         [TestMethod]
-        public void TestBundleSummary()
+        public async T.Task TestBundleSummary()
         {
             var p = new Patient
             {
@@ -219,19 +220,19 @@ namespace Hl7.Fhir.Tests.Serialization
             b.Total = 1;
             b.Type = Bundle.BundleType.Searchset;
 
-            var full = FhirXmlSerializer.SerializeToString(b);
+            var full = await FhirXmlSerializer.SerializeToStringAsync(b);
             Assert.IsTrue(full.Contains("<entry"));
             Assert.IsTrue(full.Contains("<birthDate"));
             Assert.IsTrue(full.Contains("<photo"));
             Assert.IsTrue(full.Contains("<total"));
 
-            var summ = FhirXmlSerializer.SerializeToString(b, summary: Fhir.Rest.SummaryType.True);
+            var summ = await FhirXmlSerializer.SerializeToStringAsync(b, summary: Fhir.Rest.SummaryType.True);
             Assert.IsTrue(summ.Contains("<entry"));
             Assert.IsTrue(summ.Contains("<birthDate"));
             Assert.IsFalse(summ.Contains("<photo"));
             Assert.IsTrue(summ.Contains("<total"));
 
-            summ = FhirXmlSerializer.SerializeToString(b, summary: Fhir.Rest.SummaryType.Count);
+            summ = await FhirXmlSerializer.SerializeToStringAsync(b, summary: Fhir.Rest.SummaryType.Count);
             Assert.IsFalse(summ.Contains("<entry"));
             Assert.IsFalse(summ.Contains("<birthDate"));
             Assert.IsFalse(summ.Contains("<photo"));
@@ -240,7 +241,7 @@ namespace Hl7.Fhir.Tests.Serialization
         }
 
         [TestMethod]
-        public void TestBundleWithSummaryJson()
+        public async T.Task TestBundleWithSummaryJson()
         {
             Dictionary<string, SummaryType> data = new Dictionary<string, SummaryType>
             {
@@ -296,15 +297,15 @@ namespace Hl7.Fhir.Tests.Serialization
                 };
 
                 bool inJson = Path.GetExtension(expectedFile) == ".json";
-                var actualData = inJson ? FhirJsonSerializer.SerializeToString(bundle, mode) :
-                                    FhirXmlSerializer.SerializeToString(bundle, mode);
+                var actualData = inJson ? await FhirJsonSerializer.SerializeToStringAsync(bundle, mode) :
+                                    await FhirXmlSerializer.SerializeToStringAsync(bundle, mode);
                 var expectedData = TestDataHelper.ReadTestData(expectedFile);
                 Assert.AreEqual(actualData, expectedData);
             }
         }
 
         [TestMethod]
-        public void TestResourceWithSummary()
+        public async T.Task TestResourceWithSummary()
         {
             Dictionary<string, SummaryType> data = new Dictionary<string, SummaryType>
             {
@@ -339,15 +340,15 @@ namespace Hl7.Fhir.Tests.Serialization
 
                 // Properties with IsSummary == true -> Id, Meta, Active, BirthDate, Gender, Name
                 bool inJson = Path.GetExtension(expectedFile) == ".json";
-                var actualData = inJson ? FhirJsonSerializer.SerializeToString(patientOne, mode) :
-                                    FhirXmlSerializer.SerializeToString(patientOne, mode);
+                var actualData = inJson ? await FhirJsonSerializer.SerializeToStringAsync(patientOne, mode) :
+                                    await FhirXmlSerializer.SerializeToStringAsync(patientOne, mode);
                 var expectedData = TestDataHelper.ReadTestData(expectedFile);
                 Assert.AreEqual(expectedData, actualData);
             }
         }
 
         [TestMethod]
-        public void TestIdInSummary()
+        public async T.Task TestIdInSummary()
         {
             var p = new Patient
             {
@@ -369,7 +370,7 @@ namespace Hl7.Fhir.Tests.Serialization
 
             p.AddExtension("http://example.org/ext", new FhirString("dud"));
 
-            var full = FhirXmlSerializer.SerializeToString(p);
+            var full = await FhirXmlSerializer.SerializeToStringAsync(p);
             Assert.IsTrue(full.Contains("narrative"));
             Assert.IsTrue(full.Contains("dud"));
             Assert.IsTrue(full.Contains("temp org"));
@@ -378,7 +379,7 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.IsTrue(full.Contains("<photo"));
             Assert.IsTrue(full.Contains("text/plain"));
 
-            full = FhirXmlSerializer.SerializeToString(p, summary: Hl7.Fhir.Rest.SummaryType.False);
+            full = await FhirXmlSerializer.SerializeToStringAsync(p, summary: Hl7.Fhir.Rest.SummaryType.False);
             Assert.IsTrue(full.Contains("narrative"));
             Assert.IsTrue(full.Contains("dud"));
             Assert.IsTrue(full.Contains("temp org"));
@@ -388,7 +389,7 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.IsTrue(full.Contains("<photo"));
             Assert.IsTrue(full.Contains("text/plain"));
 
-            var summ = FhirXmlSerializer.SerializeToString(p, summary: Fhir.Rest.SummaryType.True);
+            var summ = await FhirXmlSerializer.SerializeToStringAsync(p, summary: Fhir.Rest.SummaryType.True);
             Assert.IsFalse(summ.Contains("narrative"));
             Assert.IsFalse(summ.Contains("dud"));
             Assert.IsFalse(summ.Contains("contain"));
@@ -397,7 +398,7 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.IsTrue(summ.Contains("<birthDate"));
             Assert.IsFalse(summ.Contains("<photo"));
 
-            var data = FhirXmlSerializer.SerializeToString(p, summary: Hl7.Fhir.Rest.SummaryType.Data);
+            var data = await FhirXmlSerializer.SerializeToStringAsync(p, summary: Hl7.Fhir.Rest.SummaryType.Data);
             Assert.IsFalse(data.Contains("narrative"));
             Assert.IsTrue(data.Contains("contain"));
             Assert.IsTrue(data.Contains("dud"));

--- a/src/Hl7.Fhir.Core.Tests/Serialization/SummarySerializationTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/SummarySerializationTests.cs
@@ -110,7 +110,7 @@ namespace Hl7.Fhir.Tests.Serialization
 
             // Verify that reloading the content into an object...
             // make sure we accept the crappy output with empty groups
-            var nav = FhirXmlNode.Parse(qText, new FhirXmlParsingSettings { PermissiveParsing = true });
+            var nav = await FhirXmlNode.ParseAsync(qText, new FhirXmlParsingSettings { PermissiveParsing = true });
 
             var qInflate = FhirXmlParser.Parse<Questionnaire>(nav);
             Assert.AreEqual(1, qInflate.Meta.Tag.Where(t => t.System == "http://hl7.org/fhir/v3/ObservationValue" && t.Code == "SUBSETTED").Count(), "Subsetted Tag should not still be there.");

--- a/src/Hl7.Fhir.Core.Tests/Serialization/ValueQuantityParsingTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/ValueQuantityParsingTests.cs
@@ -49,7 +49,7 @@ namespace Hl7.Fhir.Tests.Serialization
             var orgExample = resource.Differential.Element[0].Example[0];
             Assert.AreEqual("Quantity", orgExample.Value.TypeName);
 
-            var parsed = xml ? XmlRoundTrip(resource) : await JsonRoundTrip(resource);
+            var parsed = xml ? await XmlRoundTripAsync(resource) : await JsonRoundTrip(resource);
 
             Assert.IsNotNull(parsed);
             Assert.IsNotNull(parsed.Differential?.Element);
@@ -64,15 +64,15 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.AreEqual("Quantity", example.Value.TypeName);
         }
 
-        static T XmlRoundTrip<T>(T resource) where T : Resource
+        async static Tasks.Task<T> XmlRoundTripAsync<T>(T resource) where T : Resource
         {
             var baseTestPath = CreateEmptyDir();
 
             var xmlFile = Path.Combine(baseTestPath, "ObservationWithValueQuantityExample.xml");
-            var xml = new FhirXmlSerializer().SerializeToString(resource);
-            File.WriteAllText(xmlFile, xml);
+            var xml = await new FhirXmlSerializer().SerializeToStringAsync(resource);
+            await File.WriteAllTextAsync(xmlFile, xml);
 
-            xml = File.ReadAllText(xmlFile);
+            xml = await File.ReadAllTextAsync(xmlFile);
             var parsed = new FhirXmlParser(new ParserSettings { PermissiveParsing = true }).Parse<T>(xml);
 
             return parsed;
@@ -83,10 +83,10 @@ namespace Hl7.Fhir.Tests.Serialization
             var baseTestPath = CreateEmptyDir();
 
             var jsonFile = Path.Combine(baseTestPath, "ObservationWithValueQuantityExample.json");
-            var json = new FhirJsonSerializer().SerializeToString(resource);
-            File.WriteAllText(jsonFile, json);
+            var json = await new FhirJsonSerializer().SerializeToStringAsync(resource);
+            await File.WriteAllTextAsync(jsonFile, json);
 
-            json = File.ReadAllText(jsonFile);
+            json = await File.ReadAllTextAsync(jsonFile);
             var parsed = await new FhirJsonParser(new ParserSettings { PermissiveParsing = true }).ParseAsync<T>(json);
 
             return parsed;

--- a/src/Hl7.Fhir.Core.Tests/Serialization/ValueQuantityParsingTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/ValueQuantityParsingTests.cs
@@ -73,7 +73,7 @@ namespace Hl7.Fhir.Tests.Serialization
             await File.WriteAllTextAsync(xmlFile, xml);
 
             xml = await File.ReadAllTextAsync(xmlFile);
-            var parsed = new FhirXmlParser(new ParserSettings { PermissiveParsing = true }).Parse<T>(xml);
+            var parsed = await new FhirXmlParser(new ParserSettings { PermissiveParsing = true }).ParseAsync<T>(xml);
 
             return parsed;
         }

--- a/src/Hl7.Fhir.Core.Tests/Serialization/ValueQuantityParsingTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/ValueQuantityParsingTests.cs
@@ -3,6 +3,7 @@ using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Utility;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
+using Tasks = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Tests.Serialization
 {
@@ -10,12 +11,12 @@ namespace Hl7.Fhir.Tests.Serialization
     public class ValueQuantityParsingTests
     {
         [TestMethod]
-        public void RoundtripValueQuantityXml() => RoundtripValueQuantity(true);
+        public async Tasks.Task RoundtripValueQuantityXml() => await RoundtripValueQuantity(true);
 
         [TestMethod]
-        public void RoundtripValueQuantityJson() => RoundtripValueQuantity(false);
+        public async Tasks.Task RoundtripValueQuantityJson() => await RoundtripValueQuantity(false);
 
-        static void RoundtripValueQuantity(bool xml)
+        static async Tasks.Task RoundtripValueQuantity(bool xml)
         {
             var resource = new StructureDefinition()
             {
@@ -48,7 +49,7 @@ namespace Hl7.Fhir.Tests.Serialization
             var orgExample = resource.Differential.Element[0].Example[0];
             Assert.AreEqual("Quantity", orgExample.Value.TypeName);
 
-            var parsed = xml ? XmlRoundTrip(resource) : JsonRoundTrip(resource);
+            var parsed = xml ? XmlRoundTrip(resource) : await JsonRoundTrip(resource);
 
             Assert.IsNotNull(parsed);
             Assert.IsNotNull(parsed.Differential?.Element);
@@ -77,7 +78,7 @@ namespace Hl7.Fhir.Tests.Serialization
             return parsed;
         }
 
-        static T JsonRoundTrip<T>(T resource) where T : Resource
+        static async Tasks.Task<T> JsonRoundTrip<T>(T resource) where T : Resource
         {
             var baseTestPath = CreateEmptyDir();
 
@@ -86,7 +87,7 @@ namespace Hl7.Fhir.Tests.Serialization
             File.WriteAllText(jsonFile, json);
 
             json = File.ReadAllText(jsonFile);
-            var parsed = new FhirJsonParser(new ParserSettings { PermissiveParsing = true }).Parse<T>(json);
+            var parsed = await new FhirJsonParser(new ParserSettings { PermissiveParsing = true }).ParseAsync<T>(json);
 
             return parsed;
         }

--- a/src/Hl7.Fhir.Core.Tests/TestDataVersionCheck.cs
+++ b/src/Hl7.Fhir.Core.Tests/TestDataVersionCheck.cs
@@ -8,7 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
+using Tasks = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Tests
 {
@@ -20,18 +20,18 @@ namespace Hl7.Fhir.Tests
     public class TestDataVersionCheck
     {
         [TestMethod]   // not everything parses correctly
-        public void VerifyAllTestData()
+        public async Tasks.Task VerifyAllTestData()
         {
             string location = typeof(TestDataHelper).GetTypeInfo().Assembly.Location;
             var path = Path.GetDirectoryName(location) + "\\TestData";
             Console.WriteLine(path);
             StringBuilder issues = new StringBuilder();
-            ValidateFolder(path, path, issues);
+            await ValidateFolder(path, path, issues);
             Console.Write(issues.ToString());
             Assert.AreEqual("", issues.ToString());
         }
 
-        private void ValidateFolder(string basePath, string path, StringBuilder issues)
+        private async Tasks.Task ValidateFolder(string basePath, string path, StringBuilder issues)
         {
             var xmlParser = new Fhir.Serialization.FhirXmlParser();
             var jsonParser = new Fhir.Serialization.FhirJsonParser();
@@ -55,7 +55,7 @@ namespace Hl7.Fhir.Tests
                     else if (new FileInfo(item).Extension == ".json")
                     {
                         Console.WriteLine($"    {item.Replace(path + "\\", "")}");
-                        jsonParser.Parse<Resource>(content);
+                        await jsonParser.ParseAsync<Resource>(content);
                     }
                     else
                     {
@@ -71,7 +71,7 @@ namespace Hl7.Fhir.Tests
             }
             foreach (var item in Directory.EnumerateDirectories(path))
             {
-                ValidateFolder(basePath, item, issues);
+                await ValidateFolder(basePath, item, issues);
             }
         }
     }

--- a/src/Hl7.Fhir.Core.Tests/TestDataVersionCheck.cs
+++ b/src/Hl7.Fhir.Core.Tests/TestDataVersionCheck.cs
@@ -50,7 +50,7 @@ namespace Hl7.Fhir.Tests
                     if (new FileInfo(item).Extension == ".xml")
                     {
                         Console.WriteLine($"    {item.Replace(path+"\\", "")}");
-                        xmlParser.Parse<Resource>(content);
+                        await xmlParser.ParseAsync<Resource>(content);
                     }
                     else if (new FileInfo(item).Extension == ".json")
                     {

--- a/src/Hl7.Fhir.Core/Rest/BaseFhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/BaseFhirClient.cs
@@ -964,7 +964,7 @@ namespace Hl7.Fhir.Rest
             var request = tx.Entry[0];
             // tx (-> ITyped)? -> entryRequest 
             // entry -> ITyped -> tx
-            var entryRequest = await request.ToEntryRequestAsync(Settings);
+            var entryRequest = await request.ToEntryRequestAsync(Settings).ConfigureAwait(false);
 
 
             EntryResponse entryResponse = await Requester.ExecuteAsync(entryRequest).ConfigureAwait(false);

--- a/src/Hl7.Fhir.Core/Rest/BaseFhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/BaseFhirClient.cs
@@ -971,7 +971,7 @@ namespace Hl7.Fhir.Rest
             TypedEntryResponse typedEntryResponse = new TypedEntryResponse();
             try
             {
-                typedEntryResponse = entryResponse.ToTypedEntryResponse(_provider);
+                typedEntryResponse = await entryResponse.ToTypedEntryResponseAsync(_provider).ConfigureAwait(false);
             }
             catch (UnsupportedBodyTypeException ex)
             {

--- a/src/Hl7.Fhir.Core/Rest/BaseFhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/BaseFhirClient.cs
@@ -964,7 +964,7 @@ namespace Hl7.Fhir.Rest
             var request = tx.Entry[0];
             // tx (-> ITyped)? -> entryRequest 
             // entry -> ITyped -> tx
-            var entryRequest = request.ToEntryRequest(Settings);
+            var entryRequest = await request.ToEntryRequestAsync(Settings);
 
 
             EntryResponse entryResponse = await Requester.ExecuteAsync(entryRequest).ConfigureAwait(false);

--- a/src/Hl7.Fhir.Core/Serialization/FhirJsonParser.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirJsonParser.cs
@@ -9,9 +9,7 @@
 using Hl7.Fhir.Model;
 using Newtonsoft.Json;
 using System;
-using Hl7.Fhir.ElementModel;
-using Hl7.Fhir.Specification;
-
+using Tasks = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Serialization
 {
@@ -22,10 +20,18 @@ namespace Hl7.Fhir.Serialization
             //
         }
 
+        /// <inheritdoc cref="ParseAsync{T}(string)" />
+        [Obsolete("Use ParseAsync<T>(string) instead.")]
         public T Parse<T>(string json) where T : Base => (T)Parse(json, typeof(T));
 
+        public async Tasks.Task<T> ParseAsync<T>(string json) where T : Base => (T)await ParseAsync(json, typeof(T)).ConfigureAwait(false);
+
+        /// <inheritdoc cref="ParseAsync{T}(JsonReader)" />
+        [Obsolete("Use ParseAsync<T>(JsonReader) instead.")]
         public T Parse<T>(JsonReader reader) where T : Base => (T)Parse(reader, typeof(T));
-        
+
+        public async Tasks.Task<T> ParseAsync<T>(JsonReader reader) where T : Base => (T)await ParseAsync(reader, typeof(T)).ConfigureAwait(false);
+
         private static FhirJsonParsingSettings buildNodeSettings(ParserSettings settings) =>
                 new FhirJsonParsingSettings
                 {
@@ -34,6 +40,8 @@ namespace Hl7.Fhir.Serialization
                     PermissiveParsing = settings.PermissiveParsing
                 };
 
+        /// <inheritdoc cref="ParseAsync(string, Type)" />
+        [Obsolete("Use ParseAsync(string, Type) instead.")]
         public Base Parse(string json, Type dataType = null)
         {
             var rootName = dataType != null ? ModelInfo.GetFhirTypeNameForType(dataType) : null;
@@ -41,10 +49,26 @@ namespace Hl7.Fhir.Serialization
             return Parse(jsonReader, dataType);
         }
 
+        public async Tasks.Task<Base> ParseAsync(string json, Type dataType = null)
+        {
+            var rootName = dataType != null ? ModelInfo.GetFhirTypeNameForType(dataType) : null;
+            var jsonReader = await FhirJsonNode.ParseAsync(json, rootName, buildNodeSettings(Settings)).ConfigureAwait(false);
+            return Parse(jsonReader, dataType);
+        }
+
+        /// <inheritdoc cref="ParseAsync(JsonReader, Type)" />
+        [Obsolete("Use ParseAsync(JsonReader, Type) instead.")]
         public Base Parse(JsonReader reader, Type dataType = null)
         {
             var rootName = dataType != null ? ModelInfo.GetFhirTypeNameForType(dataType) : null;
             var jsonReader = FhirJsonNode.Read(reader, rootName, buildNodeSettings(Settings));
+            return Parse(jsonReader, dataType);
+        }
+
+        public async Tasks.Task<Base> ParseAsync(JsonReader reader, Type dataType = null)
+        {
+            var rootName = dataType != null ? ModelInfo.GetFhirTypeNameForType(dataType) : null;
+            var jsonReader = await FhirJsonNode.ReadAsync(reader, rootName, buildNodeSettings(Settings)).ConfigureAwait(false);
             return Parse(jsonReader, dataType);
         }
     }

--- a/src/Hl7.Fhir.Core/Serialization/FhirJsonParser.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirJsonParser.cs
@@ -21,16 +21,16 @@ namespace Hl7.Fhir.Serialization
         }
 
         /// <inheritdoc cref="ParseAsync{T}(string)" />
-        [Obsolete("Use ParseAsync<T>(string) instead.")]
         public T Parse<T>(string json) where T : Base => (T)Parse(json, typeof(T));
 
-        public async Tasks.Task<T> ParseAsync<T>(string json) where T : Base => (T)await ParseAsync(json, typeof(T)).ConfigureAwait(false);
+        public async Tasks.Task<T> ParseAsync<T>(string json) where T : Base 
+            => (T)await ParseAsync(json, typeof(T)).ConfigureAwait(false);
 
         /// <inheritdoc cref="ParseAsync{T}(JsonReader)" />
-        [Obsolete("Use ParseAsync<T>(JsonReader) instead.")]
         public T Parse<T>(JsonReader reader) where T : Base => (T)Parse(reader, typeof(T));
 
-        public async Tasks.Task<T> ParseAsync<T>(JsonReader reader) where T : Base => (T)await ParseAsync(reader, typeof(T)).ConfigureAwait(false);
+        public async Tasks.Task<T> ParseAsync<T>(JsonReader reader) where T : Base 
+            => (T)await ParseAsync(reader, typeof(T)).ConfigureAwait(false);
 
         private static FhirJsonParsingSettings buildNodeSettings(ParserSettings settings) =>
                 new FhirJsonParsingSettings
@@ -41,7 +41,6 @@ namespace Hl7.Fhir.Serialization
                 };
 
         /// <inheritdoc cref="ParseAsync(string, Type)" />
-        [Obsolete("Use ParseAsync(string, Type) instead.")]
         public Base Parse(string json, Type dataType = null)
         {
             var rootName = dataType != null ? ModelInfo.GetFhirTypeNameForType(dataType) : null;
@@ -57,7 +56,6 @@ namespace Hl7.Fhir.Serialization
         }
 
         /// <inheritdoc cref="ParseAsync(JsonReader, Type)" />
-        [Obsolete("Use ParseAsync(JsonReader, Type) instead.")]
         public Base Parse(JsonReader reader, Type dataType = null)
         {
             var rootName = dataType != null ? ModelInfo.GetFhirTypeNameForType(dataType) : null;

--- a/src/Hl7.Fhir.Core/Serialization/FhirJsonSerializer.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirJsonSerializer.cs
@@ -10,6 +10,8 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System;
+using Tasks = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Serialization
 {
@@ -22,16 +24,31 @@ namespace Hl7.Fhir.Serialization
         private FhirJsonSerializationSettings buildFhirJsonWriterSettings() =>
             new FhirJsonSerializationSettings { Pretty = Settings.Pretty, AppendNewLine = Settings.AppendNewLine };
 
+        /// <inheritdoc cref="SerializeToStringAsync(Base, SummaryType, string[])" />
+        [Obsolete("Use SerializeToStringAsync(Base, SummaryType, string[]) instead.")]
         public string SerializeToString(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) =>
             MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).ToJson(buildFhirJsonWriterSettings());
 
+        public async Tasks.Task<string> SerializeToStringAsync(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) =>
+            await MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).ToJsonAsync(buildFhirJsonWriterSettings());
+
+        /// <inheritdoc cref="SerializeToBytesAsync(Base, SummaryType, string[])" />
+        [Obsolete("Use SerializeToBytesAsync(Base, SummaryType, string[]) instead.")]
         public byte[] SerializeToBytes(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) =>
             MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).ToJsonBytes(buildFhirJsonWriterSettings());
+
+        public async Tasks.Task<byte[]> SerializeToBytesAsync(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) =>
+            await MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).ToJsonBytesAsync(buildFhirJsonWriterSettings());
 
         public JObject SerializeToDocument(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) =>
             MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).ToJObject(buildFhirJsonWriterSettings());
 
+        /// <inheritdoc cref="SerializeAsync(Base, JsonWriter, SummaryType, string[])" />
+        [Obsolete("Use SerializeAsync(Base, JsonWriter, SummaryType, string[]) instead.")]
         public void Serialize(Base instance, JsonWriter writer, SummaryType summary = SummaryType.False, string[] elements = null) =>
             MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).WriteTo(writer, buildFhirJsonWriterSettings());
+
+        public async Tasks.Task SerializeAsync(Base instance, JsonWriter writer, SummaryType summary = SummaryType.False, string[] elements = null) =>
+            await MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).WriteToAsync(writer, buildFhirJsonWriterSettings());
     }
 }

--- a/src/Hl7.Fhir.Core/Serialization/FhirJsonSerializer.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirJsonSerializer.cs
@@ -10,7 +10,6 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
 using Tasks = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Serialization
@@ -25,30 +24,37 @@ namespace Hl7.Fhir.Serialization
             new FhirJsonSerializationSettings { Pretty = Settings.Pretty, AppendNewLine = Settings.AppendNewLine };
 
         /// <inheritdoc cref="SerializeToStringAsync(Base, SummaryType, string[])" />
-        [Obsolete("Use SerializeToStringAsync(Base, SummaryType, string[]) instead.")]
         public string SerializeToString(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) =>
-            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).ToJson(buildFhirJsonWriterSettings());
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
+                .ToJson(buildFhirJsonWriterSettings());
 
         public async Tasks.Task<string> SerializeToStringAsync(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) =>
-            await MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).ToJsonAsync(buildFhirJsonWriterSettings());
+            await MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
+                .ToJsonAsync(buildFhirJsonWriterSettings())
+                .ConfigureAwait(false);
 
         /// <inheritdoc cref="SerializeToBytesAsync(Base, SummaryType, string[])" />
-        [Obsolete("Use SerializeToBytesAsync(Base, SummaryType, string[]) instead.")]
         public byte[] SerializeToBytes(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) =>
-            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).ToJsonBytes(buildFhirJsonWriterSettings());
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
+                .ToJsonBytes(buildFhirJsonWriterSettings());
 
         public async Tasks.Task<byte[]> SerializeToBytesAsync(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) =>
-            await MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).ToJsonBytesAsync(buildFhirJsonWriterSettings());
+            await MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
+                .ToJsonBytesAsync(buildFhirJsonWriterSettings())
+                .ConfigureAwait(false);
 
         public JObject SerializeToDocument(Base instance, SummaryType summary = SummaryType.False, string[] elements = null) =>
-            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).ToJObject(buildFhirJsonWriterSettings());
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
+                .ToJObject(buildFhirJsonWriterSettings());
 
         /// <inheritdoc cref="SerializeAsync(Base, JsonWriter, SummaryType, string[])" />
-        [Obsolete("Use SerializeAsync(Base, JsonWriter, SummaryType, string[]) instead.")]
         public void Serialize(Base instance, JsonWriter writer, SummaryType summary = SummaryType.False, string[] elements = null) =>
-            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).WriteTo(writer, buildFhirJsonWriterSettings());
+            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
+                .WriteTo(writer, buildFhirJsonWriterSettings());
 
         public async Tasks.Task SerializeAsync(Base instance, JsonWriter writer, SummaryType summary = SummaryType.False, string[] elements = null) =>
-            await MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false).WriteToAsync(writer, buildFhirJsonWriterSettings());
+            await MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
+                .WriteToAsync(writer, buildFhirJsonWriterSettings())
+                .ConfigureAwait(false);
     }
 }

--- a/src/Hl7.Fhir.Core/Serialization/FhirXmlParser.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirXmlParser.cs
@@ -9,6 +9,7 @@
 using Hl7.Fhir.Model;
 using System;
 using System.Xml;
+using Tasks = System.Threading.Tasks;
 
 
 namespace Hl7.Fhir.Serialization
@@ -20,9 +21,17 @@ namespace Hl7.Fhir.Serialization
             //
         }
 
+        /// <inheritdoc cref="ParseAsync{T}(XmlReader)" />
         public T Parse<T>(XmlReader reader) where T : Base => (T)Parse(reader, typeof(T));
+        
+        public async Tasks.Task<T> ParseAsync<T>(XmlReader reader) where T : Base 
+            => await ParseAsync(reader, typeof(T)).ConfigureAwait(false) as T;
 
+        /// <inheritdoc cref="ParseAsync{T}(string)" />
         public T Parse<T>(string xml) where T : Base => (T)Parse(xml, typeof(T));
+        
+        public async Tasks.Task<T> ParseAsync<T>(string xml) where T : Base 
+            => await ParseAsync(xml, typeof(T)).ConfigureAwait(false) as T;
         
         private static FhirXmlParsingSettings buildNodeSettings(ParserSettings settings) =>
                 new FhirXmlParsingSettings
@@ -31,15 +40,29 @@ namespace Hl7.Fhir.Serialization
                     PermissiveParsing = settings.PermissiveParsing
                 };
 
+        /// <inheritdoc cref="ParseAsync(string, Type)" />
         public Base Parse(string xml, Type dataType = null)
         {
             var xmlReader = FhirXmlNode.Parse(xml, buildNodeSettings(Settings));
             return Parse(xmlReader, dataType);
         }
+        
+        public async Tasks.Task<Base> ParseAsync(string xml, Type dataType = null)
+        {
+            var xmlReader = await FhirXmlNode.ParseAsync(xml, buildNodeSettings(Settings)).ConfigureAwait(false);
+            return Parse(xmlReader, dataType);
+        }
 
+        /// <inheritdoc cref="ParseAsync(XmlReader, Type)" />
         public Base Parse(XmlReader reader, Type dataType = null)
         {
             var xmlReader = FhirXmlNode.Read(reader, buildNodeSettings(Settings));
+            return Parse(xmlReader, dataType);
+        }
+
+        public async Tasks.Task<Base> ParseAsync(XmlReader reader, Type dataType = null)
+        {
+            var xmlReader = await FhirXmlNode.ReadAsync(reader, buildNodeSettings(Settings)).ConfigureAwait(false);
             return Parse(xmlReader, dataType);
         }
     }

--- a/src/Hl7.Fhir.Core/Serialization/FhirXmlSerializer.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirXmlSerializer.cs
@@ -26,7 +26,6 @@ namespace Hl7.Fhir.Serialization
             new FhirXmlSerializationSettings { Pretty = Settings.Pretty, AppendNewLine = Settings.AppendNewLine, TrimWhitespaces = Settings.TrimWhiteSpacesInXml };
 
         /// <inheritdoc cref="SerializeToStringAsync(Base, SummaryType, string, string[])" />
-        [Obsolete("Use SerializeToStringAsync(Base, SummaryType, string, string[]) instead.")]
         public string SerializeToString(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
             MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
             .Rename(root)
@@ -35,10 +34,10 @@ namespace Hl7.Fhir.Serialization
         public async Tasks.Task<string> SerializeToStringAsync(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
             await MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
                 .Rename(root)
-                .ToXmlAsync(settings: buildFhirXmlWriterSettings());
+                .ToXmlAsync(settings: buildFhirXmlWriterSettings())
+                .ConfigureAwait(false);
 
         /// <inheritdoc cref="SerializeToBytesAsync(Base, SummaryType, string, string[])" />
-        [Obsolete("Use SerializeToBytesAsync(Base, SummaryType, string, string[]) instead.")]
         public byte[] SerializeToBytes(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
             MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
             .Rename(root)
@@ -47,7 +46,8 @@ namespace Hl7.Fhir.Serialization
         public async Tasks.Task<byte[]> SerializeToBytesAsync(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
             await MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
                 .Rename(root)
-                .ToXmlBytesAsync(settings: buildFhirXmlWriterSettings());
+                .ToXmlBytesAsync(settings: buildFhirXmlWriterSettings())
+                .ConfigureAwait(false);
 
         public XDocument SerializeToDocument(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
@@ -55,7 +55,6 @@ namespace Hl7.Fhir.Serialization
             .ToXDocument(buildFhirXmlWriterSettings()).Rename(root);
 
         /// <inheritdoc cref="SerializeAsync(Base, XmlWriter, SummaryType, string, string[])" />
-        [Obsolete("Use SerializeAsync(Base, SummaryType, string, string[]) instead.")]
         public void Serialize(Base instance, XmlWriter writer, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
             MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
             .Rename(root)
@@ -64,6 +63,7 @@ namespace Hl7.Fhir.Serialization
         public async Tasks.Task SerializeAsync(Base instance, XmlWriter writer, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
             await MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
                 .Rename(root)
-                .WriteToAsync(writer, settings: buildFhirXmlWriterSettings());
+                .WriteToAsync(writer, settings: buildFhirXmlWriterSettings())
+                .ConfigureAwait(false);
     }
 }

--- a/src/Hl7.Fhir.Core/Serialization/FhirXmlSerializer.cs
+++ b/src/Hl7.Fhir.Core/Serialization/FhirXmlSerializer.cs
@@ -6,11 +6,13 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+using System;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Utility;
 using System.Xml;
 using System.Xml.Linq;
+using Tasks = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Serialization
 {
@@ -23,24 +25,45 @@ namespace Hl7.Fhir.Serialization
         private FhirXmlSerializationSettings buildFhirXmlWriterSettings() =>
             new FhirXmlSerializationSettings { Pretty = Settings.Pretty, AppendNewLine = Settings.AppendNewLine, TrimWhitespaces = Settings.TrimWhiteSpacesInXml };
 
+        /// <inheritdoc cref="SerializeToStringAsync(Base, SummaryType, string, string[])" />
+        [Obsolete("Use SerializeToStringAsync(Base, SummaryType, string, string[]) instead.")]
         public string SerializeToString(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
             MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
             .Rename(root)
             .ToXml(settings: buildFhirXmlWriterSettings());
+        
+        public async Tasks.Task<string> SerializeToStringAsync(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
+            await MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
+                .Rename(root)
+                .ToXmlAsync(settings: buildFhirXmlWriterSettings());
 
+        /// <inheritdoc cref="SerializeToBytesAsync(Base, SummaryType, string, string[])" />
+        [Obsolete("Use SerializeToBytesAsync(Base, SummaryType, string, string[]) instead.")]
         public byte[] SerializeToBytes(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
             MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
             .Rename(root)
             .ToXmlBytes(settings: buildFhirXmlWriterSettings());
+        
+        public async Tasks.Task<byte[]> SerializeToBytesAsync(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
+            await MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
+                .Rename(root)
+                .ToXmlBytesAsync(settings: buildFhirXmlWriterSettings());
 
         public XDocument SerializeToDocument(Base instance, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
            MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
             .Rename(root)
             .ToXDocument(buildFhirXmlWriterSettings()).Rename(root);
 
+        /// <inheritdoc cref="SerializeAsync(Base, XmlWriter, SummaryType, string, string[])" />
+        [Obsolete("Use SerializeAsync(Base, SummaryType, string, string[]) instead.")]
         public void Serialize(Base instance, XmlWriter writer, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
             MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
             .Rename(root)
             .WriteTo(writer, settings: buildFhirXmlWriterSettings());
+        
+        public async Tasks.Task SerializeAsync(Base instance, XmlWriter writer, SummaryType summary = SummaryType.False, string root = null, string[] elements = null) =>
+            await MakeElementStack(instance, summary, elements, Settings?.IncludeMandatoryInElementsSummary ?? false)
+                .Rename(root)
+                .WriteToAsync(writer, settings: buildFhirXmlWriterSettings());
     }
 }

--- a/src/Hl7.Fhir.Core/Serialization/PocoSerializationExtensions.cs
+++ b/src/Hl7.Fhir.Core/Serialization/PocoSerializationExtensions.cs
@@ -11,65 +11,58 @@ using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
 using System.Xml;
 using System.Xml.Linq;
-using Tasks = System.Threading.Tasks;
+using T = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Serialization
 {
     public static class PocoSerializationExtensions
     {
         /// <inheritdoc cref="ToJsonAsync(Base, FhirJsonSerializationSettings)" />
-        [Obsolete("Use ToJsonAsync(Base, FhirJsonSerializationSettings) instead.")]
         public static string ToJson(this Base source, FhirJsonSerializationSettings settings = null) =>
             source.ToTypedElement().ToJson(settings);
 
-        public static async Tasks.Task<string> ToJsonAsync(this Base source, FhirJsonSerializationSettings settings = null) =>
-            await source.ToTypedElement().ToJsonAsync(settings);
+        public static async T.Task<string> ToJsonAsync(this Base source, FhirJsonSerializationSettings settings = null) =>
+            await source.ToTypedElement().ToJsonAsync(settings).ConfigureAwait(false);
 
         /// <inheritdoc cref="ToJsonBytesAsync(Base, FhirJsonSerializationSettings)" />
-        [Obsolete("Use ToJsonBytesAsync(Base, FhirJsonSerializationSettings) instead.")]
         public static byte[] ToJsonBytes(this Base source, FhirJsonSerializationSettings settings = null) =>
             source.ToTypedElement().ToJsonBytes(settings);
 
-        public static async Tasks.Task<byte[]> ToJsonBytesAsync(this Base source, FhirJsonSerializationSettings settings = null) =>
-            await source.ToTypedElement().ToJsonBytesAsync(settings);
+        public static async T.Task<byte[]> ToJsonBytesAsync(this Base source, FhirJsonSerializationSettings settings = null) =>
+            await source.ToTypedElement().ToJsonBytesAsync(settings).ConfigureAwait(false);
 
         /// <inheritdoc cref="WriteToAsync(Base, JsonWriter, FhirJsonSerializationSettings)" />
-        [Obsolete("Use WriteToAsync(Base, JsonWriter, FhirJsonSerializationSettings) instead.")]
         public static void WriteTo(this Base source, JsonWriter destination, FhirJsonSerializationSettings settings = null) =>
             source.ToTypedElement().WriteTo(destination, settings);
         
-        public static async Tasks.Task WriteToAsync(this Base source, JsonWriter destination, FhirJsonSerializationSettings settings = null) =>
-            await source.ToTypedElement().WriteToAsync(destination, settings);
+        public static async T.Task WriteToAsync(this Base source, JsonWriter destination, FhirJsonSerializationSettings settings = null) =>
+            await source.ToTypedElement().WriteToAsync(destination, settings).ConfigureAwait(false);
 
         public static JObject ToJObject(this Base source, FhirJsonSerializationSettings settings = null) =>
             source.ToTypedElement().ToJObject(settings);
 
         /// <inheritdoc cref="ToXmlAsync(Base, FhirXmlSerializationSettings)" />
-        [Obsolete("Use ToXmlAsync(Base, FhirXmlSerializationSettings) instead.")]
         public static string ToXml(this Base source, FhirXmlSerializationSettings settings = null) =>
             source.ToTypedElement().ToXml(settings);
 
-        public static async Tasks.Task<string> ToXmlAsync(this Base source, FhirXmlSerializationSettings settings = null) =>
-            await source.ToTypedElement().ToXmlAsync(settings);
+        public static async T.Task<string> ToXmlAsync(this Base source, FhirXmlSerializationSettings settings = null) =>
+            await source.ToTypedElement().ToXmlAsync(settings).ConfigureAwait(false);
 
         /// <inheritdoc cref="ToXmlBytesAsync(Base, FhirXmlSerializationSettings)" />
-        [Obsolete("Use ToXmlBytesAsync(Base, FhirXmlSerializationSettings) instead.")]
         public static byte[] ToXmlBytes(this Base source, FhirXmlSerializationSettings settings = null) =>
             source.ToTypedElement().ToXmlBytes(settings);
 
-        public static async Tasks.Task<byte[]> ToXmlBytesAsync(this Base source, FhirXmlSerializationSettings settings = null) =>
-            await source.ToTypedElement().ToXmlBytesAsync(settings);
+        public static async T.Task<byte[]> ToXmlBytesAsync(this Base source, FhirXmlSerializationSettings settings = null) =>
+            await source.ToTypedElement().ToXmlBytesAsync(settings).ConfigureAwait(false);
 
         /// <inheritdoc cref="WriteToAsync(Base, XmlWriter, FhirXmlSerializationSettings)" />
-        [Obsolete("Use WriteToAsync(Base, XmlWriter, FhirXmlSerializationSettings) instead.")]
         public static void WriteTo(this Base source, XmlWriter destination, FhirXmlSerializationSettings settings = null) =>
             source.ToTypedElement().WriteTo(destination, settings);
 
-        public static async Tasks.Task WriteToAsync(this Base source, XmlWriter destination, FhirXmlSerializationSettings settings = null) =>
-            await source.ToTypedElement().WriteToAsync(destination, settings);
+        public static async T.Task WriteToAsync(this Base source, XmlWriter destination, FhirXmlSerializationSettings settings = null) =>
+            await source.ToTypedElement().WriteToAsync(destination, settings).ConfigureAwait(false);
 
         public static XDocument ToXDocument(this Base source, FhirXmlSerializationSettings settings = null) =>
             source.ToTypedElement().ToXDocument(settings);

--- a/src/Hl7.Fhir.Core/Serialization/PocoSerializationExtensions.cs
+++ b/src/Hl7.Fhir.Core/Serialization/PocoSerializationExtensions.cs
@@ -11,28 +11,66 @@ using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System;
 using System.Xml;
 using System.Xml.Linq;
+using Tasks = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Serialization
 {
     public static class PocoSerializationExtensions
     {
+        /// <inheritdoc cref="ToJsonAsync(Base, FhirJsonSerializationSettings)" />
+        [Obsolete("Use ToJsonAsync(Base, FhirJsonSerializationSettings) instead.")]
         public static string ToJson(this Base source, FhirJsonSerializationSettings settings = null) =>
             source.ToTypedElement().ToJson(settings);
+
+        public static async Tasks.Task<string> ToJsonAsync(this Base source, FhirJsonSerializationSettings settings = null) =>
+            await source.ToTypedElement().ToJsonAsync(settings);
+
+        /// <inheritdoc cref="ToJsonBytesAsync(Base, FhirJsonSerializationSettings)" />
+        [Obsolete("Use ToJsonBytesAsync(Base, FhirJsonSerializationSettings) instead.")]
         public static byte[] ToJsonBytes(this Base source, FhirJsonSerializationSettings settings = null) =>
             source.ToTypedElement().ToJsonBytes(settings);
+
+        public static async Tasks.Task<byte[]> ToJsonBytesAsync(this Base source, FhirJsonSerializationSettings settings = null) =>
+            await source.ToTypedElement().ToJsonBytesAsync(settings);
+
+        /// <inheritdoc cref="WriteToAsync(Base, JsonWriter, FhirJsonSerializationSettings)" />
+        [Obsolete("Use WriteToAsync(Base, JsonWriter, FhirJsonSerializationSettings) instead.")]
         public static void WriteTo(this Base source, JsonWriter destination, FhirJsonSerializationSettings settings = null) =>
             source.ToTypedElement().WriteTo(destination, settings);
+        
+        public static async Tasks.Task WriteToAsync(this Base source, JsonWriter destination, FhirJsonSerializationSettings settings = null) =>
+            await source.ToTypedElement().WriteToAsync(destination, settings);
+
         public static JObject ToJObject(this Base source, FhirJsonSerializationSettings settings = null) =>
             source.ToTypedElement().ToJObject(settings);
 
+        /// <inheritdoc cref="ToXmlAsync(Base, FhirXmlSerializationSettings)" />
+        [Obsolete("Use ToXmlAsync(Base, FhirXmlSerializationSettings) instead.")]
         public static string ToXml(this Base source, FhirXmlSerializationSettings settings = null) =>
             source.ToTypedElement().ToXml(settings);
+
+        public static async Tasks.Task<string> ToXmlAsync(this Base source, FhirXmlSerializationSettings settings = null) =>
+            await source.ToTypedElement().ToXmlAsync(settings);
+
+        /// <inheritdoc cref="ToXmlBytesAsync(Base, FhirXmlSerializationSettings)" />
+        [Obsolete("Use ToXmlBytesAsync(Base, FhirXmlSerializationSettings) instead.")]
         public static byte[] ToXmlBytes(this Base source, FhirXmlSerializationSettings settings = null) =>
             source.ToTypedElement().ToXmlBytes(settings);
+
+        public static async Tasks.Task<byte[]> ToXmlBytesAsync(this Base source, FhirXmlSerializationSettings settings = null) =>
+            await source.ToTypedElement().ToXmlBytesAsync(settings);
+
+        /// <inheritdoc cref="WriteToAsync(Base, XmlWriter, FhirXmlSerializationSettings)" />
+        [Obsolete("Use WriteToAsync(Base, XmlWriter, FhirXmlSerializationSettings) instead.")]
         public static void WriteTo(this Base source, XmlWriter destination, FhirXmlSerializationSettings settings = null) =>
             source.ToTypedElement().WriteTo(destination, settings);
+
+        public static async Tasks.Task WriteToAsync(this Base source, XmlWriter destination, FhirXmlSerializationSettings settings = null) =>
+            await source.ToTypedElement().WriteToAsync(destination, settings);
+
         public static XDocument ToXDocument(this Base source, FhirXmlSerializationSettings settings = null) =>
             source.ToTypedElement().ToXDocument(settings);
     }

--- a/src/Hl7.Fhir.ElementModel.Tests/ElementNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Tests/ElementNodeTests.cs
@@ -164,7 +164,7 @@ namespace Hl7.FhirPath.Tests
         }
 
         [TestMethod]
-        public void SuccessfullyCreated()
+        public async Tasks.Task SuccessfullyCreated()
         {
             var patient = createPatient();
 
@@ -177,7 +177,7 @@ namespace Hl7.FhirPath.Tests
             pat.ActiveElement.SetStringExtension("urn:2", "world!");
             pat.Identifier.Add(new Identifier("http://nu.nl", "1234567"));
             pat.Identifier.Add(new Identifier("http://toen.nl", "7654321"));
-            XmlAssert.AreSame("in place", pat.ToXml(), patient.ToXml());
+            XmlAssert.AreSame("in place", await pat.ToXmlAsync(), await patient.ToXmlAsync());
         }
 
         [TestMethod]

--- a/src/Hl7.Fhir.ElementModel.Tests/ElementNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Tests/ElementNodeTests.cs
@@ -22,6 +22,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Hl7.Fhir.Specification.Source;
 using System.Threading.Tasks;
 using Hl7.Fhir.Specification.Snapshot;
+using Tasks = System.Threading.Tasks;
 
 namespace Hl7.FhirPath.Tests
 {
@@ -326,10 +327,10 @@ namespace Hl7.FhirPath.Tests
         }
 
         [TestMethod]
-        public void CannotUseAbstractType()
+        public async Tasks.Task CannotUseAbstractType()
         {
             var bundleJson = "{\"resourceType\":\"Bundle\", \"entry\":[{\"fullUrl\":\"http://example.org/Patient/1\"}]}";
-            var bundle = FhirJsonNode.Parse(bundleJson);
+            var bundle = await FhirJsonNode.ParseAsync(bundleJson);
             var typedBundle = bundle.ToTypedElement(_provider, "Bundle");
 
             //Type of entry is BackboneElement, but you can't set that, see below.
@@ -346,7 +347,7 @@ namespace Hl7.FhirPath.Tests
             catch (ArgumentException)
             {
             }
-        }        
+        }
 
         [TestMethod]
         public void TestImportChild()

--- a/src/Hl7.Fhir.ElementModel.Tests/TypedElementOnSourceNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Tests/TypedElementOnSourceNodeTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Specification;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -13,10 +14,10 @@ namespace Hl7.Fhir.ElementModel.Tests
 
         [ExpectedException(typeof(StructuralTypeException), "Should have thrown on .Value as complex types can't have a value")]
         [TestMethod]
-        public void TestExceptionComplexTypeValue()
+        public async Task TestExceptionComplexTypeValue()
         {
             var bundleJson = "{\"resourceType\":\"Bundle\", \"entry\":\"Invalid\"}";
-            var bundle = FhirJsonNode.Parse(bundleJson);
+            var bundle = await FhirJsonNode.ParseAsync(bundleJson);
             var typedBundle = bundle.ToTypedElement(provider, "Bundle");
 
             var _ = typedBundle.Children("entry").First().Value;

--- a/src/Hl7.Fhir.ElementModel.Tests/TypedElementToSourceNodeAdapterTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Tests/TypedElementToSourceNodeAdapterTests.cs
@@ -3,6 +3,7 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Specification;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Tasks = System.Threading.Tasks;
 
 namespace Hl7.Fhir.ElementModel.Tests
 {
@@ -31,11 +32,11 @@ namespace Hl7.Fhir.ElementModel.Tests
         }
 
         [TestMethod]
-        public void AnnotationsFromParsingTest()
+        public async Tasks.Task AnnotationsFromParsingTest()
         {
             var _sdsProvider = new PocoStructureDefinitionSummaryProvider();
             var patientJson = "{\"resourceType\":\"Patient\", \"active\":\"true\"}";
-            var patient  = FhirJsonNode.Parse(patientJson);
+            var patient = await FhirJsonNode.ParseAsync(patientJson);
             var typedPatient = patient.ToTypedElement(_sdsProvider, "Patient");
             var sourceNode = typedPatient.ToSourceNode();
 
@@ -51,15 +52,15 @@ namespace Hl7.Fhir.ElementModel.Tests
 
             var result3 = sourceNode.Annotation<IResourceTypeSupplier>();
             Assert.IsNotNull(result3);
-            Assert.AreEqual(typeof(TypedElementToSourceNodeAdapter), result3.GetType()); 
+            Assert.AreEqual(typeof(TypedElementToSourceNodeAdapter), result3.GetType());
         }
 
         [TestMethod]
-        public void SourceNodeFromElementNodeReturnsResourceTypeSupplier()
+        public async Tasks.Task SourceNodeFromElementNodeReturnsResourceTypeSupplier()
         {
             var _sdsProvider = new PocoStructureDefinitionSummaryProvider();
             var patientJson = "{\"resourceType\":\"Patient\", \"active\":\"true\"}";
-            var patientNode = FhirJsonNode.Parse(patientJson);
+            var patientNode = await FhirJsonNode.ParseAsync(patientJson);
             var typedPatient = patientNode.ToTypedElement(_sdsProvider, "Patient");
 
             var elementNode = ElementNode.FromElement(typedPatient);

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatient.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatient.cs
@@ -145,8 +145,8 @@ namespace Hl7.Fhir.Serialization.Tests
             }
 
             string output;
-            if (nav is ISourceNode isn2) output = isn2.ToJson();
-            else if (nav is ITypedElement ien2) output = ien2.ToJson();
+            if (nav is ISourceNode isn2) output = await isn2.ToJsonAsync();
+            else if (nav is ITypedElement ien2) output = await ien2.ToJsonAsync();
             else
                 throw Error.InvalidOperation("Fix unit test");
 

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatient.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatient.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using P = Hl7.Fhir.ElementModel.Types;
 
 namespace Hl7.Fhir.Serialization.Tests
@@ -99,7 +100,7 @@ namespace Hl7.Fhir.Serialization.Tests
             Assert.IsNotNull(id);
         }
 
-        public static void RoundtripXml(Func<string, object> navCreator)
+        public static async Task RoundtripXml(Func<string, object> navCreator)
         {
             var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
 
@@ -116,26 +117,23 @@ namespace Hl7.Fhir.Serialization.Tests
             }
 
             string output;
-            if (nav is ISourceNode isn2) output = isn2.ToXml();
-            else if (nav is ITypedElement ien2) output = ien2.ToXml();
+            if (nav is ISourceNode isn2) output = await isn2.ToXmlAsync();
+            else if (nav is ITypedElement ien2) output = await ien2.ToXmlAsync();
             else
                 throw Error.InvalidOperation("Fix unit test");
 
             XmlAssert.AreSame("fp-test-patient.xml", tp, output);
         }
 
-        public static void RoundtripJson(Func<string, object> navCreator)
+        public static async Task RoundtripJson(Func<string, Task<object>> navCreator)
         {
-            //var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
-            //compareJson(navCreator, tp);
-
-            var tp = File.ReadAllText(Path.Combine("TestData", "json-edge-cases.json"));
-            compareJson(@"TestData\json-edge-cases.json", navCreator, tp);
+            var tp = await File.ReadAllTextAsync(Path.Combine("TestData", "json-edge-cases.json"));
+            await compareJson(@"TestData\json-edge-cases.json", navCreator, tp);
         }
 
-        private static void compareJson(string filename, Func<string, object> navCreator, string expected)
+        private static async Task compareJson(string filename, Func<string, Task<object>> navCreator, string expected)
         {
-            var nav = navCreator(expected);
+            var nav = await navCreator(expected);
             switch (nav)
             {
                 case ISourceNode _:

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientJsonTyped.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientJsonTyped.cs
@@ -84,7 +84,7 @@ namespace Hl7.Fhir.Serialization.Tests
             var xml = await navJson.ToXmlAsync();
 
             var navXml = XmlParsingHelpers.ParseToTypedElement(xml, new PocoStructureDefinitionSummaryProvider());
-            var json = navXml.ToJson();
+            var json = await navXml.ToJsonAsync();
 
             List<string> errors = new List<string>();
             JsonAssert.AreSame(@"TestData\fp-test-patient.json", tp, json, errors);
@@ -93,14 +93,14 @@ namespace Hl7.Fhir.Serialization.Tests
         }
 
         [TestMethod]
-        public void IgnoreElements()
+        public async Task IgnoreElements()
         {
             var patient = SourceNode.Resource("Patient", "Patient", SourceNode.Valued("id", "pat1"));
-            var jsonBare = patient.ToTypedElement(new PocoStructureDefinitionSummaryProvider()).ToJson(new FhirJsonSerializationSettings { IgnoreUnknownElements = false });
+            var jsonBare = await patient.ToTypedElement(new PocoStructureDefinitionSummaryProvider()).ToJsonAsync(new FhirJsonSerializationSettings { IgnoreUnknownElements = false });
             Assert.IsTrue(jsonBare.Contains("pat1"));
 
             patient.Add(SourceNode.Valued("unknownElement", "someValue"));
-            var jsonUnknown = patient.ToTypedElement(new PocoStructureDefinitionSummaryProvider(), settings: new TypedElementSettings { ErrorMode = TypedElementSettings.TypeErrorMode.Ignore }).ToJson(new FhirJsonSerializationSettings { IgnoreUnknownElements = true });
+            var jsonUnknown = await patient.ToTypedElement(new PocoStructureDefinitionSummaryProvider(), settings: new TypedElementSettings { ErrorMode = TypedElementSettings.TypeErrorMode.Ignore }).ToJsonAsync(new FhirJsonSerializationSettings { IgnoreUnknownElements = true });
             Assert.IsFalse(jsonUnknown.Contains("unknownElement"));
         }
 

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientJsonTyped.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientJsonTyped.cs
@@ -14,13 +14,13 @@ namespace Hl7.Fhir.Serialization.Tests
     public class ParseDemoPatientJsonTyped
     {
         public async Task<ITypedElement> getJsonNode(string json, FhirJsonParsingSettings settings = null) 
-            => await JsonParsingHelpers.ParseToTypedElement(json, new PocoStructureDefinitionSummaryProvider(), settings: settings);
+            => await JsonParsingHelpers.ParseToTypedElementAsync(json, new PocoStructureDefinitionSummaryProvider(), settings: settings);
 
         // This test should resurface once you read this through a validating reader navigator (or somesuch)
         [TestMethod]
         public async Task CanReadThroughTypedNavigator()
         {
-            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
+            var tp = await File.ReadAllTextAsync(Path.Combine("TestData", "fp-test-patient.json"));
             var nav = await getJsonNode(tp);
             ParseDemoPatient.CanReadThroughTypedElement(nav, typed: true);
         }
@@ -28,7 +28,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public async Task ElementNavPerformanceTypedJson()
         {
-            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
+            var tp = await File.ReadAllTextAsync(Path.Combine("TestData", "fp-test-patient.json"));
             var nav = await getJsonNode(tp);
             ParseDemoPatient.ElementNavPerformance(nav.ToSourceNode());
         }
@@ -36,7 +36,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public async Task ProducesCorrectTypedLocations()
         {
-            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
+            var tp = await File.ReadAllTextAsync(Path.Combine("TestData", "fp-test-patient.json"));
             var patient = await getJsonNode(tp);
             ParseDemoPatient.ProducedCorrectTypedLocations(patient);
         }
@@ -55,7 +55,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public async Task HasLineNumbersTypedJson()
         {
-            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
+            var tp = await File.ReadAllTextAsync(Path.Combine("TestData", "fp-test-patient.json"));
             var nav = await getJsonNode(tp);
             ParseDemoPatient.HasLineNumbers<JsonSerializationDetails>(nav.ToSourceNode());
         }
@@ -63,7 +63,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public async Task CheckBundleEntryNavigation()
         {
-            var bundle = File.ReadAllText(Path.Combine("TestData", "BundleWithOneEntry.json"));
+            var bundle = await File.ReadAllTextAsync(Path.Combine("TestData", "BundleWithOneEntry.json"));
             var nav = await getJsonNode(bundle);
             ParseDemoPatient.CheckBundleEntryNavigation(nav);
         }
@@ -78,9 +78,9 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public async Task PingpongJson()
         {
-            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
+            var tp = await File.ReadAllTextAsync(Path.Combine("TestData", "fp-test-patient.json"));
             // will allow whitespace and comments to come through      
-            var navJson = await JsonParsingHelpers.ParseToTypedElement(tp, new PocoStructureDefinitionSummaryProvider());
+            var navJson = await JsonParsingHelpers.ParseToTypedElementAsync(tp, new PocoStructureDefinitionSummaryProvider());
             var xml = await navJson.ToXmlAsync();
 
             var navXml = XmlParsingHelpers.ParseToTypedElement(xml, new PocoStructureDefinitionSummaryProvider());
@@ -109,13 +109,13 @@ namespace Hl7.Fhir.Serialization.Tests
         {
             // First, use a simple value where a complex type was expected
             var tp = "{ 'resourceType' : 'Patient', 'maritalStatus' : 'UNK' }";
-            var navJson = await JsonParsingHelpers.ParseToTypedElement(tp, new PocoStructureDefinitionSummaryProvider());
+            var navJson = await JsonParsingHelpers.ParseToTypedElementAsync(tp, new PocoStructureDefinitionSummaryProvider());
             var errors = navJson.VisitAndCatch();
             Assert.IsTrue(errors.Single().Message.Contains("it cannot have a value"));
 
             // then, use a simple value where an array (of a complex type) was expected
             tp = "{ 'resourceType' : 'Patient', 'name' : ['Ewout'] }";
-            navJson = await JsonParsingHelpers.ParseToTypedElement(tp, new PocoStructureDefinitionSummaryProvider());
+            navJson = await JsonParsingHelpers.ParseToTypedElementAsync(tp, new PocoStructureDefinitionSummaryProvider());
             errors = navJson.VisitAndCatch();
             Assert.IsTrue(errors.Single().Message.Contains("it cannot have a value"));
         }
@@ -125,13 +125,13 @@ namespace Hl7.Fhir.Serialization.Tests
         {
             // Use a single element where an array was expected
             var tp = "{ 'resourceType' : 'Patient', 'identifier' :  { 'value': 'AB60001' }}";
-            var navJson = await JsonParsingHelpers.ParseToTypedElement(tp, new PocoStructureDefinitionSummaryProvider(), null, new FhirJsonParsingSettings() { PermissiveParsing = false });
+            var navJson = await JsonParsingHelpers.ParseToTypedElementAsync(tp, new PocoStructureDefinitionSummaryProvider(), null, new FhirJsonParsingSettings() { PermissiveParsing = false });
             var errors = navJson.VisitAndCatch();
             Assert.IsTrue(errors.Single().Message.Contains("an array must be used here"));
 
             // Use an array where a single value was expected
             tp = "{ 'resourceType' : 'Patient', 'active' : [true,false] }";
-            navJson = await JsonParsingHelpers.ParseToTypedElement(tp, new PocoStructureDefinitionSummaryProvider(), null, new FhirJsonParsingSettings() { PermissiveParsing = false });
+            navJson = await JsonParsingHelpers.ParseToTypedElementAsync(tp, new PocoStructureDefinitionSummaryProvider(), null, new FhirJsonParsingSettings() { PermissiveParsing = false });
             errors = navJson.VisitAndCatch();
             Assert.IsTrue(errors.Single().Message.Contains("an array must not be used here"));
         }

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientJsonUntyped.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientJsonUntyped.cs
@@ -63,13 +63,13 @@ namespace Hl7.Fhir.Serialization.Tests
         }
 
         [TestMethod]
-        public void TryInvalidUntypedSource()
+        public async Task TryInvalidUntypedSource()
         {
             var xmlNav = FhirXmlNode.Parse("<Patient xmlns='http://hl7.org/fhir'><active value='true'/></Patient>");
 
             try
             {
-                var output = xmlNav.ToJson();
+                var output = await xmlNav.ToJsonAsync();
                 Assert.Fail();
             }
             catch (NotSupportedException)

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientJsonUntyped.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientJsonUntyped.cs
@@ -65,7 +65,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [TestMethod]
         public async Task TryInvalidUntypedSource()
         {
-            var xmlNav = FhirXmlNode.Parse("<Patient xmlns='http://hl7.org/fhir'><active value='true'/></Patient>");
+            var xmlNav = await FhirXmlNode.ParseAsync("<Patient xmlns='http://hl7.org/fhir'><active value='true'/></Patient>");
 
             try
             {

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientJsonUntyped.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientJsonUntyped.cs
@@ -6,59 +6,60 @@ using Newtonsoft.Json;
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Hl7.Fhir.Serialization.Tests
 {
     [TestClass]
     public class ParseDemoPatientJsonUntyped
     {
-        public ISourceNode getJsonNodeU(string json, FhirJsonParsingSettings settings = null) =>
-            FhirJsonNode.Parse(json, settings: settings);
+        public async Task<ISourceNode> getJsonNodeU(string json, FhirJsonParsingSettings settings = null) =>
+            await FhirJsonNode.ParseAsync(json, settings: settings);
 
-        ISourceNode FhirJsonNodeParse(string json, string rootName) =>
-               FhirJsonNode.Parse(json, rootName, new FhirJsonParsingSettings() { PermissiveParsing = false });
+        async Task<ISourceNode> FhirJsonNodeParse(string json, string rootName) =>
+               await FhirJsonNode.ParseAsync(json, rootName, new FhirJsonParsingSettings() { PermissiveParsing = false });
 
         [TestMethod]
-        public void CanReadThroughUntypedNavigator()
+        public async Task CanReadThroughUntypedNavigator()
         {
-            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
-            var nav = getJsonNodeU(tp);
+            var tp = await File.ReadAllTextAsync(Path.Combine("TestData", "fp-test-patient.json"));
+            var nav = await getJsonNodeU(tp);
 #pragma warning disable 612, 618
             ParseDemoPatient.CanReadThroughTypedElement(nav.ToTypedElement(), typed: false);
 #pragma warning restore 612, 618
         }
 
         [TestMethod]
-        public void ElementNavPerformanceUntypedJson()
+        public async Task ElementNavPerformanceUntypedJson()
         {
-            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
-            var nav = getJsonNodeU(tp);
+            var tp = await File.ReadAllTextAsync(Path.Combine("TestData", "fp-test-patient.json"));
+            var nav = await getJsonNodeU(tp);
             ParseDemoPatient.ElementNavPerformance(nav);
         }
 
         [TestMethod]
-        public void ProducesCorrectUntypedLocations()
+        public async Task ProducesCorrectUntypedLocations()
         {
-            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
-            var patient = getJsonNodeU(tp);
+            var tp = await File.ReadAllTextAsync(Path.Combine("TestData", "fp-test-patient.json"));
+            var patient = await getJsonNodeU(tp);
 
             ParseDemoPatient.ProducesCorrectUntypedLocations(patient);
         }
 
         [TestMethod]
-        public void HasLineNumbers()
+        public async Task HasLineNumbers()
         {
-            var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
-            var nav = getJsonNodeU(tp);
+            var tp = await File.ReadAllTextAsync(Path.Combine("TestData", "fp-test-patient.json"));
+            var nav = await getJsonNodeU(tp);
 
             ParseDemoPatient.HasLineNumbers<JsonSerializationDetails>(nav);
         }
 
         [TestMethod]
-        public void RoundtripJsonUntyped()
+        public async Task RoundtripJsonUntyped()
         {
-            ParseDemoPatient.RoundtripJson(jsonText =>
-                getJsonNodeU(jsonText, new FhirJsonParsingSettings { AllowJsonComments = true }));
+            await ParseDemoPatient.RoundtripJson(async jsonText =>
+                await getJsonNodeU(jsonText, new FhirJsonParsingSettings { AllowJsonComments = true }));
         }
 
         [TestMethod]
@@ -77,21 +78,20 @@ namespace Hl7.Fhir.Serialization.Tests
         }
 
         [TestMethod]
-        public void CheckBundleEntryNavigation()
+        public async Task CheckBundleEntryNavigation()
         {
-            var bundle = File.ReadAllText(Path.Combine("TestData", "BundleWithOneEntry.json"));
-            var nav = getJsonNodeU(bundle);
+            var bundle = await File.ReadAllTextAsync(Path.Combine("TestData", "BundleWithOneEntry.json"));
+            var nav = await getJsonNodeU(bundle);
 #pragma warning disable 612,618
             ParseDemoPatient.CheckBundleEntryNavigation(nav.ToTypedElement());
 #pragma warning restore 612, 618
         }
 
-
         [TestMethod]
-        public void CanReadEdgeCases()
+        public async Task CanReadEdgeCases()
         {
-            var tpJson = File.ReadAllText(Path.Combine("TestData", "json-edge-cases.json"));
-            var patient = getJsonNodeU(tpJson, new FhirJsonParsingSettings { AllowJsonComments = true });
+            var tpJson = await File.ReadAllTextAsync(Path.Combine("TestData", "json-edge-cases.json"));
+            var patient = await getJsonNodeU(tpJson, new FhirJsonParsingSettings { AllowJsonComments = true });
 
             Assert.AreEqual("Patient", patient.Name);
             Assert.AreEqual("Patient", patient.GetResourceTypeIndicator());
@@ -138,85 +138,85 @@ namespace Hl7.Fhir.Serialization.Tests
         }
 
         [TestMethod]
-        public void CatchesArrayMismatch()
+        public async Task CatchesArrayMismatch()
         {
-            var nav = FhirJsonNodeParse("{ 'a': [2,3,4], '_a' : [2,4] }", "test");
+            var nav = await FhirJsonNodeParse("{ 'a': [2,3,4], '_a' : [2,4] }", "test");
             ExceptionAssert.Throws<FormatException>(() => nav.VisitAll());
 
-            nav = FhirJsonNodeParse("{ 'a': 2, '_a' : [2] }", "test");
+            nav = await FhirJsonNodeParse("{ 'a': 2, '_a' : [2] }", "test");
             ExceptionAssert.Throws<FormatException>(() => nav.VisitAll());
 
-            nav = FhirJsonNodeParse("{ 'a': [2,3,4], '_a' : {} }", "test");
+            nav = await FhirJsonNodeParse("{ 'a': [2,3,4], '_a' : {} }", "test");
             ExceptionAssert.Throws<FormatException>(() => nav.VisitAll());
 
-            nav = FhirJsonNodeParse("{ '_a': [4,5,6] }", "test");
+            nav = await FhirJsonNodeParse("{ '_a': [4,5,6] }", "test");
             ExceptionAssert.Throws<FormatException>(() => nav.VisitAll());
 
-            nav = FhirJsonNodeParse("{ 'a': [2,3,4] }", "test");
+            nav = await FhirJsonNodeParse("{ 'a': [2,3,4] }", "test");
             Assert.IsTrue(nav.Children().Any());
 
-            nav = FhirJsonNodeParse("{ 'a': [null,2], '_a' : [{'active':true},null] }", "test");
+            nav = await FhirJsonNodeParse("{ 'a': [null,2], '_a' : [{'active':true},null] }", "test");
             Assert.IsTrue(nav.Children().Any());
         }
 
         [TestMethod]
-        public void CatchesUnsupportedFeatures()
+        public async Task CatchesUnsupportedFeatures()
         {
-            var nav = FhirJsonNodeParse("{ 'a': '   ' }", "test");
+            var nav = await FhirJsonNodeParse("{ 'a': '   ' }", "test");
             ExceptionAssert.Throws<FormatException>(() => nav.VisitAll());
 
-            nav = FhirJsonNodeParse("{ 'a': {}, '_a' : {} }", "test");
+            nav = await FhirJsonNodeParse("{ 'a': {}, '_a' : {} }", "test");
             ExceptionAssert.Throws<FormatException>(() => nav.VisitAll());
 
-            nav = FhirJsonNodeParse("{ 'a': {'active':true}, '_a': {'dummy':4} }", "test");
+            nav = await FhirJsonNodeParse("{ 'a': {'active':true}, '_a': {'dummy':4} }", "test");
             ExceptionAssert.Throws<FormatException>(() => nav.VisitAll());
 
-            nav = FhirJsonNodeParse("{ '_a' : {} }", "test");
+            nav = await FhirJsonNodeParse("{ '_a' : {} }", "test");
             ExceptionAssert.Throws<FormatException>(() => nav.VisitAll());
 
-            nav = FhirJsonNodeParse("{ 'a': 3, '_a' : 4 }", "test");
+            nav = await FhirJsonNodeParse("{ 'a': 3, '_a' : 4 }", "test");
             ExceptionAssert.Throws<FormatException>(() => nav.VisitAll());
 
-            nav = FhirJsonNodeParse("{ 'a': new DateTime() }", "test");
+            nav = await FhirJsonNodeParse("{ 'a': new DateTime() }", "test");
             ExceptionAssert.Throws<FormatException>(() => nav.VisitAll());
 
-            nav = FhirJsonNodeParse("{ '_a': new DateTime() }", "test");
+            nav = await FhirJsonNodeParse("{ '_a': new DateTime() }", "test");
             ExceptionAssert.Throws<FormatException>(() => nav.VisitAll());
         }
 
         [TestMethod]
         [ExpectedException(typeof(InvalidOperationException), "Expected an InvalidOperationException about resourceType is missing.")]
-        public void CatchResourceTypeMissing()
+        public async Task CatchResourceTypeMissing()
         {
             var json = "{  \"resourceType\": \"\",  \"id\": \"rt1\",  \"meta\": {\"lastUpdated\": \"2020-04-23T13:45:32Z\"  } }";
-            _ = FhirJsonNodeParse(json, null);
+            _ = await FhirJsonNodeParse(json, null);
         }
 
         [TestMethod]
-        public void CatchNullErrors()
+        public async Task CatchNullErrors()
         {
-            var nav = FhirJsonNodeParse("{ 'a': null }", "test");
+            var nav = await FhirJsonNodeParse("{ 'a': null }", "test");
             ExceptionAssert.Throws<FormatException>(() => nav.VisitAll());
 
-            nav = FhirJsonNodeParse("{ '_a': null }", "test");
+            nav = await FhirJsonNodeParse("{ '_a': null }", "test");
             ExceptionAssert.Throws<FormatException>(() => nav.VisitAll());
 
-            nav = FhirJsonNodeParse("{ 'a': null, '_a' : null }", "test");
+            nav = await FhirJsonNodeParse("{ 'a': null, '_a' : null }", "test");
             ExceptionAssert.Throws<FormatException>(() => nav.VisitAll());
 
-            nav = FhirJsonNodeParse("{ 'a': [null] }", "test");
+            nav = await FhirJsonNodeParse("{ 'a': [null] }", "test");
             ExceptionAssert.Throws<FormatException>(() => nav.VisitAll());
 
-            nav = FhirJsonNodeParse("{ 'a': [null], '_a': [null] }", "test");
+            nav = await FhirJsonNodeParse("{ 'a': [null], '_a': [null] }", "test");
             ExceptionAssert.Throws<FormatException>(() => nav.VisitAll());
         }
 
         [TestMethod]
-        public void PreservesParsingExceptionDetails()
+        public async Task PreservesParsingExceptionDetails()
         {
             try
             {
-                var nav = FhirJsonNode.Parse("<bla", "test");
+                var nav = await FhirJsonNode.ParseAsync("<bla", "test");
                 var dummy = nav.Text;
                 Assert.Fail();
             }
@@ -227,13 +227,13 @@ namespace Hl7.Fhir.Serialization.Tests
         }
 
         [TestMethod]
-        public void CatchParseErrors()
+        public async Task CatchParseErrors()
         {
             var text = "{";
 
             try
             {
-                var patient = getJsonNodeU(text);
+                var patient = await getJsonNodeU(text);
                 Assert.Fail();
             }
             catch (FormatException fe)

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientXmlTyped.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientXmlTyped.cs
@@ -108,7 +108,7 @@ namespace Hl7.Fhir.Serialization.Tests
             var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             // will allow whitespace and comments to come through      
             var navXml = XmlParsingHelpers.ParseToTypedElement(tp, new PocoStructureDefinitionSummaryProvider());
-            var json = navXml.ToJson();
+            var json = await navXml.ToJsonAsync();
 
             var navJson = await JsonParsingHelpers.ParseToTypedElement(json, new PocoStructureDefinitionSummaryProvider());
             var xml = await navJson.ToXmlAsync();

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientXmlTyped.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientXmlTyped.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Hl7.Fhir.Serialization.Tests
 {
@@ -58,7 +59,7 @@ namespace Hl7.Fhir.Serialization.Tests
 
 
         [TestMethod]
-        public void CompareXmlJsonParseOutcomes()
+        public async Task CompareXmlJsonParseOutcomes()
         {
             var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var tpJson = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
@@ -66,7 +67,7 @@ namespace Hl7.Fhir.Serialization.Tests
             if(Environment.NewLine == "\n")
                 tpJson = tpJson.Replace(@"\r\n", @"\n");
             var navXml = getXmlNode(tpXml);
-            var navJson = JsonParsingHelpers.ParseToTypedElement(tpJson, new PocoStructureDefinitionSummaryProvider());
+            var navJson = await JsonParsingHelpers.ParseToTypedElement(tpJson, new PocoStructureDefinitionSummaryProvider());
 
             var compare = navXml.IsEqualTo(navJson);
 
@@ -96,21 +97,21 @@ namespace Hl7.Fhir.Serialization.Tests
 
 
         [TestMethod]
-        public void RoundtripXml()
+        public async Task RoundtripXml()
         {
-            ParseDemoPatient.RoundtripXml(reader => XmlParsingHelpers.ParseToTypedElement(reader, new PocoStructureDefinitionSummaryProvider()));
+            await ParseDemoPatient.RoundtripXml(reader => XmlParsingHelpers.ParseToTypedElement(reader, new PocoStructureDefinitionSummaryProvider()));
         }
 
         [TestMethod]
-        public void PingpongXml()
+        public async Task PingpongXml()
         {
             var tp = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             // will allow whitespace and comments to come through      
             var navXml = XmlParsingHelpers.ParseToTypedElement(tp, new PocoStructureDefinitionSummaryProvider());
             var json = navXml.ToJson();
 
-            var navJson = JsonParsingHelpers.ParseToTypedElement(json, new PocoStructureDefinitionSummaryProvider());
-            var xml = navJson.ToXml();
+            var navJson = await JsonParsingHelpers.ParseToTypedElement(json, new PocoStructureDefinitionSummaryProvider());
+            var xml = await navJson.ToXmlAsync();
 
             XmlAssert.AreSame("fp-test-patient.xml", tp, xml, ignoreSchemaLocation: true);
         }

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientXmlTyped.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientXmlTyped.cs
@@ -67,7 +67,7 @@ namespace Hl7.Fhir.Serialization.Tests
             if(Environment.NewLine == "\n")
                 tpJson = tpJson.Replace(@"\r\n", @"\n");
             var navXml = getXmlNode(tpXml);
-            var navJson = await JsonParsingHelpers.ParseToTypedElement(tpJson, new PocoStructureDefinitionSummaryProvider());
+            var navJson = await JsonParsingHelpers.ParseToTypedElementAsync(tpJson, new PocoStructureDefinitionSummaryProvider());
 
             var compare = navXml.IsEqualTo(navJson);
 
@@ -110,7 +110,7 @@ namespace Hl7.Fhir.Serialization.Tests
             var navXml = XmlParsingHelpers.ParseToTypedElement(tp, new PocoStructureDefinitionSummaryProvider());
             var json = await navXml.ToJsonAsync();
 
-            var navJson = await JsonParsingHelpers.ParseToTypedElement(json, new PocoStructureDefinitionSummaryProvider());
+            var navJson = await JsonParsingHelpers.ParseToTypedElementAsync(json, new PocoStructureDefinitionSummaryProvider());
             var xml = await navJson.ToXmlAsync();
 
             XmlAssert.AreSame("fp-test-patient.xml", tp, xml, ignoreSchemaLocation: true);

--- a/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientXmlUntyped.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/ParseDemoPatientXmlUntyped.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
 
@@ -191,19 +192,19 @@ namespace Hl7.Fhir.Serialization.Tests
         }
 
         [TestMethod]
-        public void RoundtripXmlUntyped()
+        public async Task RoundtripXmlUntyped()
         {
-            ParseDemoPatient.RoundtripXml(xmlText => FhirXmlNode.Parse(xmlText));
+            await ParseDemoPatient.RoundtripXml(xmlText => FhirXmlNode.Parse(xmlText));
         }
 
         [TestMethod]
-        public void TryInvalidUntypedSource()
+        public async Task TryInvalidUntypedSource()
         {
-            var jsonNav = FhirJsonNode.Parse("{ 'resourceType': 'Patient', 'active':true }");
+            var jsonNav = await FhirJsonNode.ParseAsync("{ 'resourceType': 'Patient', 'active':true }");
 
             try
             {
-                var output = jsonNav.ToXml();
+                var output = await jsonNav.ToXmlAsync();
                 Assert.Fail();
             }
             catch (NotSupportedException)

--- a/src/Hl7.Fhir.Serialization.Tests/RoundtripTest.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/RoundtripTest.cs
@@ -368,14 +368,14 @@ namespace Hl7.Fhir.Serialization.Tests
                 Assert.IsFalse(resource.Matches(null), "Serialization of " + inputFile + " matched null - Matches test");
                 Assert.IsFalse(resource.IsExactly(null), "Serialization of " + inputFile + " matched null - IsExactly test");
 
-                var json = new FhirJsonSerializer().SerializeToString(resource);
+                var json = await new FhirJsonSerializer().SerializeToStringAsync(resource);
                 await File.WriteAllTextAsync(outputFile, json);
             }
             else
             {
                 var json = File.ReadAllText(inputFile);
                 var resource = await new FhirJsonParser(new ParserSettings { PermissiveParsing = true }).ParseAsync<Resource>(json);
-                var xml = new FhirXmlSerializer().SerializeToString(resource);
+                var xml = await new FhirXmlSerializer().SerializeToStringAsync(resource);
                 await File.WriteAllTextAsync(outputFile, xml);
             }
         }
@@ -386,7 +386,7 @@ namespace Hl7.Fhir.Serialization.Tests
             {
                 var xml = await File.ReadAllTextAsync(inputFile);
                 var nav = XmlParsingHelpers.ParseToTypedElement(xml, provider, new FhirXmlParsingSettings { PermissiveParsing = true });
-                var json = nav.ToJson();
+                var json = await nav.ToJsonAsync();
                 await File.WriteAllTextAsync(outputFile, json);
             }
             else

--- a/src/Hl7.Fhir.Serialization.Tests/RoundtripTest.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/RoundtripTest.cs
@@ -360,7 +360,7 @@ namespace Hl7.Fhir.Serialization.Tests
             if (inputFile.EndsWith(".xml"))
             {
                 var xml = File.ReadAllText(inputFile);
-                var resource = new FhirXmlParser(new ParserSettings { PermissiveParsing = true }).Parse<Resource>(xml);
+                var resource = await new FhirXmlParser(new ParserSettings { PermissiveParsing = true }).ParseAsync<Resource>(xml);
 
                 var r2 = resource.DeepCopy();
                 Assert.IsTrue(resource.Matches(r2 as Resource), "Serialization of " + inputFile + " did not match output - Matches test");

--- a/src/Hl7.Fhir.Serialization.Tests/RoundtripTest.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/RoundtripTest.cs
@@ -29,51 +29,101 @@ namespace Hl7.Fhir.Serialization.Tests
     { 
         [TestMethod]
         [TestCategory("LongRunner")]
-        public async Tasks.Task FullRoundtripOfAllExamplesXmlPoco()
+        public void FullRoundtripOfAllExamplesXmlPoco()
         {
-            await FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml", 
+            FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml", 
+                "Roundtripping xml->json->xml", usingPoco: true, provider:null);
+        }
+        
+        [TestMethod]
+        [TestCategory("LongRunner")]
+        public async Tasks.Task FullRoundtripOfAllExamplesXmlPocoAsync()
+        {
+            await FullRoundtripOfAllExamplesAsync("examples.zip", "FHIRRoundTripTestXml", 
                 "Roundtripping xml->json->xml", usingPoco: true, provider:null);
         }
 
         [TestMethod]
         [TestCategory("LongRunner")]
-        public async Tasks.Task FullRoundtripOfAllExamplesJsonPoco()
+        public void FullRoundtripOfAllExamplesJsonPoco()
         {
-            await FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
+            FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
+                "Roundtripping json->xml->json", usingPoco: true, provider: null);
+        }
+        
+        [TestMethod]
+        [TestCategory("LongRunner")]
+        public async Tasks.Task FullRoundtripOfAllExamplesJsonPocoAsync()
+        {
+            await FullRoundtripOfAllExamplesAsync("examples-json.zip", "FHIRRoundTripTestJson",
                 "Roundtripping json->xml->json", usingPoco: true, provider: null);
         }
 
         [TestMethod]
         [TestCategory("LongRunner")]
-        public async Tasks.Task FullRoundtripOfAllExamplesXmlNavPocoProvider()
+        public void FullRoundtripOfAllExamplesXmlNavPocoProvider()
         {
-            await FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml",
+            FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml",
+                "Roundtripping xml->json->xml", usingPoco: false, provider: new PocoStructureDefinitionSummaryProvider());
+        }
+        
+        [TestMethod]
+        [TestCategory("LongRunner")]
+        public async Tasks.Task FullRoundtripOfAllExamplesXmlNavPocoProviderAsync()
+        {
+            await FullRoundtripOfAllExamplesAsync("examples.zip", "FHIRRoundTripTestXml",
                 "Roundtripping xml->json->xml", usingPoco: false, provider: new PocoStructureDefinitionSummaryProvider());
         }
 
         [TestMethod]
         [TestCategory("LongRunner")]
-        public async Tasks.Task FullRoundtripOfAllExamplesJsonNavPocoProvider()
+        public void FullRoundtripOfAllExamplesJsonNavPocoProvider()
         {
-            await FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
+            FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
+                "Roundtripping json->xml->json", usingPoco: false, provider: new PocoStructureDefinitionSummaryProvider());
+        }
+        
+        [TestMethod]
+        [TestCategory("LongRunner")]
+        public async Tasks.Task FullRoundtripOfAllExamplesJsonNavPocoProviderAsync()
+        {
+            await FullRoundtripOfAllExamplesAsync("examples-json.zip", "FHIRRoundTripTestJson",
                 "Roundtripping json->xml->json", usingPoco: false, provider: new PocoStructureDefinitionSummaryProvider());
         }
 
         [TestMethod]
         [TestCategory("LongRunner")]
-        public async Tasks.Task FullRoundtripOfAllExamplesXmlNavSdProvider()
+        public void FullRoundtripOfAllExamplesXmlNavSdProvider()
         {
             var source = new CachedResolver(ZipSource.CreateValidationSource());
-            await FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml",
+            FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml",
+                "Roundtripping xml->json->xml", usingPoco: false, provider: new StructureDefinitionSummaryProvider(source));
+        }
+        
+        [TestMethod]
+        [TestCategory("LongRunner")]
+        public async Tasks.Task FullRoundtripOfAllExamplesXmlNavSdProviderAsync()
+        {
+            var source = new CachedResolver(ZipSource.CreateValidationSource());
+            await FullRoundtripOfAllExamplesAsync("examples.zip", "FHIRRoundTripTestXml",
                 "Roundtripping xml->json->xml", usingPoco: false, provider: new StructureDefinitionSummaryProvider(source));
         }
 
         [TestMethod]
         [TestCategory("LongRunner")]
-        public async Tasks.Task FullRoundtripOfAllExamplesJsonNavSdProvider()
+        public void FullRoundtripOfAllExamplesJsonNavSdProvider()
         {
             var source = new CachedResolver(ZipSource.CreateValidationSource());
-            await FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
+            FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
+                "Roundtripping json->xml->json", usingPoco: false, provider: new StructureDefinitionSummaryProvider(source));
+        }
+        
+        [TestMethod]
+        [TestCategory("LongRunner")]
+        public async Tasks.Task FullRoundtripOfAllExamplesJsonNavSdProviderAsync()
+        {
+            var source = new CachedResolver(ZipSource.CreateValidationSource());
+            await FullRoundtripOfAllExamplesAsync("examples-json.zip", "FHIRRoundTripTestJson",
                 "Roundtripping json->xml->json", usingPoco: false, provider: new StructureDefinitionSummaryProvider(source));
         }
 
@@ -171,7 +221,7 @@ namespace Hl7.Fhir.Serialization.Tests
         }
 #endif
 
-        public static async Tasks.Task FullRoundtripOfAllExamples(string zipname, string dirname, string label, bool usingPoco, IStructureDefinitionSummaryProvider provider)
+        public static void FullRoundtripOfAllExamples(string zipname, string dirname, string label, bool usingPoco, IStructureDefinitionSummaryProvider provider)
         {
             ZipArchive examples = ReadTestZip(zipname);
 
@@ -181,7 +231,20 @@ namespace Hl7.Fhir.Serialization.Tests
 
             Debug.WriteLine(label);
             createEmptyDir(baseTestPath);
-            await doRoundTrip(examples, baseTestPath, usingPoco, provider);
+            doRoundTrip(examples, baseTestPath, usingPoco, provider);
+        }
+        
+        public static async Tasks.Task FullRoundtripOfAllExamplesAsync(string zipname, string dirname, string label, bool usingPoco, IStructureDefinitionSummaryProvider provider)
+        {
+            ZipArchive examples = ReadTestZip(zipname);
+
+            // Create an empty temporary directory for us to dump the roundtripped intermediary files in
+            string baseTestPath = Path.Combine(Path.GetTempPath(), dirname);
+            createEmptyDir(baseTestPath);
+
+            Debug.WriteLine(label);
+            createEmptyDir(baseTestPath);
+            await doRoundTripAsync(examples, baseTestPath, usingPoco, provider);
         }
 
 
@@ -210,8 +273,8 @@ namespace Hl7.Fhir.Serialization.Tests
             if (Directory.Exists(baseTestPath)) Directory.Delete(baseTestPath, true);
             Directory.CreateDirectory(baseTestPath);
         }
-
-        private static async Tasks.Task doRoundTrip(ZipArchive examplesZip, string baseTestPath, bool usingPoco, IStructureDefinitionSummaryProvider provider)
+        
+        private static void doRoundTrip(ZipArchive examplesZip, string baseTestPath, bool usingPoco, IStructureDefinitionSummaryProvider provider)
         {
             var examplePath = Path.Combine(baseTestPath, "input");
             Directory.CreateDirectory(examplePath);
@@ -225,17 +288,52 @@ namespace Hl7.Fhir.Serialization.Tests
             Debug.WriteLine("Converting files in {0} to {1}", baseTestPath, intermediate1Path);
             var sw = new Stopwatch();
             sw.Start();
-            int convertedFileCount = await convertFiles(examplePath, intermediate1Path, usingPoco, provider, errors);
+            int convertedFileCount = convertFiles(examplePath, intermediate1Path, usingPoco, provider, errors);
             sw.Stop();
-            Debug.WriteLine("Conversion took {0} seconds", sw.ElapsedMilliseconds / 1000);
+            Debug.WriteLine("Conversion of {1} files took {0} seconds", sw.ElapsedMilliseconds / 1000, convertedFileCount);
             sw.Reset();
 
             var intermediate2Path = Path.Combine(baseTestPath, "intermediate2");
             Debug.WriteLine("Re-converting files in {0} back to original format in {1}", intermediate1Path, intermediate2Path);
             sw.Start();
-            await convertFiles(intermediate1Path, intermediate2Path, usingPoco, provider, errors);
+            convertedFileCount = convertFiles(intermediate1Path, intermediate2Path, usingPoco, provider, errors);
             sw.Stop();
-            Console.WriteLine("Conversion of {1} files took {0} seconds", sw.ElapsedMilliseconds / 1000, convertedFileCount);
+            Debug.WriteLine("Conversion of {1} files took {0} seconds", sw.ElapsedMilliseconds / 1000, convertedFileCount);
+            sw.Reset();
+
+            Debug.WriteLine("Comparing files in {0} to files in {1}", baseTestPath, intermediate2Path);
+
+            compareFiles(examplePath, intermediate2Path, errors);
+            Console.WriteLine("------------------------------------------------");
+            Console.WriteLine(String.Join("\r\n", errors));
+            Assert.AreEqual(0, errors.Count, "Errors were encountered comparing converted content");
+        }
+
+        private static async Tasks.Task doRoundTripAsync(ZipArchive examplesZip, string baseTestPath, bool usingPoco, IStructureDefinitionSummaryProvider provider)
+        {
+            var examplePath = Path.Combine(baseTestPath, "input");
+            Directory.CreateDirectory(examplePath);
+            // Unzip files into this path
+            Debug.WriteLine("Unzipping example files from {0} to {1}", examplesZip, examplePath);
+
+            examplesZip.ExtractToDirectory(examplePath);
+
+            List<string> errors = new List<string>();
+            var intermediate1Path = Path.Combine(baseTestPath, "intermediate1");
+            Debug.WriteLine("Converting files in {0} to {1}", baseTestPath, intermediate1Path);
+            var sw = new Stopwatch();
+            sw.Start();
+            int convertedFileCount = await convertFilesAsync(examplePath, intermediate1Path, usingPoco, provider, errors);
+            sw.Stop();
+            Debug.WriteLine("Conversion of {1} files took {0} seconds", sw.ElapsedMilliseconds / 1000, convertedFileCount);
+            sw.Reset();
+
+            var intermediate2Path = Path.Combine(baseTestPath, "intermediate2");
+            Debug.WriteLine("Re-converting files in {0} back to original format in {1}", intermediate1Path, intermediate2Path);
+            sw.Start();
+            convertedFileCount = await convertFilesAsync(intermediate1Path, intermediate2Path, usingPoco, provider, errors);
+            sw.Stop();
+            Debug.WriteLine("Conversion of {1} files took {0} seconds", sw.ElapsedMilliseconds / 1000, convertedFileCount);
             sw.Reset();
 
             Debug.WriteLine("Comparing files in {0} to files in {1}", baseTestPath, intermediate2Path);
@@ -272,8 +370,8 @@ namespace Hl7.Fhir.Serialization.Tests
                              // https://chat.fhir.org/#narrow/stream/48-terminology/subject/v2.20Table.200550
             return false;
         }
-
-        private static async Tasks.Task<int> convertFiles(string inputPath, string outputPath, bool usingPoco, IStructureDefinitionSummaryProvider provider, List<string> errors)
+        
+        private static int convertFiles(string inputPath, string outputPath, bool usingPoco, IStructureDefinitionSummaryProvider provider, List<string> errors)
         {
             int fileCount = 0;
             var files = Directory.EnumerateFiles(inputPath);
@@ -297,9 +395,47 @@ namespace Hl7.Fhir.Serialization.Tests
                 try
                 {
                     if (usingPoco)
-                        await convertResourcePoco(file, outputFile);
+                        convertResourcePoco(file, outputFile);
                     else
-                        await convertResourceNav(file, outputFile, provider);
+                        convertResourceNav(file, outputFile, provider);
+                }
+                catch(Exception ex)
+                {
+                    errors.Add($"{exampleName}{ext}: " + ex.Message);
+                }
+            }
+
+            Debug.WriteLine("Done!");
+            return fileCount;
+        }
+
+        private static async Tasks.Task<int> convertFilesAsync(string inputPath, string outputPath, bool usingPoco, IStructureDefinitionSummaryProvider provider, List<string> errors)
+        {
+            int fileCount = 0;
+            var files = Directory.EnumerateFiles(inputPath);
+            if (!Directory.Exists(outputPath)) Directory.CreateDirectory(outputPath);
+
+            foreach (string file in files)
+            {
+                if (SkipFile(file))
+                    continue;
+                string exampleName = Path.GetFileNameWithoutExtension(file);
+                string ext = Path.GetExtension(file);
+                var toExt = ext == ".xml" ? ".json" : ".xml";
+                string outputFile = Path.Combine(outputPath, exampleName) + toExt;
+
+                Debug.WriteLine("Converting {0} [{1}->{2}] ", exampleName, ext, toExt);
+
+                if (file.Contains("expansions.") || file.Contains("profiles-resources") || file.Contains("profiles-others") || file.Contains("valuesets."))
+                    continue;
+
+                fileCount++;
+                try
+                {
+                    if (usingPoco)
+                        await convertResourcePocoAsync(file, outputFile);
+                    else
+                        await convertResourceNavAsync(file, outputFile, provider);
                 }
                 catch(Exception ex)
                 {
@@ -354,12 +490,36 @@ namespace Hl7.Fhir.Serialization.Tests
             }
         }
 
-
-        private static async Tasks.Task convertResourcePoco(string inputFile, string outputFile)
+        private static void convertResourcePoco(string inputFile, string outputFile)
         {
             if (inputFile.EndsWith(".xml"))
             {
                 var xml = File.ReadAllText(inputFile);
+                var resource = new FhirXmlParser(new ParserSettings { PermissiveParsing = true }).Parse<Resource>(xml);
+
+                var r2 = resource.DeepCopy();
+                Assert.IsTrue(resource.Matches(r2 as Resource), "Serialization of " + inputFile + " did not match output - Matches test");
+                Assert.IsTrue(resource.IsExactly(r2 as Resource), "Serialization of " + inputFile + " did not match output - IsExactly test");
+                Assert.IsFalse(resource.Matches(null), "Serialization of " + inputFile + " matched null - Matches test");
+                Assert.IsFalse(resource.IsExactly(null), "Serialization of " + inputFile + " matched null - IsExactly test");
+
+                var json = new FhirJsonSerializer().SerializeToString(resource);
+                File.WriteAllText(outputFile, json);
+            }
+            else
+            {
+                var json = File.ReadAllText(inputFile);
+                var resource = new FhirJsonParser(new ParserSettings { PermissiveParsing = true }).Parse<Resource>(json);
+                var xml = new FhirXmlSerializer().SerializeToString(resource);
+                File.WriteAllText(outputFile, xml);
+            }
+        }
+
+        private static async Tasks.Task convertResourcePocoAsync(string inputFile, string outputFile)
+        {
+            if (inputFile.EndsWith(".xml"))
+            {
+                var xml = await File.ReadAllTextAsync(inputFile);
                 var resource = await new FhirXmlParser(new ParserSettings { PermissiveParsing = true }).ParseAsync<Resource>(xml);
 
                 var r2 = resource.DeepCopy();
@@ -379,8 +539,27 @@ namespace Hl7.Fhir.Serialization.Tests
                 await File.WriteAllTextAsync(outputFile, xml);
             }
         }
+        
+        private static void convertResourceNav(string inputFile, string outputFile, IStructureDefinitionSummaryProvider provider)
+        {
+            if (inputFile.EndsWith(".xml"))
+            {
+                var xml = File.ReadAllText(inputFile);
+                var nav = XmlParsingHelpers.ParseToTypedElement(xml, provider, new FhirXmlParsingSettings { PermissiveParsing = true });
+                var json = nav.ToJson();
+                File.WriteAllText(outputFile, json);
+            }
+            else
+            {
+                var json = File.ReadAllText(inputFile);
+                var nav = JsonParsingHelpers.ParseToTypedElement(json, provider, 
+                    settings: new FhirJsonParsingSettings { AllowJsonComments = true, PermissiveParsing = true } );
+                var xml = nav.ToXml();
+                File.WriteAllText(outputFile, xml);
+            }
+        }
 
-        private static async Tasks.Task convertResourceNav(string inputFile, string outputFile, IStructureDefinitionSummaryProvider provider)
+        private static async Tasks.Task convertResourceNavAsync(string inputFile, string outputFile, IStructureDefinitionSummaryProvider provider)
         {
             if (inputFile.EndsWith(".xml"))
             {
@@ -392,7 +571,7 @@ namespace Hl7.Fhir.Serialization.Tests
             else
             {
                 var json = await File.ReadAllTextAsync(inputFile);
-                var nav = await JsonParsingHelpers.ParseToTypedElement(json, provider, 
+                var nav = await JsonParsingHelpers.ParseToTypedElementAsync(json, provider, 
                     settings: new FhirJsonParsingSettings { AllowJsonComments = true, PermissiveParsing = true } );
                 var xml = await nav.ToXmlAsync();
                 await File.WriteAllTextAsync(outputFile, xml);

--- a/src/Hl7.Fhir.Serialization.Tests/RoundtripTest.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/RoundtripTest.cs
@@ -16,6 +16,7 @@ using Hl7.Fhir.Specification.Source;
 using System.Collections.Generic;
 using System;
 using Hl7.Fhir.Tests;
+using Tasks = System.Threading.Tasks;
 #if NET40
 using ICSharpCode.SharpZipLib.Zip;
 using System.Linq;
@@ -28,51 +29,51 @@ namespace Hl7.Fhir.Serialization.Tests
     { 
         [TestMethod]
         [TestCategory("LongRunner")]
-        public void FullRoundtripOfAllExamplesXmlPoco()
+        public async Tasks.Task FullRoundtripOfAllExamplesXmlPoco()
         {
-            FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml", 
+            await FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml", 
                 "Roundtripping xml->json->xml", usingPoco: true, provider:null);
         }
 
         [TestMethod]
         [TestCategory("LongRunner")]
-        public void FullRoundtripOfAllExamplesJsonPoco()
+        public async Tasks.Task FullRoundtripOfAllExamplesJsonPoco()
         {
-            FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
+            await FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
                 "Roundtripping json->xml->json", usingPoco: true, provider: null);
         }
 
         [TestMethod]
         [TestCategory("LongRunner")]
-        public void FullRoundtripOfAllExamplesXmlNavPocoProvider()
+        public async Tasks.Task FullRoundtripOfAllExamplesXmlNavPocoProvider()
         {
-            FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml",
+            await FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml",
                 "Roundtripping xml->json->xml", usingPoco: false, provider: new PocoStructureDefinitionSummaryProvider());
         }
 
         [TestMethod]
         [TestCategory("LongRunner")]
-        public void FullRoundtripOfAllExamplesJsonNavPocoProvider()
+        public async Tasks.Task FullRoundtripOfAllExamplesJsonNavPocoProvider()
         {
-            FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
+            await FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
                 "Roundtripping json->xml->json", usingPoco: false, provider: new PocoStructureDefinitionSummaryProvider());
         }
 
         [TestMethod]
         [TestCategory("LongRunner")]
-        public void FullRoundtripOfAllExamplesXmlNavSdProvider()
+        public async Tasks.Task FullRoundtripOfAllExamplesXmlNavSdProvider()
         {
             var source = new CachedResolver(ZipSource.CreateValidationSource());
-            FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml",
+            await FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml",
                 "Roundtripping xml->json->xml", usingPoco: false, provider: new StructureDefinitionSummaryProvider(source));
         }
 
         [TestMethod]
         [TestCategory("LongRunner")]
-        public void FullRoundtripOfAllExamplesJsonNavSdProvider()
+        public async Tasks.Task FullRoundtripOfAllExamplesJsonNavSdProvider()
         {
             var source = new CachedResolver(ZipSource.CreateValidationSource());
-            FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
+            await FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
                 "Roundtripping json->xml->json", usingPoco: false, provider: new StructureDefinitionSummaryProvider(source));
         }
 
@@ -170,7 +171,7 @@ namespace Hl7.Fhir.Serialization.Tests
         }
 #endif
 
-        public static void FullRoundtripOfAllExamples(string zipname, string dirname, string label, bool usingPoco, IStructureDefinitionSummaryProvider provider)
+        public static async Tasks.Task FullRoundtripOfAllExamples(string zipname, string dirname, string label, bool usingPoco, IStructureDefinitionSummaryProvider provider)
         {
             ZipArchive examples = ReadTestZip(zipname);
 
@@ -180,7 +181,7 @@ namespace Hl7.Fhir.Serialization.Tests
 
             Debug.WriteLine(label);
             createEmptyDir(baseTestPath);
-            doRoundTrip(examples, baseTestPath, usingPoco, provider);
+            await doRoundTrip(examples, baseTestPath, usingPoco, provider);
         }
 
 
@@ -210,7 +211,7 @@ namespace Hl7.Fhir.Serialization.Tests
             Directory.CreateDirectory(baseTestPath);
         }
 
-        private static void doRoundTrip(ZipArchive examplesZip, string baseTestPath, bool usingPoco, IStructureDefinitionSummaryProvider provider)
+        private static async Tasks.Task doRoundTrip(ZipArchive examplesZip, string baseTestPath, bool usingPoco, IStructureDefinitionSummaryProvider provider)
         {
             var examplePath = Path.Combine(baseTestPath, "input");
             Directory.CreateDirectory(examplePath);
@@ -224,7 +225,7 @@ namespace Hl7.Fhir.Serialization.Tests
             Debug.WriteLine("Converting files in {0} to {1}", baseTestPath, intermediate1Path);
             var sw = new Stopwatch();
             sw.Start();
-            int convertedFileCount = convertFiles(examplePath, intermediate1Path, usingPoco, provider, errors);
+            int convertedFileCount = await convertFiles(examplePath, intermediate1Path, usingPoco, provider, errors);
             sw.Stop();
             Debug.WriteLine("Conversion took {0} seconds", sw.ElapsedMilliseconds / 1000);
             sw.Reset();
@@ -232,7 +233,7 @@ namespace Hl7.Fhir.Serialization.Tests
             var intermediate2Path = Path.Combine(baseTestPath, "intermediate2");
             Debug.WriteLine("Re-converting files in {0} back to original format in {1}", intermediate1Path, intermediate2Path);
             sw.Start();
-            convertFiles(intermediate1Path, intermediate2Path, usingPoco, provider, errors);
+            await convertFiles(intermediate1Path, intermediate2Path, usingPoco, provider, errors);
             sw.Stop();
             Console.WriteLine("Conversion of {1} files took {0} seconds", sw.ElapsedMilliseconds / 1000, convertedFileCount);
             sw.Reset();
@@ -272,7 +273,7 @@ namespace Hl7.Fhir.Serialization.Tests
             return false;
         }
 
-        private static int convertFiles(string inputPath, string outputPath, bool usingPoco, IStructureDefinitionSummaryProvider provider, List<string> errors)
+        private static async Tasks.Task<int> convertFiles(string inputPath, string outputPath, bool usingPoco, IStructureDefinitionSummaryProvider provider, List<string> errors)
         {
             int fileCount = 0;
             var files = Directory.EnumerateFiles(inputPath);
@@ -296,9 +297,9 @@ namespace Hl7.Fhir.Serialization.Tests
                 try
                 {
                     if (usingPoco)
-                        convertResourcePoco(file, outputFile);
+                        await convertResourcePoco(file, outputFile);
                     else
-                        convertResourceNav(file, outputFile, provider);
+                        await convertResourceNav(file, outputFile, provider);
                 }
                 catch(Exception ex)
                 {
@@ -354,7 +355,7 @@ namespace Hl7.Fhir.Serialization.Tests
         }
 
 
-        private static void convertResourcePoco(string inputFile, string outputFile)
+        private static async Tasks.Task convertResourcePoco(string inputFile, string outputFile)
         {
             if (inputFile.EndsWith(".xml"))
             {
@@ -368,33 +369,33 @@ namespace Hl7.Fhir.Serialization.Tests
                 Assert.IsFalse(resource.IsExactly(null), "Serialization of " + inputFile + " matched null - IsExactly test");
 
                 var json = new FhirJsonSerializer().SerializeToString(resource);
-                File.WriteAllText(outputFile, json);
+                await File.WriteAllTextAsync(outputFile, json);
             }
             else
             {
                 var json = File.ReadAllText(inputFile);
-                var resource = new FhirJsonParser(new ParserSettings { PermissiveParsing = true }).Parse<Resource>(json);
+                var resource = await new FhirJsonParser(new ParserSettings { PermissiveParsing = true }).ParseAsync<Resource>(json);
                 var xml = new FhirXmlSerializer().SerializeToString(resource);
-                File.WriteAllText(outputFile, xml);
+                await File.WriteAllTextAsync(outputFile, xml);
             }
         }
 
-        private static void convertResourceNav(string inputFile, string outputFile, IStructureDefinitionSummaryProvider provider)
+        private static async Tasks.Task convertResourceNav(string inputFile, string outputFile, IStructureDefinitionSummaryProvider provider)
         {
             if (inputFile.EndsWith(".xml"))
             {
-                var xml = File.ReadAllText(inputFile);
+                var xml = await File.ReadAllTextAsync(inputFile);
                 var nav = XmlParsingHelpers.ParseToTypedElement(xml, provider, new FhirXmlParsingSettings { PermissiveParsing = true });
                 var json = nav.ToJson();
-                File.WriteAllText(outputFile, json);
+                await File.WriteAllTextAsync(outputFile, json);
             }
             else
             {
-                var json = File.ReadAllText(inputFile);
-                var nav = JsonParsingHelpers.ParseToTypedElement(json, provider, 
+                var json = await File.ReadAllTextAsync(inputFile);
+                var nav = await JsonParsingHelpers.ParseToTypedElement(json, provider, 
                     settings: new FhirJsonParsingSettings { AllowJsonComments = true, PermissiveParsing = true } );
-                var xml = nav.ToXml();
-                File.WriteAllText(outputFile, xml);
+                var xml = await nav.ToXmlAsync();
+                await File.WriteAllTextAsync(outputFile, xml);
             }
         }
 

--- a/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientJson.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientJson.cs
@@ -24,7 +24,7 @@ namespace Hl7.Fhir.Serialization.Tests
             var json = await File.ReadAllTextAsync(Path.Combine("TestData", "fp-test-patient.json"));
 
             var nav = await getJsonElement(json);
-            var output = nav.ToJson();
+            var output = await nav.ToJsonAsync();
 
             List<string> errors = new List<string>();
             JsonAssert.AreSame(@"TestData\fp-test-patient.json", json, output, errors);
@@ -40,7 +40,7 @@ namespace Hl7.Fhir.Serialization.Tests
             // Make sure permissive parsing is on - otherwise the parser will complain about all those empty nodes
             var nav = await getJsonElement(tp, new FhirJsonParsingSettings { PermissiveParsing = true });
 
-            var output = nav.ToJson();
+            var output = await nav.ToJsonAsync();
             var doc = JObject.Parse(output);
             Assert.AreEqual(17, doc.DescendantsAndSelf().Count());
         }
@@ -53,7 +53,7 @@ namespace Hl7.Fhir.Serialization.Tests
             var pser = new FhirJsonParser(new ParserSettings { DisallowXsiAttributesOnRoot = false } );
             var pat = await pser.ParseAsync<Patient>(tp);
 
-            var output = pat.ToJson();
+            var output = await pat.ToJsonAsync();
 
             List<string> errors = new List<string>();
             JsonAssert.AreSame(@"TestData\fp-test-patient.json", tp, output, errors);
@@ -67,15 +67,15 @@ namespace Hl7.Fhir.Serialization.Tests
             var json = await File.ReadAllTextAsync(Path.Combine("TestData", "fp-test-patient.json"));
 
             var nav = await getJsonElement(json);
-            var output = nav.ToJson();
+            var output = await nav.ToJsonAsync();
             Assert.IsFalse(output.Substring(0, 20).Contains('\n'));
-            var pretty = nav.ToJson(new FhirJsonSerializationSettings { Pretty = true });
+            var pretty = await nav.ToJsonAsync(new FhirJsonSerializationSettings { Pretty = true });
             Assert.IsTrue(pretty.Substring(0, 20).Contains('\n'));
 
             var p = await new FhirJsonParser().ParseAsync<Patient>(json);
-            output = (new FhirJsonSerializer(new SerializerSettings { Pretty = false })).SerializeToString(p);
+            output = await (new FhirJsonSerializer(new SerializerSettings { Pretty = false })).SerializeToStringAsync(p);
             Assert.IsFalse(output.Substring(0, 20).Contains('\n'));
-            pretty = (new FhirJsonSerializer(new SerializerSettings { Pretty = true, AppendNewLine = true })).SerializeToString(p);
+            pretty = await (new FhirJsonSerializer(new SerializerSettings { Pretty = true, AppendNewLine = true })).SerializeToStringAsync(p);
             Assert.IsTrue(pretty.Substring(0, 20).Contains('\n'));
         }
 
@@ -85,18 +85,18 @@ namespace Hl7.Fhir.Serialization.Tests
             var json = await File.ReadAllTextAsync(Path.Combine("TestData", "fp-test-patient.json"));
 
             var nav = await getJsonElement(json);
-            var output = nav.ToJson();
+            var output = await nav.ToJsonAsync();
             Assert.IsFalse(output.Contains('\n'));
-            var pretty = nav.ToJson(new FhirJsonSerializationSettings { Pretty = true });
+            var pretty = await nav.ToJsonAsync(new FhirJsonSerializationSettings { Pretty = true });
             Assert.IsTrue(pretty.Contains('\n'));
             var lastLine = pretty.Split('\n').Last();
             Assert.IsFalse(string.IsNullOrEmpty(lastLine));
 
             var p = await new FhirJsonParser().ParseAsync<Patient>(json);
-            output = (new FhirJsonSerializer(new SerializerSettings { Pretty = false, AppendNewLine = true })).SerializeToString(p);
+            output = await (new FhirJsonSerializer(new SerializerSettings { Pretty = false, AppendNewLine = true })).SerializeToStringAsync(p);
             lastLine = output.Split('\n').Last();
             Assert.IsTrue(string.IsNullOrEmpty(lastLine));
-            pretty = (new FhirJsonSerializer(new SerializerSettings { Pretty = true, AppendNewLine = true })).SerializeToString(p);
+            pretty = await (new FhirJsonSerializer(new SerializerSettings { Pretty = true, AppendNewLine = true })).SerializeToStringAsync(p);
             lastLine = pretty.Split('\n').Last();
             Assert.IsTrue(string.IsNullOrEmpty(lastLine));
         }

--- a/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientJson.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientJson.cs
@@ -16,7 +16,7 @@ namespace Hl7.Fhir.Serialization.Tests
     public class SerializeDemoPatientJson
     {
         public async Tasks.Task<ITypedElement> getJsonElement(string json, FhirJsonParsingSettings s = null) => 
-            await JsonParsingHelpers.ParseToTypedElement(json, new PocoStructureDefinitionSummaryProvider(), settings: s);
+            await JsonParsingHelpers.ParseToTypedElementAsync(json, new PocoStructureDefinitionSummaryProvider(), settings: s);
 
         [TestMethod]
         public async Tasks.Task CanSerializeThroughNavigatorAndCompare()

--- a/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientXml.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientXml.cs
@@ -16,7 +16,7 @@ namespace Hl7.Fhir.Serialization.Tests
         public ITypedElement getXmlElement(string xml, FhirXmlParsingSettings s = null) =>
             XmlParsingHelpers.ParseToTypedElement(xml, new PocoStructureDefinitionSummaryProvider(), s);
         public async Tasks.Task<ITypedElement> getJsonElement(string json, FhirJsonParsingSettings s = null) =>
-            await JsonParsingHelpers.ParseToTypedElement(json, new PocoStructureDefinitionSummaryProvider(), settings: s);
+            await JsonParsingHelpers.ParseToTypedElementAsync(json, new PocoStructureDefinitionSummaryProvider(), settings: s);
 
 
         [TestMethod]

--- a/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientXml.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientXml.cs
@@ -59,7 +59,7 @@ namespace Hl7.Fhir.Serialization.Tests
         {
             var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var pser = new FhirXmlParser(new ParserSettings { DisallowXsiAttributesOnRoot = false });
-            var pat = pser.Parse<Patient>(tpXml);
+            var pat = await pser.ParseAsync<Patient>(tpXml);
 
             var nav = pat.ToTypedElement();
             var output = await nav.ToXmlAsync();
@@ -74,7 +74,7 @@ namespace Hl7.Fhir.Serialization.Tests
             // If on a Unix platform replace \\r\\n in json strings to \\n.
             if(Environment.NewLine == "\n")
                 tpJson = tpJson.Replace(@"\r\n", @"\n");
-            var pat = (new FhirXmlParser()).Parse<Patient>(tpXml);
+            var pat = await (new FhirXmlParser()).ParseAsync<Patient>(tpXml);
 
             var navXml = getXmlElement(tpXml);
             var navJson = await getJsonElement(tpJson);
@@ -106,7 +106,7 @@ namespace Hl7.Fhir.Serialization.Tests
             var pretty = await nav.ToXmlAsync(new FhirXmlSerializationSettings { Pretty = true });
             Assert.IsTrue(pretty.Substring(0, 50).Contains('\n'));
 
-            var p = (new FhirXmlParser()).Parse<Patient>(xml);
+            var p = await (new FhirXmlParser()).ParseAsync<Patient>(xml);
             output = await (new FhirXmlSerializer(new SerializerSettings { Pretty = false })).SerializeToStringAsync(p);
             Assert.IsFalse(output.Substring(0, 50).Contains('\n'));
             pretty = await (new FhirXmlSerializer(new SerializerSettings { Pretty = true })).SerializeToStringAsync(p);
@@ -126,7 +126,7 @@ namespace Hl7.Fhir.Serialization.Tests
             var lastLine = pretty.Split('\n').Last();
             Assert.IsFalse(string.IsNullOrEmpty(lastLine));
 
-            var p = (new FhirXmlParser()).Parse<Patient>(xml);
+            var p = await (new FhirXmlParser()).ParseAsync<Patient>(xml);
             output = await (new FhirXmlSerializer(new SerializerSettings { Pretty = false, AppendNewLine = true })).SerializeToStringAsync(p);
             lastLine = output.Split('\n').Last();
             Assert.IsTrue(string.IsNullOrEmpty(lastLine));

--- a/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientXml.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientXml.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
 using System.Linq;
+using Tasks = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Serialization.Tests
 {
@@ -14,16 +15,16 @@ namespace Hl7.Fhir.Serialization.Tests
     {
         public ITypedElement getXmlElement(string xml, FhirXmlParsingSettings s = null) =>
             XmlParsingHelpers.ParseToTypedElement(xml, new PocoStructureDefinitionSummaryProvider(), s);
-        public ITypedElement getJsonElement(string json, FhirJsonParsingSettings s = null) =>
-            JsonParsingHelpers.ParseToTypedElement(json, new PocoStructureDefinitionSummaryProvider(), settings: s);
+        public async Tasks.Task<ITypedElement> getJsonElement(string json, FhirJsonParsingSettings s = null) =>
+            await JsonParsingHelpers.ParseToTypedElement(json, new PocoStructureDefinitionSummaryProvider(), settings: s);
 
 
         [TestMethod]
-        public void CanSerializeThroughNavigatorAndCompare()
+        public async Tasks.Task CanSerializeThroughNavigatorAndCompare()
         {
             var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var nav = getXmlElement(tpXml);
-            var output = nav.ToXml();
+            var output = await nav.ToXmlAsync();
             XmlAssert.AreSame("fp-test-patient.xml", tpXml, output, ignoreSchemaLocation: true);
         }
 
@@ -54,29 +55,29 @@ namespace Hl7.Fhir.Serialization.Tests
         }
 
         [TestMethod]
-        public void CanSerializeFromPoco()
+        public async Tasks.Task CanSerializeFromPoco()
         {
             var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var pser = new FhirXmlParser(new ParserSettings { DisallowXsiAttributesOnRoot = false });
             var pat = pser.Parse<Patient>(tpXml);
 
             var nav = pat.ToTypedElement();
-            var output = nav.ToXml();
+            var output = await nav.ToXmlAsync();
             XmlAssert.AreSame("fp-test-patient.xml", tpXml, output, ignoreSchemaLocation: true);
         }
 
         [TestMethod]
-        public void CompareSubtrees()
+        public async Tasks.Task CompareSubtrees()
         {
-            var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
-            var tpJson = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
+            var tpXml = await File.ReadAllTextAsync(Path.Combine("TestData", "fp-test-patient.xml"));
+            var tpJson = await File.ReadAllTextAsync(Path.Combine("TestData", "fp-test-patient.json"));
             // If on a Unix platform replace \\r\\n in json strings to \\n.
             if(Environment.NewLine == "\n")
                 tpJson = tpJson.Replace(@"\r\n", @"\n");
             var pat = (new FhirXmlParser()).Parse<Patient>(tpXml);
 
             var navXml = getXmlElement(tpXml);
-            var navJson = getJsonElement(tpJson);
+            var navJson = await getJsonElement(tpJson);
             var navPoco = pat.ToTypedElement();
             assertAreAllEqual(navXml, navJson, navPoco);
 
@@ -95,14 +96,14 @@ namespace Hl7.Fhir.Serialization.Tests
         }
 
         [TestMethod]
-        public void DoesPretty()
+        public async Tasks.Task DoesPretty()
         {
             var xml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
 
             var nav = getXmlElement(xml);
-            var output = nav.ToXml();
+            var output = await nav.ToXmlAsync();
             Assert.IsFalse(output.Substring(0, 50).Contains('\n'));
-            var pretty = nav.ToXml(new FhirXmlSerializationSettings { Pretty = true });
+            var pretty = await nav.ToXmlAsync(new FhirXmlSerializationSettings { Pretty = true });
             Assert.IsTrue(pretty.Substring(0, 50).Contains('\n'));
 
             var p = (new FhirXmlParser()).Parse<Patient>(xml);
@@ -113,14 +114,14 @@ namespace Hl7.Fhir.Serialization.Tests
         }
 
         [TestMethod]
-        public void TestAppendNewLine()
+        public async Tasks.Task TestAppendNewLine()
         {
             var xml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
 
             var nav = getXmlElement(xml);
-            var output = nav.ToXml();
+            var output = await nav.ToXmlAsync();
             Assert.IsFalse(output.Substring(0, 50).Contains('\n'));
-            var pretty = nav.ToXml(new FhirXmlSerializationSettings { Pretty = true });
+            var pretty = await nav.ToXmlAsync(new FhirXmlSerializationSettings { Pretty = true });
             Assert.IsTrue(pretty.Substring(0, 50).Contains('\n'));
             var lastLine = pretty.Split('\n').Last();
             Assert.IsFalse(string.IsNullOrEmpty(lastLine));

--- a/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientXml.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SerializeDemoPatientXml.cs
@@ -107,9 +107,9 @@ namespace Hl7.Fhir.Serialization.Tests
             Assert.IsTrue(pretty.Substring(0, 50).Contains('\n'));
 
             var p = (new FhirXmlParser()).Parse<Patient>(xml);
-            output = (new FhirXmlSerializer(new SerializerSettings { Pretty = false })).SerializeToString(p);
+            output = await (new FhirXmlSerializer(new SerializerSettings { Pretty = false })).SerializeToStringAsync(p);
             Assert.IsFalse(output.Substring(0, 50).Contains('\n'));
-            pretty = (new FhirXmlSerializer(new SerializerSettings { Pretty = true })).SerializeToString(p);
+            pretty = await (new FhirXmlSerializer(new SerializerSettings { Pretty = true })).SerializeToStringAsync(p);
             Assert.IsTrue(pretty.Substring(0, 50).Contains('\n'));
         }
 
@@ -127,10 +127,10 @@ namespace Hl7.Fhir.Serialization.Tests
             Assert.IsFalse(string.IsNullOrEmpty(lastLine));
 
             var p = (new FhirXmlParser()).Parse<Patient>(xml);
-            output = (new FhirXmlSerializer(new SerializerSettings { Pretty = false, AppendNewLine = true })).SerializeToString(p);
+            output = await (new FhirXmlSerializer(new SerializerSettings { Pretty = false, AppendNewLine = true })).SerializeToStringAsync(p);
             lastLine = output.Split('\n').Last();
             Assert.IsTrue(string.IsNullOrEmpty(lastLine));
-            pretty = (new FhirXmlSerializer(new SerializerSettings { Pretty = true, AppendNewLine = true })).SerializeToString(p);
+            pretty = await (new FhirXmlSerializer(new SerializerSettings { Pretty = true, AppendNewLine = true })).SerializeToStringAsync(p);
             lastLine = pretty.Split('\n').Last();
             Assert.IsTrue(string.IsNullOrEmpty(lastLine));
         }

--- a/src/Hl7.Fhir.Serialization.Tests/SerializePartialTree.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SerializePartialTree.cs
@@ -38,7 +38,7 @@ namespace Hl7.Fhir.Serialization.Tests
             // If on a Unix platform replace \\r\\n in json strings to \\n.
             if(Environment.NewLine == "\n")
                 tpJson = tpJson.Replace(@"\r\n", @"\n");
-            var pat = (new FhirXmlParser()).Parse<Patient>(tpXml);
+            var pat = await (new FhirXmlParser()).ParseAsync<Patient>(tpXml);
 
             // Should work on the parent resource
             var navXml = getXmlNode(tpXml);

--- a/src/Hl7.Fhir.Serialization.Tests/SerializePartialTree.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SerializePartialTree.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
 using System.Linq;
+using Tasks = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Serialization.Tests
 {
@@ -15,8 +16,8 @@ namespace Hl7.Fhir.Serialization.Tests
     {
         public ITypedElement getXmlNode(string xml, FhirXmlParsingSettings s = null) =>
             XmlParsingHelpers.ParseToTypedElement(xml, new PocoStructureDefinitionSummaryProvider(), s);
-        public ITypedElement getJsonNode(string json, FhirJsonParsingSettings s = null) =>
-            JsonParsingHelpers.ParseToTypedElement(json, new PocoStructureDefinitionSummaryProvider(), settings: s);
+        public async Tasks.Task<ITypedElement> getJsonNode(string json, FhirJsonParsingSettings s = null) =>
+            await JsonParsingHelpers.ParseToTypedElement(json, new PocoStructureDefinitionSummaryProvider(), settings: s);
 
         [TestMethod]
         public void DeterminePocoInstanceTypeWithRedirect()
@@ -30,7 +31,7 @@ namespace Hl7.Fhir.Serialization.Tests
         }
 
         [TestMethod]
-        public void CanSerializeSubtree()
+        public async Tasks.Task CanSerializeSubtree()
         {
             var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var tpJson = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.json"));
@@ -41,15 +42,15 @@ namespace Hl7.Fhir.Serialization.Tests
 
             // Should work on the parent resource
             var navXml = getXmlNode(tpXml);
-            var navJson = getJsonNode(tpJson);
+            var navJson = await getJsonNode(tpJson);
             var navPoco = pat.ToTypedElement();
-            testSubtree(navXml, navJson, navPoco);
+            await testSubtree(navXml, navJson, navPoco);
 
             // An on a child that's a normal datatype
             var subnavXml = navXml.Children("photo").First();
             var subnavJson = navJson.Children("photo").First();
             var subnavPoco = navPoco.Children("photo").First();
-            testSubtree(subnavXml, subnavJson, subnavPoco);
+            await testSubtree(subnavXml, subnavJson, subnavPoco);
 
             // And on a child that's a primitive datatype
             //subnavXml = navXml.Children("id").First();
@@ -61,23 +62,23 @@ namespace Hl7.Fhir.Serialization.Tests
             subnavXml = navXml.Children("contained").First();
             subnavJson = navJson.Children("contained").First();
             subnavPoco = navPoco.Children("contained").First();
-            testSubtree(subnavXml, subnavJson, subnavPoco);
+            await testSubtree(subnavXml, subnavJson, subnavPoco);
 
             // And on a child of the contained resource
             subnavXml = navXml.Children("contained").First().Children("name").First();
             subnavJson = navJson.Children("contained").First().Children("name").First();
             subnavPoco = navPoco.Children("contained").First().Children("name").First();
-            testSubtree(subnavXml, subnavJson, subnavPoco);
+            await testSubtree(subnavXml, subnavJson, subnavPoco);
         }
 
-        private void testSubtree(ITypedElement navXml, ITypedElement navJson, ITypedElement navPoco)
+        private async Tasks.Task testSubtree(ITypedElement navXml, ITypedElement navJson, ITypedElement navPoco)
         {
             assertAreNavsEqual(navXml, navJson, navPoco);
 
-            var navRtXml = JsonParsingHelpers.ParseToTypedElement(navXml.ToJson(), navXml.InstanceType,
+            var navRtXml = await JsonParsingHelpers.ParseToTypedElement(navXml.ToJson(), navXml.InstanceType,
                 new PocoStructureDefinitionSummaryProvider(), navXml.Name);
             var navRtJson = navJson.ToPoco().ToTypedElement(navJson.Name);
-            var navRtPoco = XmlParsingHelpers.ParseToTypedElement(navPoco.ToXml(), navPoco.InstanceType,
+            var navRtPoco = XmlParsingHelpers.ParseToTypedElement(await navPoco.ToXmlAsync(), navPoco.InstanceType,
                 new PocoStructureDefinitionSummaryProvider());
             assertAreNavsEqual(navRtXml, navRtJson, navRtPoco);
         }
@@ -93,23 +94,23 @@ namespace Hl7.Fhir.Serialization.Tests
 
     internal static class JsonParsingHelpers
     {
-        internal static ITypedElement ParseToTypedElement(string json, IStructureDefinitionSummaryProvider provider, string rootName = null,
+        internal static async Tasks.Task<ITypedElement> ParseToTypedElement(string json, IStructureDefinitionSummaryProvider provider, string rootName = null,
     FhirJsonParsingSettings settings = null, TypedElementSettings tnSettings = null)
         {
             if (json == null) throw Error.ArgumentNull(nameof(json));
             if (provider == null) throw Error.ArgumentNull(nameof(provider));
 
-            return FhirJsonNode.Parse(json, rootName, settings).ToTypedElement(provider, null, tnSettings);
+            return (await FhirJsonNode.ParseAsync(json, rootName, settings)).ToTypedElement(provider, null, tnSettings);
         }
 
-        internal static ITypedElement ParseToTypedElement(string json, string type, IStructureDefinitionSummaryProvider provider, string rootName = null,
+        internal static async Tasks.Task<ITypedElement> ParseToTypedElement(string json, string type, IStructureDefinitionSummaryProvider provider, string rootName = null,
             FhirJsonParsingSettings settings = null, TypedElementSettings tnSettings = null)
         {
             if (json == null) throw Error.ArgumentNull(nameof(json));
             if (type == null) throw Error.ArgumentNull(nameof(type));
             if (provider == null) throw Error.ArgumentNull(nameof(provider));
 
-            return FhirJsonNode.Parse(json, rootName, settings).ToTypedElement(provider, type, tnSettings);
+            return (await FhirJsonNode.ParseAsync(json, rootName, settings)).ToTypedElement(provider, type, tnSettings);
         }
     }
 

--- a/src/Hl7.Fhir.Serialization.Tests/SerializePartialTree.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SerializePartialTree.cs
@@ -17,7 +17,7 @@ namespace Hl7.Fhir.Serialization.Tests
         public ITypedElement getXmlNode(string xml, FhirXmlParsingSettings s = null) =>
             XmlParsingHelpers.ParseToTypedElement(xml, new PocoStructureDefinitionSummaryProvider(), s);
         public async Tasks.Task<ITypedElement> getJsonNode(string json, FhirJsonParsingSettings s = null) =>
-            await JsonParsingHelpers.ParseToTypedElement(json, new PocoStructureDefinitionSummaryProvider(), settings: s);
+            await JsonParsingHelpers.ParseToTypedElementAsync(json, new PocoStructureDefinitionSummaryProvider(), settings: s);
 
         [TestMethod]
         public void DeterminePocoInstanceTypeWithRedirect()
@@ -94,8 +94,17 @@ namespace Hl7.Fhir.Serialization.Tests
 
     internal static class JsonParsingHelpers
     {
-        internal static async Tasks.Task<ITypedElement> ParseToTypedElement(string json, IStructureDefinitionSummaryProvider provider, string rootName = null,
-    FhirJsonParsingSettings settings = null, TypedElementSettings tnSettings = null)
+        internal static ITypedElement ParseToTypedElement(string json, IStructureDefinitionSummaryProvider provider, string rootName = null,
+            FhirJsonParsingSettings settings = null, TypedElementSettings tnSettings = null)
+        {
+            if (json == null) throw Error.ArgumentNull(nameof(json));
+            if (provider == null) throw Error.ArgumentNull(nameof(provider));
+
+            return FhirJsonNode.Parse(json, rootName, settings).ToTypedElement(provider, null, tnSettings);
+        }
+        
+        internal static async Tasks.Task<ITypedElement> ParseToTypedElementAsync(string json, IStructureDefinitionSummaryProvider provider, string rootName = null,
+            FhirJsonParsingSettings settings = null, TypedElementSettings tnSettings = null)
         {
             if (json == null) throw Error.ArgumentNull(nameof(json));
             if (provider == null) throw Error.ArgumentNull(nameof(provider));

--- a/src/Hl7.Fhir.Serialization.Tests/SerializePartialTree.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SerializePartialTree.cs
@@ -75,7 +75,7 @@ namespace Hl7.Fhir.Serialization.Tests
         {
             assertAreNavsEqual(navXml, navJson, navPoco);
 
-            var navRtXml = await JsonParsingHelpers.ParseToTypedElement(navXml.ToJson(), navXml.InstanceType,
+            var navRtXml = await JsonParsingHelpers.ParseToTypedElement(await navXml.ToJsonAsync(), navXml.InstanceType,
                 new PocoStructureDefinitionSummaryProvider(), navXml.Name);
             var navRtJson = navJson.ToPoco().ToTypedElement(navJson.Name);
             var navRtPoco = XmlParsingHelpers.ParseToTypedElement(await navPoco.ToXmlAsync(), navPoco.InstanceType,

--- a/src/Hl7.Fhir.Serialization.Tests/SummaryTests.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/SummaryTests.cs
@@ -4,6 +4,7 @@ using Hl7.Fhir.Specification.Source;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 
 namespace Hl7.Fhir.Serialization.Tests
@@ -15,7 +16,7 @@ namespace Hl7.Fhir.Serialization.Tests
             XmlParsingHelpers.ParseToTypedElement(xml, new PocoStructureDefinitionSummaryProvider(), s);
         
         [TestMethod]
-        public void Summary()
+        public async Task Summary()
         {
             var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var typeinfo = new PocoStructureDefinitionSummaryProvider().Provide("Patient");
@@ -23,7 +24,7 @@ namespace Hl7.Fhir.Serialization.Tests
 
             var nav = new ScopedNode(getXmlNode(tpXml));
             var masker = MaskingNode.ForSummary(nav);
-            var output = masker.ToXml();
+            var output = await masker.ToXmlAsync();
 
             var maskedChildren = masker.Children().ToList();
             Assert.IsTrue(maskedChildren.Count < inSummary.Count);
@@ -31,14 +32,14 @@ namespace Hl7.Fhir.Serialization.Tests
         }
 
         [TestMethod]
-        public void SummaryText()
+        public async Task SummaryText()
         {
             var tpXml = File.ReadAllText(Path.Combine("TestData", "mask-text.xml"));
             var typeinfo = new PocoStructureDefinitionSummaryProvider().Provide("ValueSet");
 
             var nav = new ScopedNode(getXmlNode(tpXml));
             var masker = MaskingNode.ForText(nav);
-            var output = masker.ToXml();
+            var output = await masker.ToXmlAsync();
 
             var m = masker.Descendants().ToList();
             var maskedChildren = masker.Descendants().Count();
@@ -46,14 +47,14 @@ namespace Hl7.Fhir.Serialization.Tests
         }
 
         [TestMethod]
-        public void SummaryData()
+        public async Task SummaryData()
         {
             var tpXml = File.ReadAllText(Path.Combine("TestData", "mask-text.xml"));
             var typeinfo = new PocoStructureDefinitionSummaryProvider().Provide("ValueSet");
 
             var nav = new ScopedNode(getXmlNode(tpXml));
             var masker = MaskingNode.ForData(nav);
-            var output = masker.ToXml();
+            var output = await masker.ToXmlAsync();
 
             var maskedChildren = masker.Descendants().Count();
             Assert.AreEqual(nav.Descendants().Count()-3 , maskedChildren);

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -1058,8 +1058,8 @@ namespace Hl7.Fhir.Specification.Tests
             // {
             var tempPath = Path.GetTempPath();
             var xmlSer = new FhirXmlSerializer();
-            File.WriteAllText(Path.Combine(tempPath, "snapshotgen-source.xml"), xmlSer.SerializeToString(original));
-            File.WriteAllText(Path.Combine(tempPath, "snapshotgen-dest.xml"), xmlSer.SerializeToString(expanded));
+            await File.WriteAllTextAsync(Path.Combine(tempPath, "snapshotgen-source.xml"), await xmlSer.SerializeToStringAsync(original));
+            await File.WriteAllTextAsync(Path.Combine(tempPath, "snapshotgen-dest.xml"), await xmlSer.SerializeToStringAsync(expanded));
             // }
 
             // Assert.IsTrue(areEqual);

--- a/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSourceTests.cs
@@ -433,7 +433,7 @@ namespace Hl7.Fhir.Specification.Tests
         // https://github.com/FirelyTeam/firely-net-sdk/issues/875
 
         [TestMethod]
-        public void OpenDuplicateFileNames()
+        public async T.Task OpenDuplicateFileNames()
         {
             var testPath = prepareExampleDirectory(out int _);
 
@@ -469,7 +469,7 @@ namespace Hl7.Fhir.Specification.Tests
             var dupId = res.Id;
             var rootId = Guid.NewGuid().ToString();
             res.Id = rootId;
-            _ = new FhirXmlSerializer().SerializeToString(res);
+            _ = await new FhirXmlSerializer().SerializeToStringAsync(res);
 
             var dupFilePath = Path.Combine(fullSubFolderPath, srcFile);
             Assert.IsTrue(File.Exists(dupFilePath));

--- a/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ArtifactSourceTests.cs
@@ -451,11 +451,11 @@ namespace Hl7.Fhir.Specification.Tests
 
             var dirSource = new DirectorySource(testPath, new DirectorySourceSettings() { IncludeSubDirectories = true });
 
-            Resource OpenStream(string filePath)
+            async T.Task<Resource> OpenStream(string filePath)
             {
                 using (var stream = dirSource.LoadArtifactByName(filePath))
                 {
-                    return new FhirXmlParser().Parse<Resource>(SerializationUtil.XmlReaderFromStream(stream));
+                    return await new FhirXmlParser().ParseAsync<Resource>(SerializationUtil.XmlReaderFromStream(stream));
                 }
             }
 
@@ -463,7 +463,7 @@ namespace Hl7.Fhir.Specification.Tests
 
             var rootFilePath = Path.Combine(testPath, srcFile);
             Assert.IsTrue(File.Exists(rootFilePath));
-            var res = OpenStream(rootFilePath);
+            var res = await OpenStream(rootFilePath);
             Assert.IsNotNull(res);
             // Modify the resource id and save back
             var dupId = res.Id;
@@ -473,7 +473,7 @@ namespace Hl7.Fhir.Specification.Tests
 
             var dupFilePath = Path.Combine(fullSubFolderPath, srcFile);
             Assert.IsTrue(File.Exists(dupFilePath));
-            res = OpenStream(dupFilePath);
+            res = await OpenStream(dupFilePath);
             Assert.IsNotNull(res);
             // Verify that we received the duplicate file from subfolder,
             // not the modified file in the root content directory
@@ -482,14 +482,14 @@ namespace Hl7.Fhir.Specification.Tests
 
             // Retrieve artifact by file name
             // Should return nearest match, i.e. from content directory
-            res = OpenStream(srcFile);
+            res = await OpenStream(srcFile);
             Assert.IsNotNull(res);
             Assert.AreEqual(dupId, res.Id);
 
             // Retrieve artifact by relative path
             // Should return duplicate from subfolder
             var relPath = Path.Combine(subFolderName, srcFile);
-            res = OpenStream(relPath);
+            res = await OpenStream(relPath);
             Assert.IsNotNull(res);
             Assert.AreEqual(dupId, res.Id);
         }

--- a/src/Hl7.Fhir.Specification.Tests/Source/ConformanceSourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ConformanceSourceTests.cs
@@ -451,12 +451,12 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [TestMethod]
-        public void TestRefreshAll() => TestRefresh(true);
+        public async T.Task TestRefreshAll() => await TestRefreshAsync(true);
 
         [TestMethod]
-        public void TestRefreshFile() => TestRefresh(false);
+        public async T.Task TestRefreshFile() => await TestRefreshAsync(false);
 
-        void TestRefresh(bool refreshAll)
+        async T.Task TestRefreshAsync(bool refreshAll)
         {
             // Create a temporary folder with a single artifact file
             const string srcFileName = "TestPatient.xml";
@@ -530,7 +530,7 @@ namespace Hl7.Fhir.Specification.Tests
                 Assert.AreEqual(patient.Id, "pat1");
                 patient.Id = "CHANGED";
                 var serializer = new FhirXmlSerializer();
-                var xml = serializer.SerializeToString(patient);
+                var xml = await serializer.SerializeToStringAsync(patient);
                 File.WriteAllText(tmpFilePath, xml);
 
                 // Verify that Refresh updates the summary information
@@ -552,7 +552,7 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [TestMethod]
-        public void TestParserSettings()
+        public async T.Task TestParserSettings()
         {
             // Create an invalid patient resource on disk
             var obs = new Observation()
@@ -561,7 +561,7 @@ namespace Hl7.Fhir.Specification.Tests
                 Comment = " " // Illegal empty value
             };
             var nav = obs.ToTypedElement();
-            var xml = nav.ToXml();
+            var xml = await nav.ToXmlAsync();
 
             var folderPath = Path.Combine(Path.GetTempPath(), "TestDirectorySource");
             var filePath = Path.Combine(folderPath, "TestPatient.xml");

--- a/src/Hl7.Fhir.Specification.Tests/Source/ResourceResolverTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ResourceResolverTests.cs
@@ -316,7 +316,7 @@ namespace Hl7.Fhir.Specification.Tests
 
         // [WMR 20160823] NEW - Verify FileDirectoryArtifactSource & ResolvingConflictException
         [TestMethod]
-        public void TestCanonicalUrlConflicts()
+        public async T.Task TestCanonicalUrlConflicts()
         {
             //const string srcFileName = "extension-definitions.xml";
             const string dupFileName = "diagnosticorder-reason-duplicate";
@@ -332,7 +332,7 @@ namespace Hl7.Fhir.Specification.Tests
             // Save back to disk to create a conflicting duplicate
             var b = new Bundle();
             b.AddResourceEntry(ext, url);
-            var xml = new FhirXmlSerializer().SerializeToString(b);
+            var xml = await new FhirXmlSerializer().SerializeToStringAsync(b);
             var filePath = Path.Combine(DirectorySource.SpecificationDirectory, dupFileName) + ".xml";
             var filePath2 = Path.Combine(DirectorySource.SpecificationDirectory, dupFileName) + "2.xml";
             File.WriteAllText(filePath, xml);

--- a/src/Hl7.Fhir.Specification.Tests/SpecificationTestDataVersionCheck.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SpecificationTestDataVersionCheck.cs
@@ -59,7 +59,7 @@ namespace Hl7.Fhir.Specification.Tests
                     if (new FileInfo(item).Extension == ".xml")
                     {
                         // Console.WriteLine($"    {item.Replace(path + "\\", "")}");
-                        resource = xmlParser.Parse<Resource>(content);
+                        resource = await xmlParser.ParseAsync<Resource>(content);
                     }
                     else if (new FileInfo(item).Extension == ".json")
                     {

--- a/src/Hl7.Fhir.Specification.Tests/SpecificationTestDataVersionCheck.cs
+++ b/src/Hl7.Fhir.Specification.Tests/SpecificationTestDataVersionCheck.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Xml;
+using Tasks = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Specification.Tests
 {
@@ -16,17 +17,17 @@ namespace Hl7.Fhir.Specification.Tests
     public class SpecificationTestDataVersionCheck
     {
         [TestMethod]
-        public void VerifyAllTestDataSpecification()
+        public async Tasks.Task VerifyAllTestDataSpecification()
         {
             string location = typeof(TestDataHelper).GetTypeInfo().Assembly.Location;
             var path = Path.GetDirectoryName(location) + "\\TestData";
             Console.WriteLine(path);
             List <string> issues = new List<string>();
-            ValidateFolder(path, path, issues);
+            await ValidateFolder(path, path, issues);
             Assert.AreEqual(0, issues.Count);
         }
 
-        private void ValidateFolder(string basePath, string path, List<string> issues)
+        private async Tasks.Task ValidateFolder(string basePath, string path, List<string> issues)
         {
             if (path.Contains("grahame-validation-examples"))
                 return;
@@ -63,7 +64,7 @@ namespace Hl7.Fhir.Specification.Tests
                     else if (new FileInfo(item).Extension == ".json")
                     {
                         // Console.WriteLine($"    {item.Replace(path + "\\", "")}");
-                        resource = jsonParser.Parse<Resource>(content);
+                        resource = await jsonParser.ParseAsync<Resource>(content);
                     }
                     else
                     {
@@ -79,7 +80,7 @@ namespace Hl7.Fhir.Specification.Tests
             }
             foreach (var item in Directory.EnumerateDirectories(path))
             {
-                ValidateFolder(basePath, item, issues);
+                await ValidateFolder(basePath, item, issues);
             }
         }
 

--- a/src/Hl7.Fhir.Specification.Tests/StructureDefinitionWalkerTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/StructureDefinitionWalkerTests.cs
@@ -122,7 +122,7 @@ namespace Hl7.Fhir.Specification.Tests
             nav.JumpToFirst("Patient.communication");
             nav.MoveToNextSlice();
 
-            var fortest = nav.StructureDefinition.ToXml();
+            var fortest = await nav.StructureDefinition.ToXmlAsync();
             var walker = new StructureDefinitionWalker(nav, _source);
 
             var elem = walker.Extension("http://hl7.org/fhir/StructureDefinition/patient-proficiency");

--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -978,13 +978,13 @@ namespace Hl7.Fhir.Specification.Tests
             // var source = new DirectorySource(Path.Combine("TestData", "validation"));
             // var res = source.ResolveByUri("Patient/pat1"); // cf. "Patient/Levin"
 
-            var jsonPatient = File.ReadAllText(Path.Combine("TestData", "validation", "patient-ck.json"));
+            var jsonPatient = await File.ReadAllTextAsync(Path.Combine("TestData", "validation", "patient-ck.json"));
             var parser = new FhirJsonParser();
-            var patient = parser.Parse<Patient>(jsonPatient);
+            var patient = await parser.ParseAsync<Patient>(jsonPatient);
             Assert.NotNull(patient);
 
-            var jsonOrganization = File.ReadAllText(Path.Combine("TestData", "validation", "organization-ck.json"));
-            var organization = parser.Parse<Organization>(jsonOrganization);
+            var jsonOrganization = await File.ReadAllTextAsync(Path.Combine("TestData", "validation", "organization-ck.json"));
+            var organization = await parser.ParseAsync<Organization>(jsonOrganization);
             Assert.NotNull(organization);
 
             var resources = new Resource[] { patient, organization };

--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -604,7 +604,7 @@ namespace Hl7.Fhir.Specification.Tests
         {
             var careplanXml = File.ReadAllText(Path.Combine("TestData", "validation", "careplan-example-integrated.xml"));
 
-            var careplan = (new FhirXmlParser()).Parse<CarePlan>(careplanXml);
+            var careplan =  await (new FhirXmlParser()).ParseAsync<CarePlan>(careplanXml);
             Assert.NotNull(careplan);
             var careplanSd = await _asyncSource.FindStructureDefinitionForCoreTypeAsync(FHIRAllTypes.CarePlan);
             var report = _validator.Validate(careplan, careplanSd);

--- a/src/Hl7.Fhir.Specification.Tests/Validation/CustomResourceValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/CustomResourceValidationTests.cs
@@ -21,13 +21,13 @@ namespace Hl7.Fhir.Specification.Tests.Validation
         public async T.Task CustomResourceCanBeValidated()
         {
             #region Read StructureDefinition for Custom Resource
-            var structureDefJson = File.ReadAllText(@"TestData\CustomBasic-StructureDefinition-R3.json");
-            var structureDefNode = FhirJsonNode.Parse(structureDefJson);
+            var structureDefJson = await File.ReadAllTextAsync(@"TestData\CustomBasic-StructureDefinition-R3.json");
+            var structureDefNode = await FhirJsonNode.ParseAsync(structureDefJson);
             var customBasicCanonical = structureDefNode.Children("url").First().Text;
             #endregion
 
             #region Create a Provider that knows this CustomBasic resource
-            var structureDef = new FhirJsonParser().Parse<StructureDefinition>(structureDefJson);
+            var structureDef = await new FhirJsonParser().ParseAsync<StructureDefinition>(structureDefJson);
             var snapShotGenerator = new SnapshotGenerator(ZipSource.CreateValidationSource());
             await snapShotGenerator.UpdateAsync(structureDef);
 
@@ -45,7 +45,7 @@ namespace Hl7.Fhir.Specification.Tests.Validation
 
             #region Validate Custom Resource
 
-            var customNode = FhirJsonNode.Parse(_custom1);
+            var customNode = await FhirJsonNode.ParseAsync(_custom1);
             var customTyped = customNode.ToTypedElement(provider);
             var typingErrors = customTyped.VisitAndCatch();
             Assert.Empty(typingErrors);
@@ -61,8 +61,8 @@ namespace Hl7.Fhir.Specification.Tests.Validation
         public async T.Task BundleWithCustomResourceCanBeValidated()
         {
             #region Read StructureDefinition for Custom Resource
-            var structureDefJson = File.ReadAllText(@"TestData\CustomBasic-StructureDefinition-R3.json");
-            var structureDefNode = FhirJsonNode.Parse(structureDefJson);
+            var structureDefJson = await File.ReadAllTextAsync(@"TestData\CustomBasic-StructureDefinition-R3.json");
+            var structureDefNode = await FhirJsonNode.ParseAsync(structureDefJson);
             var structureDef = structureDefNode.ToPoco<StructureDefinition>();
             var customBasicCanonical = structureDefNode.Children("url").First().Text;
             #endregion
@@ -86,7 +86,7 @@ namespace Hl7.Fhir.Specification.Tests.Validation
 
             #region Validate Bundle with Custom Resource
 
-            var customNode = FhirJsonNode.Parse(_bundleWithCustom1);
+            var customNode = await FhirJsonNode.ParseAsync(_bundleWithCustom1);
             var customTyped = customNode.ToTypedElement(provider);
             var typingErrors = customTyped.VisitAndCatch();
             Assert.Empty(typingErrors);

--- a/src/Hl7.Fhir.Specification.Tests/Validation/CustomResourceValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/CustomResourceValidationTests.cs
@@ -53,7 +53,7 @@ namespace Hl7.Fhir.Specification.Tests.Validation
             var validator = new Validator(new ValidationSettings() { ResourceResolver = customResolver, GenerateSnapshot = true, ResourceMapping = mapTypeName });
             var result = validator.Validate(customTyped);
 
-            Assert.True(result.Success, "Validation should be successful but was not. Outcome: " + result.ToJson());
+            Assert.True(result.Success, "Validation should be successful but was not. Outcome: " + await result.ToJsonAsync());
             #endregion
         }
 
@@ -94,7 +94,7 @@ namespace Hl7.Fhir.Specification.Tests.Validation
             var validator = new Validator(new ValidationSettings() { ResourceResolver = customResolver, GenerateSnapshot = true, ResourceMapping = mapTypeName });
             var result = validator.Validate(customTyped);
 
-            Assert.True(result.Success, "Validation should be successful but was not. Outcome: " + result.ToJson());
+            Assert.True(result.Success, "Validation should be successful but was not. Outcome: " + await result.ToJsonAsync());
             //CK: This is failing with message "The declared type of the element (Resource) is incompatible with that of the instance ('CustomBasic')"},"location":["Bundle.entry[0].resource[0]"]". 
             //Cause: the implementation of ModelInfo.IsInstanceTypeFor, called from ProfileAssertion.Validate, line 248 (and 255).
             #endregion

--- a/src/Hl7.Fhir.Specification.Tests/Validation/IssuesTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/IssuesTests.cs
@@ -3,6 +3,7 @@ using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Validation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Tasks = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Specification.Tests
 {
@@ -13,7 +14,7 @@ namespace Hl7.Fhir.Specification.Tests
         /// See https://github.com/FirelyTeam/firely-net-sdk/issues/474
         /// </summary>
         [TestMethod]
-        public void Issue474StartdateIs0001_01_01()
+        public async Tasks.Task Issue474StartdateIs0001_01_01()
         {
             var json = "{ \"resourceType\": \"Patient\", \"active\": true, \"contact\": [{\"organization\": {\"reference\": \"Organization/1\", \"display\": \"Walt Disney Corporation\" }, \"period\": { \"start\": \"0001-01-01\", \"end\": \"2018\" } } ],}";
 
@@ -24,7 +25,7 @@ namespace Hl7.Fhir.Specification.Tests
 
             var validator = new Validator(ctx);
 
-            var pat = new FhirJsonParser().Parse<Patient>(json);
+            var pat = await new FhirJsonParser().ParseAsync<Patient>(json);
 
             var report = validator.Validate(pat);
             Assert.IsTrue(report.Success);

--- a/src/Hl7.Fhir.Specification.Tests/Validation/ValidationManifestTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/ValidationManifestTest.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Tasks = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Specification.Tests
 {
@@ -42,17 +43,17 @@ namespace Hl7.Fhir.Specification.Tests
         [TestMethod]
         [DataTestMethod]
         [CustomDataSource]
-        public void TestValidationManifest(ValidationTestCase testCase)
+        public async Tasks.Task TestValidationManifest(ValidationTestCase testCase)
         {
-            RunTestCase(testCase);
+            await RunTestCase(testCase);
         } 
 
-        public static void RunTestCase(ValidationTestCase testCase)
+        public static async Tasks.Task RunTestCase(ValidationTestCase testCase)
         {            
-            var resourceText = File.ReadAllText(@$"TestData\validation-test-suite\{testCase.FileName}");
+            var resourceText = await File.ReadAllTextAsync(@$"TestData\validation-test-suite\{testCase.FileName}");
             var testResource = testCase.FileName.EndsWith(".xml") ?
                 new FhirXmlParser().Parse<Resource>(resourceText) :
-                new FhirJsonParser().Parse<Resource>(resourceText);
+                await new FhirJsonParser().ParseAsync<Resource>(resourceText);
             Assert.IsNotNull(testResource);
 
             var profileFilePath = testCase?.Profiles?.FirstOrDefault() ?? testCase?.ValidationProfile?.Source;
@@ -90,11 +91,11 @@ namespace Hl7.Fhir.Specification.Tests
       
         [Ignore]
         [TestMethod]
-        public void RunSingleTest()
+        public async Tasks.Task RunSingleTest()
         {
             var testCase = ValidatorManifestParser.Parse().Where(t => t.FileName == "questionnaireResponse-enableWhen-test3.xml").FirstOrDefault();
             Assert.IsNotNull(testCase);
-            RunTestCase(testCase);
+            await RunTestCase(testCase);
         }
 
     }

--- a/src/Hl7.Fhir.Specification.Tests/Validation/ValidationManifestTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/ValidationManifestTest.cs
@@ -52,7 +52,7 @@ namespace Hl7.Fhir.Specification.Tests
         {            
             var resourceText = await File.ReadAllTextAsync(@$"TestData\validation-test-suite\{testCase.FileName}");
             var testResource = testCase.FileName.EndsWith(".xml") ?
-                new FhirXmlParser().Parse<Resource>(resourceText) :
+                await new FhirXmlParser().ParseAsync<Resource>(resourceText) :
                 await new FhirJsonParser().ParseAsync<Resource>(resourceText);
             Assert.IsNotNull(testResource);
 

--- a/src/Hl7.Fhir.Specification/Specification/Terminology/ExternalTerminologyService.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Terminology/ExternalTerminologyService.cs
@@ -141,8 +141,10 @@ namespace Hl7.Fhir.Specification.Terminology
 
                     // Serialize the code or coding to json for display purposes in the issue
                     var jsonSer = new FhirJsonSerializer();
+#pragma warning disable 618 // Obsolete member or type
                     var codeDisplay = codeableConcept != null ? jsonSer.SerializeToString(codeableConcept)
-                                            : jsonSer.SerializeToString(coding);
+                        : jsonSer.SerializeToString(coding);
+#pragma warning restore 618 // Obsolete member or type
 
                     outcome.AddIssue($"Validation of '{codeDisplay}' failed, but" +
                                 $"the terminology service at {Endpoint.Endpoint} did not provide further details.",

--- a/src/Hl7.Fhir.Specification/Specification/Terminology/ExternalTerminologyService.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Terminology/ExternalTerminologyService.cs
@@ -141,10 +141,8 @@ namespace Hl7.Fhir.Specification.Terminology
 
                     // Serialize the code or coding to json for display purposes in the issue
                     var jsonSer = new FhirJsonSerializer();
-#pragma warning disable 618 // Obsolete member or type
                     var codeDisplay = codeableConcept != null ? jsonSer.SerializeToString(codeableConcept)
                         : jsonSer.SerializeToString(coding);
-#pragma warning restore 618 // Obsolete member or type
 
                     outcome.AddIssue($"Validation of '{codeDisplay}' failed, but" +
                                 $"the terminology service at {Endpoint.Endpoint} did not provide further details.",

--- a/src/Hl7.Fhir.Specification/Validation/FixedPatternValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/FixedPatternValidationExtensions.cs
@@ -64,10 +64,7 @@ namespace Hl7.Fhir.Validation
             if (value is PrimitiveType)
                 return value.ToString();
             else
-#pragma warning disable CS0618 // Obsolete member or type
-                // TODO: Validation Async Support
                 return new FhirJsonSerializer().SerializeToString(value);
-#pragma warning restore CS0618 // Obsolete member or type
         }
 
         public static bool IsExactlyEqualTo(this ITypedElement left, ITypedElement right)

--- a/src/Hl7.Fhir.Specification/Validation/FixedPatternValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/FixedPatternValidationExtensions.cs
@@ -64,7 +64,10 @@ namespace Hl7.Fhir.Validation
             if (value is PrimitiveType)
                 return value.ToString();
             else
+#pragma warning disable CS0618 // Obsolete member or type
+                // TODO: Validation Async Support
                 return new FhirJsonSerializer().SerializeToString(value);
+#pragma warning restore CS0618 // Obsolete member or type
         }
 
         public static bool IsExactlyEqualTo(this ITypedElement left, ITypedElement right)

--- a/src/Hl7.Fhir.Specification/Validation/Validator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Validator.cs
@@ -506,7 +506,10 @@ namespace Hl7.Fhir.Validation
 #pragma warning restore CS0618 // Type or member is obsolete
 
 #if DEBUG
+#pragma warning disable 618 // Obsolete member or type
+                // TODO: Validation Async Support
                 string xml = (new FhirXmlSerializer()).SerializeToString(definition);
+#pragma warning restore 618 // Obsolete member or type
                 string name = definition.Id ?? definition.Name.Replace(" ", "").Replace("/", "");
                 var dir = Path.Combine(Path.GetTempPath(), "validation");
 

--- a/src/Hl7.Fhir.Specification/Validation/Validator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Validator.cs
@@ -506,10 +506,8 @@ namespace Hl7.Fhir.Validation
 #pragma warning restore CS0618 // Type or member is obsolete
 
 #if DEBUG
-#pragma warning disable 618 // Obsolete member or type
                 // TODO: Validation Async Support
                 string xml = (new FhirXmlSerializer()).SerializeToString(definition);
-#pragma warning restore 618 // Obsolete member or type
                 string name = definition.Id ?? definition.Name.Replace(" ", "").Replace("/", "");
                 var dir = Path.Combine(Path.GetTempPath(), "validation");
 


### PR DESCRIPTION
## Description
Async support for Json Parsers related and Json/Xml Serializers

Non-async methods marked as obsolete, documentation refers to the corresponding Async method

Code in some of the smaller non-async methods are currently not modified since there was so little actual code affected

Corresponding PR: https://github.com/FirelyTeam/firely-net-common/pull/112

## Testing
Tested by running the unit tests, except for unit tests marked as IntegrationTests

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] Mark the PR with the label **breaking change** when this PR introduces breaking changes