### PR TITLE
STU3: Combined discriminators can now also be used when one of them cannot discriminate

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/TestData/validation/profile-communication.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/validation/profile-communication.xml
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<url value="http://example.com/fhir/StructureDefinition/profile-communication"/>
+	<name value="SomeCommunication"/>
+	<status value="draft"/>
+	<fhirVersion value="4.0.1"/>
+	<kind value="resource"/>
+	<abstract value="false"/>
+	<type value="Communication"/>
+	<baseDefinition value="http://hl7.org/fhir/StructureDefinition/Communication"/>
+	<derivation value="constraint"/>
+	<differential>
+		<element id="Communication">
+			<path value="Communication"/>
+		</element>
+		<element id="Communication.payload">
+			<path value="Communication.payload"/>
+			<slicing>
+				<discriminator>
+					<type value="type"/>
+					<path value="content"/>
+				</discriminator>
+				<discriminator>
+					<type value="type"/>
+					<path value="content.ofType(Reference).resolve()"/>
+				</discriminator>
+				<rules value="open"/>
+			</slicing>
+		</element>
+		<element id="Communication.payload.content[x]">
+			<path value="Communication.payload.content[x]"/>
+			<type>
+				<code value="string"/>
+			</type>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="http://hl7.org/fhir/StructureDefinition/DocumentReference"/>
+				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Task"/>
+			</type>
+		</element>
+    
+		<element id="Communication.payload:String">
+			<path value="Communication.payload"/>
+			<sliceName value="String"/>
+			<max value="1"/>
+		</element>
+		<element id="Communication.payload:String.content[x]">
+			<path value="Communication.payload.content[x]"/>
+			<type>
+				<code value="string"/>
+			</type>
+		</element>
+    
+		<element id="Communication.payload:DocumentReference">
+			<path value="Communication.payload"/>
+			<sliceName value="DocumentReference"/>
+			<max value="20"/>
+		</element>
+		<element id="Communication.payload:DocumentReference.content[x]">
+			<path value="Communication.payload.content[x]"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="http://hl7.org/fhir/StructureDefinition/DocumentReference"/>
+			</type>
+		</element>
+    
+		<element id="Communication.payload:Task">
+			<path value="Communication.payload"/>
+			<sliceName value="Task"/>
+			<max value="11"/>
+		</element>
+		<element id="Communication.payload:Task.content[x]">
+			<path value="Communication.payload.content[x]"/>
+			<min value="1"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Task"/>
+			</type>
+		</element>
+	</differential>
+</StructureDefinition>

--- a/src/Hl7.Fhir.Specification.Tests/TestData/validation/profile-communication.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/validation/profile-communication.xml
@@ -3,7 +3,7 @@
 	<url value="http://example.com/fhir/StructureDefinition/profile-communication"/>
 	<name value="SomeCommunication"/>
 	<status value="draft"/>
-	<fhirVersion value="4.0.1"/>
+	<fhirVersion value="3.0.2"/>
 	<kind value="resource"/>
 	<abstract value="false"/>
 	<type value="Communication"/>
@@ -35,8 +35,11 @@
 			<type>
 				<code value="Reference"/>
 				<targetProfile value="http://hl7.org/fhir/StructureDefinition/DocumentReference"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Task"/>
 			</type>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Task"/>
+      </type>
 		</element>
     
 		<element id="Communication.payload:String">

--- a/src/Hl7.Fhir.Specification.Tests/Validation/SliceValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/SliceValidationTests.cs
@@ -1,4 +1,5 @@
-﻿using Hl7.Fhir.ElementModel;
+﻿using FluentAssertions;
+using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Specification.Source;
@@ -51,6 +52,31 @@ namespace Hl7.Fhir.Specification.Tests
 		 *          telecom:other/home [0..1]
 		 *          telecom:other/work [0..1]
 	    */
+
+        [Fact]
+        public void TestMixedTypeSlicingProfile()
+        {
+            var sliceDefs = createSliceDefs("http://example.com/fhir/StructureDefinition/profile-communication", "Communication.payload");
+
+            sliceDefs.Should().BeOfType<SliceGroupBucket>().Which.ChildSlices.Length.Should().Be(3);
+
+            var sliceGroup = sliceDefs as SliceGroupBucket;
+
+            sliceGroup.ChildSlices[0].Should().Match<DiscriminatorBucket>(s =>
+                    s.Cardinality.Max == "1" &&
+                    s.Name == "Communication.payload:String"
+                  );
+
+            sliceGroup.ChildSlices[1].Should().Match<DiscriminatorBucket>(s =>
+                    s.Cardinality.Max == "20" &&
+                    s.Name == "Communication.payload:DocumentReference"
+                  );
+
+            sliceGroup.ChildSlices[2].Should().Match<DiscriminatorBucket>(s =>
+                    s.Cardinality.Max == "11" &&
+                    s.Name == "Communication.payload:Task"
+                  );
+        }
 
         [Fact]
         public void TestSliceSetup()

--- a/src/Hl7.Fhir.Specification/Specification/Navigation/StructureDefinitionWalker.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Navigation/StructureDefinitionWalker.cs
@@ -6,6 +6,9 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+
+#nullable enable
+
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Specification.Source;
@@ -26,28 +29,45 @@ namespace Hl7.Fhir.Specification
     /// </summary>
     public class StructureDefinitionWalker
     {
-        public IResourceResolver Resolver => _resolver as IResourceResolver;
+        public IResourceResolver? Resolver => _resolver as IResourceResolver;
         public IAsyncResourceResolver AsyncResolver => _resolver.AsAsync();
 
 #pragma warning disable CS0618 // Type or member is obsolete
         private readonly ISyncOrAsyncResourceResolver _resolver;
+#pragma warning restore CS0618 // Type or member is obsolete
 
         public readonly ElementDefinitionNavigator Current;
 
+        /// <summary>
+        /// When walked into a Reference, the targetprofiles are copied to here
+        /// </summary>
+        private readonly string[]? _targetProfile;
+
+#pragma warning disable CS0618 // Type or member is obsolete
         public StructureDefinitionWalker(StructureDefinition sd, ISyncOrAsyncResourceResolver resolver)
+#pragma warning restore CS0618 // Type or member is obsolete
             : this(ElementDefinitionNavigator.ForSnapshot(sd), resolver)
         {
             // nothing more
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         public StructureDefinitionWalker(ElementDefinitionNavigator element, ISyncOrAsyncResourceResolver resolver)
-        {
 #pragma warning restore CS0618 // Type or member is obsolete
+        {
             Current = element.ShallowCopy();
             _resolver = resolver;
 
             // Make sure there is always a current item
             if (Current.AtRoot) Current.MoveToFirstChild();
+        }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        public StructureDefinitionWalker(ElementDefinitionNavigator element, IEnumerable<string> targetProfiles, ISyncOrAsyncResourceResolver resolver) :
+#pragma warning restore CS0618 // Type or member is obsolete
+            this(element, resolver)
+        {
+            _targetProfile = targetProfiles?.ToArray();
         }
 
         public StructureDefinitionWalker(StructureDefinitionWalker other)
@@ -56,16 +76,18 @@ namespace Hl7.Fhir.Specification
             _resolver = other._resolver;
         }
 
-        public StructureDefinitionWalker FromCanonical(string canonical) =>
-            TaskHelper.Await(() => FromCanonicalAsync(canonical));
+        public StructureDefinitionWalker FromCanonical(string canonical, IEnumerable<string>? targetProfiles = null) =>
+            TaskHelper.Await(() => FromCanonicalAsync(canonical, targetProfiles));
 
-        public async T.Task<StructureDefinitionWalker> FromCanonicalAsync(string canonical)
+        public async T.Task<StructureDefinitionWalker> FromCanonicalAsync(string canonical, IEnumerable<string>? targetProfiles = null)
         {
             var sd = await AsyncResolver.FindStructureDefinitionAsync(canonical).ConfigureAwait(false);
             if (sd == null)
                 throw new StructureDefinitionWalkerException($"Cannot walk into unknown StructureDefinition with canonical '{canonical}' at '{Current.CanonicalPath()}'");
 
-            return new StructureDefinitionWalker(ElementDefinitionNavigator.ForSnapshot(sd), _resolver);
+            return (targetProfiles is not null)
+                ? new StructureDefinitionWalker(ElementDefinitionNavigator.ForSnapshot(sd), targetProfiles, _resolver)
+                : new StructureDefinitionWalker(ElementDefinitionNavigator.ForSnapshot(sd), _resolver);
         }
 
 
@@ -91,7 +113,7 @@ namespace Hl7.Fhir.Specification
                 throw new StructureDefinitionWalkerException($"Child with name '{childName}' is sliced to more than one choice and cannot be used as a discriminator at '{Current.CanonicalPath()}' ");
         }
 
-        private IEnumerable<ElementDefinitionNavigator> childDefinitions(string childName = null)
+        private IEnumerable<ElementDefinitionNavigator> childDefinitions(string? childName = null)
         {
             var canonicals = Current.Current.Type.Select(t => t.GetTypeProfile()).Distinct().ToArray();
             if (canonicals.Length > 1)
@@ -141,9 +163,9 @@ namespace Hl7.Fhir.Specification
             else if (Current.Current.Type.Count >= 1)
             {
                 return Current.Current.Type
-                    .Select(t => t.GetTypeProfile())
+                    .Select(t => (profile: t.GetTypeProfile(), targetProfiles: t.TargetProfile))
                     .Distinct()     // no use returning multiple "reference" profiles when they only differ in targetReference
-                    .Select(c => FromCanonical(c));
+                    .Select(c => FromCanonical(c.profile, new[] { c.targetProfiles }));
             }
 
             throw new StructureDefinitionWalkerException("Invalid StructureDefinition: element misses either a type reference or " +
@@ -170,7 +192,7 @@ namespace Hl7.Fhir.Specification
             // types into their definitions:
             // 1) The root node of an SD for a type or constraint on the type => derive the base type
             // 2) At a non-root BackboneElement or Element => use the TypeRef.Type (After the expand, this can be only 1)
-            string typeCanonical(ElementDefinitionNavigator nav) =>
+            string? typeCanonical(ElementDefinitionNavigator nav) =>
                nav.Current.IsRootElement() ?
                     nav.StructureDefinition.Type
                     : nav.Current.Type.FirstOrDefault()?.Code;
@@ -184,6 +206,11 @@ namespace Hl7.Fhir.Specification
         /// <exception cref="StructureDefinitionWalkerException">Thrown when the ElementDefinition's type is not a Reference.</exception>
         public IEnumerable<StructureDefinitionWalker> Resolve()
         {
+            if (_targetProfile is not null)
+            {
+                return _targetProfile.Select(p => FromCanonical(p));
+            }
+
             if (!Current.Current.Type.Any(t => t.IsReference()))
                 throw new StructureDefinitionWalkerException($"resolve() should only be called on elements of type Reference at '{Current.CanonicalPath()}'.");
 
@@ -283,3 +310,5 @@ namespace Hl7.Fhir.Specification
             me.Select(w => w.Extension(canonical));
     }
 }
+
+#nullable restore

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/BucketFactory.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/BucketFactory.cs
@@ -43,6 +43,11 @@ namespace Hl7.Fhir.Validation
                 if (discriminatorSpecs.Any())
                 {
                     var discriminators = discriminatorSpecs.Select(ds => DiscriminatorFactory.Build(ds, resolver, location, root, validator));
+
+                    if (discriminators.All(d => d is ComprehensiveDiscriminator))
+                    {
+                        throw new IncorrectElementDefinitionException($"There is nothing to discriminate on at {location}.");
+                    }
                     subBucket = new DiscriminatorBucket(root, validator, discriminators.ToArray());
                 }
                 else

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/ComprehensiveDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/ComprehensiveDiscriminator.cs
@@ -1,0 +1,25 @@
+﻿/* 
+ * Copyright (c) 2021, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+#nullable enable
+
+using Hl7.Fhir.ElementModel;
+
+namespace Hl7.Fhir.Validation
+{
+    /// <summary>
+    /// Not really a discriminator, but a helper discriminator in the case of multiple discriminators for slicing. 
+    /// It will match on any candidate.
+    /// </summary>
+    internal class ComprehensiveDiscriminator : IDiscriminator
+    {
+        public bool Matches(ITypedElement candidate) => true;
+    }
+}
+
+#nullable restore

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/DisciminatorFactory.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/DisciminatorFactory.cs
@@ -6,6 +6,8 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+#nullable enable
+
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification;
 using Hl7.Fhir.Specification.Navigation;
@@ -31,6 +33,11 @@ namespace Hl7.Fhir.Validation
             var context = $"{root.StructureDefinition.Url}#{location}";
 
             var condition = walkToCondition(root, spec.Path, resolver);
+
+            if (condition is null)
+            {
+                return new ComprehensiveDiscriminator();
+            }
 
             switch (spec.Type.Value)
             {
@@ -94,12 +101,17 @@ namespace Hl7.Fhir.Validation
         private static IDiscriminator buildTypeDiscriminator(ElementDefinitionNavigator nav, string discriminator, Validator validator)
         {
             var spec = nav.Current;
+            if (spec.IsRootElement())
+            {
+                // When we are at a root of a structuredefinition, then return the type of this structuredefinition.
+                return new TypeDiscriminator(new[] { nav.StructureDefinition.Type }, discriminator, validator);
+            }
+
             var codes = spec.Type.Select(tr => tr.Code).ToArray();
 
-            if (codes.Any())
-                return new TypeDiscriminator(codes, discriminator, validator);
-            else
-                throw new IncorrectElementDefinitionException($"A type discriminator should have at least one 'type' element with a code set on '{nav.CanonicalPath()}'.");
+            return codes.Any()
+                ? new TypeDiscriminator(codes, discriminator, validator)
+                : throw new IncorrectElementDefinitionException($"A type discriminator should have at least one 'type' element with a code set on '{nav.CanonicalPath()}'.");
         }
 
         private static IDiscriminator buildProfileDiscriminator(ElementDefinitionNavigator nav, string discriminator, Validator validator)
@@ -132,17 +144,17 @@ namespace Hl7.Fhir.Validation
         }
 
 
-        private static ElementDefinitionNavigator walkToCondition(ElementDefinitionNavigator root, string discriminator, IResourceResolver resolver)
+        private static ElementDefinitionNavigator? walkToCondition(ElementDefinitionNavigator root, string discriminator, IResourceResolver resolver)
         {
             var walker = new StructureDefinitionWalker(root, resolver);
             var conditions = walker.Walk(discriminator);
 
             // Well, we could check whether the conditions are Equal, since that's what really matters - they should not differ.
-            if (conditions.Count > 1)
-                throw new IncorrectElementDefinitionException($"The discriminator path '{discriminator}' at {root.CanonicalPath()} leads to multiple ElementDefinitions, which is not allowed.");
-
-            return conditions.Single().Current;
+            return conditions.Count > 1
+                ? throw new IncorrectElementDefinitionException($"The discriminator path '{discriminator}' at {root.CanonicalPath()} leads to multiple ElementDefinitions, which is not allowed.")
+                : (conditions.SingleOrDefault()?.Current);
         }
-
     }
 }
+
+#nullable restore


### PR DESCRIPTION
## Description
Using combined discriminators will now also work when one of the discriminators does not discriminate. 
Also solved in this PR:
- `resolve()` in a discriminator expression will also work when it is executed on the Reference definition (the targetProfiles are copied into the SDWalker

## Related issues
Fixes #1686.

## Testing
Describe how this change was tested.

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes