### PR TITLE
FhirClient: remove MIME-type fhirVersion from Accept header

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Rest/ContentTypeTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/ContentTypeTests.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Text;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using FluentAssertions;
 using Hl7.Fhir.Rest;
-using Hl7.Fhir.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Hl7.Fhir.Tests.Rest
 {
@@ -21,11 +17,14 @@ namespace Hl7.Fhir.Tests.Rest
             Assert.AreEqual(ResourceFormat.Unknown, ContentType.GetResourceFormatFromContentType("\"application\blah"));
         }
 
-        [TestMethod]
-        public void TestBuildingContentType()
+        [DataTestMethod]
+        [DataRow(ResourceFormat.Json, "3.0", "application/fhir+json; charset=utf-8; fhirVersion=3.0")]
+        [DataRow(ResourceFormat.Xml, "3.0", "application/fhir+xml; charset=utf-8; fhirVersion=3.0")]
+        [DataRow(ResourceFormat.Json, "4.0", "application/fhir+json; charset=utf-8; fhirVersion=4.0")]
+        [DataRow(ResourceFormat.Json, "", "application/fhir+json; charset=utf-8")]
+        public void TestBuildingContentType(ResourceFormat format, string fhirVersion, string expected)
         {
-            var type = ContentType.BuildContentType(ResourceFormat.Json, ModelInfo.Version);
-            Assert.AreEqual("application/fhir+json; charset=utf-8; fhirVersion=3.0", type);
+            ContentType.BuildContentType(format, fhirVersion).Should().Be(expected);
         }
     }
 }

--- a/src/Hl7.Fhir.Core.Tests/Rest/FhirClientMockTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/FhirClientMockTests.cs
@@ -143,11 +143,6 @@ namespace Hl7.Fhir.Core.Tests.Rest
         [DataRow(false, DisplayName = "Don't use FhirVersion in Accept header")]
         public async System.Threading.Tasks.Task AcceptHeaderTest(bool useFhirVersionHeader)
         {
-            var item = new QuestionnaireResponse.ItemComponent();
-
-            item.LinkId = "myLinkId";
-            item.Answer.Add(new QuestionnaireResponse.AnswerComponent() { Value = new FhirBoolean(true) });
-
             var mock = new Mock<HttpMessageHandler>();
             var response = new HttpResponseMessage
             {

--- a/src/Hl7.Fhir.Core.Tests/Rest/FhirClientMockTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/FhirClientMockTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text;
 using System.Threading;
@@ -135,6 +136,52 @@ namespace Hl7.Fhir.Core.Tests.Rest
 
             Assert.AreEqual("/fhir/*/Bundle/example", client.LastResult.Location);
         }
+
+
+        [DataTestMethod]
+        [DataRow(true, DisplayName = "Use FhirVersion in Accept header")]
+        [DataRow(false, DisplayName = "Don't use FhirVersion in Accept header")]
+        public async System.Threading.Tasks.Task AcceptHeaderTest(bool useFhirVersionHeader)
+        {
+            var item = new QuestionnaireResponse.ItemComponent();
+
+            item.LinkId = "myLinkId";
+            item.Answer.Add(new QuestionnaireResponse.AnswerComponent() { Value = new FhirBoolean(true) });
+
+            var mock = new Mock<HttpMessageHandler>();
+            var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(@"{""resourceType"": ""Bundle"",  ""id"": ""example:""}", Encoding.UTF8, "application/json"),
+                RequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.com/Patient?name=henry"),
+            };
+
+            mock
+             .Protected()
+                         .As<IHttpResponseMessage>()
+                         .Setup(m => m.SendAsync(
+                            It.Is<HttpRequestMessage>(h => h.RequestUri == new Uri("http://example.com/Patient?name=henry")),
+                            It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(response);
+
+            using var client = new FhirClient("http://example.com", new FhirClientSettings
+            {
+                VerifyFhirVersion = false,
+                UseFhirVersionInAcceptHeader = useFhirVersionHeader
+            }, mock.Object);
+
+            var patient = await client.SearchAsync<Patient>(new string[] { "name=henry" });
+
+            mock
+                .Protected()
+                .As<IHttpResponseMessage>()
+                .Verify(m => m.SendAsync(
+                    It.Is<HttpRequestMessage>(h => findInAcceptHeader(h.Headers.Accept, "fhirVersion", useFhirVersionHeader)),
+                    It.IsAny<CancellationToken>()));
+        }
+
+        private static bool findInAcceptHeader(HttpHeaderValueCollection<MediaTypeWithQualityHeaderValue> acceptHeader, string headerName, bool exists)
+            => acceptHeader.SelectMany(a => a.Parameters).Any(p => p.Name == headerName) == exists;
 
         public static IEnumerable<object[]> GetData()
         {

--- a/src/Hl7.Fhir.Core/Rest/BundleToEntryRequest.cs
+++ b/src/Hl7.Fhir.Core/Rest/BundleToEntryRequest.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Rest
                     result.Method == HTTPVerb.POST
                     && entry.Annotation<InteractionType>() == InteractionType.Search
                     && entry.Resource is Parameters;
-                TaskHelper.Await(() => setBodyAndContentTypeAsync(result, entry.Resource, settings.PreferredFormat, searchUsingPost));
+                TaskHelper.Await(() => setBodyAndContentTypeAsync(result, entry.Resource, settings, searchUsingPost));
             }
 
             return result;
@@ -81,7 +81,7 @@ namespace Hl7.Fhir.Rest
                     result.Method == HTTPVerb.POST
                     && entry.Annotation<InteractionType>() == InteractionType.Search
                     && entry.Resource is Parameters;
-                await setBodyAndContentTypeAsync(result, entry.Resource, settings.PreferredFormat, searchUsingPost).ConfigureAwait(false);
+                await setBodyAndContentTypeAsync(result, entry.Resource, settings, searchUsingPost).ConfigureAwait(false);
             }
 
             return result;
@@ -115,7 +115,7 @@ namespace Hl7.Fhir.Rest
             }
         }
 
-        private static async Task setBodyAndContentTypeAsync(EntryRequest request, Resource data, ResourceFormat format, bool searchUsingPost)
+        private static async Task setBodyAndContentTypeAsync(EntryRequest request, Resource data, FhirClientSettings settings, bool searchUsingPost)
         {
             if (data == null) throw Error.ArgumentNull(nameof(data));
 
@@ -151,14 +151,14 @@ namespace Hl7.Fhir.Rest
             }
             else
             {
-                request.RequestBodyContent = format == ResourceFormat.Xml ?
+                request.RequestBodyContent = settings.PreferredFormat == ResourceFormat.Xml ?
                     await new FhirXmlSerializer().SerializeToBytesAsync(data, summary: Fhir.Rest.SummaryType.False).ConfigureAwait(false) :
                     await new FhirJsonSerializer().SerializeToBytesAsync(data, summary: Fhir.Rest.SummaryType.False).ConfigureAwait(false);
 
                 // This is done by the caller after the OnBeforeRequest is called so that other properties
                 // can be set before the content is committed
                 // request.WriteBody(CompressRequestBody, body);
-                request.ContentType = ContentType.BuildContentType(format, ModelInfo.Version);
+                request.ContentType = ContentType.BuildContentType(settings, ModelInfo.Version);
             }
         }
     }

--- a/src/Hl7.Fhir.Core/Rest/BundleToEntryRequest.cs
+++ b/src/Hl7.Fhir.Core/Rest/BundleToEntryRequest.cs
@@ -6,12 +6,10 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
-using System;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Utility;
 using System.Collections.Generic;
-using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Task = System.Threading.Tasks.Task;
@@ -40,7 +38,7 @@ namespace Hl7.Fhir.Rest
 
             if (!settings.UseFormatParameter)
             {
-                result.Headers.Accept = ContentType.BuildContentType(settings.PreferredFormat, ModelInfo.Version);
+                result.Headers.Accept = ContentType.BuildContentType(settings, ModelInfo.Version);
             }
 
             if (entry.Resource != null)
@@ -69,12 +67,12 @@ namespace Hl7.Fhir.Rest
                     IfModifiedSince = entry.Request.IfModifiedSince,
                     IfNoneExist = entry.Request.IfNoneExist,
                     IfNoneMatch = entry.Request.IfNoneMatch
-                }                
+                }
             };
 
             if (!settings.UseFormatParameter)
             {
-                result.Headers.Accept = ContentType.BuildContentType(settings.PreferredFormat, ModelInfo.Version);
+                result.Headers.Accept = ContentType.BuildContentType(settings, ModelInfo.Version);
             }
 
             if (entry.Resource != null)
@@ -91,32 +89,32 @@ namespace Hl7.Fhir.Rest
 
         private static HTTPVerb? bundleHttpVerbToRestHttpVerb(Bundle.HTTPVerb? bundleHttp, InteractionType type)
         {
-            switch(bundleHttp)
+            switch (bundleHttp)
             {
                 case Bundle.HTTPVerb.POST:
-                {
-                    return HTTPVerb.POST;
-                }
+                    {
+                        return HTTPVerb.POST;
+                    }
                 case Bundle.HTTPVerb.GET:
-                {
-                    return HTTPVerb.GET;
-                }
+                    {
+                        return HTTPVerb.GET;
+                    }
                 case Bundle.HTTPVerb.DELETE:
-                {
-                    return HTTPVerb.DELETE;
-                }
+                    {
+                        return HTTPVerb.DELETE;
+                    }
                 case Bundle.HTTPVerb.PUT:
-                {
+                    {
                         //No PATCH in Bundle.HttpVerb in STU3, so this is corrected here. 
                         return type == InteractionType.Patch ? HTTPVerb.PATCH : HTTPVerb.PUT;
-                }
+                    }
                 default:
-                {
-                    return null;
-                }
+                    {
+                        return null;
+                    }
             }
         }
-        
+
         private static async Task setBodyAndContentTypeAsync(EntryRequest request, Resource data, ResourceFormat format, bool searchUsingPost)
         {
             if (data == null) throw Error.ArgumentNull(nameof(data));
@@ -137,7 +135,7 @@ namespace Hl7.Fhir.Rest
                 List<KeyValuePair<string, string>> bodyParameters = new List<KeyValuePair<string, string>>();
                 foreach (Parameters.ParameterComponent parameter in ((Parameters)data).Parameter)
                 {
-                    bodyParameters.Add(new KeyValuePair<string,string>(parameter.Name, parameter.Value.ToString()));
+                    bodyParameters.Add(new KeyValuePair<string, string>(parameter.Name, parameter.Value.ToString()));
                 }
                 if (bodyParameters.Count > 0)
                 {


### PR DESCRIPTION
## Description
Removes MIME-type `fhirVersion` from Accept header. Use the `FhirClientSettings.UseFhirVersionInAcceptHeader` to add the `fhirVersion` back into the Accept header. The default behavior is that this MIME-type parameter is not added to the Accept header. Hence the breaking change.

See also PR https://github.com/FirelyTeam/firely-net-common/pull/165 

## Related issues
Fixes #1899.

## Testing
Unit test `Hl7.Fhir.Core.Tests.Rest.FhirClientMockTest.AcceptHeaderTest`

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] Mark the PR with the label **breaking change** when this PR introduces breaking changes