### PR TITLE
Validate resources with targetprofiles and child definitions

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -604,7 +604,7 @@ namespace Hl7.Fhir.Specification.Tests
         {
             var careplanXml = File.ReadAllText(Path.Combine("TestData", "validation", "careplan-example-integrated.xml"));
 
-            var careplan =  await (new FhirXmlParser()).ParseAsync<CarePlan>(careplanXml);
+            var careplan = await (new FhirXmlParser()).ParseAsync<CarePlan>(careplanXml);
             Assert.NotNull(careplan);
             var careplanSd = await _asyncSource.FindStructureDefinitionForCoreTypeAsync(FHIRAllTypes.CarePlan);
             var report = _validator.Validate(careplan, careplanSd);
@@ -1221,10 +1221,10 @@ namespace Hl7.Fhir.Specification.Tests
 
 
         [Fact]
-        public void Issue_1654()
+        public void ValidateWithTargetProfileAndChildDefinitions()
         {
             var visitResolver = new VisitResolver();
-            var resolver = new MultiResolver(visitResolver, _source);
+            var resolver = new MultiResolver(visitResolver, new InMemoryResourceResolver(new Patient() { Id = "example" }), _source);
 
             var validator = new Validator(new ValidationSettings() { ResourceResolver = resolver, ResolveExternalReferences = true, GenerateSnapshot = true });
 
@@ -1240,7 +1240,7 @@ namespace Hl7.Fhir.Specification.Tests
             var outcome = validator.Validate(observation, new[] { "http://validationtest.org/fhir/StructureDefinition/Observation-issue-1654" });
             Assert.True(outcome.Success);
             Assert.True(visitResolver.Visited(patientReference), "no attempt was made to resolve the example patient");
-            Assert.True(1 == outcome.Warnings, $"Found {outcome.Warnings} warnings, where only 1 warning was exptected because of an unresolved patient");
+            Assert.True(0 == outcome.Warnings, $"Found {outcome.Warnings} warnings");
 
         }
 

--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -1220,6 +1220,49 @@ namespace Hl7.Fhir.Specification.Tests
 
 
 
+        [Fact]
+        public void Issue_1654()
+        {
+            var visitResolver = new VisitResolver();
+            var resolver = new MultiResolver(visitResolver, _source);
+
+            var validator = new Validator(new ValidationSettings() { ResourceResolver = resolver, ResolveExternalReferences = true, GenerateSnapshot = true });
+
+            var patientReference = "Patient/example";
+
+            var observation = new Observation()
+            {
+                Status = ObservationStatus.Registered,
+                Code = new CodeableConcept("system", "code"),
+                Subject = new ResourceReference(patientReference)
+            };
+
+            var outcome = validator.Validate(observation, new[] { "http://validationtest.org/fhir/StructureDefinition/Observation-issue-1654" });
+            Assert.True(outcome.Success);
+            Assert.True(visitResolver.Visited(patientReference), "no attempt was made to resolve the example patient");
+            Assert.True(1 == outcome.Warnings, $"Found {outcome.Warnings} warnings, where only 1 warning was exptected because of an unresolved patient");
+
+        }
+
+        class VisitResolver : IResourceResolver
+        {
+            private List<string> _visits = new List<string>();
+
+            public Resource ResolveByCanonicalUri(string uri)
+            {
+                _visits.Add(uri);
+                return null;
+            }
+
+            public Resource ResolveByUri(string uri)
+            {
+                _visits.Add(uri);
+                return null;
+            }
+
+            internal bool Visited(string uri) => _visits.Contains(uri);
+        }
+
         private class ClearSnapshotResolver : IResourceResolver
         {
             private readonly IResourceResolver _resolver;

--- a/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
@@ -58,7 +58,6 @@ namespace Hl7.Fhir.Validation
             {
                 ElementId = "Observation.subject.display",
                 MaxLength = 10
-
             });
 
             return result;

--- a/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
@@ -40,26 +40,26 @@ namespace Hl7.Fhir.Validation
             buildPatientWithExistsSlicing(),
             buildTranslatableCodeableConcept(),
             buildObservationWithTranslatableCode(),
-            buildObservationWithTargetProfiles()
+            buildObservationWithTargetProfilesAndChildDefs()
         };
 
-        private static StructureDefinition buildObservationWithTargetProfiles()
+        private static StructureDefinition buildObservationWithTargetProfilesAndChildDefs()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/Observation-issue-1654", "Observation-issue-1654", "", FHIRAllTypes.Observation);
+            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/Observation-issue-1654", "Observation-issue-1654",
+                "Observation with targetprofile on subject and children definition under subject as well", FHIRAllTypes.Observation);
 
             var cons = result.Differential.Element;
-            var ed = new ElementDefinition("Observation.subject")
+            cons.Add(new ElementDefinition("Observation.subject")
             {
                 ElementId = "Observation.subject",
-            };
-            ed.OfReference(targetProfile: new[] { "Patient" });
-            cons.Add(ed);
-            ed = new ElementDefinition("Observation.subject.identifier.assigner")
+            }.OfReference(targetProfile: ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient)));
+
+            cons.Add(new ElementDefinition("Observation.subject.display")
             {
-                ElementId = "Observation.subject.identifier.assigner",
-            };
-            ed.OfReference(targetProfile: new[] { "Organization" });
-            cons.Add(ed);
+                ElementId = "Observation.subject.display",
+                MaxLength = 10
+
+            });
 
             return result;
         }

--- a/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
@@ -40,7 +40,29 @@ namespace Hl7.Fhir.Validation
             buildPatientWithExistsSlicing(),
             buildTranslatableCodeableConcept(),
             buildObservationWithTranslatableCode(),
+            buildObservationWithTargetProfiles()
         };
+
+        private static StructureDefinition buildObservationWithTargetProfiles()
+        {
+            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/Observation-issue-1654", "Observation-issue-1654", "", FHIRAllTypes.Observation);
+
+            var cons = result.Differential.Element;
+            var ed = new ElementDefinition("Observation.subject")
+            {
+                ElementId = "Observation.subject",
+            };
+            ed.OfReference(targetProfile: new[] { "Patient" });
+            cons.Add(ed);
+            ed = new ElementDefinition("Observation.subject.identifier.assigner")
+            {
+                ElementId = "Observation.subject.identifier.assigner",
+            };
+            ed.OfReference(targetProfile: new[] { "Organization" });
+            cons.Add(ed);
+
+            return result;
+        }
 
         private static StructureDefinition buildTranslatableCodeableConcept()
         {

--- a/src/Hl7.Fhir.Specification/Validation/ChildConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/ChildConstraintValidationExtensions.cs
@@ -26,6 +26,9 @@ namespace Hl7.Fhir.Validation
 
             validator.Trace(outcome, "Start validation of inlined child constraints for '{0}'".FormatWith(definition.Path), Issue.PROCESSING_PROGRESS, instance);
 
+            // validate the type on the parent of children. If this is a reference type, it will follow that reference as well
+            outcome.Add(validator.ValidateType(definition.Current, instance));
+
             var matchResult = ChildNameMatcher.Match(definition, instance);
 
             if (matchResult.UnmatchedInstanceElements.Any() && !allowAdditionalChildren)

--- a/src/Hl7.Fhir.Specification/Validation/ChildConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/ChildConstraintValidationExtensions.cs
@@ -27,7 +27,7 @@ namespace Hl7.Fhir.Validation
             validator.Trace(outcome, "Start validation of inlined child constraints for '{0}'".FormatWith(definition.Path), Issue.PROCESSING_PROGRESS, instance);
 
             // validate the type on the parent of children. If this is a reference type, it will follow that reference as well
-            outcome.Add(validator.ValidateType(definition.Current, instance));
+            outcome.Add(validator.ValidateTargetProfiles(definition.Current, instance));
 
             var matchResult = ChildNameMatcher.Match(definition, instance);
 


### PR DESCRIPTION
## Description
A profile that had a target profile on a reference type *and* other child definitions on that reference, then the validator did not resolve the reference and skipped the whole validation of that referenced resource. This has been resolved now. 

## Related issues
Fixes #1654 

## Testing
See `BasicValidationTests.ValidateWithTargetProfileAndChildDefinitions`

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes