### PR TITLE
Devops: delay signing of dll's

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -39,7 +39,6 @@ stages:
       clean: true
       submodules: true
       fetchDepth: 1
-    - template: templates/apply-signingkey-steps-template.yml
     - template: templates/apply-versioning-steps-template.yml
     
     - powershell: |
@@ -104,6 +103,8 @@ stages:
       inputs:
         targetPath: $(System.DefaultWorkingDirectory)/bin
         artifactName: TestBuild
+    
+    - template: templates/apply-signingkey-steps-template.yml
     
     - task: DotNetCoreCLI@2
       displayName: Pack

--- a/build/templates/sign-dlls-template.yml
+++ b/build/templates/sign-dlls-template.yml
@@ -1,0 +1,28 @@
+# Repo: FirelyTeam/firely-net-sdk
+# File: build/templates/signing-dlls-template-template.yml
+
+steps:
+  - task: DownloadSecureFile@1
+    displayName: Download Signing key file
+    inputs:
+      secureFile: 47f5a9d4-7009-4fe1-9cb2-c0d6122ded23
+      retryCount: 
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest')) # not a PR
+  - task: CopyFiles@2
+    displayName: Copy key file to $(Build.SourcesDirectory)/src
+    inputs:
+      SourceFolder: $(Agent.TempDirectory)
+      Contents: FhirNetApi.snk
+      TargetFolder: $(Build.SourcesDirectory)/src
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest')) # not a PR
+  - powershell: |
+        $sdkfiles   =  Get-ChildItem -Path $(Build.SourcesDirectory)\src\Hl7.Fhir*\bin\Release\*\Hl7.Fhir*.dll -Exclude Hl7.Fhir*Tests
+        $commonfiles = Get-ChildItem -Path $(Build.SourcesDirectory)\common\src\Hl7.Fhir*\bin\Release\*\Hl7.Fhir*.dll -Exclude Hl7.Fhir*Tests
+        foreach ($file in ($sdkfiles + $commonfiles))
+        {
+          sn -R $file $(Build.SourcesDirectory)\src\FhirNetApi.snk
+        }
+    displayName: Signing the dlls
+    name: signing
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest')) # not a PR
+  

--- a/src/firely-net-sdk.props
+++ b/src/firely-net-sdk.props
@@ -52,7 +52,8 @@
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <SignAssembly>True</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\FhirNetApi.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>true</DelaySign>
+    <AssemblyOriginatorKeyFile>..\FhirNetApi.publickey</AssemblyOriginatorKeyFile>
     <IncludeSymbols>True</IncludeSymbols>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
## Description
We delay the signing of the dll's in order to allow external pull requests. The signing is done now just before packaging the dll's.

See also PR: https://github.com/FirelyTeam/firely-net-common/pull/142

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes