### PR TITLE
Tests: FhirPath 'as' can return FHIR primtives

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Model/FhirPathOperationTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Model/FhirPathOperationTests.cs
@@ -1,0 +1,48 @@
+﻿using Hl7.Fhir.Model;
+using Hl7.Fhir.FhirPath;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace Hl7.Fhir.Core.Tests.Model
+{
+    [TestClass]
+    public class FhirPathOperationTests
+    {
+        [TestMethod]
+        public void AsOperationCanCastToUri()
+        {
+            var conceptMap = new ConceptMap
+            {
+                Status = PublicationStatus.Draft,
+                Source = new FhirUri("http://ValueSet.fhir.org/test"),
+            };
+            var values = conceptMap.Select("ConceptMap.source.as(uri)");
+            var value = values.FirstOrDefault();
+            Assert.AreEqual("uri", value.TypeName);
+
+            var values2 = conceptMap.Select("(ConceptMap.source as uri)");
+            var value2 = values2.FirstOrDefault();
+            Assert.AreEqual("uri", value2.TypeName);
+        }
+
+        [TestMethod]
+        public void Issue_1643()
+        {
+            var poco = new ConceptMap
+            {
+                Identifier = new Identifier("system", "value"),
+                Source = new FhirUri("http://example.com"),
+                DateElement = FhirDateTime.Now()
+            };
+
+            Assert.AreEqual("Identifier", poco.Select("ConceptMap.identifier").First().TypeName);
+            Assert.AreEqual("Identifier", poco.Select("ConceptMap.identifier as Identifier").First().TypeName);
+
+            Assert.AreEqual("dateTime", poco.Select("ConceptMap.date").First().TypeName);
+            Assert.AreEqual("dateTime", poco.Select("ConceptMap.date as dateTime").First().TypeName);
+
+            Assert.AreEqual("uri", poco.Select("ConceptMap.source").First().TypeName);
+            Assert.AreEqual("uri", poco.Select("ConceptMap.source as uri").First().TypeName);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Unit Tests for the fix for the 'as' operator committed in FhirPath
library in the firely-net-common repository
Related PR: https://github.com/FirelyTeam/firely-net-common/pull/117

## Related issues
Fixes #1643.

## Testing
Tested with the unit tests in this PR

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes