### PR TITLE
Devops: Create Release Notes automatically

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -33,7 +33,7 @@ stages:
   displayName: Build
   jobs:
   - job: restoreAndBuild
-    displayName: 'Build in $(buildConfiguration) mode'
+    displayName: 'Build Artifacts'
     steps:
     - checkout: self
       clean: true
@@ -138,7 +138,7 @@ stages:
         echo "##vso[task.setvariable variable=current_tag;isOutput=true]$currenttag"
         echo "##vso[task.setvariable variable=previous_tag;isOutput=true]$previoustag"
         echo "##vso[task.setvariable variable=release_title;isOutput=true]$title_release"
-      name: tagnames
+      name: Determine tagnames
 
 - stage: test
   displayName: Test

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -118,6 +118,27 @@ stages:
       inputs:
         pathToPublish: $(Build.ArtifactStagingDirectory)
         ArtifactName: NuGetPackages
+    - bash: |
+        echo $(Build.SourceBranchName)
+
+        IFS='-'
+        read -a version <<<"$(Build.SourceBranchName)"
+
+        release=${version[1]}
+        echo $release
+
+        currenttag=$(git tag --sort=v:refname | grep -E "^v.*-$release$" | tail -1)
+        previoustag=$(git tag --sort=v:refname | grep -E "^v.*-$release$" | tail -2 | head -n 1)
+        title_release="${version[0]:1} for ${version[1]^^} (release $(date '+%Y%m%d'))"
+
+        echo $currenttag
+        echo $previoustag
+        echo $title_release
+
+        echo "##vso[task.setvariable variable=current_tag;isOutput=true]$currenttag"
+        echo "##vso[task.setvariable variable=previous_tag;isOutput=true]$previoustag"
+        echo "##vso[task.setvariable variable=release_title;isOutput=true]$title_release"
+      name: tagnames
 
 - stage: test
   displayName: Test
@@ -177,6 +198,41 @@ stages:
         parameters:
           testRunTitle: Tests ElementModel test project
           projects: '**/publish/Hl7.Fhir.ElementModel.Tests.dll'
+
+- stage: releaseNotes
+  displayName: Create Release Notes
+  dependsOn: build
+  jobs:
+    - deployment: relNotes
+      displayName: Release Notes
+      variables:
+        - name: curTag
+          value: $[ stageDependencies.build.restoreAndBuild.outputs['tagnames.current_tag'] ]
+        - name: prevTag
+          value: $[ stageDependencies.build.restoreAndBuild.outputs['tagnames.previous_tag'] ]
+        - name: releaseTitle
+          value: $[ stageDependencies.build.restoreAndBuild.outputs['tagnames.release_title'] ]
+      strategy:
+        runOnce:
+          deploy:
+              steps:
+              - download: none
+              - task: GitHubRelease@1
+                displayName: 'GitHub release notes (create)'  
+                inputs:
+                  gitHubConnection: 'GitHub Fhir-net-api'
+                  repositoryName: '$(Build.Repository.Name)'
+                  action: 'create'
+                  target: '$(Build.SourceVersion)'
+                  tagSource: userSpecifiedTag
+                  tag: '$(curTag)'
+                  title: '$(releaseTitle)'
+                  isDraft: true
+                  changeLogCompareToRelease: lastNonDraftReleaseByTag
+                  changeLogCompareToReleaseTag: '$(prevTag)'
+                  changeLogType: issueBased
+                  changeLogLabels: '[{ "label" : "bug", "displayName" : "Bugfixes", "state" : "closed" },{ "label" : "enhancement", "displayName" : "New Functionality", "state" : "closed" }]'
+
 
 - stage: deploy_myget
   displayName: Deploy to MyGet

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -200,42 +200,6 @@ stages:
           testRunTitle: Tests ElementModel test project
           projects: '**/publish/Hl7.Fhir.ElementModel.Tests.dll'
 
-- stage: releaseNotes
-  displayName: Create Release Notes
-  dependsOn: build
-  jobs:
-    - deployment: relNotes
-      displayName: Release Notes
-      environment: MyGet
-      variables:
-        - name: curTag
-          value: $[ stageDependencies.build.restoreAndBuild.outputs['tagnames.current_tag'] ]
-        - name: prevTag
-          value: $[ stageDependencies.build.restoreAndBuild.outputs['tagnames.previous_tag'] ]
-        - name: releaseTitle
-          value: $[ stageDependencies.build.restoreAndBuild.outputs['tagnames.release_title'] ]
-      strategy:
-        runOnce:
-          deploy:
-              steps:
-              - download: none
-              - task: GitHubRelease@1
-                displayName: 'GitHub release notes (create)'  
-                inputs:
-                  gitHubConnection: 'GitHub Fhir-net-api'
-                  repositoryName: '$(Build.Repository.Name)'
-                  action: 'create'
-                  target: '$(Build.SourceVersion)'
-                  tagSource: userSpecifiedTag
-                  tag: '$(curTag)'
-                  title: '$(releaseTitle)'
-                  isDraft: true
-                  changeLogCompareToRelease: lastNonDraftReleaseByTag
-                  changeLogCompareToReleaseTag: '$(prevTag)'
-                  changeLogType: issueBased
-                  changeLogLabels: '[{ "label" : "bug", "displayName" : "Bugfixes", "state" : "closed" },{ "label" : "enhancement", "displayName" : "New Functionality", "state" : "closed" }]'
-
-
 - stage: deploy_myget
   displayName: Deploy to MyGet
   dependsOn: test
@@ -270,7 +234,9 @@ stages:
 
 - stage: deploy_nuget 
   displayName: Deploy to NuGet
-  dependsOn: deploy_myget
+  dependsOn:
+    - deploy_myget
+    - build
   condition: and(succeeded(), eq(variables.isTagBranch, true)) 
   jobs:
   - deployment: nuget
@@ -337,26 +303,22 @@ stages:
                 publishFeedCredentials: NuGet
                 verbosityPush: normal 
                 includeSymbols: false  
-            - bash: |
-                echo $(Build.SourceBranchName)
-
-                IFS='-'
-                read -a version <<<"$(Build.SourceBranchName)"
-
-                release=${version[1]}
-                echo $release
-
-                currenttag=$(git tag --sort=v:refname | grep -E "^v.*-$release$" | tail -1)
-                previoustag=$(git tag --sort=v:refname | grep -E "^v.*-$release$" | tail -2 | head -n 1)
-                title_release="${version[0]:1} for ${version[1]^^} (release $(date '+%Y%m%d'))"
-
-                echo $currenttag
-                echo $previoustag
-                echo $title_release
-
-                echo "##vso[task.setvariable variable=current_tag]$currenttag"
-                echo "##vso[task.setvariable variable=previous_tag]$previoustag"
-                echo "##vso[task.setvariable variable=release_title]$title_release"
+            
+  - deployment: relNotes
+    displayName: Release Notes
+    environment: NuGet
+    variables:
+      - name: curTag
+        value: $[ stageDependencies.build.restoreAndBuild.outputs['tagnames.current_tag'] ]
+      - name: prevTag
+        value: $[ stageDependencies.build.restoreAndBuild.outputs['tagnames.previous_tag'] ]
+      - name: releaseTitle
+        value: $[ stageDependencies.build.restoreAndBuild.outputs['tagnames.release_title'] ]
+    strategy:
+      runOnce:
+        deploy:
+            steps:
+            - download: none
             - task: GitHubRelease@1
               displayName: 'GitHub release notes (create)'  
               inputs:
@@ -365,11 +327,11 @@ stages:
                 action: 'create'
                 target: '$(Build.SourceVersion)'
                 tagSource: userSpecifiedTag
-                tag: '$(current_tag)'
-                title: '$(release_title)'
+                tag: '$(curTag)'
+                title: '$(releaseTitle)'
                 isDraft: true
                 changeLogCompareToRelease: lastNonDraftReleaseByTag
-                changeLogCompareToReleaseTag: '$(previous_tag)'
+                changeLogCompareToReleaseTag: '$(prevTag)'
                 changeLogType: issueBased
                 changeLogLabels: '[{ "label" : "bug", "displayName" : "Bugfixes", "state" : "closed" },{ "label" : "enhancement", "displayName" : "New Functionality", "state" : "closed" }]'
-              
+    

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -205,7 +205,7 @@ stages:
   jobs:
     - deployment: relNotes
       displayName: Release Notes
-      environment: ReleaseNotes
+      environment: MyGet
       variables:
         - name: curTag
           value: $[ stageDependencies.build.restoreAndBuild.outputs['tagnames.current_tag'] ]

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -138,7 +138,8 @@ stages:
         echo "##vso[task.setvariable variable=current_tag;isOutput=true]$currenttag"
         echo "##vso[task.setvariable variable=previous_tag;isOutput=true]$previoustag"
         echo "##vso[task.setvariable variable=release_title;isOutput=true]$title_release"
-      name: Determine tagnames
+      name: tagnames
+      displayName: Determine tagnames
 
 - stage: test
   displayName: Test

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -202,6 +202,7 @@ stages:
 - stage: releaseNotes
   displayName: Create Release Notes
   dependsOn: build
+  environment: ReleaseNotes
   jobs:
     - deployment: relNotes
       displayName: Release Notes

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -202,10 +202,10 @@ stages:
 - stage: releaseNotes
   displayName: Create Release Notes
   dependsOn: build
-  environment: ReleaseNotes
   jobs:
     - deployment: relNotes
       displayName: Release Notes
+      environment: ReleaseNotes
       variables:
         - name: curTag
           value: $[ stageDependencies.build.restoreAndBuild.outputs['tagnames.current_tag'] ]


### PR DESCRIPTION
## Description
In the previous release the determination of the current and previous tags went wrong. Now these tags are determined in the build stage.

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes