### PR TITLE
SnapshotGenerator: continue merging diff child constraints with multiple types

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -7529,6 +7529,25 @@ namespace Hl7.Fhir.Specification.Tests
             baseElement.Slicing.Discriminator[0].Type.Should().Be(ElementDefinition.DiscriminatorType.Pattern);
             baseElement.Slicing.Discriminator[0].Path.Should().Be("$this");
         }
+        [DataTestMethod]
+        [DataRow("http://validationtest.org/fhir/StructureDefinition/DeceasedPatient", "Patient.deceased[x].extension:range")]
+        [DataRow("http://validationtest.org/fhir/StructureDefinition/DeceasedPatientRequiredBoolean", "Patient.deceased[x].extension:range")]
+        public async T.Task Forge580(string url, string elementId)
+        {
+            var resolver = new CachedResolver(new MultiResolver(ZipSource.CreateValidationSource(), new TestProfileArtifactSource()));
+            var snapshotGenerator = new SnapshotGenerator(resolver, SnapshotGeneratorSettings.CreateDefault());
+            var sd = await resolver.ResolveByCanonicalUriAsync(url) as StructureDefinition;
+
+            // Act
+            var elements = await snapshotGenerator.GenerateAsync(sd);
+
+            // Assert
+            snapshotGenerator.Outcome.Should().BeNull();
+
+            var extensionElement = elements.SingleOrDefault(x => x.ElementId == elementId);
+
+            extensionElement.Should().NotBeNull();
+        }
 
         private sealed class TestAnnotation
         {

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -7532,7 +7532,7 @@ namespace Hl7.Fhir.Specification.Tests
         [DataTestMethod]
         [DataRow("http://validationtest.org/fhir/StructureDefinition/DeceasedPatient", "Patient.deceased[x].extension:range")]
         [DataRow("http://validationtest.org/fhir/StructureDefinition/DeceasedPatientRequiredBoolean", "Patient.deceased[x].extension:range")]
-        public async T.Task Forge580(string url, string elementId)
+        public async T.Task ContinueMergingChildConstraintMultipleTypes(string url, string elementId)
         {
             var resolver = new CachedResolver(new MultiResolver(ZipSource.CreateValidationSource(), new TestProfileArtifactSource()));
             var snapshotGenerator = new SnapshotGenerator(resolver, SnapshotGeneratorSettings.CreateDefault());

--- a/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
@@ -616,7 +616,7 @@ namespace Hl7.Fhir.Validation
             if (profile is not null)
             {
                 cons.Add(new ElementDefinition("Patient.deceased[x]")
-                    .OfType(FHIRAllTypes.Boolean, new[] { "http://validationtest.org/fhir/StructureDefinition/RequiredBoolean" })
+                    .OfType(FHIRAllTypes.Boolean, "http://validationtest.org/fhir/StructureDefinition/RequiredBoolean")
                     .OrType(FHIRAllTypes.DateTime));
             }
 
@@ -629,7 +629,7 @@ namespace Hl7.Fhir.Validation
             {
                 ElementId = "Patient.deceased[x].extension:range",
                 SliceName = "range",
-            }.OfType(FHIRAllTypes.Extension, new[] { "http://validationtest.org/fhir/StructureDefinition/MyRangeExtension" }));
+            }.OfType(FHIRAllTypes.Extension, "http://validationtest.org/fhir/StructureDefinition/MyRangeExtension"));
             return result;
         }
     }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -966,19 +966,13 @@ namespace Hl7.Fhir.Specification.Snapshot
 
             var diffTypes = diff.Current.Type;
             var distinctTypeCodeCnt = diffTypes.DistinctTypeCodes().Count;
-            if (distinctTypeCodeCnt == 0)
+            if (distinctTypeCodeCnt != 1)
             {
                 // Element has no type constraints, nothing to merge
                 // return true to continue merging child constraints
-                return true;
-            }
-            else if (distinctTypeCodeCnt > 1)
-            {
+                // OR
                 // Element specifies multiple type codes, cannot expand children
-                // return false to prevent merging child constraints
-
-                // return false;
-                // [MV 20211123] return true to continue merging diff child constraints
+                // return true to continue merging diff child constraints
                 return true;
             }
 

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -976,6 +976,9 @@ namespace Hl7.Fhir.Specification.Snapshot
             {
                 // Element specifies multiple type codes, cannot expand children
                 // return false to prevent merging child constraints
+
+                // return false;
+                // [MV 20211123] return true to continue merging diff child constraints
                 return true;
             }
 

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -976,7 +976,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             {
                 // Element specifies multiple type codes, cannot expand children
                 // return false to prevent merging child constraints
-                return false;
+                return true;
             }
 
             // [WMR 20171004] New


### PR DESCRIPTION
## Description
Continue merging diff child constraints in the case of multiple types.

## Related issues
Resolves #1898.

## Testing
See unit test `Hl7.Fhir.Specification.Tests.SnapshotGeneratorTest2.ContinueMergingChildConstraintsMultipleTypes`

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes