### PR TITLE
R4: Validate resources with targetprofiles and child definitions

### DIFF
--- a/src/Hl7.Fhir.Core/Model/ElementDefinitionExtensions.cs
+++ b/src/Hl7.Fhir.Core/Model/ElementDefinitionExtensions.cs
@@ -6,15 +6,9 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
-using Hl7.Fhir.Model;
-using Hl7.Fhir.Support;
-using System;
+using Hl7.Fhir.Utility;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Hl7.Fhir.Rest;
-using Hl7.Fhir.Introspection;
-using Hl7.Fhir.Utility;
 
 namespace Hl7.Fhir.Model
 {
@@ -40,7 +34,7 @@ namespace Hl7.Fhir.Model
             return ed;
         }
 
-        public static ElementDefinition OfType(this ElementDefinition ed, FHIRAllTypes type, string[] profile=null)
+        public static ElementDefinition OfType(this ElementDefinition ed, FHIRAllTypes type, string[] profile = null)
         {
             ed.Type.Clear();
             ed.OrType(type, profile);
@@ -48,7 +42,14 @@ namespace Hl7.Fhir.Model
             return ed;
         }
 
-        public static ElementDefinition OfReference(this ElementDefinition ed, string[] targetProfile, IEnumerable<ElementDefinition.AggregationMode> aggregation = null, string[] profile=null)
+        public static ElementDefinition OfReference(this ElementDefinition ed, string targetProfile, IEnumerable<ElementDefinition.AggregationMode> aggregation = null, string[] profile = null)
+        {
+            ed.OrReference(new[] { targetProfile }, aggregation, profile);
+
+            return ed;
+        }
+
+        public static ElementDefinition OfReference(this ElementDefinition ed, string[] targetProfile, IEnumerable<ElementDefinition.AggregationMode> aggregation = null, string[] profile = null)
         {
             ed.Type.Clear();
             ed.OrReference(targetProfile, aggregation, profile);
@@ -101,7 +102,7 @@ namespace Hl7.Fhir.Model
             return ed;
         }
 
-        public static ElementDefinition Value(this ElementDefinition ed, DataType fix=null, DataType pattern=null )
+        public static ElementDefinition Value(this ElementDefinition ed, DataType fix = null, DataType pattern = null)
         {
             ed.Fixed = fix;
             ed.Pattern = pattern;
@@ -122,14 +123,14 @@ namespace Hl7.Fhir.Model
             return ed;
         }
 
-        public static ElementDefinition WithSlicingIntro(this ElementDefinition ed, ElementDefinition.SlicingRules rules, 
-            params (ElementDefinition.DiscriminatorType type,string path)[] discriminators)
+        public static ElementDefinition WithSlicingIntro(this ElementDefinition ed, ElementDefinition.SlicingRules rules,
+            params (ElementDefinition.DiscriminatorType type, string path)[] discriminators)
 
         {
             ed.Slicing = new ElementDefinition.SlicingComponent
             {
                 Rules = rules,
-                Discriminator = discriminators.Select(t => 
+                Discriminator = discriminators.Select(t =>
                     new ElementDefinition.DiscriminatorComponent { Path = t.path, Type = t.type })
                     .ToList()
             };

--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -1384,10 +1384,10 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [Fact]
-        public void Issue_1654()
+        public void ValidateWithTargetProfileAndChildDefinitions()
         {
             var visitResolver = new VisitResolver();
-            var resolver = new MultiResolver(visitResolver, _source);
+            var resolver = new MultiResolver(visitResolver, new InMemoryResourceResolver(new Patient() { Id = "example" }), _source);
 
             var validator = new Validator(new ValidationSettings() { ResourceResolver = resolver, ResolveExternalReferences = true, GenerateSnapshot = true });
 
@@ -1403,7 +1403,7 @@ namespace Hl7.Fhir.Specification.Tests
             var outcome = validator.Validate(observation, new[] { "http://validationtest.org/fhir/StructureDefinition/Observation-issue-1654" });
             Assert.True(outcome.Success);
             Assert.True(visitResolver.Visited(patientReference), "no attempt was made to resolve the example patient");
-            Assert.True(1 == outcome.Warnings, $"Found {outcome.Warnings} warnings, where only 1 warning was exptected because of an unresolved patient");
+            Assert.True(0 == outcome.Warnings, $"Found {outcome.Warnings} warnings");
 
         }
 

--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -1383,6 +1383,49 @@ namespace Hl7.Fhir.Specification.Tests
             internal bool Visited(string uri) => _visits.Contains(uri);
         }
 
+        [Fact]
+        public void Issue_1654()
+        {
+            var visitResolver = new VisitResolver();
+            var resolver = new MultiResolver(visitResolver, _source);
+
+            var validator = new Validator(new ValidationSettings() { ResourceResolver = resolver, ResolveExternalReferences = true, GenerateSnapshot = true });
+
+            var patientReference = "Patient/example";
+
+            var observation = new Observation()
+            {
+                Status = ObservationStatus.Registered,
+                Code = new CodeableConcept("system", "code"),
+                Subject = new ResourceReference(patientReference)
+            };
+
+            var outcome = validator.Validate(observation, new[] { "http://validationtest.org/fhir/StructureDefinition/Observation-issue-1654" });
+            Assert.True(outcome.Success);
+            Assert.True(visitResolver.Visited(patientReference), "no attempt was made to resolve the example patient");
+            Assert.True(1 == outcome.Warnings, $"Found {outcome.Warnings} warnings, where only 1 warning was exptected because of an unresolved patient");
+
+        }
+
+        class VisitResolver : IResourceResolver
+        {
+            private List<string> _visits = new List<string>();
+
+            public Resource ResolveByCanonicalUri(string uri)
+            {
+                _visits.Add(uri);
+                return null;
+            }
+
+            public Resource ResolveByUri(string uri)
+            {
+                _visits.Add(uri);
+                return null;
+            }
+
+            internal bool Visited(string uri) => _visits.Contains(uri);
+        }
+
         private class ClearSnapshotResolver : IResourceResolver
         {
             private readonly IResourceResolver _resolver;

--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -1341,49 +1341,6 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [Fact]
-        public void Issue_1654()
-        {
-            var visitResolver = new VisitResolver();
-            var resolver = new MultiResolver(visitResolver, _source);
-
-            var validator = new Validator(new ValidationSettings() { ResourceResolver = resolver, ResolveExternalReferences = true, GenerateSnapshot = true });
-
-            var patientReference = "Patient/example";
-
-            var observation = new Observation()
-            {
-                Status = ObservationStatus.Registered,
-                Code = new CodeableConcept("system", "code"),
-                Subject = new ResourceReference(patientReference)
-            };
-
-            var outcome = validator.Validate(observation, new[] { "http://validationtest.org/fhir/StructureDefinition/Observation-issue-1654" });
-            Assert.True(outcome.Success);
-            Assert.True(visitResolver.Visited(patientReference), "no attempt was made to resolve the example patient");
-            Assert.True(1 == outcome.Warnings, $"Found {outcome.Warnings} warnings, where only 1 warning was exptected because of an unresolved patient");
-
-        }
-
-        class VisitResolver : IResourceResolver
-        {
-            private List<string> _visits = new List<string>();
-
-            public Resource ResolveByCanonicalUri(string uri)
-            {
-                _visits.Add(uri);
-                return null;
-            }
-
-            public Resource ResolveByUri(string uri)
-            {
-                _visits.Add(uri);
-                return null;
-            }
-
-            internal bool Visited(string uri) => _visits.Contains(uri);
-        }
-
-        [Fact]
         public void ValidateWithTargetProfileAndChildDefinitions()
         {
             var visitResolver = new VisitResolver();

--- a/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
@@ -58,7 +58,6 @@ namespace Hl7.Fhir.Validation
             {
                 ElementId = "Observation.subject.display",
                 MaxLength = 10
-
             });
 
             return result;

--- a/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
@@ -40,26 +40,26 @@ namespace Hl7.Fhir.Validation
             buildPatientWithExistsSlicing(),
             buildTranslatableCodeableConcept(),
             buildObservationWithTranslatableCode(),
-            buildObservationWithTargetProfiles()
+            buildObservationWithTargetProfilesAndChildDefs()
         };
 
-        private static StructureDefinition buildObservationWithTargetProfiles()
+        private static StructureDefinition buildObservationWithTargetProfilesAndChildDefs()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/Observation-issue-1654", "Observation-issue-1654", "", FHIRAllTypes.Observation);
+            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/Observation-issue-1654", "Observation-issue-1654",
+                "Observation with targetprofile on subject and children definition under subject as well", FHIRAllTypes.Observation);
 
             var cons = result.Differential.Element;
-            var ed = new ElementDefinition("Observation.subject")
+            cons.Add(new ElementDefinition("Observation.subject")
             {
                 ElementId = "Observation.subject",
-            };
-            ed.OfReference(targetProfile: new[] { "Patient" });
-            cons.Add(ed);
-            ed = new ElementDefinition("Observation.subject.identifier.assigner")
+            }.OfReference(targetProfile: ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient)));
+
+            cons.Add(new ElementDefinition("Observation.subject.display")
             {
-                ElementId = "Observation.subject.identifier.assigner",
-            };
-            ed.OfReference(targetProfile: new[] { "Organization" });
-            cons.Add(ed);
+                ElementId = "Observation.subject.display",
+                MaxLength = 10
+
+            });
 
             return result;
         }

--- a/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
@@ -40,7 +40,29 @@ namespace Hl7.Fhir.Validation
             buildPatientWithExistsSlicing(),
             buildTranslatableCodeableConcept(),
             buildObservationWithTranslatableCode(),
+            buildObservationWithTargetProfiles()
         };
+
+        private static StructureDefinition buildObservationWithTargetProfiles()
+        {
+            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/Observation-issue-1654", "Observation-issue-1654", "", FHIRAllTypes.Observation);
+
+            var cons = result.Differential.Element;
+            var ed = new ElementDefinition("Observation.subject")
+            {
+                ElementId = "Observation.subject",
+            };
+            ed.OfReference(targetProfile: new[] { "Patient" });
+            cons.Add(ed);
+            ed = new ElementDefinition("Observation.subject.identifier.assigner")
+            {
+                ElementId = "Observation.subject.identifier.assigner",
+            };
+            ed.OfReference(targetProfile: new[] { "Organization" });
+            cons.Add(ed);
+
+            return result;
+        }
 
         private static StructureDefinition buildTranslatableCodeableConcept()
         {

--- a/src/Hl7.Fhir.Specification/Validation/ChildConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/ChildConstraintValidationExtensions.cs
@@ -26,6 +26,9 @@ namespace Hl7.Fhir.Validation
 
             validator.Trace(outcome, "Start validation of inlined child constraints for '{0}'".FormatWith(definition.Path), Issue.PROCESSING_PROGRESS, instance);
 
+            // validate the type on the parent of children. If this is a reference type, it will follow that reference as well
+            outcome.Add(validator.ValidateType(definition.Current, instance));
+
             var matchResult = ChildNameMatcher.Match(definition, instance);
 
             if (matchResult.UnmatchedInstanceElements.Any() && !allowAdditionalChildren)

--- a/src/Hl7.Fhir.Specification/Validation/ChildConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/ChildConstraintValidationExtensions.cs
@@ -27,7 +27,7 @@ namespace Hl7.Fhir.Validation
             validator.Trace(outcome, "Start validation of inlined child constraints for '{0}'".FormatWith(definition.Path), Issue.PROCESSING_PROGRESS, instance);
 
             // validate the type on the parent of children. If this is a reference type, it will follow that reference as well
-            outcome.Add(validator.ValidateType(definition.Current, instance));
+            outcome.Add(validator.ValidateTargetProfiles(definition.Current, instance));
 
             var matchResult = ChildNameMatcher.Match(definition, instance);
 

--- a/src/Hl7.Fhir.Specification/Validation/TypeRefValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/TypeRefValidationExtensions.cs
@@ -7,7 +7,6 @@
  */
 
 using Hl7.Fhir.ElementModel;
-using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Support;
@@ -26,7 +25,7 @@ namespace Hl7.Fhir.Validation
 
             validator.Trace(outcome, "Validating against constraints specified by the element's defined type", Issue.PROCESSING_PROGRESS, instance);
 
-            if(definition.Type.Any(tr => tr.Code == null))
+            if (definition.Type.Any(tr => tr.Code == null))
                 validator.Trace(outcome, "ElementDefinition contains a type with an empty type code", Issue.PROFILE_ELEMENTDEF_CONTAINS_NULL_TYPE, instance);
 
             // Check if this is a choice: there are multiple distinct Codes to choose from
@@ -45,8 +44,8 @@ namespace Hl7.Fhir.Validation
                         // In fact, the next statements are just an optimalization, without them, we would do an ANY validation
                         // against *all* choices, what we do here is pre-filtering for sensible choices, and report if there isn't
                         // any.
-                        var applicableChoices = typeRefs.Where(tr=> !tr.Code.StartsWith("http:"))
-                                        .Where(tr => ModelInfo.IsInstanceTypeFor(ModelInfo.FhirTypeNameToFhirType(tr.Code).Value, 
+                        var applicableChoices = typeRefs.Where(tr => !tr.Code.StartsWith("http:"))
+                                        .Where(tr => ModelInfo.IsInstanceTypeFor(ModelInfo.FhirTypeNameToFhirType(tr.Code).Value,
                                             instanceType.Value));
 
                         // Instance typename must be one of the applicable types in the choice
@@ -78,8 +77,8 @@ namespace Hl7.Fhir.Validation
             return outcome;
         }
 
-     
-        internal static OperationOutcome ValidateTypeReferences(this Validator validator, 
+
+        internal static OperationOutcome ValidateTypeReferences(this Validator validator,
             IEnumerable<ElementDefinition.TypeRefComponent> typeRefs, ScopedNode instance)
         {
             //TODO: It's more efficient to do the non-reference types FIRST, since ANY match would be ok,
@@ -88,7 +87,7 @@ namespace Hl7.Fhir.Validation
             //better separate the fetching of the instance from the validation, so we do not run the rest of the validation (multiple times!)
             //when a reference cannot be resolved.  (this happens in a choice type where there are multiple references with multiple profiles)
 
-            IEnumerable<Func<OperationOutcome>> validations = typeRefs.Select(tr => createValidatorForTypeRef(validator, instance,tr));
+            IEnumerable<Func<OperationOutcome>> validations = typeRefs.Select(tr => createValidatorForTypeRef(validator, instance, tr));
             return validator.Combine(BatchValidationMode.Any, instance, validations);
         }
 
@@ -102,10 +101,26 @@ namespace Hl7.Fhir.Validation
                 var validations = tr.GetDeclaredProfiles()?.Select(profile => createValidatorForDeclaredProfile(validator, instance, profile));
                 var result = validator.Combine(BatchValidationMode.Any, instance, validations);
 
-                // If this is a reference, also validate the reference against the targetProfile
-                if (ModelInfo.FhirTypeNameToFhirType(tr.Code) == FHIRAllTypes.Reference)
-                    result.Add( validator.ValidateResourceReference(instance, tr) );
+                result.Add(validateTargetProfiles(validator, instance, tr));
 
+                return result;
+            }
+        }
+
+        internal static OperationOutcome ValidateTargetProfiles(this Validator validator, ElementDefinition definition, ScopedNode instance)
+        {
+            var typeRefs = definition.Type.Where(tr => tr.Code != null);
+            IEnumerable<Func<OperationOutcome>> validations = typeRefs.Select(tr => createValidatorForTargetProfiles(validator, instance, tr));
+            return validator.Combine(BatchValidationMode.Any, instance, validations);
+        }
+
+        private static Func<OperationOutcome> createValidatorForTargetProfiles(Validator validator, ScopedNode instance, ElementDefinition.TypeRefComponent tr)
+        {
+            return validate;
+
+            OperationOutcome validate()
+            {
+                var result = validateTargetProfiles(validator, instance, tr);
                 return result;
             }
         }
@@ -119,6 +134,17 @@ namespace Hl7.Fhir.Validation
                 return validator.Validate(instance, declaredProfile, statedCanonicals: null, statedProfiles: null);
             }
         }
+        
+        private static OperationOutcome validateTargetProfiles(Validator validator, ScopedNode instance, ElementDefinition.TypeRefComponent tr)
+        {
+            var result = new OperationOutcome();
+
+            // If this is a reference, also validate the reference against the targetProfile
+            if (ModelInfo.FhirTypeNameToFhirType(tr.Code) == FHIRAllTypes.Reference)
+                result.Add(validator.ValidateResourceReference(instance, tr));
+
+            return result;
+        }
 
         internal static OperationOutcome ValidateResourceReference(this Validator validator, ScopedNode instance, ElementDefinition.TypeRefComponent typeRef)
         {
@@ -129,7 +155,7 @@ namespace Hl7.Fhir.Validation
             if (reference == null)       // No reference found -> this is always valid
                 return outcome;
 
-            
+
             // Try to resolve the reference *within* the current instance (Bundle, resource with contained resources) first
             var referencedResource = validator.resolveReference(instance, reference,
                 out ElementDefinition.AggregationMode? encounteredKind, outcome);
@@ -228,7 +254,7 @@ namespace Hl7.Fhir.Validation
             if (identity.Form == ResourceIdentityForm.Local)
             {
                 referenceKind = ElementDefinition.AggregationMode.Contained;
-                if(result == null)
+                if (result == null)
                     validator.Trace(outcome, $"Contained reference ({reference}) is not resolvable", Issue.CONTENT_CONTAINED_REFERENCE_NOT_RESOLVABLE, instance);
             }
             else


### PR DESCRIPTION
## Description
A profile that had a target profile on a reference type *and* other child definitions on that reference, then the validator did not resolve the reference and skipped the whole validation of that referenced resource. This has been resolved now. 

## Related issues
Fixes #1654 

## Testing
See `BasicValidationTests.ValidateWithTargetProfileAndChildDefinitions`

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes