### PR TITLE
Make the location for XSD schemas configurable

### DIFF
--- a/src/Hl7.Fhir.Specification/Specification/Source/SchemaCollection.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/SchemaCollection.cs
@@ -7,43 +7,67 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Xml;
 using System.Xml.Schema;
 
+#nullable enable
+
 namespace Hl7.Fhir.Specification.Source
 {
+    /// <summary>
+    /// A class that retrieves, compiles and caches an <see cref="XmlSchemaSet"/> necessary to validate FHIR XML.
+    /// </summary>
     public class SchemaCollection
     {
+        private static readonly string[] minimalSchemas = { "xml.xsd", "fhir-single.xsd", "fhir-xhtml.xsd", "xmldsig-core-schema.xsd" };
 
-        private static Lazy<XmlSchemaSet> _validationSchemaSet = new Lazy<XmlSchemaSet>(compileValidationSchemas);
-
-        public static XmlSchemaSet ValidationSchemaSet
+        /// <summary>
+        /// Constructs a SchemaCollection which retrieves XML schemas from the given <see cref="IArtifactSource"/>.
+        /// </summary>
+        public SchemaCollection(IArtifactSource xsdSource)
         {
-            get { return _validationSchemaSet.Value; }
+            _validationSchemaSet = new(() => compileValidationSchemas(xsdSource));
         }
 
-
-        private static string[] minimalSchemas = { "xml.xsd", "fhir-single.xsd", "fhir-xhtml.xsd","xmldsig-core-schema.xsd" };
-        
-        private static XmlSchemaSet compileValidationSchemas()
+        /// <summary>
+        /// Constructs a SchemaCollection which retrieves XML schemas from the default source.
+        /// </summary>
+        /// <remarks>The default source is the source returned by <see cref="ZipSource.CreateValidationSource()"/>.</remarks>
+        public SchemaCollection()
         {
-            var resolver = ZipSource.CreateValidationSource();
+            _validationSchemaSet = new(() => compileValidationSchemas(ZipSource.CreateValidationSource()));
+        }
 
-            XmlSchemaSet schemas = new XmlSchemaSet();
+        private readonly Lazy<XmlSchemaSet> _validationSchemaSet;
 
-            foreach(var schemaName in minimalSchemas)
+        /// <summary>
+        /// Return an XmlSchemaSet that contains the minimal set necessary to validate FHIR XML.
+        /// </summary>
+        public XmlSchemaSet MinimalSchemas => _validationSchemaSet.Value;
+
+        /// <summary>
+        /// Returns the schemas necessary to use XML validation on FHIR resources.
+        /// </summary>
+        /// <remarks>The schemas will be searched for at the default location, <see cref="DirectorySource.SpecificationDirectory"/>.</remarks>
+        public static XmlSchemaSet ValidationSchemaSet => Default.MinimalSchemas;
+
+
+        public static SchemaCollection Default = new();
+
+
+        private static XmlSchemaSet compileValidationSchemas(IArtifactSource source)
+        {
+            var schemas = new XmlSchemaSet();
+
+            foreach (var schemaName in minimalSchemas)
             {
-                using (var schema = resolver.LoadArtifactByName(schemaName))
-                {
-                    if(schema == null)
-                        throw new FileNotFoundException("Cannot find manifest resources that represent the minimal set of schemas required for validation");
+                using var schema = source.LoadArtifactByName(schemaName);
 
-                    schemas.Add(null, XmlReader.Create(schema));   // null = use schema namespace as specified in schema file
-                }
+                if (schema == null)
+                    throw new FileNotFoundException("Cannot find manifest resources that represent the minimal set of schemas required for validation");
+
+                schemas.Add(null, XmlReader.Create(schema));   // null = use schema namespace as specified in schema file
             }
 
             schemas.Compile();
@@ -52,3 +76,5 @@ namespace Hl7.Fhir.Specification.Source
         }
     }
 }
+
+#nullable restore

--- a/src/Hl7.Fhir.Specification/Specification/Source/ZipSource.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/ZipSource.cs
@@ -24,16 +24,24 @@ namespace Hl7.Fhir.Specification.Source
     {
         public const string SpecificationZipFileName = "specification.zip";
 
+
+        /// <summary>Create a new <see cref="ZipSource"/> instance to read FHIR artifacts from the core specification archive "specification.zip"
+        /// found in the path passed to this function.</summary>
+        /// <returns>A new <see cref="ZipSource"/> instance.</returns>
+        /// <param name="path">A path to a directory containing the specification.zip file.</param>
+        public static ZipSource CreateValidationSource(string path)
+        {
+            return !File.Exists(path)
+                ? throw new FileNotFoundException($"Cannot create a {nameof(ZipSource)} for the core specification: '{SpecificationZipFileName}' was not found.")
+                : new ZipSource(path);
+        }
+
         /// <summary>Create a new <see cref="ZipSource"/> instance to read FHIR artifacts from the core specification archive "specification.zip".</summary>
         /// <returns>A new <see cref="ZipSource"/> instance.</returns>
         public static ZipSource CreateValidationSource()
         {
             var path = Path.Combine(DirectorySource.SpecificationDirectory, SpecificationZipFileName);
-            if(!File.Exists(path))
-            {
-                throw new FileNotFoundException($"Cannot create a {nameof(ZipSource)} for the core specification: '{SpecificationZipFileName}' was not found.");
-            }
-            return new ZipSource(path);
+            return CreateValidationSource(path);
         }
 
         private string _mask;
@@ -83,7 +91,8 @@ namespace Hl7.Fhir.Specification.Source
         public string Mask
         {
             get { return _mask; }
-            set {
+            set
+            {
                 _mask = value;
                 // No need to lock, DirectorySource is synchronized
                 var source = _lazySource.Value;
@@ -222,7 +231,7 @@ namespace Hl7.Fhir.Specification.Source
         private string GetCacheKey()
         {
             Assembly assembly = typeof(ZipSource).GetTypeInfo().Assembly;
-            var versionInfo =  assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            var versionInfo = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
             var productInfo = assembly.GetCustomAttribute<AssemblyProductAttribute>();
             return $"FhirArtifactCache-{versionInfo.InformationalVersion}-{productInfo.Product}";
         }

--- a/src/Hl7.Fhir.Specification/Validation/ValidationSettings.cs
+++ b/src/Hl7.Fhir.Specification/Validation/ValidationSettings.cs
@@ -19,7 +19,7 @@ namespace Hl7.Fhir.Validation
     public class ValidationSettings
     {
         public StructureDefinitionSummaryProvider.TypeNameMapper ResourceMapping { get; set; }
-        
+
         [Obsolete("Use the CreateDefault() method, as using this static member may cause threading issues.")]
         public static readonly ValidationSettings Default = new ValidationSettings();
 
@@ -93,6 +93,12 @@ namespace Hl7.Fhir.Validation
         /// </summary>
         public bool EnableXsdValidation { get; set; } // = false;
 
+        /// <summary>
+        /// Determine where to retrieve the XSD schemas from when when Xsd validation is enabled and run.
+        /// </summary>
+        /// <remarks>If this is not set, the default location (using specification.zip) will be used.</remarks>
+        public SchemaCollection XsdSchemaCollection { get; set; }
+
         /// <summary>Default constructor. Creates a new <see cref="ValidationSettings"/> instance with default property values.</summary>
         public ValidationSettings() { }
 
@@ -121,6 +127,7 @@ namespace Hl7.Fhir.Validation
             other.Trace = Trace;
             other.FhirPathCompiler = FhirPathCompiler;
             other.ResourceMapping = ResourceMapping;
+            other.XsdSchemaCollection = XsdSchemaCollection;
         }
 
         /// <summary>Creates a new <see cref="ValidationSettings"/> object that is a copy of the current instance.</summary>


### PR DESCRIPTION
When using the XML validation features of the validator, the user should be able to configure where to get the necessary XSD schemas from.