### PR TITLE
FhirClient: History operations have now a nullable summary parameter

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Rest/FhirClientMockTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/FhirClientMockTests.cs
@@ -1,13 +1,18 @@
-﻿using Hl7.Fhir.Model;
+﻿using FluentAssertions;
+using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Moq.Protected;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Hl7.Fhir.Core.Tests.Rest
 {
@@ -35,19 +40,19 @@ namespace Hl7.Fhir.Core.Tests.Rest
             //Two mocks, since response messages get disposed after each "SendAsync()", and the test required two rest calls.
             mock
                .Protected()
-                       .Setup<System.Threading.Tasks.Task<HttpResponseMessage>>(
-                          "SendAsync",
-                          ItExpr.Is<HttpRequestMessage>(h => h.RequestUri == new Uri("http://example.com/metadata?_summary=true")), //the call to check capabilitystatement
-                          ItExpr.IsAny<CancellationToken>())
+                       .As<IHttpResponseMessage>()
+                       .Setup(m => m.SendAsync(
+                          It.Is<HttpRequestMessage>(h => h.RequestUri == new Uri("http://example.com/metadata?_summary=true")), //the call to check capabilitystatement
+                          It.IsAny<CancellationToken>()))
                        .ReturnsAsync(response);
 
 
             mock
                .Protected()
-                       .Setup<System.Threading.Tasks.Task<HttpResponseMessage>>(
-                          "SendAsync",
-                          ItExpr.Is<HttpRequestMessage>(h => h.RequestUri == new Uri("http://example.com/Patient/1")),  //the GET Patient
-                          ItExpr.IsAny<CancellationToken>())
+                       .As<IHttpResponseMessage>()
+                       .Setup(m => m.SendAsync(
+                          It.Is<HttpRequestMessage>(h => h.RequestUri == new Uri("http://example.com/Patient/1")),  //the GET Patient
+                          It.IsAny<CancellationToken>()))
                        .ReturnsAsync(patientResponse);
 
             using var client = new FhirClient("http://example.com", new FhirClientSettings { VerifyFhirVersion = true }, mock.Object);
@@ -83,19 +88,18 @@ namespace Hl7.Fhir.Core.Tests.Rest
             //Two mocks, since response messages get disposed after each "SendAsync()", and the test required two rest calls.
             mock
                .Protected()
-                       .Setup<System.Threading.Tasks.Task<HttpResponseMessage>>(
-                          "SendAsync",
-                          ItExpr.Is<HttpRequestMessage>(h => h.RequestUri == new Uri("http://example.com/metadata?_summary=true")), //the call to check capabilitystatement
-                          ItExpr.IsAny<CancellationToken>())
+                       .As<IHttpResponseMessage>()
+                       .Setup(m => m.SendAsync(
+                          It.Is<HttpRequestMessage>(h => h.RequestUri == new Uri("http://example.com/metadata?_summary=true")), //the call to check capabilitystatement
+                          It.IsAny<CancellationToken>()))
                        .ReturnsAsync(response);
-
 
             mock
                .Protected()
-                       .Setup<System.Threading.Tasks.Task<HttpResponseMessage>>(
-                          "SendAsync",
-                          ItExpr.Is<HttpRequestMessage>(h => h.RequestUri == new Uri("http://example.com/Patient/1")),  //the GET Patient
-                          ItExpr.IsAny<CancellationToken>())
+                       .As<IHttpResponseMessage>()
+                       .Setup(m => m.SendAsync(
+                          It.Is<HttpRequestMessage>(h => h.RequestUri == new Uri("http://example.com/Patient/1")),  //the GET Patient
+                          It.IsAny<CancellationToken>()))
                        .ReturnsAsync(patientResponse);
 
             using var client = new FhirClient("http://example.com", new FhirClientSettings { VerifyFhirVersion = true }, mock.Object);
@@ -119,10 +123,10 @@ namespace Hl7.Fhir.Core.Tests.Rest
 
             mock
              .Protected()
-                     .Setup<System.Threading.Tasks.Task<HttpResponseMessage>>(
-                        "SendAsync",
-                        ItExpr.Is<HttpRequestMessage>(h => h.RequestUri == new Uri("http://example.com/Patient?name=henry")), 
-                        ItExpr.IsAny<CancellationToken>())
+                     .As<IHttpResponseMessage>()
+                     .Setup(m => m.SendAsync(
+                        It.Is<HttpRequestMessage>(h => h.RequestUri == new Uri("http://example.com/Patient?name=henry")),
+                        It.IsAny<CancellationToken>()))
                      .ReturnsAsync(response);
 
             using var client = new FhirClient("http://example.com", new FhirClientSettings { VerifyFhirVersion = false }, mock.Object);
@@ -130,6 +134,71 @@ namespace Hl7.Fhir.Core.Tests.Rest
             var patient = await client.SearchAsync<Patient>(new string[] { "name=henry" });
 
             Assert.AreEqual("/fhir/*/Bundle/example", client.LastResult.Location);
+        }
+
+        public static IEnumerable<object[]> GetData()
+        {
+            yield return new object[] { "http://example.com/Patient/example/_history", "HistoryAsync", "Patient/example" };
+            yield return new object[] { "http://example.com/Patient/example/_history", "HistoryAsync", new Uri("http://example.com/Patient/example") };
+            yield return new object[] { "http://example.com/Patient/example/_history", "History", "Patient/example" };
+            yield return new object[] { "http://example.com/Patient/example/_history", "History", new Uri("http://example.com/Patient/example") };
+            yield return new object[] { "http://example.com/Patient/_history", "TypeHistory", "Patient" };
+            yield return new object[] { "http://example.com/Patient/_history", "TypeHistoryAsync", "Patient" };
+            yield return new object[] { "http://example.com/_history", "WholeSystemHistory", null };
+            yield return new object[] { "http://example.com/_history", "WholeSystemHistoryAsync", null };
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetData), DynamicDataSourceType.Method)]
+        public void HistoryContainsNoSummaryParameter(string expectedRequest, string methodName, object parameter)
+        {
+            Uri expectedRequestUri = new(expectedRequest);
+            var requests = new List<HttpRequestMessage>();
+
+            var client = setupClient();
+
+            var methods = typeof(FhirClient).GetMethods(BindingFlags.Instance | BindingFlags.Public);
+            var method = parameter is null
+                ? methods.SingleOrDefault(m => m.Name == methodName)
+                : methods.SingleOrDefault(m => m.Name == methodName && m.GetParameters().First().ParameterType == parameter.GetType());
+
+            method.Should().NotBeNull($"{methodName} should be a method of FhirClient");
+
+            var p = parameter is null ? Enumerable.Empty<object>() : new[] { parameter };
+            p = p.Concat(method.GetParameters().Skip(parameter is null ? 0 : 1).Select(param => param.HasDefaultValue ? param.DefaultValue : null));
+            method.Invoke(client, p.ToArray());
+
+
+            requests.Should().OnlyContain(req => req.RequestUri == expectedRequestUri);
+
+            FhirClient setupClient()
+            {
+                var mock = new Mock<HttpMessageHandler>();
+
+                var response = new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(@"{""resourceType"": ""Bundle"",  ""id"": ""example:""}", Encoding.UTF8, "application/json"), // not interested in the Content
+                    RequestMessage = new HttpRequestMessage(HttpMethod.Get, expectedRequestUri),
+                };
+
+                mock
+                 .Protected()
+                         .As<IHttpResponseMessage>()
+                         .Setup(m => m.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                         .Callback<HttpRequestMessage, CancellationToken>((request, token) => requests.Add(request))
+                         .ReturnsAsync(response);
+
+                return new FhirClient(expectedRequestUri.GetLeftPart(UriPartial.Authority), new FhirClientSettings { VerifyFhirVersion = false }, mock.Object);
+            }
+        }
+
+        /// <summary>
+        /// Used only for intelligence help
+        /// </summary>
+        private interface IHttpResponseMessage
+        {
+            Task<HttpResponseMessage> SendAsync(HttpRequestMessage message, CancellationToken token);
         }
     }
 }

--- a/src/Hl7.Fhir.Core/Rest/BaseFhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/BaseFhirClient.cs
@@ -553,10 +553,11 @@ namespace Hl7.Fhir.Rest
         /// <param name="summary">Optional. Asks the server to only provide the fields defined for the summary</param>        
         /// <returns>A bundle with the history for the indicated instance, may contain both 
         /// ResourceEntries and DeletedEntries.</returns>
-        public Task<Bundle> TypeHistoryAsync(string resourceType, DateTimeOffset? since = null, int? pageSize = null, SummaryType summary = SummaryType.False)
+        public Task<Bundle> TypeHistoryAsync(string resourceType, DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null)
         {
             return internalHistoryAsync(resourceType, null, since, pageSize, summary);
         }
+
         /// <summary>
         /// Retrieve the version history for a specific resource type
         /// </summary>
@@ -566,7 +567,7 @@ namespace Hl7.Fhir.Rest
         /// <param name="summary">Optional. Asks the server to only provide the fields defined for the summary</param>        
         /// <returns>A bundle with the history for the indicated instance, may contain both 
         /// ResourceEntries and DeletedEntries.</returns>
-        public Bundle TypeHistory(string resourceType, DateTimeOffset? since = null, int? pageSize = null, SummaryType summary = SummaryType.False)
+        public Bundle TypeHistory(string resourceType, DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null)
         {
             return TypeHistoryAsync(resourceType, since, pageSize, summary).WaitResult();
         }
@@ -580,11 +581,12 @@ namespace Hl7.Fhir.Rest
         /// <typeparam name="TResource">The type of Resource to get the history for</typeparam>
         /// <returns>A bundle with the history for the indicated instance, may contain both 
         /// ResourceEntries and DeletedEntries.</returns>
-        public Task<Bundle> TypeHistoryAsync<TResource>(DateTimeOffset? since = null, int? pageSize = null, SummaryType summary = SummaryType.False) where TResource : Resource, new()
+        public Task<Bundle> TypeHistoryAsync<TResource>(DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null) where TResource : Resource, new()
         {
             string collection = ModelInfo.GetFhirTypeNameForType(typeof(TResource));
             return internalHistoryAsync(collection, null, since, pageSize, summary);
         }
+
         /// <summary>
         /// Retrieve the version history for a specific resource type
         /// </summary>
@@ -594,7 +596,7 @@ namespace Hl7.Fhir.Rest
         /// <typeparam name="TResource">The type of Resource to get the history for</typeparam>
         /// <returns>A bundle with the history for the indicated instance, may contain both 
         /// ResourceEntries and DeletedEntries.</returns>
-        public Bundle TypeHistory<TResource>(DateTimeOffset? since = null, int? pageSize = null, SummaryType summary = SummaryType.False) where TResource : Resource, new()
+        public Bundle TypeHistory<TResource>(DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null) where TResource : Resource, new()
         {
             return TypeHistoryAsync<TResource>(since, pageSize, summary).WaitResult();
         }
@@ -608,13 +610,14 @@ namespace Hl7.Fhir.Rest
         /// <param name="summary">Optional. Asks the server to only provide the fields defined for the summary</param>
         /// <returns>A bundle with the history for the indicated instance, may contain both 
         /// ResourceEntries and DeletedEntries.</returns>
-        public Task<Bundle> HistoryAsync(Uri location, DateTimeOffset? since = null, int? pageSize = null, SummaryType summary = SummaryType.False)
+        public Task<Bundle> HistoryAsync(Uri location, DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null)
         {
             if (location == null) throw Error.ArgumentNull(nameof(location));
 
             var id = verifyResourceIdentity(location, needId: true, needVid: false);
             return internalHistoryAsync(id.ResourceType, id.Id, since, pageSize, summary);
         }
+
         /// <summary>
         /// Retrieve the version history for a resource at a given location
         /// </summary>
@@ -624,7 +627,7 @@ namespace Hl7.Fhir.Rest
         /// <param name="summary">Optional. Asks the server to only provide the fields defined for the summary</param>
         /// <returns>A bundle with the history for the indicated instance, may contain both 
         /// ResourceEntries and DeletedEntries.</returns>
-        public Bundle History(Uri location, DateTimeOffset? since = null, int? pageSize = null, SummaryType summary = SummaryType.False)
+        public Bundle History(Uri location, DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null)
         {
             return HistoryAsync(location, since, pageSize, summary).WaitResult();
         }
@@ -638,10 +641,11 @@ namespace Hl7.Fhir.Rest
         /// <param name="summary">Optional. Asks the server to only provide the fields defined for the summary</param>
         /// <returns>A bundle with the history for the indicated instance, may contain both 
         /// ResourceEntries and DeletedEntries.</returns>
-        public Task<Bundle> HistoryAsync(string location, DateTimeOffset? since = null, int? pageSize = null, SummaryType summary = SummaryType.False)
+        public Task<Bundle> HistoryAsync(string location, DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null)
         {
             return HistoryAsync(new Uri(location, UriKind.Relative), since, pageSize, summary);
         }
+
         /// <summary>
         /// Retrieve the version history for a resource at a given location
         /// </summary>
@@ -651,7 +655,7 @@ namespace Hl7.Fhir.Rest
         /// <param name="summary">Optional. Asks the server to only provide the fields defined for the summary</param>
         /// <returns>A bundle with the history for the indicated instance, may contain both 
         /// ResourceEntries and DeletedEntries.</returns>
-        public Bundle History(string location, DateTimeOffset? since = null, int? pageSize = null, SummaryType summary = SummaryType.False)
+        public Bundle History(string location, DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null)
         {
             return HistoryAsync(location, since, pageSize, summary).WaitResult();
         }
@@ -661,26 +665,28 @@ namespace Hl7.Fhir.Rest
         /// </summary>
         /// <param name="since">Optional. Returns only changes after the given date</param>
         /// <param name="pageSize">Optional. Asks server to limit the number of entries per page returned</param>
-        /// <param name="summary">Indicates whether the returned resources should just contain the minimal set of elements</param>
+        /// <param name="summary">Optional. Indicates whether the returned resources should just contain the minimal set of elements</param>
         /// <returns>A bundle with the history for the indicated instance, may contain both 
         /// ResourceEntries and DeletedEntries.</returns>
-        public Task<Bundle> WholeSystemHistoryAsync(DateTimeOffset? since = null, int? pageSize = null, SummaryType summary = SummaryType.False)
+        public Task<Bundle> WholeSystemHistoryAsync(DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null)
         {
             return internalHistoryAsync(null, null, since, pageSize, summary);
         }
+
         /// <summary>
         /// Retrieve the full version history of the server
         /// </summary>
         /// <param name="since">Optional. Returns only changes after the given date</param>
         /// <param name="pageSize">Optional. Asks server to limit the number of entries per page returned</param>
-        /// <param name="summary">Indicates whether the returned resources should just contain the minimal set of elements</param>
+        /// <param name="summary">Optional. Indicates whether the returned resources should just contain the minimal set of elements</param>
         /// <returns>A bundle with the history for the indicated instance, may contain both 
         /// ResourceEntries and DeletedEntries.</returns>
-        public Bundle WholeSystemHistory(DateTimeOffset? since = null, int? pageSize = null, SummaryType summary = SummaryType.False)
+        public Bundle WholeSystemHistory(DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null)
         {
             return WholeSystemHistoryAsync(since, pageSize, summary).WaitResult();
         }
-        private Task<Bundle> internalHistoryAsync(string resourceType = null, string id = null, DateTimeOffset? since = null, int? pageSize = null, SummaryType summary = SummaryType.False)
+
+        private Task<Bundle> internalHistoryAsync(string resourceType = null, string id = null, DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null)
         {
             TransactionBuilder history;
 
@@ -692,11 +698,6 @@ namespace Hl7.Fhir.Rest
                 history = new TransactionBuilder(Endpoint).ResourceHistory(resourceType, id, summary, pageSize, since);
 
             return executeAsync<Bundle>(history.ToBundle(), HttpStatusCode.OK);
-        }
-        private Bundle internalHistory(string resourceType = null, string id = null, DateTimeOffset? since = null,
-            int? pageSize = null, SummaryType summary = SummaryType.False)
-        {
-            return internalHistoryAsync(resourceType, id, since, pageSize, summary).WaitResult();
         }
 
         #endregion


### PR DESCRIPTION
## Description
For History operations: the summary parameter has changed to nullable, so that the parameter will not end up in the httprequest.

## Related issues
Resolves #1886.

## Testing
See unit test `Hl7.Fhir.Core.Tests.Rest.FhirClientMockTest.HistoryContainsNoSummaryParameter`.

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] Mark the PR with the label **breaking change** when this PR introduces breaking changes