### PR TITLE
[R4] Always wrap FhirPath input in scopednode before evaluating 

### DIFF
--- a/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
+++ b/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
@@ -303,5 +303,36 @@ namespace Hl7.FhirPath.R4.Tests
             var result = typedElement.Select("(Observation.value as Quantity) | (Observation.component.value as Quantity)");
             Assert.AreEqual(2, result.Count());
         }
-    }
+
+        [TestMethod]
+        public void TestFhirPathResolve()
+        {
+            ElementNavFhirExtensions.PrepareFhirSymbolTableFunctions();
+            var bundle = new Bundle
+            {
+                Entry = new List<Bundle.EntryComponent>
+        {
+            new Bundle.EntryComponent
+            {
+                FullUrl = $"urn:uuid:123456",
+                Resource = new Organization
+                {
+                    Id = "123456"
+                }
+            },
+            new Bundle.EntryComponent
+            {
+                FullUrl = $"urn:uuid:555",
+                Resource = new Patient
+                {
+                    ManagingOrganization = new ResourceReference($"urn:uuid:123456")
+                }
+            }
+        }
+            };
+
+            var result = bundle.Select("Bundle.entry.where(fullUrl = 'urn:uuid:555').resource.managingOrganization.resolve()");
+            Assert.IsTrue(result.Any());
+        }
+    }   
 }


### PR DESCRIPTION
## Description
Points to new common commit where FhirPath input is wrapped in ScopedNode before evaluating

## Related issues
Fixes #1525 

## Testing
Added unit test in FhirPathTests.cs

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes