### PR TITLE
Adds license type

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+BSD 3-Clause License
+
 Copyright (c) 2013-2020, HL7, Firely (info@fire.ly), Microsoft Open Technologies 
 and contributors. See the file CONTRIBUTORS for details
 


### PR DESCRIPTION
## Description
Adds the license type, this allows Github to give more contextual licensing information, e.g.

![image](https://user-images.githubusercontent.com/197221/125323807-12c91e00-e2f4-11eb-8dea-db7e0ae3a5a0.png)

## Related issues
Closes|Fixes|Resolves [issue #].

## Testing
Documentation update

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes