### PR TITLE
Added netstandard2.0 as one of the TargetFrameworks

### DIFF
--- a/src/Hl7.Fhir.Core/Hl7.Fhir.Core.csproj
+++ b/src/Hl7.Fhir.Core/Hl7.Fhir.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net45;netstandard1.6</TargetFrameworks>
+		<TargetFrameworks>net5.0;net45;netstandard1.6;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<Import Project="..\firely-net-sdk.props" />

--- a/src/Hl7.Fhir.Specification/Hl7.Fhir.Specification.csproj
+++ b/src/Hl7.Fhir.Specification/Hl7.Fhir.Specification.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net45</TargetFrameworks>
+		<TargetFrameworks>net5.0;net45;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<Import Project="..\firely-net-sdk.props" />


### PR DESCRIPTION
## Description
[Recommended](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#which-net-standard-version-to-target) by Microsoft to add `netstandard2.0` as a TargetFramework as well. Also when you already target `netstandard1.x`


## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes