### PR TITLE
R4: 1283 - Repair of constraint con-3 of Condition

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -1275,6 +1275,33 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.True(result.Success);
         }
 
+        [Fact]
+        public void ConditionCon3ConstraintTest()
+        {
+            // the invariant con-3 of condition is wrong in the specification (R4). For now we fixed this in profiles-resources.xml. The correct FhirPath is
+            // "clinicalStatus.exists() or verificationStatus.coding.where(system='http://terminology.hl7.org/CodeSystem/condition-ver-status' and code = 'entered-in-error').exists() or category.coding.where($this.code='problem-list-item').empty()"
+            // So when the profiles-resources.xml has been overwritten and this unit test is failing, then the above FP expression should be set again (snapshot and 
+            // differential
+            // MV 28-06-2021
+
+            var condition = new Condition
+            {
+                Text = new Narrative() { Div = "<div xmlns=\"http://www.w3.org/1999/xhtml\">Testing the con-3 invariant</div>", Status = Narrative.NarrativeStatus.Additional },
+                Subject = new ResourceReference("Patient/1"),
+                Category = new List<CodeableConcept> { new CodeableConcept("http://terminology.hl7.org/CodeSystem/condition-category", "encounter-diagnosis") },
+            };
+
+            var settings = new ValidationSettings
+            {
+                ConstraintBestPractices = ConstraintBestPractices.Enabled,
+                ResourceResolver = new CachedResolver(ZipSource.CreateValidationSource())
+            };
+
+            var validator = new Validator(settings);
+            var result = validator.Validate(condition);
+            Assert.True(result.Success);
+        }
+
         private class ClearSnapshotResolver : IResourceResolver
         {
             private readonly IResourceResolver _resolver;

--- a/src/Hl7.Fhir.Specification/Validation/ValidationSettings.cs
+++ b/src/Hl7.Fhir.Specification/Validation/ValidationSettings.cs
@@ -26,7 +26,7 @@ namespace Hl7.Fhir.Validation
     public class ValidationSettings
     {
         public StructureDefinitionSummaryProvider.TypeNameMapper ResourceMapping { get; set; }
-        
+
         [Obsolete("Use the CreateDefault() method, as using this static member may cause threading issues.")]
         public static readonly ValidationSettings Default = new ValidationSettings();
 
@@ -123,6 +123,7 @@ namespace Hl7.Fhir.Validation
         {
             if (other == null) throw Error.ArgumentNull(nameof(other));
 
+            other.ConstraintBestPractices = ConstraintBestPractices;
             other.GenerateSnapshot = GenerateSnapshot;
             other.GenerateSnapshotSettings = GenerateSnapshotSettings?.Clone();
             other.EnableXsdValidation = EnableXsdValidation;


### PR DESCRIPTION
## Description
There was incorrect FhirPath expression for `con-3`. This should be fixed by the standard, but in the meantime we fix this in our definition files.

In addition, we encountered another error in the `CopyTo` function of `ValidationSettings`: the member `ConstraintBestPractices` was missing during copying.

## Related issues
Fixes #1283 

## Testing
Tested by `BasicValidationTests.ConditionCon3ConstraintTest`

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes