### PR TITLE
Validator: also validate the cardinality of extensions in an instance  

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -604,7 +604,7 @@ namespace Hl7.Fhir.Specification.Tests
         {
             var careplanXml = File.ReadAllText(Path.Combine("TestData", "validation", "careplan-example-integrated.xml"));
 
-            var careplan =  await (new FhirXmlParser()).ParseAsync<CarePlan>(careplanXml);
+            var careplan = await (new FhirXmlParser()).ParseAsync<CarePlan>(careplanXml);
             Assert.NotNull(careplan);
             var careplanSd = await _asyncSource.FindStructureDefinitionForCoreTypeAsync(FHIRAllTypes.CarePlan);
             var report = _validator.Validate(careplan, careplanSd);
@@ -1193,6 +1193,32 @@ namespace Hl7.Fhir.Specification.Tests
             var result = _validator.Validate(bundle);
 
             Assert.True(result.Success);
+        }
+
+        [Fact]
+        public void ValidateExtensionCardinality()
+        {
+            var patient = new Patient();
+            patient.AddExtension("http://hl7.org/fhir/StructureDefinition/patient-congregation", new FhirString("place1"));
+            patient.AddExtension("http://hl7.org/fhir/StructureDefinition/patient-congregation", new FhirString("place2"));
+            patient.AddExtension("http://hl7.org/fhir/StructureDefinition/patient-cadavericDonor", new FhirBoolean(true));
+
+            var report = _validator.Validate(patient);
+            Assert.False(report.Success, "because patient-congregation has cardinality of 0..1");
+            Assert.Equal(1, report.Errors);
+            Assert.Equal(0, report.Warnings);
+
+            patient.RemoveExtension("http://hl7.org/fhir/StructureDefinition/patient-congregation");
+            report = _validator.Validate(patient);
+            Assert.True(report.Success);
+            Assert.Equal(0, report.Warnings);
+
+            patient.AddExtension("http://hl7.org/fhir/StructureDefinition/patient-disability", new CodeableConcept("system", "code1"));
+            patient.AddExtension("http://hl7.org/fhir/StructureDefinition/patient-disability", new CodeableConcept("system", "code2"));
+            patient.AddExtension("http://hl7.org/fhir/StructureDefinition/patient-disability", new CodeableConcept("system", "code3"));
+            report = _validator.Validate(patient);
+            Assert.True(report.Success, "because patient-disability has cardinality of 0..*");
+            Assert.Equal(0, report.Warnings);
         }
 
         // Verify aggregated element constraints

--- a/src/Hl7.Fhir.Specification/Validation/ChildConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/ChildConstraintValidationExtensions.cs
@@ -6,13 +6,18 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+#nullable enable
+
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Navigation;
+using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Support;
 using Hl7.Fhir.Utility;
+using Hl7.FhirPath;
 using System;
 using System.Linq;
+
 
 namespace Hl7.Fhir.Validation
 {
@@ -41,13 +46,13 @@ namespace Hl7.Fhir.Validation
             // Recursively validate my children
             foreach (var match in matchResult.Matches)
             {
-                outcome.Add(validator.ValidateMatch(match, instance));
+                outcome.Add(validator.validateMatch(match, instance));
             }
 
             return outcome;
         }
 
-        private static OperationOutcome ValidateMatch(this Validator validator, Match match, ScopedNode parent)
+        private static OperationOutcome validateMatch(this Validator validator, Match match, ScopedNode parent)
         {
             var outcome = new OperationOutcome();
 
@@ -64,6 +69,14 @@ namespace Hl7.Fhir.Validation
 
             var resolver = validator?.Settings?.ResourceResolver ??
                 throw Error.Argument("Discriminator validation needs a ResourceResolver to be set in the ValidationSettings.");
+
+            if (isExtension(definition))
+            {
+                outcome.Add(validateExtensionCardinality(validator, match, parent, definition, resolver));
+            }
+
+            static bool isExtension(ElementDefinition def)
+                    => def.Type.FirstOrDefault()?.Code == "Extension";
 
             try
             {
@@ -83,7 +96,7 @@ namespace Hl7.Fhir.Validation
 
             foreach (var element in match.InstanceElements)
             {
-                var success = bucket.Add(element);
+                var _ = bucket.Add(element);
 
                 // For the "root" slice group (=the original core element that was sliced, not resliced)
                 // any element that does not match is an error
@@ -93,6 +106,38 @@ namespace Hl7.Fhir.Validation
             outcome.Add(bucket.Validate(validator, parent));
 
             return outcome;
+        }
+
+        private static OperationOutcome validateExtensionCardinality(Validator validator, Match match, ScopedNode parent, ElementDefinition definition, IResourceResolver resolver)
+        {
+            var outcome = new OperationOutcome();
+
+            var groups = match.InstanceElements.GroupBy(instance => getStringValue(instance, "url"));
+
+            foreach (var group in groups)
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                var extension = group.Key is not null ? resolver.FindExtensionDefinition(group.Key) : null;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                // extension could not be resolved. This error will be raised somewhere else. Continue for now.
+                if (extension is null) continue;
+
+                var nav = ElementDefinitionNavigator.ForSnapshot(extension);
+                nav.MoveToFirstChild();
+                var cardinality = Cardinality.FromElementDefinition(nav.Current);
+
+                if (!cardinality.InRange(group.Count()))
+                {
+                    validator.Trace(outcome, $"Instance count for extension '{extension.Name}' ('{definition.Path}') is {group.Count()}, which is not within the specified cardinality of {cardinality}",
+                                            Issue.CONTENT_INCORRECT_OCCURRENCE, parent);
+                }
+            }
+
+            return outcome;
+
+            static string? getStringValue(ITypedElement instance, string childName) =>
+                instance.Children(childName).Select(s => s.Value).OfType<string>().SingleOrDefault();
         }
     }
 }


### PR DESCRIPTION
## Description
The Validator now also checks the cardinality of extensions used in an instance. The cardinality is defined in the root of the extension.

## Related issues
Fixes #1790 

## Testing
Unit test `Hl7.Fhir.Specification.Tests.BasicValidationTests.ValidateExtensionCardinality`

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes