### PR TITLE
Changed TargetFramework from net45 to net452

### DIFF
--- a/src/Hl7.Fhir.Core/Hl7.Fhir.Core.csproj
+++ b/src/Hl7.Fhir.Core/Hl7.Fhir.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net45;netstandard1.6;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net5.0;net452;netstandard1.6;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<Import Project="..\firely-net-sdk.props" />
@@ -18,16 +18,13 @@
 		<RootNamespace>Hl7.Fhir</RootNamespace>
 	</PropertyGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' != 'net45'">
+	<ItemGroup Condition=" '$(TargetFramework)' != 'net452'">
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net45'">
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net452'">
 		<Reference Include="System.ComponentModel.DataAnnotations" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-		<Reference Include="System.Net.Http"/>
+    <Reference Include="System.Net.Http"/>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">

--- a/src/Hl7.Fhir.Specification/Hl7.Fhir.Specification.csproj
+++ b/src/Hl7.Fhir.Specification/Hl7.Fhir.Specification.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net45;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net5.0;net452;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<Import Project="..\firely-net-sdk.props" />
@@ -24,7 +24,7 @@
 		<ProjectReference Include="..\..\common\src\Hl7.FhirPath\Hl7.FhirPath.csproj" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net452'">
 		<Reference Include="System.Net.Http"/>
 	</ItemGroup>
 


### PR DESCRIPTION
## Description
Upgrade one of the TargetFrameworks from .NET 4.5 (`net45`) to .NET 4.5.2 (`net452`).

.NET 4.5 is not supported anymore by Microsoft

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes