### PR TITLE
Support serialization of types in Common

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/SerializationTests.cs
@@ -127,8 +127,8 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.IsTrue(SerializationUtil.ProbeIsXml("<?xml />"));
         }
 
-        private FhirXmlParser FhirXmlParser = new FhirXmlParser();
-        private FhirJsonParser FhirJsonParser = new FhirJsonParser();
+        private readonly FhirXmlParser FhirXmlParser = new FhirXmlParser();
+        private readonly FhirJsonParser FhirJsonParser = new FhirJsonParser();
 
 
         //[TestMethod]
@@ -403,7 +403,7 @@ namespace Hl7.Fhir.Tests.Serialization
         [TestMethod]
         public void TestDerivedPoCoSerialization()
         {
-            ModelInfo.GetStructureDefinitionSummaryProvider().ImportType(typeof(CustomBundle));
+            ModelInfo.ModelInspector.ImportType(typeof(CustomBundle));
 
             var bundle = new CustomBundle()
             {

--- a/src/Hl7.Fhir.Core/ElementModel/PocoBuilderExtensions.cs
+++ b/src/Hl7.Fhir.Core/ElementModel/PocoBuilderExtensions.cs
@@ -16,13 +16,13 @@ namespace Hl7.Fhir.ElementModel
     public static class PocoBuilderExtensions
     {
         public static Base ToPoco(this ISourceNode source, Type pocoType = null, PocoBuilderSettings settings = null) =>
-            new PocoBuilder(ModelInfo.GetStructureDefinitionSummaryProvider(), settings).BuildFrom(source, pocoType);
+            new PocoBuilder(ModelInfo.ModelInspector, settings).BuildFrom(source, pocoType);
 
         public static T ToPoco<T>(this ISourceNode source, PocoBuilderSettings settings = null) where T : Base =>
                (T)source.ToPoco(typeof(T), settings);
 
         public static Base ToPoco(this ITypedElement element, PocoBuilderSettings settings = null) =>
-            new PocoBuilder(ModelInfo.GetStructureDefinitionSummaryProvider(), settings).BuildFrom(element);
+            new PocoBuilder(ModelInfo.ModelInspector, settings).BuildFrom(element);
 
         public static T ToPoco<T>(this ITypedElement element, PocoBuilderSettings settings = null) where T : Base =>
                (T)element.ToPoco(settings);

--- a/src/Hl7.Fhir.Core/ElementModel/TypedElementExtensions.cs
+++ b/src/Hl7.Fhir.Core/ElementModel/TypedElementExtensions.cs
@@ -13,6 +13,6 @@ namespace Hl7.Fhir.ElementModel
     public static class TypedElementExtensions
     {
         public static ITypedElement ToTypedElement(this Base @base, string rootName = null) =>
-            new PocoElementNode(ModelInfo.GetStructureDefinitionSummaryProvider(), @base, rootName: rootName);
+            new PocoElementNode(ModelInfo.ModelInspector, @base, rootName: rootName);
     }
 }

--- a/src/Hl7.Fhir.Core/Model/ModelInfo.cs
+++ b/src/Hl7.Fhir.Core/Model/ModelInfo.cs
@@ -28,12 +28,13 @@
 
 */
 
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Introspection;
+using Hl7.Fhir.Utility;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Hl7.Fhir.Introspection;
 using System.Diagnostics;
-using Hl7.Fhir.Utility;
+using System.Linq;
 using System.Reflection;
 
 namespace Hl7.Fhir.Model
@@ -100,7 +101,7 @@ namespace Hl7.Fhir.Model
 
         /// <summary>Returns the FHIR type name represented by the specified <see cref="FHIRAllTypes"/> enum value, or <c>null</c>.</summary>
         public static FHIRAllTypes? FhirTypeNameToFhirType(string typeName)
-            => _fhirTypeNameToFhirType.TryGetValue(typeName, out var result) ? (FHIRAllTypes?)result : null;
+            => _fhirTypeNameToFhirType.TryGetValue(typeName, out var result) ? result : null;
 
         /// <summary>Returns the <see cref="FHIRAllTypes"/> enum value that represents the specified FHIR type name, or <c>null</c>.</summary>
         public static string FhirTypeToFhirTypeName(FHIRAllTypes type)
@@ -116,7 +117,7 @@ namespace Hl7.Fhir.Model
 
         /// <summary>Returns the FHIR type name represented by the specified <see cref="ResourceType"/> enum value, or <c>null</c>.</summary>
         public static ResourceType? FhirTypeNameToResourceType(string typeName)
-            => _fhirTypeNameToResourceType.TryGetValue(typeName, out var result) ? (ResourceType?)result : null;
+            => _fhirTypeNameToResourceType.TryGetValue(typeName, out var result) ? result : null;
 
         /// <summary>Returns the <see cref="ResourceType"/> enum value that represents the specified FHIR type name, or <c>null</c>.</summary>
         public static string ResourceTypeToFhirTypeName(ResourceType type)
@@ -246,7 +247,7 @@ namespace Hl7.Fhir.Model
         }
 
         /// <summary>Subset of <see cref="FHIRAllTypes"/> enumeration values for conformance resources.</summary>
-        public static readonly FHIRAllTypes[] ConformanceResources = 
+        public static readonly FHIRAllTypes[] ConformanceResources =
         {
             FHIRAllTypes.StructureDefinition,
             FHIRAllTypes.StructureMap,
@@ -316,9 +317,9 @@ namespace Hl7.Fhir.Model
         /// <remarks>This function does not recognize "system" types, these are the basic types that the FHIR
         /// datatypes are built upon, but are not specific to the FHIR datamodel.</remarks>
         public static bool IsCoreModelType(string name) => FhirTypeToCsType.ContainsKey(name);
-            // => IsKnownResource(name) || IsDataType(name) || IsPrimitive(name);
+        // => IsKnownResource(name) || IsDataType(name) || IsPrimitive(name);
 
-        
+
         public static readonly Uri FhirCoreProfileBaseUri = new Uri(@"http://hl7.org/fhir/StructureDefinition/");
 
         /// <summary>Determines if the specified value represents the canonical uri of a core FHIR Resource, FHIR Datatype or FHIR primitive.</summary>
@@ -329,7 +330,7 @@ namespace Hl7.Fhir.Model
             return uri != null
                 // [WMR 20181025] Issue #746
                 // Note: FhirCoreProfileBaseUri.IsBaseOf(new Uri("Dummy", UriKind.RelativeOrAbsolute)) = true...?!
-                && uri.IsAbsoluteUri 
+                && uri.IsAbsoluteUri
                 && FhirCoreProfileBaseUri.IsBaseOf(uri)
                 && IsCoreModelType(FhirCoreProfileBaseUri.MakeRelativeUri(uri).ToString());
         }
@@ -474,23 +475,8 @@ namespace Hl7.Fhir.Model
             return CanonicalUriForFhirCoreType(type.GetLiteral());
         }
 
-        // The lazy here is not used for purposes of performance (delaying creation of the versioned provider, which
-        // is cheap anyway), but to use the framework to have a nicely multithread-aware singleton.
-        private static readonly Lazy<ModelInspector> _versionedProvider
-            = new Lazy<ModelInspector>(createVersionedProvider);
-
-        private static ModelInspector createVersionedProvider()
-        {
-            var result = new ModelInspector(Specification.FhirRelease.STU3);
-
-            result.Import(typeof(Resource).GetTypeInfo().Assembly);
-            result.Import(typeof(ModelInfo).GetTypeInfo().Assembly);
-
-            return result;
-        }
-
-        internal static ModelInspector GetStructureDefinitionSummaryProvider() =>
-            _versionedProvider.Value;
+        internal static ModelInspector ModelInspector => TypedSerialization.GetInspectorForAssembly(
+            typeof(ModelInfo).GetTypeInfo().Assembly);
 
         public static readonly Type[] OpenTypes =
         {

--- a/src/Hl7.Fhir.Core/Properties/AssemblyInfo.cs
+++ b/src/Hl7.Fhir.Core/Properties/AssemblyInfo.cs
@@ -1,9 +1,11 @@
+using Hl7.Fhir.Introspection;
 using System;
 using System.Runtime.CompilerServices;
 
 // This assembly is not fully CLSCompliant, but this triggers compiler warnings to avoid the issue as described here, when mixing C# and VB 
 // https://msdn.microsoft.com/en-us/library/ms235408(v=vs.90).aspx 
 [assembly: CLSCompliant(true)]
+[assembly: FhirModelAssembly(Hl7.Fhir.Specification.FhirRelease.STU3)]
 
 #if DEBUG
 [assembly: InternalsVisibleTo("Hl7.Fhir.Core.Tests")]

--- a/src/Hl7.Fhir.Core/Specification/PocoStructureDefinitionSummaryProvider.cs
+++ b/src/Hl7.Fhir.Core/Specification/PocoStructureDefinitionSummaryProvider.cs
@@ -6,21 +6,17 @@
  * available at https://github.com/FirelyTeam/firely-net-sdk/blob/master/LICENSE
  */
 
-using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
-using Hl7.Fhir.Serialization;
-using Hl7.Fhir.Utility;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Threading;
 
 namespace Hl7.Fhir.Specification
 {
+    /// <summary>
+    /// An implementation of <see cref="IStructureDefinitionSummaryProvider"/> that obtains
+    /// its metadata from the POCO assemblies for this release.
+    /// </summary>
     public class PocoStructureDefinitionSummaryProvider : IStructureDefinitionSummaryProvider
     {
         public IStructureDefinitionSummary Provide(string canonical) =>
-            ModelInfo.GetStructureDefinitionSummaryProvider().Provide(canonical);
+            ModelInfo.ModelInspector.Provide(canonical);
     }
 }


### PR DESCRIPTION
Adds functionality to convert common POCOs to/from ITypedElement without the need of FHIR-version specific assemblies