### PR TITLE
R4: FHIR Specific variables %rootResource and %resource are set correctly now

### DIFF
--- a/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
@@ -9,7 +9,6 @@
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.FhirPath;
 using Hl7.Fhir.Model;
-using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Support;
 using Hl7.Fhir.Utility;
 using Hl7.FhirPath;
@@ -32,16 +31,6 @@ namespace Hl7.Fhir.Validation
             if (!definition.Constraint.Any()) return outcome;
             if (v.Settings.SkipConstraintValidation) return outcome;
 
-            // Determine %resource: if the current instance is a resource, %resource is simply
-            // a pointer to the current data. If the data is a datatype, %resource is the parent resource
-            // the datatype is part of.
-            var resource = instance.AtResource ? instance : instance.ResourceContext;
-
-            // Determine %rootResource: this is the parent of the current %resource, not being the
-            // container bundle. So, this only differs from %resource, when %resource is a contained resource
-            // within a DomainResource
-            var rootResource = resource is ScopedNode sn ? sn.ResourceContext : resource;
-
             foreach (var constraintElement in definition.Constraint)
             {
                 // 20190703 Issue 447 - rng-2 is incorrect in DSTU2 and STU3. EK
@@ -58,13 +47,13 @@ namespace Hl7.Fhir.Validation
                         constraintElement.Severity = ElementDefinition.ConstraintSeverity.Warning;
 
                 bool success = false;
-               
+
                 try
                 {
                     var compiled = getExecutableConstraint(v, outcome, instance, constraintElement);
-                    success = compiled.Predicate(instance, 
-                        new FhirEvaluationContext(resource: resource, rootResource: rootResource)
-                        { ElementResolver = callExternalResolver } );
+                    success = compiled.Predicate(instance,
+                        new FhirEvaluationContext(instance)
+                        { ElementResolver = callExternalResolver });
                 }
                 catch (Exception e)
                 {

--- a/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
+++ b/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
@@ -197,22 +197,22 @@ namespace Hl7.FhirPath.R4.Tests
             var patBundle = new ScopedNode(bundle.ToTypedElement());
 
             // focus on the contained resource
-            EvaluationContext ctx = new FhirEvaluationContext(patBundle.Select("entry.first().resource.contained")?.FirstOrDefault());
+            EvaluationContext ctx = new FhirEvaluationContext(patBundle.Select("entry.first().resource.contained")?.FirstOrDefault() as ScopedNode);
             Assert.AreEqual("contained-1", patBundle.Scalar("%resource.id", ctx));
             Assert.AreEqual("patient-1", patBundle.Scalar("%rootResource.id", ctx));
 
             // focus on the id of the contained resource
-            ctx = new FhirEvaluationContext(patBundle.Select("entry.first().resource.contained.id")?.FirstOrDefault());
+            ctx = new FhirEvaluationContext(patBundle.Select("entry.first().resource.contained.id")?.FirstOrDefault() as ScopedNode);
             Assert.AreEqual("contained-1", patBundle.Scalar("%resource.id", ctx));
             Assert.AreEqual("patient-1", patBundle.Scalar("%rootResource.id", ctx));
 
             // focus on the property of the entry resource
-            ctx = new FhirEvaluationContext(patBundle.Select("entry.first().resource.id")?.FirstOrDefault());
+            ctx = new FhirEvaluationContext(patBundle.Select("entry.first().resource.id")?.FirstOrDefault() as ScopedNode);
             Assert.AreEqual("patient-1", patBundle.Scalar("%resource.id", ctx));
             Assert.AreEqual("patient-1", patBundle.Scalar("%rootResource.id", ctx));
 
             // focus on the entry resource
-            ctx = new FhirEvaluationContext(patBundle.Select("entry.first().resource")?.FirstOrDefault());
+            ctx = new FhirEvaluationContext(patBundle.Select("entry.first().resource")?.FirstOrDefault() as ScopedNode);
             Assert.AreEqual("patient-1", patBundle.Scalar("%resource.id", ctx));
             Assert.AreEqual("patient-1", patBundle.Scalar("%rootResource.id", ctx));
 
@@ -222,7 +222,7 @@ namespace Hl7.FhirPath.R4.Tests
             Assert.AreEqual("bundle-1", patBundle.Scalar("%rootResource.id", ctx));
 
             // focus on a property of the bundle 
-            ctx = new FhirEvaluationContext(patBundle.Select("id")?.FirstOrDefault());
+            ctx = new FhirEvaluationContext(patBundle.Select("id")?.FirstOrDefault() as ScopedNode);
             Assert.AreEqual("bundle-1", patBundle.Scalar("%resource.id", ctx));
             Assert.AreEqual("bundle-1", patBundle.Scalar("%rootResource.id", ctx));
 

--- a/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
+++ b/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
@@ -184,9 +184,7 @@ namespace Hl7.FhirPath.R4.Tests
         //    Assert.False(TypeInfo.Any.CanBeCastTo(typeof(long)));
         //}
 
-        [TestMethod, Ignore("%resource and %rootResource don't really work well unless run from within the validator. " +
-            "Need to fix this by letting the FP evaluator pick up these context variables from the ScopedNode focus." +
-            "But that's not yet the case.")]
+        [TestMethod]
         public void TestFhirPathRootResource()
         {
             var bundle = new Bundle() { Type = Bundle.BundleType.Collection, Id = "bundle-1" };
@@ -203,19 +201,28 @@ namespace Hl7.FhirPath.R4.Tests
             Assert.AreEqual("contained-1", patBundle.Scalar("%resource.id", ctx));
             Assert.AreEqual("patient-1", patBundle.Scalar("%rootResource.id", ctx));
 
-            // focus on the property of a contained resource
+            // focus on the id of the contained resource
+            ctx = new FhirEvaluationContext(patBundle.Select("entry.first().resource.contained.id")?.FirstOrDefault());
+            Assert.AreEqual("contained-1", patBundle.Scalar("%resource.id", ctx));
+            Assert.AreEqual("patient-1", patBundle.Scalar("%rootResource.id", ctx));
+
+            // focus on the property of the entry resource
             ctx = new FhirEvaluationContext(patBundle.Select("entry.first().resource.id")?.FirstOrDefault());
-            Assert.AreEqual("patient-1", patBundle.Scalar("%resource", ctx));
-            Assert.AreEqual("patient-1", patBundle.Scalar("%rootResource", ctx));
+            Assert.AreEqual("patient-1", patBundle.Scalar("%resource.id", ctx));
+            Assert.AreEqual("patient-1", patBundle.Scalar("%rootResource.id", ctx));
 
-
-            //focus on bundle entry
+            // focus on the entry resource
             ctx = new FhirEvaluationContext(patBundle.Select("entry.first().resource")?.FirstOrDefault());
             Assert.AreEqual("patient-1", patBundle.Scalar("%resource.id", ctx));
             Assert.AreEqual("patient-1", patBundle.Scalar("%rootResource.id", ctx));
 
             // focus on bundle 
             ctx = new FhirEvaluationContext(patBundle);
+            Assert.AreEqual("bundle-1", patBundle.Scalar("%resource.id", ctx));
+            Assert.AreEqual("bundle-1", patBundle.Scalar("%rootResource.id", ctx));
+
+            // focus on a property of the bundle 
+            ctx = new FhirEvaluationContext(patBundle.Select("id")?.FirstOrDefault());
             Assert.AreEqual("bundle-1", patBundle.Scalar("%resource.id", ctx));
             Assert.AreEqual("bundle-1", patBundle.Scalar("%rootResource.id", ctx));
 


### PR DESCRIPTION
## Description
FHIR Specific variables `%rootResource` and `%resource` are now set correctly. See also the assumptions in https://github.com/FirelyTeam/firely-net-sdk/issues/1742#issuecomment-875598124.

See also PR FirelyTeam/firely-net-common#135

## Related issues
Resolves #1742 

## Testing
`TestFhirPathRootResource()` in FhirPathTest.cs 

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes