### PR TITLE
Return correct match when parsing similar polymorphic elements in a single resource [R5]

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Serialization/ResourceParsingTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/ResourceParsingTests.cs
@@ -15,6 +15,7 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using Tasks = System.Threading.Tasks;
 using Hl7.Fhir.ElementModel;
+using FluentAssertions;
 
 namespace Hl7.Fhir.Tests.Serialization
 {
@@ -369,6 +370,22 @@ namespace Hl7.Fhir.Tests.Serialization
             var parser = new FhirXmlParser();
 
             ExceptionAssert.Throws<StructuralTypeException>(() => parser.Parse<Patient>(xml));
+        }
+
+        //test for https://github.com/FirelyTeam/firely-net-sdk/issues/1858
+        [TestMethod]
+        public async Tasks.Task CanReadSimilarValueXElements()
+        {
+            var json = TestDataHelper.ReadTestData("test-similar-valuex.json");
+            var pser = new FhirJsonParser();
+
+            // Assume that we can happily read the data and no errors occur
+            var i = await pser.ParseAsync<Ingredient>(json);
+        
+            (i.Substance.Strength[0].Presentation as Quantity).Value.Should().Be(1);
+            (i.Substance.Strength[0].PresentationHighLimit as Quantity).Value.Should().Be(2);
+            (i.Substance.Strength[0].Concentration as CodeableConcept).Text.Should().Be("text");
+            (i.Substance.Strength[0].ConcentrationHighLimit as Ratio).Numerator.Value.Should().Be(3);
         }
     }
 }

--- a/src/Hl7.Fhir.Core.Tests/TestData/test-similar-valuex.json
+++ b/src/Hl7.Fhir.Core.Tests/TestData/test-similar-valuex.json
@@ -1,0 +1,49 @@
+{
+  "resourceType": "Ingredient",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><p><b>role</b>: <span>ActiveBase</span></p><p><b>manufacturer</b>: <a>Organization/example</a></p><blockquote><p><b>specifiedSubstance</b></p><h3>Codes</h3><table><tr><td>-</td></tr><tr><td>*</td></tr></table><p><b>group</b>: <span>2</span></p></blockquote><blockquote><p><b>specifiedSubstance</b></p><h3>Codes</h3><table><tr><td>-</td></tr><tr><td>*</td></tr></table><p><b>group</b>: <span>2</span></p></blockquote></div>"
+  },
+  "role": {
+    "coding": [
+      {
+        "system": "http://ema.europa.eu/example/ingredientRole",
+        "code": "ActiveBase"
+      }
+    ]
+  },
+  "substance": {
+    "code": {
+      "concept": {
+        "coding": [
+          {
+            "system": "http://ema.europa.eu/example/specifiedSubstance",
+            "code": "equixabanCompany1"
+          }
+        ]
+      }
+    },
+    "strength": [
+      {
+        "presentationHighLimitQuantity": {
+          "value": "2",
+          "unit": "mm"
+        },
+        "presentationQuantity": {
+          "value": "1",
+          "unit": "mm"
+        },
+        "concentrationCodeableConcept": {
+          "text": "text"
+        },
+        "concentrationHighLimitRatio": {
+          "numerator": {
+            "value": "3",
+            "unit": "mm"
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
fixes https://github.com/FirelyTeam/firely-net-sdk/issues/1858