### PR TITLE
Suppress warning CS1591 (Missing XML comments) in Release mode

### DIFF
--- a/src/firely-net-sdk.props
+++ b/src/firely-net-sdk.props
@@ -56,6 +56,7 @@
     <IncludeSymbols>True</IncludeSymbols>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <NoWarn>1591</NoWarn> <!-- Missing XML comments -->
   </PropertyGroup>
 </Project>
 


### PR DESCRIPTION
## Description
Suppress warning CS1591 (Missing XML comments) in Release mode. It flooded the warnings in Azure Devops, in such a way that we do not see important warnings anymore.


## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes