### PR TITLE
Keep existing timezone by default in FhirDateTime.ToDateTimeOffset - STU3

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Model/ModelTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Model/ModelTests.cs
@@ -86,11 +86,14 @@ namespace Hl7.Fhir.Tests.Model
             fdt = new FhirDateTime("2021-03-18T12:22:35.999Z");
             Assert.IsTrue(fdt.TryToDateTimeOffset(out var dto3));
             Assert.AreEqual("2021-03-18T12:22:35.9990000+00:00", dto3.ToString("o"));
+            
+            fdt = new FhirDateTime("2021-03-18T12:22:35.1234+04:00");
+            Assert.IsTrue(fdt.TryToDateTimeOffset(out var dto4));
+            Assert.AreEqual("2021-03-18T12:22:35.1234000+04:00", dto4.ToString("o"));
 
             fdt = new FhirDateTime("2021-03-18T12:22:35.999");
             Assert.AreEqual("2021-03-18T12:22:35.999", fdt.Value);
-            Assert.IsFalse(fdt.TryToDateTimeOffset(out var dto4));
-          
+            Assert.IsFalse(fdt.TryToDateTimeOffset(out var dto5));
         }
 
         [TestMethod]

--- a/src/Hl7.Fhir.Core.Tests/Model/ModelTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Model/ModelTests.cs
@@ -69,15 +69,28 @@ namespace Hl7.Fhir.Tests.Model
 
         //Added for issue #1498
         [TestMethod]
-        public void FhirDateTimeConversionTimeZoneInformationLoss()
+        public void TestTryToDateTimeOffset()
         {
             var fdt = new FhirDateTime(new DateTimeOffset(2021, 3, 18, 12, 22, 35, 999, new TimeSpan(-4, 0, 0)));           
             Assert.AreEqual("2021-03-18T12:22:35.999-04:00", fdt.Value);
 
-            var dto1 = PrimitiveTypeConverter.ConvertTo<DateTimeOffset>(fdt.Value);
-            var dto2 = fdt.ToDateTimeOffset();
+            Assert.IsTrue(fdt.TryToDateTimeOffset(out var dto1));
             Assert.AreEqual("2021-03-18T12:22:35.9990000-04:00", dto1.ToString("o"));
-            Assert.AreEqual("2021-03-18T12:22:35.9990000-04:00", dto2.ToString("o"));
+
+            fdt = new FhirDateTime(new DateTimeOffset(2021, 3, 18, 12, 22, 35, 999, new TimeSpan(4, 0, 0)));
+            Assert.AreEqual("2021-03-18T12:22:35.999+04:00", fdt.Value);
+
+            Assert.IsTrue(fdt.TryToDateTimeOffset(out var dto2));
+            Assert.AreEqual("2021-03-18T12:22:35.9990000+04:00", dto2.ToString("o"));
+
+            fdt = new FhirDateTime("2021-03-18T12:22:35.999Z");
+            Assert.IsTrue(fdt.TryToDateTimeOffset(out var dto3));
+            Assert.AreEqual("2021-03-18T12:22:35.9990000+00:00", dto3.ToString("o"));
+
+            fdt = new FhirDateTime("2021-03-18T12:22:35.999");
+            Assert.AreEqual("2021-03-18T12:22:35.999", fdt.Value);
+            Assert.IsFalse(fdt.TryToDateTimeOffset(out var dto4));
+          
         }
 
         [TestMethod]

--- a/src/Hl7.Fhir.Core.Tests/Model/ModelTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Model/ModelTests.cs
@@ -15,6 +15,7 @@ using Hl7.Fhir.Model;
 using System.Xml.Linq;
 using System.ComponentModel.DataAnnotations;
 using Hl7.Fhir.Validation;
+using Hl7.Fhir.Serialization;
 
 namespace Hl7.Fhir.Tests.Model
 {
@@ -64,6 +65,19 @@ namespace Hl7.Fhir.Tests.Model
             var stamp = new DateTimeOffset(1972, 11, 30, 15, 10, 0, TimeSpan.Zero);
             dt = new FhirDateTime(stamp);
             Assert.IsTrue(dt.Value.EndsWith("+00:00"));
+        }
+
+        //Added for issue #1498
+        [TestMethod]
+        public void FhirDateTimeConversionTimeZoneInformationLoss()
+        {
+            var fdt = new FhirDateTime(new DateTimeOffset(2021, 3, 18, 12, 22, 35, 999, new TimeSpan(-4, 0, 0)));           
+            Assert.AreEqual("2021-03-18T12:22:35.999-04:00", fdt.Value);
+
+            var dto1 = PrimitiveTypeConverter.ConvertTo<DateTimeOffset>(fdt.Value);
+            var dto2 = fdt.ToDateTimeOffset();
+            Assert.AreEqual("2021-03-18T12:22:35.9990000-04:00", dto1.ToString("o"));
+            Assert.AreEqual("2021-03-18T12:22:35.9990000-04:00", dto2.ToString("o"));
         }
 
         [TestMethod]


### PR DESCRIPTION
fixes: #1498