### PR TITLE
Tests: FhirPath 'as' can return FHIR primtives (for R4)

### DIFF
--- a/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathOperationTests.cs
+++ b/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathOperationTests.cs
@@ -1,0 +1,48 @@
+﻿using Hl7.Fhir.Model;
+using Hl7.Fhir.FhirPath;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace Hl7.Fhir.Core.Tests.Model
+{
+    [TestClass]
+    public class FhirPathOperationTests
+    {
+        [TestMethod]
+        public void AsOperationCanCastToUri()
+        {
+            var conceptMap = new ConceptMap
+            {
+                Status = PublicationStatus.Draft,
+                Source = new FhirUri("http://ValueSet.fhir.org/test"),
+            };
+            var values = conceptMap.Select("ConceptMap.source.as(uri)");
+            var value = values.FirstOrDefault();
+            Assert.AreEqual("uri", value.TypeName);
+
+            var values2 = conceptMap.Select("(ConceptMap.source as uri)");
+            var value2 = values2.FirstOrDefault();
+            Assert.AreEqual("uri", value2.TypeName);
+        }
+
+        [TestMethod]
+        public void Issue_1643()
+        {
+            var poco = new ConceptMap
+            {
+                Identifier = new Identifier("system", "value"),
+                Source = new FhirUri("http://example.com"),
+                DateElement = FhirDateTime.Now()
+            };
+
+            Assert.AreEqual("Identifier", poco.Select("ConceptMap.identifier").First().TypeName);
+            Assert.AreEqual("Identifier", poco.Select("ConceptMap.identifier as Identifier").First().TypeName);
+
+            Assert.AreEqual("dateTime", poco.Select("ConceptMap.date").First().TypeName);
+            Assert.AreEqual("dateTime", poco.Select("ConceptMap.date as dateTime").First().TypeName);
+
+            Assert.AreEqual("uri", poco.Select("ConceptMap.source").First().TypeName);
+            Assert.AreEqual("uri", poco.Select("ConceptMap.source as uri").First().TypeName);
+        }
+    }
+}


### PR DESCRIPTION
Unit Tests for the fix for the 'as' operator committed in FhirPath
library in the firely-net-common repository

(note: this is a cherry-picked version of PR #1721, but moved unto the R4 branch, where we keep all our poco-based FhirPath tests)