### PR TITLE
Support for the FiveWs property mappings - R5

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/ElementModel/PocoTypedElementTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/ElementModel/PocoTypedElementTests.cs
@@ -164,5 +164,19 @@ namespace Hl7.Fhir.Core.Tests.ElementModel
             }
         }
 
+        [TestMethod]
+        public async Tasks.Task ValidateFiveWs()
+        {
+            var json = TestDataHelper.ReadTestData("test-observation.json");
+            var poco = await (new FhirJsonParser()).ParseAsync<Observation>(json);
+
+            var inspector = ModelInfo.ModelInspector;
+            var aResourceMapping = inspector.FindClassMapping(typeof(Observation));
+            var fiveWsProp = aResourceMapping.PropertyMappings.Where(p => p.FiveWs != null && p.FiveWs == "FiveWs.subject").First();
+
+            var subjectProp = fiveWsProp.GetValue(poco) as ResourceReference;
+
+            Assert.AreEqual(poco.Subject, subjectProp);
+        }
     }
 }

--- a/src/Hl7.Fhir.Core.Tests/TestData/test-observation.json
+++ b/src/Hl7.Fhir.Core.Tests/TestData/test-observation.json
@@ -1,0 +1,72 @@
+{
+  "resourceType": "Observation",
+  "id": "f001",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: f001</p><p><b>identifier</b>: 6323 (OFFICIAL)</p><p><b>status</b>: final</p><p><b>code</b>: Glucose [Moles/volume] in Blood <span>(Details : {LOINC code '15074-8' = 'Glucose [Moles/volume] in Blood', given as 'Glucose [Moles/volume] in Blood'})</span></p><p><b>subject</b>: <a>P. van de Heuvel</a></p><p><b>effective</b>: 02/04/2013 9:30:10 AM --&gt; (ongoing)</p><p><b>issued</b>: 03/04/2013 3:30:10 PM</p><p><b>performer</b>: <a>A. Langeveld</a></p><p><b>value</b>: 6.3 mmol/l<span> (Details: UCUM code mmol/L = 'mmol/L')</span></p><p><b>interpretation</b>: High <span>(Details : {http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation code 'H' = 'High', given as 'High'})</span></p><h3>ReferenceRanges</h3><table><tr><td>-</td><td><b>Low</b></td><td><b>High</b></td></tr><tr><td>*</td><td>3.1 mmol/l<span> (Details: UCUM code mmol/L = 'mmol/L')</span></td><td>6.2 mmol/l<span> (Details: UCUM code mmol/L = 'mmol/L')</span></td></tr></table></div>"
+  },
+  "identifier": [
+    {
+      "use": "official",
+      "system": "http://www.bmc.nl/zorgportal/identifiers/observations",
+      "value": "6323"
+    }
+  ],
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "15074-8",
+        "display": "Glucose [Moles/volume] in Blood"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/f001",
+    "display": "P. van de Heuvel"
+  },
+  "effectivePeriod": {
+    "start": "2013-04-02T09:30:10+01:00"
+  },
+  "issued": "2013-04-03T15:30:10+01:00",
+  "performer": [
+    {
+      "reference": "Practitioner/f005",
+      "display": "A. Langeveld"
+    }
+  ],
+  "valueQuantity": {
+    "value": 6.3,
+    "unit": "mmol/l",
+    "system": "http://unitsofmeasure.org",
+    "code": "mmol/L"
+  },
+  "interpretation": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+          "code": "H",
+          "display": "High"
+        }
+      ]
+    }
+  ],
+  "referenceRange": [
+    {
+      "low": {
+        "value": 3.1,
+        "unit": "mmol/l",
+        "system": "http://unitsofmeasure.org",
+        "code": "mmol/L"
+      },
+      "high": {
+        "value": 6.2,
+        "unit": "mmol/l",
+        "system": "http://unitsofmeasure.org",
+        "code": "mmol/L"
+      }
+    }
+  ]
+}

--- a/src/Hl7.Fhir.Core/Model/Generated/Account.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Account.cs
@@ -424,7 +424,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Account number
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -438,7 +438,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | inactive | entered-in-error | on-hold | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -484,7 +484,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// E.g. patient, expense, depreciation
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=120)]
+    [FhirElement("type", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Type
     {
@@ -497,7 +497,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Human-readable label
     /// </summary>
-    [FhirElement("name", InSummary=true, Order=130)]
+    [FhirElement("name", InSummary=true, Order=130, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString NameElement
     {
@@ -528,7 +528,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The entity that caused the expenses
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=140)]
+    [FhirElement("subject", InSummary=true, Order=140, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Device","Practitioner","PractitionerRole","Location","HealthcareService","Organization")]
     [Cardinality(Min=0,Max=-1)]
@@ -544,7 +544,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Transaction window
     /// </summary>
-    [FhirElement("servicePeriod", InSummary=true, Order=150)]
+    [FhirElement("servicePeriod", InSummary=true, Order=150, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Period ServicePeriod
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/ActivityDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ActivityDefinition.cs
@@ -505,7 +505,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this activity definition, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -536,7 +536,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the activity definition
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -550,7 +550,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the activity definition
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -674,7 +674,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=150)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=150, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -707,7 +707,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=160)]
+    [FhirElement("experimental", InSummary=true, Order=160, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -754,7 +754,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=180)]
+    [FhirElement("date", InSummary=true, Order=180, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -785,7 +785,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=190)]
+    [FhirElement("publisher", InSummary=true, Order=190, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -871,7 +871,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this activity definition is defined
     /// </summary>
-    [FhirElement("purpose", Order=240)]
+    [FhirElement("purpose", Order=240, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/AdverseEvent.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/AdverseEvent.cs
@@ -140,7 +140,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Who was involved in the adverse event or the potential adverse event
       /// </summary>
-      [FhirElement("actor", InSummary=true, Order=50)]
+      [FhirElement("actor", InSummary=true, Order=50, FiveWs="FiveWs.actor")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole","Organization","CareTeam","Patient","Device","RelatedPerson")]
       [Cardinality(Min=1,Max=1)]
@@ -1004,7 +1004,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// in-progress | completed | entered-in-error | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1037,7 +1037,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// actual | potential
     /// </summary>
-    [FhirElement("actuality", InSummary=true, IsModifier=true, Order=110)]
+    [FhirElement("actuality", InSummary=true, IsModifier=true, Order=110, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1070,7 +1070,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// wrong-patient | procedure-mishap | medication-mishap | device | unsafe-physical-environment | hospital-aquired-infection | wrong-body-site
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=120)]
+    [FhirElement("category", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -1084,7 +1084,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Event or incident that occurred or was averted
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=130)]
+    [FhirElement("code", InSummary=true, Order=130, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
     {
@@ -1097,7 +1097,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Subject impacted by event
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=140)]
+    [FhirElement("subject", InSummary=true, Order=140, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group","Practitioner","RelatedPerson")]
     [Cardinality(Min=1,Max=1)]
@@ -1113,7 +1113,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The Encounter associated with the start of the AdverseEvent
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=150)]
+    [FhirElement("encounter", InSummary=true, Order=150, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -1128,7 +1128,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the event occurred
     /// </summary>
-    [FhirElement("occurrence", InSummary=true, Order=160, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("occurrence", InSummary=true, Order=160, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period),typeof(Hl7.Fhir.Model.Timing))]
     [DataMember]
@@ -1174,7 +1174,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the event was recorded
     /// </summary>
-    [FhirElement("recordedDate", InSummary=true, Order=180)]
+    [FhirElement("recordedDate", InSummary=true, Order=180, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime RecordedDateElement
     {
@@ -1263,7 +1263,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who recorded the adverse event
     /// </summary>
-    [FhirElement("recorder", InSummary=true, Order=230)]
+    [FhirElement("recorder", InSummary=true, Order=230, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Patient","Practitioner","PractitionerRole","RelatedPerson")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/AllergyIntolerance.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/AllergyIntolerance.cs
@@ -536,7 +536,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External ids for this item
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -550,7 +550,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | inactive | resolved
     /// </summary>
-    [FhirElement("clinicalStatus", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("clinicalStatus", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept ClinicalStatus
     {
@@ -563,7 +563,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// unconfirmed | presumed | confirmed | refuted | entered-in-error
     /// </summary>
-    [FhirElement("verificationStatus", InSummary=true, IsModifier=true, Order=110)]
+    [FhirElement("verificationStatus", InSummary=true, IsModifier=true, Order=110, FiveWs="FiveWs.status")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept VerificationStatus
     {
@@ -576,7 +576,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// allergy | intolerance - Underlying mechanism (if known)
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=120)]
+    [FhirElement("type", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.AllergyIntolerance.AllergyIntoleranceType> TypeElement
@@ -608,7 +608,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// food | medication | environment | biologic
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=130)]
+    [FhirElement("category", InSummary=true, Order=130, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
@@ -641,7 +641,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// low | high | unable-to-assess
     /// </summary>
-    [FhirElement("criticality", InSummary=true, Order=140)]
+    [FhirElement("criticality", InSummary=true, Order=140, FiveWs="FiveWs.grade")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.AllergyIntolerance.AllergyIntoleranceCriticality> CriticalityElement
@@ -673,7 +673,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Code that identifies the allergy or intolerance
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=150)]
+    [FhirElement("code", InSummary=true, Order=150, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
     {
@@ -686,7 +686,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who the sensitivity is for
     /// </summary>
-    [FhirElement("patient", InSummary=true, Order=160)]
+    [FhirElement("patient", InSummary=true, Order=160, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]
@@ -702,7 +702,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Encounter when the allergy or intolerance was asserted
     /// </summary>
-    [FhirElement("encounter", Order=170)]
+    [FhirElement("encounter", Order=170, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -717,7 +717,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When allergy or intolerance was identified
     /// </summary>
-    [FhirElement("onset", Order=180, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("onset", Order=180, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.init")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Age),typeof(Hl7.Fhir.Model.Period),typeof(Hl7.Fhir.Model.Range),typeof(Hl7.Fhir.Model.FhirString))]
     [DataMember]
@@ -732,7 +732,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date first version of the resource instance was recorded
     /// </summary>
-    [FhirElement("recordedDate", Order=190)]
+    [FhirElement("recordedDate", Order=190, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime RecordedDateElement
     {
@@ -763,7 +763,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who recorded the sensitivity
     /// </summary>
-    [FhirElement("recorder", Order=200)]
+    [FhirElement("recorder", Order=200, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Patient","RelatedPerson","Organization")]
     [DataMember]
@@ -778,7 +778,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Source of the information about the allergy
     /// </summary>
-    [FhirElement("asserter", InSummary=true, Order=210)]
+    [FhirElement("asserter", InSummary=true, Order=210, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Patient","RelatedPerson","Practitioner","PractitionerRole")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/Appointment.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Appointment.cs
@@ -169,7 +169,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Person, Location/HealthcareService or Device
       /// </summary>
-      [FhirElement("actor", InSummary=true, Order=60)]
+      [FhirElement("actor", InSummary=true, Order=60, FiveWs="FiveWs.who")]
       [CLSCompliant(false)]
       [References("Patient","Group","Practitioner","PractitionerRole","CareTeam","RelatedPerson","Device","HealthcareService","Location")]
       [DataMember]
@@ -367,7 +367,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External Ids for this item
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -381,7 +381,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// proposed | pending | booked | arrived | fulfilled | cancelled | noshow | entered-in-error | checked-in | waitlist
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -455,7 +455,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The specialty of a practitioner that would be required to perform the service requested in this appointment
     /// </summary>
-    [FhirElement("specialty", InSummary=true, Order=140)]
+    [FhirElement("specialty", InSummary=true, Order=140, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Specialty
@@ -496,7 +496,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Used to make informed decisions if needing to re-prioritize
     /// </summary>
-    [FhirElement("priority", Order=170)]
+    [FhirElement("priority", Order=170, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Priority
     {
@@ -540,7 +540,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Appointment replaced by this Appointment
     /// </summary>
-    [FhirElement("replaces", Order=190)]
+    [FhirElement("replaces", Order=190, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Appointment")]
     [Cardinality(Min=0,Max=-1)]
@@ -556,7 +556,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional information to support the appointment
     /// </summary>
-    [FhirElement("supportingInformation", Order=200)]
+    [FhirElement("supportingInformation", Order=200, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Resource")]
     [Cardinality(Min=0,Max=-1)]
@@ -572,7 +572,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When appointment is to take place
     /// </summary>
-    [FhirElement("start", InSummary=true, Order=210)]
+    [FhirElement("start", InSummary=true, Order=210, FiveWs="FiveWs.init")]
     [DataMember]
     public Hl7.Fhir.Model.Instant StartElement
     {
@@ -603,7 +603,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When appointment is to conclude
     /// </summary>
-    [FhirElement("end", InSummary=true, Order=220)]
+    [FhirElement("end", InSummary=true, Order=220, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Instant EndElement
     {
@@ -772,7 +772,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The patient or group associated with the appointment
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=300)]
+    [FhirElement("subject", InSummary=true, Order=300, FiveWs="FiveWs.who")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/AppointmentResponse.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/AppointmentResponse.cs
@@ -58,7 +58,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External Ids for this item
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -88,7 +88,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Time from appointment, or requested new start time
     /// </summary>
-    [FhirElement("start", Order=110)]
+    [FhirElement("start", Order=110, FiveWs="FiveWs.init")]
     [DataMember]
     public Hl7.Fhir.Model.Instant StartElement
     {
@@ -119,7 +119,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Time from appointment, or requested new end time
     /// </summary>
-    [FhirElement("end", Order=120)]
+    [FhirElement("end", Order=120, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Instant EndElement
     {
@@ -164,7 +164,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Person(s), Location, HealthcareService, or Device
     /// </summary>
-    [FhirElement("actor", InSummary=true, Order=140)]
+    [FhirElement("actor", InSummary=true, Order=140, FiveWs="FiveWs.who")]
     [CLSCompliant(false)]
     [References("Patient","Group","Practitioner","PractitionerRole","RelatedPerson","Device","HealthcareService","Location")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/ArtifactAssessment.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ArtifactAssessment.cs
@@ -554,7 +554,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the artifact assessment
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -584,7 +584,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=110)]
+    [FhirElement("date", InSummary=true, Order=110, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/AuditEvent.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/AuditEvent.cs
@@ -169,7 +169,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Whether the event succeeded or failed
       /// </summary>
-      [FhirElement("code", InSummary=true, Order=40)]
+      [FhirElement("code", InSummary=true, Order=40, FiveWs="FiveWs.what[x]")]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
       public Hl7.Fhir.Model.Coding Code
@@ -183,7 +183,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Additional outcome detail
       /// </summary>
-      [FhirElement("detail", InSummary=true, Order=50)]
+      [FhirElement("detail", InSummary=true, Order=50, FiveWs="FiveWs.what[x]")]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.CodeableConcept> Detail
@@ -302,7 +302,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// How agent participated
       /// </summary>
-      [FhirElement("type", Order=40)]
+      [FhirElement("type", Order=40, FiveWs="FiveWs.who")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Type
       {
@@ -315,7 +315,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Agent role in the event
       /// </summary>
-      [FhirElement("role", Order=50)]
+      [FhirElement("role", Order=50, FiveWs="FiveWs.who")]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.CodeableConcept> Role
@@ -329,7 +329,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Identifier of who
       /// </summary>
-      [FhirElement("who", InSummary=true, Order=60)]
+      [FhirElement("who", InSummary=true, Order=60, FiveWs="FiveWs.who")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole","Organization","CareTeam","Patient","Device","RelatedPerson")]
       [Cardinality(Min=1,Max=1)]
@@ -345,7 +345,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Whether user is initiator
       /// </summary>
-      [FhirElement("requestor", InSummary=true, Order=70)]
+      [FhirElement("requestor", InSummary=true, Order=70, FiveWs="FiveWs.who")]
       [DataMember]
       public Hl7.Fhir.Model.FhirBoolean RequestorElement
       {
@@ -376,7 +376,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// The agent location when the event occurred
       /// </summary>
-      [FhirElement("location", Order=80)]
+      [FhirElement("location", Order=80, FiveWs="FiveWs.where[x]")]
       [CLSCompliant(false)]
       [References("Location")]
       [DataMember]
@@ -391,7 +391,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Policy that authorized the agent participation in the event
       /// </summary>
-      [FhirElement("policy", Order=90)]
+      [FhirElement("policy", Order=90, FiveWs="FiveWs.why[x]")]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.FhirUri> PolicyElement
@@ -423,7 +423,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// This agent network location for the activity
       /// </summary>
-      [FhirElement("network", Order=100, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("network", Order=100, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.where[x]")]
       [CLSCompliant(false)]
       [References("Endpoint")]
       [AllowedTypes(typeof(Hl7.Fhir.Model.ResourceReference),typeof(Hl7.Fhir.Model.FhirUri),typeof(Hl7.Fhir.Model.FhirString))]
@@ -439,7 +439,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Allowable authorization for this agent
       /// </summary>
-      [FhirElement("authorization", Order=110)]
+      [FhirElement("authorization", Order=110, FiveWs="FiveWs.why[x]")]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.CodeableConcept> Authorization
@@ -612,7 +612,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Logical source location within the enterprise
       /// </summary>
-      [FhirElement("site", Order=40)]
+      [FhirElement("site", Order=40, FiveWs="FiveWs.witness")]
       [CLSCompliant(false)]
       [References("Location")]
       [DataMember]
@@ -627,7 +627,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// The identity of source detecting the event
       /// </summary>
-      [FhirElement("observer", InSummary=true, Order=50)]
+      [FhirElement("observer", InSummary=true, Order=50, FiveWs="FiveWs.witness")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole","Organization","CareTeam","Patient","Device","RelatedPerson")]
       [Cardinality(Min=1,Max=1)]
@@ -643,7 +643,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// The type of source where event originated
       /// </summary>
-      [FhirElement("type", Order=60)]
+      [FhirElement("type", Order=60, FiveWs="FiveWs.witness")]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.CodeableConcept> Type
@@ -771,7 +771,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Specific instance of resource
       /// </summary>
-      [FhirElement("what", InSummary=true, Order=40)]
+      [FhirElement("what", InSummary=true, Order=40, FiveWs="FiveWs.what[x]")]
       [CLSCompliant(false)]
       [References("Resource")]
       [DataMember]
@@ -786,7 +786,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// What role the entity played
       /// </summary>
-      [FhirElement("role", Order=50)]
+      [FhirElement("role", Order=50, FiveWs="FiveWs.context")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Role
       {
@@ -799,7 +799,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Security labels on the entity
       /// </summary>
-      [FhirElement("securityLabel", Order=60)]
+      [FhirElement("securityLabel", Order=60, FiveWs="FiveWs.context")]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.CodeableConcept> SecurityLabel
@@ -813,7 +813,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Query parameters
       /// </summary>
-      [FhirElement("query", InSummary=true, Order=70)]
+      [FhirElement("query", InSummary=true, Order=70, FiveWs="FiveWs.context")]
       [DataMember]
       public Hl7.Fhir.Model.Base64Binary QueryElement
       {
@@ -844,7 +844,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Additional Information about the entity
       /// </summary>
-      [FhirElement("detail", Order=80)]
+      [FhirElement("detail", Order=80, FiveWs="FiveWs.context")]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.AuditEvent.DetailComponent> Detail
@@ -1013,7 +1013,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Name of the property
       /// </summary>
-      [FhirElement("type", Order=40)]
+      [FhirElement("type", Order=40, FiveWs="FiveWs.context")]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Type
@@ -1027,7 +1027,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Property value
       /// </summary>
-      [FhirElement("value", Order=50, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("value", Order=50, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.context")]
       [CLSCompliant(false)]
       [AllowedTypes(typeof(Hl7.Fhir.Model.Quantity),typeof(Hl7.Fhir.Model.CodeableConcept),typeof(Hl7.Fhir.Model.FhirString),typeof(Hl7.Fhir.Model.FhirBoolean),typeof(Hl7.Fhir.Model.Integer),typeof(Hl7.Fhir.Model.Range),typeof(Hl7.Fhir.Model.Ratio),typeof(Hl7.Fhir.Model.Time),typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period),typeof(Hl7.Fhir.Model.Base64Binary))]
       [Cardinality(Min=1,Max=1)]
@@ -1135,7 +1135,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Type/identifier of event
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=90)]
+    [FhirElement("category", InSummary=true, Order=90, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -1149,7 +1149,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Specific type of event
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=100)]
+    [FhirElement("code", InSummary=true, Order=100, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
@@ -1163,7 +1163,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Type of action performed during the event
     /// </summary>
-    [FhirElement("action", InSummary=true, Order=110)]
+    [FhirElement("action", InSummary=true, Order=110, FiveWs="FiveWs.what[x]")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.AuditEvent.AuditEventAction> ActionElement
@@ -1227,7 +1227,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the activity occurred
     /// </summary>
-    [FhirElement("occurred", Order=130, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("occurred", Order=130, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.Period),typeof(Hl7.Fhir.Model.FhirDateTime))]
     [DataMember]
@@ -1242,7 +1242,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Time when the event was recorded
     /// </summary>
-    [FhirElement("recorded", InSummary=true, Order=140)]
+    [FhirElement("recorded", InSummary=true, Order=140, FiveWs="FiveWs.recorded")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.Instant RecordedElement
@@ -1274,7 +1274,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Whether the event succeeded or failed
     /// </summary>
-    [FhirElement("outcome", InSummary=true, Order=150)]
+    [FhirElement("outcome", InSummary=true, Order=150, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.AuditEvent.OutcomeComponent Outcome
     {
@@ -1287,7 +1287,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Authorization related to the event
     /// </summary>
-    [FhirElement("authorization", InSummary=true, Order=160)]
+    [FhirElement("authorization", InSummary=true, Order=160, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Authorization
@@ -1301,7 +1301,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Workflow authorization within which this event occurred
     /// </summary>
-    [FhirElement("basedOn", Order=170)]
+    [FhirElement("basedOn", Order=170, FiveWs="FiveWs.why[x]")]
     [CLSCompliant(false)]
     [References("CarePlan","DeviceRequest","ImmunizationRecommendation","MedicationRequest","NutritionOrder","ServiceRequest","Task")]
     [Cardinality(Min=0,Max=-1)]
@@ -1317,7 +1317,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Encounter within which this event occurred or which the event is tightly associated
     /// </summary>
-    [FhirElement("encounter", Order=180)]
+    [FhirElement("encounter", Order=180, FiveWs="FiveWs.why[x]")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -1332,7 +1332,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Actor involved in the event
     /// </summary>
-    [FhirElement("agent", Order=190)]
+    [FhirElement("agent", Order=190, FiveWs="FiveWs.who")]
     [Cardinality(Min=1,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.AuditEvent.AgentComponent> Agent
@@ -1346,7 +1346,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Audit Event Reporter
     /// </summary>
-    [FhirElement("source", Order=200)]
+    [FhirElement("source", Order=200, FiveWs="FiveWs.witness")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.AuditEvent.SourceComponent Source
@@ -1360,7 +1360,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Data or objects used
     /// </summary>
-    [FhirElement("entity", Order=210)]
+    [FhirElement("entity", Order=210, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.AuditEvent.EntityComponent> Entity

--- a/src/Hl7.Fhir.Core/Model/Generated/Basic.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Basic.cs
@@ -58,7 +58,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business identifier
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -72,7 +72,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Kind of Resource
     /// </summary>
-    [FhirElement("code", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("code", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
@@ -86,7 +86,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Identifies the focus of this resource
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=110)]
+    [FhirElement("subject", InSummary=true, Order=110, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Resource")]
     [DataMember]
@@ -101,7 +101,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When created
     /// </summary>
-    [FhirElement("created", InSummary=true, Order=120)]
+    [FhirElement("created", InSummary=true, Order=120, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.Date CreatedElement
     {
@@ -132,7 +132,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who created
     /// </summary>
-    [FhirElement("author", InSummary=true, Order=130)]
+    [FhirElement("author", InSummary=true, Order=130, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Patient","RelatedPerson","Organization")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/BiologicallyDerivedProduct.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/BiologicallyDerivedProduct.cs
@@ -491,7 +491,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External ids for this item
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=130)]
+    [FhirElement("identifier", InSummary=true, Order=130, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -505,7 +505,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// An identifier that supports traceability to the biological entity that is the source of biological material in the product
     /// </summary>
-    [FhirElement("biologicalSource", InSummary=true, Order=140)]
+    [FhirElement("biologicalSource", InSummary=true, Order=140, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.Identifier BiologicalSource
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/BodyStructure.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/BodyStructure.cs
@@ -71,7 +71,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Code that represents the included structure
       /// </summary>
-      [FhirElement("structure", InSummary=true, Order=40)]
+      [FhirElement("structure", InSummary=true, Order=40, FiveWs="FiveWs.what[x]")]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Structure
@@ -85,7 +85,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Code that represents the included structure laterality
       /// </summary>
-      [FhirElement("laterality", Order=50)]
+      [FhirElement("laterality", Order=50, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Laterality
       {
@@ -98,7 +98,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Code that represents the included structure qualifier
       /// </summary>
-      [FhirElement("qualifier", Order=60)]
+      [FhirElement("qualifier", Order=60, FiveWs="FiveWs.what[x]")]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.CodeableConcept> Qualifier
@@ -226,7 +226,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Code that represents the excluded structure
       /// </summary>
-      [FhirElement("structure", InSummary=true, Order=40)]
+      [FhirElement("structure", InSummary=true, Order=40, FiveWs="FiveWs.what[x]")]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Structure
@@ -240,7 +240,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Code that represents the excluded structure laterality
       /// </summary>
-      [FhirElement("laterality", Order=50)]
+      [FhirElement("laterality", Order=50, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Laterality
       {
@@ -253,7 +253,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Code that represents the excluded structure qualifier
       /// </summary>
-      [FhirElement("qualifier", Order=60)]
+      [FhirElement("qualifier", Order=60, FiveWs="FiveWs.what[x]")]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.CodeableConcept> Qualifier
@@ -368,7 +368,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Bodystructure identifier
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -382,7 +382,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Whether this record is in active use
     /// </summary>
-    [FhirElement("active", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("active", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ActiveElement
     {
@@ -413,7 +413,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Kind of Structure
     /// </summary>
-    [FhirElement("morphology", InSummary=true, Order=110)]
+    [FhirElement("morphology", InSummary=true, Order=110, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Morphology
     {
@@ -467,7 +467,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Text description
     /// </summary>
-    [FhirElement("description", InSummary=true, Order=150)]
+    [FhirElement("description", InSummary=true, Order=150, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString DescriptionElement
     {
@@ -498,7 +498,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Attached images
     /// </summary>
-    [FhirElement("image", Order=160)]
+    [FhirElement("image", Order=160, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Attachment> Image
@@ -512,7 +512,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who this is about
     /// </summary>
-    [FhirElement("patient", InSummary=true, Order=170)]
+    [FhirElement("patient", InSummary=true, Order=170, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/Bundle.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Bundle.cs
@@ -1381,7 +1381,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Persistent identifier for the bundle
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=50)]
+    [FhirElement("identifier", InSummary=true, Order=50, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.Identifier Identifier
     {
@@ -1394,7 +1394,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// document | message | transaction | transaction-response | batch | batch-response | history | searchset | collection | subscription-notification
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=60)]
+    [FhirElement("type", InSummary=true, Order=60, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1427,7 +1427,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the bundle was assembled
     /// </summary>
-    [FhirElement("timestamp", InSummary=true, Order=70)]
+    [FhirElement("timestamp", InSummary=true, Order=70, FiveWs="FiveWs.init")]
     [DataMember]
     public Hl7.Fhir.Model.Instant TimestampElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/CapabilityStatement.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/CapabilityStatement.cs
@@ -3251,7 +3251,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this capability statement, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -3282,7 +3282,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the capability statement
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=100)]
+    [FhirElement("version", InSummary=true, Order=100, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -3375,7 +3375,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=130)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=130, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -3408,7 +3408,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=140)]
+    [FhirElement("experimental", InSummary=true, Order=140, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -3439,7 +3439,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=150)]
+    [FhirElement("date", InSummary=true, Order=150, FiveWs="FiveWs.recorded")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
@@ -3471,7 +3471,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=160)]
+    [FhirElement("publisher", InSummary=true, Order=160, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -3557,7 +3557,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this capability statement is defined
     /// </summary>
-    [FhirElement("purpose", Order=210)]
+    [FhirElement("purpose", Order=210, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/CapabilityStatement2.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/CapabilityStatement2.cs
@@ -2271,7 +2271,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this capability statement2, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -2302,7 +2302,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the capability statement2
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=100)]
+    [FhirElement("version", InSummary=true, Order=100, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -2395,7 +2395,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=130)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=130, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -2428,7 +2428,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=140)]
+    [FhirElement("experimental", InSummary=true, Order=140, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -2459,7 +2459,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=150)]
+    [FhirElement("date", InSummary=true, Order=150, FiveWs="FiveWs.recorded")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
@@ -2491,7 +2491,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=160)]
+    [FhirElement("publisher", InSummary=true, Order=160, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -2577,7 +2577,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this capability statement2 is defined
     /// </summary>
-    [FhirElement("purpose", Order=210)]
+    [FhirElement("purpose", Order=210, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/CarePlan.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/CarePlan.cs
@@ -656,7 +656,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Reported rather than primary record
       /// </summary>
-      [FhirElement("reported", Order=150, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("reported", Order=150, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.source")]
       [CLSCompliant(false)]
       [References("Patient","RelatedPerson","Practitioner","PractitionerRole","Organization")]
       [AllowedTypes(typeof(Hl7.Fhir.Model.FhirBoolean),typeof(Hl7.Fhir.Model.ResourceReference))]
@@ -988,7 +988,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External Ids for this plan
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1114,7 +1114,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | on-hold | revoked | completed | entered-in-error | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=150)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=150, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1180,7 +1180,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Type of plan
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=170)]
+    [FhirElement("category", InSummary=true, Order=170, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -1225,7 +1225,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Summary of nature of plan
     /// </summary>
-    [FhirElement("description", InSummary=true, Order=190)]
+    [FhirElement("description", InSummary=true, Order=190, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString DescriptionElement
     {
@@ -1256,7 +1256,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who the care plan is for
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=200)]
+    [FhirElement("subject", InSummary=true, Order=200, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [Cardinality(Min=1,Max=1)]
@@ -1272,7 +1272,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The Encounter during which this CarePlan was created
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=210)]
+    [FhirElement("encounter", InSummary=true, Order=210, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -1287,7 +1287,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Time period plan covers
     /// </summary>
-    [FhirElement("period", InSummary=true, Order=220)]
+    [FhirElement("period", InSummary=true, Order=220, FiveWs="FiveWs.planned")]
     [DataMember]
     public Hl7.Fhir.Model.Period Period
     {
@@ -1300,7 +1300,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date record was first recorded
     /// </summary>
-    [FhirElement("created", InSummary=true, Order=230)]
+    [FhirElement("created", InSummary=true, Order=230, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime CreatedElement
     {
@@ -1331,7 +1331,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who is the designated responsible party
     /// </summary>
-    [FhirElement("author", InSummary=true, Order=240)]
+    [FhirElement("author", InSummary=true, Order=240, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Patient","Practitioner","PractitionerRole","Device","RelatedPerson","Organization","CareTeam")]
     [DataMember]
@@ -1362,7 +1362,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who's involved in plan?
     /// </summary>
-    [FhirElement("careTeam", Order=260)]
+    [FhirElement("careTeam", Order=260, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("CareTeam")]
     [Cardinality(Min=0,Max=-1)]
@@ -1378,7 +1378,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Health issues this plan addresses
     /// </summary>
-    [FhirElement("addresses", InSummary=true, Order=270)]
+    [FhirElement("addresses", InSummary=true, Order=270, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Addresses

--- a/src/Hl7.Fhir.Core/Model/Generated/CareTeam.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/CareTeam.cs
@@ -124,7 +124,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Who is involved
       /// </summary>
-      [FhirElement("member", InSummary=true, Order=50)]
+      [FhirElement("member", InSummary=true, Order=50, FiveWs="FiveWs.actor")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole","RelatedPerson","Patient","Organization","CareTeam")]
       [DataMember]
@@ -279,7 +279,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External Ids for this team
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -293,7 +293,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// proposed | active | suspended | inactive | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.CareTeam.CareTeamStatus> StatusElement
@@ -325,7 +325,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Type of team
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=110)]
+    [FhirElement("category", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -370,7 +370,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who care team is for
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=130)]
+    [FhirElement("subject", InSummary=true, Order=130, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [DataMember]
@@ -385,7 +385,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Time period team covers
     /// </summary>
-    [FhirElement("period", InSummary=true, Order=140)]
+    [FhirElement("period", InSummary=true, Order=140, FiveWs="FiveWs.init")]
     [DataMember]
     public Hl7.Fhir.Model.Period Period
     {
@@ -412,7 +412,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why the care team exists
     /// </summary>
-    [FhirElement("reason", Order=160)]
+    [FhirElement("reason", Order=160, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason

--- a/src/Hl7.Fhir.Core/Model/Generated/ChargeItem.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ChargeItem.cs
@@ -136,7 +136,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Individual who was performing
       /// </summary>
-      [FhirElement("actor", Order=50)]
+      [FhirElement("actor", Order=50, FiveWs="FiveWs.actor")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole","Organization","CareTeam","Patient","Device","RelatedPerson")]
       [Cardinality(Min=1,Max=1)]
@@ -244,7 +244,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for item
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -322,7 +322,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// planned | billable | not-billable | aborted | billed | entered-in-error | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=120)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=120, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -371,7 +371,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// A code that identifies the charge, like a billing code
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=140)]
+    [FhirElement("code", InSummary=true, Order=140, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
@@ -385,7 +385,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Individual service was done for/to
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=150)]
+    [FhirElement("subject", InSummary=true, Order=150, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [Cardinality(Min=1,Max=1)]
@@ -401,7 +401,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Encounter / Episode associated with event
     /// </summary>
-    [FhirElement("context", InSummary=true, Order=160)]
+    [FhirElement("context", InSummary=true, Order=160, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter","EpisodeOfCare")]
     [DataMember]
@@ -416,7 +416,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the charged service was applied
     /// </summary>
-    [FhirElement("occurrence", InSummary=true, Order=170, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("occurrence", InSummary=true, Order=170, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period),typeof(Hl7.Fhir.Model.Timing))]
     [DataMember]
@@ -592,7 +592,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Individual who was entering
     /// </summary>
-    [FhirElement("enterer", InSummary=true, Order=270)]
+    [FhirElement("enterer", InSummary=true, Order=270, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization","Patient","Device","RelatedPerson")]
     [DataMember]
@@ -638,7 +638,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why was the charged  service rendered?
     /// </summary>
-    [FhirElement("reason", Order=290)]
+    [FhirElement("reason", Order=290, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Reason
@@ -652,7 +652,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Which rendered service is being charged?
     /// </summary>
-    [FhirElement("service", Order=300)]
+    [FhirElement("service", Order=300, FiveWs="FiveWs.why[x]")]
     [CLSCompliant(false)]
     [References("DiagnosticReport","ImagingStudy","Immunization","MedicationAdministration","MedicationDispense","Observation","Procedure","SupplyDelivery")]
     [Cardinality(Min=0,Max=-1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/ChargeItemDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ChargeItemDefinition.cs
@@ -611,7 +611,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this charge item definition, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
@@ -643,7 +643,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the charge item definition
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -657,7 +657,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the charge item definition
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -815,7 +815,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=160)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=160, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -848,7 +848,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=170)]
+    [FhirElement("experimental", InSummary=true, Order=170, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -879,7 +879,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=180)]
+    [FhirElement("date", InSummary=true, Order=180, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -910,7 +910,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=190)]
+    [FhirElement("publisher", InSummary=true, Order=190, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Citation.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Citation.cs
@@ -4661,7 +4661,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this citation, represented as a globally unique URI
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -4692,7 +4692,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Identifier for the Citation resource itself
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -4706,7 +4706,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the citation
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -4832,7 +4832,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=150)]
+    [FhirElement("experimental", InSummary=true, Order=150, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -4863,7 +4863,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=160)]
+    [FhirElement("date", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -4894,7 +4894,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The publisher of the Citation, not the publisher of the article or artifact being cited
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=170)]
+    [FhirElement("publisher", InSummary=true, Order=170, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -4980,7 +4980,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this citation is defined
     /// </summary>
-    [FhirElement("purpose", Order=220)]
+    [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Claim.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Claim.cs
@@ -392,7 +392,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Practitioner or organization
       /// </summary>
-      [FhirElement("provider", Order=50)]
+      [FhirElement("provider", Order=50, FiveWs="FiveWs.actor")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole","Organization")]
       [Cardinality(Min=1,Max=1)]
@@ -1368,7 +1368,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Pre-assigned Claim number
       /// </summary>
-      [FhirElement("identifier", Order=60)]
+      [FhirElement("identifier", Order=60, FiveWs="FiveWs.identifier")]
       [DataMember]
       public Hl7.Fhir.Model.Identifier Identifier
       {
@@ -2028,7 +2028,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Date or dates of service or product delivery
       /// </summary>
-      [FhirElement("serviced", Order=140, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("serviced", Order=140, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
       [CLSCompliant(false)]
       [AllowedTypes(typeof(Hl7.Fhir.Model.Date),typeof(Hl7.Fhir.Model.Period))]
       [DataMember]
@@ -2043,7 +2043,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Place of service or where product was supplied
       /// </summary>
-      [FhirElement("location", Order=150, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("location", Order=150, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.where[x]")]
       [CLSCompliant(false)]
       [References("Location")]
       [AllowedTypes(typeof(Hl7.Fhir.Model.CodeableConcept),typeof(Hl7.Fhir.Model.Address),typeof(Hl7.Fhir.Model.ResourceReference))]
@@ -3232,7 +3232,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for claim
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -3246,7 +3246,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | cancelled | draft | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -3279,7 +3279,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Category or discipline
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=110)]
+    [FhirElement("type", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Type
@@ -3293,7 +3293,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// More granular claim type
     /// </summary>
-    [FhirElement("subType", Order=120)]
+    [FhirElement("subType", Order=120, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept SubType
     {
@@ -3306,7 +3306,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// claim | preauthorization | predetermination
     /// </summary>
-    [FhirElement("use", InSummary=true, Order=130)]
+    [FhirElement("use", InSummary=true, Order=130, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -3339,7 +3339,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The recipient of the products and services
     /// </summary>
-    [FhirElement("patient", InSummary=true, Order=140)]
+    [FhirElement("patient", InSummary=true, Order=140, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]
@@ -3355,7 +3355,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Relevant time frame for the claim
     /// </summary>
-    [FhirElement("billablePeriod", InSummary=true, Order=150)]
+    [FhirElement("billablePeriod", InSummary=true, Order=150, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Period BillablePeriod
     {
@@ -3368,7 +3368,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Resource creation date
     /// </summary>
-    [FhirElement("created", InSummary=true, Order=160)]
+    [FhirElement("created", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime CreatedElement
@@ -3400,7 +3400,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Author of the claim
     /// </summary>
-    [FhirElement("enterer", Order=170)]
+    [FhirElement("enterer", Order=170, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole")]
     [DataMember]
@@ -3430,7 +3430,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Party responsible for the claim
     /// </summary>
-    [FhirElement("provider", InSummary=true, Order=190)]
+    [FhirElement("provider", InSummary=true, Order=190, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization")]
     [Cardinality(Min=1,Max=1)]
@@ -3530,7 +3530,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Treatment referral
     /// </summary>
-    [FhirElement("referral", Order=260)]
+    [FhirElement("referral", Order=260, FiveWs="FiveWs.cause")]
     [CLSCompliant(false)]
     [References("ServiceRequest")]
     [DataMember]
@@ -3545,7 +3545,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Servicing facility
     /// </summary>
-    [FhirElement("facility", Order=270)]
+    [FhirElement("facility", Order=270, FiveWs="FiveWs.where[x]")]
     [CLSCompliant(false)]
     [References("Location")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/ClaimResponse.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ClaimResponse.cs
@@ -983,7 +983,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Authorized providers
       /// </summary>
-      [FhirElement("provider", Order=70)]
+      [FhirElement("provider", Order=70, FiveWs="FiveWs.source")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole","Organization")]
       [Cardinality(Min=0,Max=-1)]
@@ -1041,7 +1041,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Date or dates of service or product delivery
       /// </summary>
-      [FhirElement("serviced", Order=110, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("serviced", Order=110, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
       [CLSCompliant(false)]
       [AllowedTypes(typeof(Hl7.Fhir.Model.Date),typeof(Hl7.Fhir.Model.Period))]
       [DataMember]
@@ -1056,7 +1056,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Place of service or where product was supplied
       /// </summary>
-      [FhirElement("location", Order=120, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("location", Order=120, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.where[x]")]
       [CLSCompliant(false)]
       [References("Location")]
       [AllowedTypes(typeof(Hl7.Fhir.Model.CodeableConcept),typeof(Hl7.Fhir.Model.Address),typeof(Hl7.Fhir.Model.ResourceReference))]
@@ -3185,7 +3185,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for a claim response
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -3199,7 +3199,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | cancelled | draft | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -3232,7 +3232,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// More granular claim type
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=110)]
+    [FhirElement("type", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Type
@@ -3246,7 +3246,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// More granular claim type
     /// </summary>
-    [FhirElement("subType", Order=120)]
+    [FhirElement("subType", Order=120, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept SubType
     {
@@ -3259,7 +3259,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// claim | preauthorization | predetermination
     /// </summary>
-    [FhirElement("use", InSummary=true, Order=130)]
+    [FhirElement("use", InSummary=true, Order=130, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -3292,7 +3292,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The recipient of the products and services
     /// </summary>
-    [FhirElement("patient", InSummary=true, Order=140)]
+    [FhirElement("patient", InSummary=true, Order=140, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]
@@ -3308,7 +3308,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Response creation date
     /// </summary>
-    [FhirElement("created", InSummary=true, Order=150)]
+    [FhirElement("created", InSummary=true, Order=150, FiveWs="FiveWs.recorded")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime CreatedElement
@@ -3356,7 +3356,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Party responsible for the claim
     /// </summary>
-    [FhirElement("requestor", Order=170)]
+    [FhirElement("requestor", Order=170, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization")]
     [DataMember]
@@ -3371,7 +3371,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Id of resource triggering adjudication
     /// </summary>
-    [FhirElement("request", InSummary=true, Order=180)]
+    [FhirElement("request", InSummary=true, Order=180, FiveWs="FiveWs.why[x]")]
     [CLSCompliant(false)]
     [References("Claim")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/ClinicalImpression.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ClinicalImpression.cs
@@ -207,7 +207,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business identifier
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -221,7 +221,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -298,7 +298,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Patient or group assessed
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=130)]
+    [FhirElement("subject", InSummary=true, Order=130, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [Cardinality(Min=1,Max=1)]
@@ -314,7 +314,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The Encounter during which this ClinicalImpression was created
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=140)]
+    [FhirElement("encounter", InSummary=true, Order=140, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -329,7 +329,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Time of assessment
     /// </summary>
-    [FhirElement("effective", InSummary=true, Order=150, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("effective", InSummary=true, Order=150, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period))]
     [DataMember]
@@ -344,7 +344,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the assessment was documented
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=160)]
+    [FhirElement("date", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -375,7 +375,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The clinician performing the assessment
     /// </summary>
-    [FhirElement("performer", InSummary=true, Order=170)]
+    [FhirElement("performer", InSummary=true, Order=170, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole")]
     [DataMember]
@@ -405,7 +405,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Relevant impressions of patient state
     /// </summary>
-    [FhirElement("problem", InSummary=true, Order=190)]
+    [FhirElement("problem", InSummary=true, Order=190, FiveWs="FiveWs.why[x]")]
     [CLSCompliant(false)]
     [References("Condition","AllergyIntolerance")]
     [Cardinality(Min=0,Max=-1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/CodeSystem.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/CodeSystem.cs
@@ -1305,7 +1305,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this code system, represented as a URI (globally unique) (Coding.system)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -1336,7 +1336,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the code system (business identifier)
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1350,7 +1350,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the code system (Coding.version)
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -1443,7 +1443,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=140)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=140, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1476,7 +1476,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=150)]
+    [FhirElement("experimental", InSummary=true, Order=150, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -1507,7 +1507,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=160)]
+    [FhirElement("date", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -1538,7 +1538,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=170)]
+    [FhirElement("publisher", InSummary=true, Order=170, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -1624,7 +1624,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this code system is defined
     /// </summary>
-    [FhirElement("purpose", Order=220)]
+    [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Communication.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Communication.cs
@@ -171,7 +171,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Unique identifier
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -297,7 +297,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=150)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=150, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -343,7 +343,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Message category
     /// </summary>
-    [FhirElement("category", Order=170)]
+    [FhirElement("category", Order=170, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -357,7 +357,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// routine | urgent | asap | stat
     /// </summary>
-    [FhirElement("priority", InSummary=true, Order=180)]
+    [FhirElement("priority", InSummary=true, Order=180, FiveWs="FiveWs.grade")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.RequestPriority> PriorityElement
@@ -403,7 +403,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Focus of message
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=200)]
+    [FhirElement("subject", InSummary=true, Order=200, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [DataMember]
@@ -418,7 +418,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Description of the purpose/content
     /// </summary>
-    [FhirElement("topic", Order=210)]
+    [FhirElement("topic", Order=210, FiveWs="FiveWs.context")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Topic
     {
@@ -431,7 +431,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Resources that pertain to this communication
     /// </summary>
-    [FhirElement("about", Order=220)]
+    [FhirElement("about", Order=220, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Resource")]
     [Cardinality(Min=0,Max=-1)]
@@ -447,7 +447,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The Encounter during which this Communication was created
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=230)]
+    [FhirElement("encounter", InSummary=true, Order=230, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -462,7 +462,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When sent
     /// </summary>
-    [FhirElement("sent", Order=240)]
+    [FhirElement("sent", Order=240, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime SentElement
     {
@@ -493,7 +493,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When received
     /// </summary>
-    [FhirElement("received", Order=250)]
+    [FhirElement("received", Order=250, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime ReceivedElement
     {
@@ -524,7 +524,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who the information is shared with
     /// </summary>
-    [FhirElement("recipient", Order=260)]
+    [FhirElement("recipient", Order=260, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("CareTeam","Device","Group","HealthcareService","Location","Organization","Patient","Practitioner","PractitionerRole","RelatedPerson","Endpoint")]
     [Cardinality(Min=0,Max=-1)]
@@ -540,7 +540,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who shares the information
     /// </summary>
-    [FhirElement("sender", Order=270)]
+    [FhirElement("sender", Order=270, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Device","Organization","Patient","Practitioner","PractitionerRole","RelatedPerson","HealthcareService","Endpoint","CareTeam")]
     [DataMember]
@@ -555,7 +555,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Indication for message
     /// </summary>
-    [FhirElement("reason", InSummary=true, Order=280)]
+    [FhirElement("reason", InSummary=true, Order=280, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason

--- a/src/Hl7.Fhir.Core/Model/Generated/CommunicationRequest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/CommunicationRequest.cs
@@ -171,7 +171,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Unique identifier
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -230,7 +230,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | on-hold | revoked | completed | entered-in-error | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=130)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=130, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -276,7 +276,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// proposal | plan | directive | order | original-order | reflex-order | filler-order | instance-order | option
     /// </summary>
-    [FhirElement("intent", InSummary=true, IsModifier=true, Order=150)]
+    [FhirElement("intent", InSummary=true, IsModifier=true, Order=150, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -309,7 +309,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Message category
     /// </summary>
-    [FhirElement("category", Order=160)]
+    [FhirElement("category", Order=160, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -323,7 +323,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// routine | urgent | asap | stat
     /// </summary>
-    [FhirElement("priority", InSummary=true, Order=170)]
+    [FhirElement("priority", InSummary=true, Order=170, FiveWs="FiveWs.grade")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.RequestPriority> PriorityElement
@@ -400,7 +400,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Focus of message
     /// </summary>
-    [FhirElement("subject", Order=200)]
+    [FhirElement("subject", Order=200, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [DataMember]
@@ -415,7 +415,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Resources that pertain to this communication request
     /// </summary>
-    [FhirElement("about", Order=210)]
+    [FhirElement("about", Order=210, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Resource")]
     [Cardinality(Min=0,Max=-1)]
@@ -431,7 +431,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The Encounter during which this CommunicationRequest was created
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=220)]
+    [FhirElement("encounter", InSummary=true, Order=220, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -460,7 +460,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When scheduled
     /// </summary>
-    [FhirElement("occurrence", InSummary=true, Order=240, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("occurrence", InSummary=true, Order=240, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.planned")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period))]
     [DataMember]
@@ -475,7 +475,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When request transitioned to being actionable
     /// </summary>
-    [FhirElement("authoredOn", InSummary=true, Order=250)]
+    [FhirElement("authoredOn", InSummary=true, Order=250, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime AuthoredOnElement
     {
@@ -506,7 +506,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who asks for the information to be shared
     /// </summary>
-    [FhirElement("requester", InSummary=true, Order=260)]
+    [FhirElement("requester", InSummary=true, Order=260, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization","Patient","RelatedPerson","Device")]
     [DataMember]
@@ -521,7 +521,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who to share the information with
     /// </summary>
-    [FhirElement("recipient", Order=270)]
+    [FhirElement("recipient", Order=270, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Device","Organization","Patient","Practitioner","PractitionerRole","RelatedPerson","Group","CareTeam","HealthcareService","Endpoint")]
     [Cardinality(Min=0,Max=-1)]
@@ -537,7 +537,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who should share the information
     /// </summary>
-    [FhirElement("informationProvider", InSummary=true, Order=280)]
+    [FhirElement("informationProvider", InSummary=true, Order=280, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Device","Organization","Patient","Practitioner","PractitionerRole","RelatedPerson","HealthcareService","Endpoint")]
     [Cardinality(Min=0,Max=-1)]
@@ -553,7 +553,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why is communication needed?
     /// </summary>
-    [FhirElement("reason", InSummary=true, Order=290)]
+    [FhirElement("reason", InSummary=true, Order=290, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason

--- a/src/Hl7.Fhir.Core/Model/Generated/CompartmentDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/CompartmentDefinition.cs
@@ -268,7 +268,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this compartment definition, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
@@ -300,7 +300,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the compartment definition
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=100)]
+    [FhirElement("version", InSummary=true, Order=100, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -363,7 +363,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=120)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=120, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -396,7 +396,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=130)]
+    [FhirElement("experimental", InSummary=true, Order=130, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -427,7 +427,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=140)]
+    [FhirElement("date", InSummary=true, Order=140, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -458,7 +458,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=150)]
+    [FhirElement("publisher", InSummary=true, Order=150, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -530,7 +530,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this compartment definition is defined
     /// </summary>
-    [FhirElement("purpose", Order=190)]
+    [FhirElement("purpose", Order=190, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Composition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Composition.cs
@@ -162,7 +162,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Who attested the composition
       /// </summary>
-      [FhirElement("party", Order=60)]
+      [FhirElement("party", Order=60, FiveWs="FiveWs.witness")]
       [CLSCompliant(false)]
       [References("Patient","RelatedPerson","Practitioner","PractitionerRole","Organization")]
       [DataMember]
@@ -492,7 +492,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Who and/or what authored the section
       /// </summary>
-      [FhirElement("author", Order=60)]
+      [FhirElement("author", Order=60, FiveWs="FiveWs.author")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole","Device","Patient","RelatedPerson","Organization")]
       [Cardinality(Min=0,Max=-1)]
@@ -536,7 +536,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// working | snapshot | changes
       /// </summary>
-      [FhirElement("mode", Order=90)]
+      [FhirElement("mode", Order=90, FiveWs="FiveWs.class")]
       [DeclaredType(Type = typeof(Code))]
       [DataMember]
       public Code<Hl7.Fhir.Model.ListMode> ModeElement
@@ -788,7 +788,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Version-independent identifier for the Composition
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.Identifier Identifier
     {
@@ -801,7 +801,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// preliminary | final | amended | entered-in-error | deprecated
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -834,7 +834,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Kind of composition (LOINC if possible)
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=110)]
+    [FhirElement("type", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Type
@@ -848,7 +848,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Categorization of Composition
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=120)]
+    [FhirElement("category", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -862,7 +862,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who and/or what the composition is about
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=130)]
+    [FhirElement("subject", InSummary=true, Order=130, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Resource")]
     [DataMember]
@@ -877,7 +877,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Context of the Composition
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=140)]
+    [FhirElement("encounter", InSummary=true, Order=140, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -892,7 +892,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Composition editing time
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=150)]
+    [FhirElement("date", InSummary=true, Order=150, FiveWs="FiveWs.done[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
@@ -924,7 +924,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who and/or what authored the composition
     /// </summary>
-    [FhirElement("author", InSummary=true, Order=160)]
+    [FhirElement("author", InSummary=true, Order=160, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Device","Patient","RelatedPerson","Organization")]
     [Cardinality(Min=1,Max=-1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/ConceptMap.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ConceptMap.cs
@@ -1293,7 +1293,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this concept map, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -1324,7 +1324,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the concept map
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1338,7 +1338,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the concept map
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -1431,7 +1431,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=140)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=140, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1464,7 +1464,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=150)]
+    [FhirElement("experimental", InSummary=true, Order=150, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -1495,7 +1495,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=160)]
+    [FhirElement("date", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -1526,7 +1526,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=170)]
+    [FhirElement("publisher", InSummary=true, Order=170, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -1612,7 +1612,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this concept map is defined
     /// </summary>
-    [FhirElement("purpose", Order=220)]
+    [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/ConceptMap2.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ConceptMap2.cs
@@ -1317,7 +1317,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this concept map, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -1348,7 +1348,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the concept map
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1362,7 +1362,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the concept map
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -1455,7 +1455,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=140)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=140, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1488,7 +1488,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=150)]
+    [FhirElement("experimental", InSummary=true, Order=150, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -1519,7 +1519,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=160)]
+    [FhirElement("date", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -1550,7 +1550,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=170)]
+    [FhirElement("publisher", InSummary=true, Order=170, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -1636,7 +1636,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this concept map is defined
     /// </summary>
-    [FhirElement("purpose", Order=220)]
+    [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Condition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Condition.cs
@@ -319,7 +319,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Manifestation/symptom
       /// </summary>
-      [FhirElement("code", InSummary=true, Order=40)]
+      [FhirElement("code", InSummary=true, Order=40, FiveWs="FiveWs.why[x]")]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.CodeableConcept> Code
@@ -333,7 +333,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Supporting information found elsewhere
       /// </summary>
-      [FhirElement("detail", InSummary=true, Order=50)]
+      [FhirElement("detail", InSummary=true, Order=50, FiveWs="FiveWs.why[x]")]
       [CLSCompliant(false)]
       [References("Resource")]
       [Cardinality(Min=0,Max=-1)]
@@ -441,7 +441,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External Ids for this condition
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -455,7 +455,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | recurrence | relapse | inactive | remission | resolved
     /// </summary>
-    [FhirElement("clinicalStatus", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("clinicalStatus", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept ClinicalStatus
@@ -469,7 +469,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// unconfirmed | provisional | differential | confirmed | refuted | entered-in-error
     /// </summary>
-    [FhirElement("verificationStatus", InSummary=true, IsModifier=true, Order=110)]
+    [FhirElement("verificationStatus", InSummary=true, IsModifier=true, Order=110, FiveWs="FiveWs.status")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept VerificationStatus
     {
@@ -482,7 +482,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// problem-list-item | encounter-diagnosis
     /// </summary>
-    [FhirElement("category", Order=120)]
+    [FhirElement("category", Order=120, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -496,7 +496,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Subjective severity of condition
     /// </summary>
-    [FhirElement("severity", Order=130)]
+    [FhirElement("severity", Order=130, FiveWs="FiveWs.grade")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Severity
     {
@@ -509,7 +509,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Identification of the condition, problem or diagnosis
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=140)]
+    [FhirElement("code", InSummary=true, Order=140, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
     {
@@ -536,7 +536,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who has the condition?
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=160)]
+    [FhirElement("subject", InSummary=true, Order=160, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [Cardinality(Min=1,Max=1)]
@@ -552,7 +552,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The Encounter during which this Condition was created
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=170)]
+    [FhirElement("encounter", InSummary=true, Order=170, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -567,7 +567,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Estimated or actual date,  date-time, or age
     /// </summary>
-    [FhirElement("onset", InSummary=true, Order=180, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("onset", InSummary=true, Order=180, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.init")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Age),typeof(Hl7.Fhir.Model.Period),typeof(Hl7.Fhir.Model.Range),typeof(Hl7.Fhir.Model.FhirString))]
     [DataMember]
@@ -582,7 +582,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When in resolution/remission
     /// </summary>
-    [FhirElement("abatement", Order=190, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("abatement", Order=190, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Age),typeof(Hl7.Fhir.Model.Period),typeof(Hl7.Fhir.Model.Range),typeof(Hl7.Fhir.Model.FhirString))]
     [DataMember]
@@ -597,7 +597,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date record was first recorded
     /// </summary>
-    [FhirElement("recordedDate", InSummary=true, Order=200)]
+    [FhirElement("recordedDate", InSummary=true, Order=200, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime RecordedDateElement
     {
@@ -628,7 +628,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who recorded the condition
     /// </summary>
-    [FhirElement("recorder", InSummary=true, Order=210)]
+    [FhirElement("recorder", InSummary=true, Order=210, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Patient","RelatedPerson")]
     [DataMember]
@@ -643,7 +643,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Person or device that asserts this condition
     /// </summary>
-    [FhirElement("asserter", InSummary=true, Order=220)]
+    [FhirElement("asserter", InSummary=true, Order=220, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Patient","RelatedPerson","Device")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/ConditionDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ConditionDefinition.cs
@@ -834,7 +834,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this condition definition, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -865,7 +865,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the condition definition
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -879,7 +879,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the condition definition
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -1003,7 +1003,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=150)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=150, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1036,7 +1036,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=160)]
+    [FhirElement("experimental", InSummary=true, Order=160, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -1067,7 +1067,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=170)]
+    [FhirElement("date", InSummary=true, Order=170, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -1098,7 +1098,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=180)]
+    [FhirElement("publisher", InSummary=true, Order=180, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Consent.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Consent.cs
@@ -1225,7 +1225,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Identifier for this record (external references)
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1239,7 +1239,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | inactive | entered-in-error | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1272,7 +1272,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Classification of the consent statement - for indexing/retrieval
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=110)]
+    [FhirElement("category", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -1286,7 +1286,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who the consent applies to
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=120)]
+    [FhirElement("subject", InSummary=true, Order=120, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Practitioner","Group")]
     [DataMember]
@@ -1301,7 +1301,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When consent was agreed to
     /// </summary>
-    [FhirElement("dateTime", InSummary=true, Order=130)]
+    [FhirElement("dateTime", InSummary=true, Order=130, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateTimeElement
     {
@@ -1364,7 +1364,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Consent workflow management
     /// </summary>
-    [FhirElement("manager", Order=160)]
+    [FhirElement("manager", Order=160, FiveWs="FiveWs.witness")]
     [CLSCompliant(false)]
     [References("HealthcareService","Organization","Patient","Practitioner")]
     [Cardinality(Min=0,Max=-1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/Contract.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Contract.cs
@@ -544,7 +544,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Contract Term Issue Date Time
       /// </summary>
-      [FhirElement("issued", InSummary=true, Order=50)]
+      [FhirElement("issued", InSummary=true, Order=50, FiveWs="FiveWs.recorded")]
       [DataMember]
       public Hl7.Fhir.Model.FhirDateTime IssuedElement
       {
@@ -575,7 +575,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Contract Term Effective Time
       /// </summary>
-      [FhirElement("applies", InSummary=true, Order=60)]
+      [FhirElement("applies", InSummary=true, Order=60, FiveWs="FiveWs.done[x]")]
       [DataMember]
       public Hl7.Fhir.Model.Period Applies
       {
@@ -604,7 +604,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Contract Term Type or Form
       /// </summary>
-      [FhirElement("type", Order=80)]
+      [FhirElement("type", Order=80, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Type
       {
@@ -617,7 +617,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Contract Term Type specific classification
       /// </summary>
-      [FhirElement("subType", Order=90)]
+      [FhirElement("subType", Order=90, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept SubType
       {
@@ -717,7 +717,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Nested Contract Term Group
       /// </summary>
-      [FhirElement("group", Order=150)]
+      [FhirElement("group", Order=150, FiveWs="FiveWs.what[x]")]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.Contract.TermComponent> Group
@@ -1166,7 +1166,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Contract Offer Type or Form
       /// </summary>
-      [FhirElement("type", Order=70)]
+      [FhirElement("type", Order=70, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Type
       {
@@ -1179,7 +1179,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Accepting party choice
       /// </summary>
-      [FhirElement("decision", Order=80)]
+      [FhirElement("decision", Order=80, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Decision
       {
@@ -2416,7 +2416,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Contract Valued Item Type
       /// </summary>
-      [FhirElement("entity", Order=40, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("entity", Order=40, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.what[x]")]
       [CLSCompliant(false)]
       [References("Resource")]
       [AllowedTypes(typeof(Hl7.Fhir.Model.CodeableConcept),typeof(Hl7.Fhir.Model.ResourceReference))]
@@ -2445,7 +2445,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Contract Valued Item Effective Tiem
       /// </summary>
-      [FhirElement("effectiveTime", Order=60)]
+      [FhirElement("effectiveTime", Order=60, FiveWs="FiveWs.done[x]")]
       [DataMember]
       public Hl7.Fhir.Model.FhirDateTime EffectiveTimeElement
       {
@@ -2476,7 +2476,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Count of Contract Valued Items
       /// </summary>
-      [FhirElement("quantity", Order=70)]
+      [FhirElement("quantity", Order=70, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.Quantity Quantity
       {
@@ -2489,7 +2489,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Contract Valued Item fee, charge, or cost
       /// </summary>
-      [FhirElement("unitPrice", Order=80)]
+      [FhirElement("unitPrice", Order=80, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.Money UnitPrice
       {
@@ -2502,7 +2502,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Contract Valued Item Price Scaling Factor
       /// </summary>
-      [FhirElement("factor", Order=90)]
+      [FhirElement("factor", Order=90, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.FhirDecimal FactorElement
       {
@@ -2533,7 +2533,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Contract Valued Item Difficulty Scaling Factor
       /// </summary>
-      [FhirElement("points", Order=100)]
+      [FhirElement("points", Order=100, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.FhirDecimal PointsElement
       {
@@ -2564,7 +2564,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Total Contract Valued Item Value
       /// </summary>
-      [FhirElement("net", Order=110)]
+      [FhirElement("net", Order=110, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.Money Net
       {
@@ -3005,7 +3005,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Purpose for the Contract Term Action
       /// </summary>
-      [FhirElement("intent", Order=70)]
+      [FhirElement("intent", Order=70, FiveWs="FiveWs.why[x]")]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Intent
@@ -3733,7 +3733,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Contract Signatory Role
       /// </summary>
-      [FhirElement("type", Order=40)]
+      [FhirElement("type", Order=40, FiveWs="FiveWs.actor")]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
       public Hl7.Fhir.Model.Coding Type
@@ -3747,7 +3747,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Contract Signatory Party
       /// </summary>
-      [FhirElement("party", Order=50)]
+      [FhirElement("party", Order=50, FiveWs="FiveWs.author")]
       [CLSCompliant(false)]
       [References("Organization","Patient","Practitioner","PractitionerRole","RelatedPerson")]
       [Cardinality(Min=1,Max=1)]
@@ -3763,7 +3763,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Contract Documentation Signature
       /// </summary>
-      [FhirElement("signature", Order=60)]
+      [FhirElement("signature", Order=60, FiveWs="FiveWs.author")]
       [Cardinality(Min=1,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.Signature> Signature
@@ -3891,7 +3891,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Easily comprehended representation of this Contract
       /// </summary>
-      [FhirElement("content", Order=40, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("content", Order=40, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.what[x]")]
       [CLSCompliant(false)]
       [References("Composition","DocumentReference","QuestionnaireResponse")]
       [AllowedTypes(typeof(Hl7.Fhir.Model.Attachment),typeof(Hl7.Fhir.Model.ResourceReference))]
@@ -4004,7 +4004,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Contract Legal Text
       /// </summary>
-      [FhirElement("content", Order=40, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("content", Order=40, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.what[x]")]
       [CLSCompliant(false)]
       [References("Composition","DocumentReference","QuestionnaireResponse")]
       [AllowedTypes(typeof(Hl7.Fhir.Model.Attachment),typeof(Hl7.Fhir.Model.ResourceReference))]
@@ -4117,7 +4117,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Computable Contract Rules
       /// </summary>
-      [FhirElement("content", Order=40, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("content", Order=40, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.what[x]")]
       [CLSCompliant(false)]
       [References("DocumentReference")]
       [AllowedTypes(typeof(Hl7.Fhir.Model.Attachment),typeof(Hl7.Fhir.Model.ResourceReference))]
@@ -4293,7 +4293,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// amended | appended | cancelled | disputed | entered-in-error | executable +
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=120)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=120, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.Contract.ContractResourceStatusCodes> StatusElement
@@ -4384,7 +4384,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Content derived from the basal information
     /// </summary>
-    [FhirElement("contentDerivative", Order=160)]
+    [FhirElement("contentDerivative", Order=160, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept ContentDerivative
     {
@@ -4687,7 +4687,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Legal instrument category
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=310)]
+    [FhirElement("type", InSummary=true, Order=310, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Type
     {
@@ -4700,7 +4700,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Subtype within the context of type
     /// </summary>
-    [FhirElement("subType", InSummary=true, Order=320)]
+    [FhirElement("subType", InSummary=true, Order=320, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> SubType
@@ -4727,7 +4727,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Contract Term List
     /// </summary>
-    [FhirElement("term", Order=340)]
+    [FhirElement("term", Order=340, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Contract.TermComponent> Term
@@ -4787,7 +4787,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Contract Friendly Language
     /// </summary>
-    [FhirElement("friendly", Order=380)]
+    [FhirElement("friendly", Order=380, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Contract.FriendlyLanguageComponent> Friendly
@@ -4801,7 +4801,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Contract Legal Language
     /// </summary>
-    [FhirElement("legal", Order=390)]
+    [FhirElement("legal", Order=390, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Contract.LegalLanguageComponent> Legal
@@ -4815,7 +4815,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Computable Contract Language
     /// </summary>
-    [FhirElement("rule", Order=400)]
+    [FhirElement("rule", Order=400, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Contract.ComputableLanguageComponent> Rule

--- a/src/Hl7.Fhir.Core/Model/Generated/Coverage.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Coverage.cs
@@ -538,7 +538,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for the coverage
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -552,7 +552,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | cancelled | draft | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -585,7 +585,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Coverage category such as medical or accident
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=110)]
+    [FhirElement("type", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Type
     {
@@ -598,7 +598,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Owner of the policy
     /// </summary>
-    [FhirElement("policyHolder", InSummary=true, Order=120)]
+    [FhirElement("policyHolder", InSummary=true, Order=120, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","RelatedPerson","Organization")]
     [DataMember]
@@ -613,7 +613,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Subscriber to the policy
     /// </summary>
-    [FhirElement("subscriber", InSummary=true, Order=130)]
+    [FhirElement("subscriber", InSummary=true, Order=130, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","RelatedPerson")]
     [DataMember]
@@ -628,7 +628,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// ID assigned to the subscriber
     /// </summary>
-    [FhirElement("subscriberId", InSummary=true, Order=140)]
+    [FhirElement("subscriberId", InSummary=true, Order=140, FiveWs="FiveWs.subject")]
     [DataMember]
     public Hl7.Fhir.Model.Identifier SubscriberId
     {
@@ -641,7 +641,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Plan beneficiary
     /// </summary>
-    [FhirElement("beneficiary", InSummary=true, Order=150)]
+    [FhirElement("beneficiary", InSummary=true, Order=150, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]
@@ -701,7 +701,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Coverage start and end dates
     /// </summary>
-    [FhirElement("period", InSummary=true, Order=180)]
+    [FhirElement("period", InSummary=true, Order=180, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Period Period
     {
@@ -714,7 +714,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Issuer of the policy
     /// </summary>
-    [FhirElement("payor", InSummary=true, Order=190)]
+    [FhirElement("payor", InSummary=true, Order=190, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Organization","Patient","RelatedPerson")]
     [Cardinality(Min=1,Max=-1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/CoverageEligibilityRequest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/CoverageEligibilityRequest.cs
@@ -562,7 +562,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Perfoming practitioner
       /// </summary>
-      [FhirElement("provider", Order=80)]
+      [FhirElement("provider", Order=80, FiveWs="FiveWs.source")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole")]
       [DataMember]
@@ -924,7 +924,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for coverage eligiblity request
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -938,7 +938,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | cancelled | draft | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -971,7 +971,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Desired processing priority
     /// </summary>
-    [FhirElement("priority", Order=110)]
+    [FhirElement("priority", Order=110, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Priority
     {
@@ -984,7 +984,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// auth-requirements | benefits | discovery | validation
     /// </summary>
-    [FhirElement("purpose", InSummary=true, Order=120)]
+    [FhirElement("purpose", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=-1)]
     [DataMember]
@@ -1017,7 +1017,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Intended recipient of products and services
     /// </summary>
-    [FhirElement("patient", InSummary=true, Order=130)]
+    [FhirElement("patient", InSummary=true, Order=130, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]
@@ -1033,7 +1033,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Estimated date or dates of service
     /// </summary>
-    [FhirElement("serviced", Order=140, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("serviced", Order=140, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.Date),typeof(Hl7.Fhir.Model.Period))]
     [DataMember]
@@ -1048,7 +1048,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Creation date
     /// </summary>
-    [FhirElement("created", InSummary=true, Order=150)]
+    [FhirElement("created", InSummary=true, Order=150, FiveWs="FiveWs.recorded")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime CreatedElement
@@ -1080,7 +1080,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Author
     /// </summary>
-    [FhirElement("enterer", Order=160)]
+    [FhirElement("enterer", Order=160, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole")]
     [DataMember]
@@ -1095,7 +1095,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Party responsible for the request
     /// </summary>
-    [FhirElement("provider", Order=170)]
+    [FhirElement("provider", Order=170, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization")]
     [DataMember]
@@ -1110,7 +1110,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Coverage issuer
     /// </summary>
-    [FhirElement("insurer", InSummary=true, Order=180)]
+    [FhirElement("insurer", InSummary=true, Order=180, FiveWs="FiveWs.who")]
     [CLSCompliant(false)]
     [References("Organization")]
     [Cardinality(Min=1,Max=1)]
@@ -1126,7 +1126,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Servicing facility
     /// </summary>
-    [FhirElement("facility", Order=190)]
+    [FhirElement("facility", Order=190, FiveWs="FiveWs.where[x]")]
     [CLSCompliant(false)]
     [References("Location")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/CoverageEligibilityResponse.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/CoverageEligibilityResponse.cs
@@ -376,7 +376,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Performing practitioner
       /// </summary>
-      [FhirElement("provider", Order=70)]
+      [FhirElement("provider", Order=70, FiveWs="FiveWs.source")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole")]
       [DataMember]
@@ -1081,7 +1081,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for coverage eligiblity request
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1095,7 +1095,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | cancelled | draft | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1128,7 +1128,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// auth-requirements | benefits | discovery | validation
     /// </summary>
-    [FhirElement("purpose", InSummary=true, Order=110)]
+    [FhirElement("purpose", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=-1)]
     [DataMember]
@@ -1161,7 +1161,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Intended recipient of products and services
     /// </summary>
-    [FhirElement("patient", InSummary=true, Order=120)]
+    [FhirElement("patient", InSummary=true, Order=120, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]
@@ -1177,7 +1177,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Estimated date or dates of service
     /// </summary>
-    [FhirElement("serviced", Order=130, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("serviced", Order=130, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.Date),typeof(Hl7.Fhir.Model.Period))]
     [DataMember]
@@ -1192,7 +1192,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Response creation date
     /// </summary>
-    [FhirElement("created", InSummary=true, Order=140)]
+    [FhirElement("created", InSummary=true, Order=140, FiveWs="FiveWs.recorded")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime CreatedElement
@@ -1224,7 +1224,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Party responsible for the request
     /// </summary>
-    [FhirElement("requestor", Order=150)]
+    [FhirElement("requestor", Order=150, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization")]
     [DataMember]
@@ -1239,7 +1239,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Eligibility request reference
     /// </summary>
-    [FhirElement("request", InSummary=true, Order=160)]
+    [FhirElement("request", InSummary=true, Order=160, FiveWs="FiveWs.why[x]")]
     [CLSCompliant(false)]
     [References("CoverageEligibilityRequest")]
     [Cardinality(Min=1,Max=1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/DetectedIssue.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DetectedIssue.cs
@@ -99,7 +99,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Manifestation
       /// </summary>
-      [FhirElement("code", Order=40)]
+      [FhirElement("code", Order=40, FiveWs="FiveWs.why[x]")]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.CodeableConcept> Code
@@ -113,7 +113,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Supporting information
       /// </summary>
-      [FhirElement("detail", Order=50)]
+      [FhirElement("detail", Order=50, FiveWs="FiveWs.why[x]")]
       [CLSCompliant(false)]
       [References("Resource")]
       [Cardinality(Min=0,Max=-1)]
@@ -395,7 +395,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Unique id for the detected issue
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -409,7 +409,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// registered | preliminary | final | amended +
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -442,7 +442,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Issue Category, e.g. drug-drug, duplicate therapy, etc.
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=110)]
+    [FhirElement("code", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
     {
@@ -455,7 +455,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// high | moderate | low
     /// </summary>
-    [FhirElement("severity", InSummary=true, Order=120)]
+    [FhirElement("severity", InSummary=true, Order=120, FiveWs="FiveWs.grade")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.DetectedIssue.DetectedIssueSeverity> SeverityElement
@@ -487,7 +487,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Associated patient
     /// </summary>
-    [FhirElement("patient", InSummary=true, Order=130)]
+    [FhirElement("patient", InSummary=true, Order=130, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [DataMember]
@@ -502,7 +502,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When identified
     /// </summary>
-    [FhirElement("identified", InSummary=true, Order=140, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("identified", InSummary=true, Order=140, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.recorded")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period))]
     [DataMember]
@@ -517,7 +517,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The provider or device that identified the issue
     /// </summary>
-    [FhirElement("author", InSummary=true, Order=150)]
+    [FhirElement("author", InSummary=true, Order=150, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Device")]
     [DataMember]
@@ -548,7 +548,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Supporting evidence
     /// </summary>
-    [FhirElement("evidence", Order=170)]
+    [FhirElement("evidence", Order=170, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.DetectedIssue.EvidenceComponent> Evidence

--- a/src/Hl7.Fhir.Core/Model/Generated/Device.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Device.cs
@@ -151,7 +151,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Mandatory fixed portion of UDI
       /// </summary>
-      [FhirElement("deviceIdentifier", InSummary=true, Order=40)]
+      [FhirElement("deviceIdentifier", InSummary=true, Order=40, FiveWs="FiveWs.what[x]")]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
       public Hl7.Fhir.Model.FhirString DeviceIdentifierElement
@@ -512,7 +512,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// registered-name | user-friendly-name | patient-reported-name
       /// </summary>
-      [FhirElement("type", Order=50)]
+      [FhirElement("type", Order=50, FiveWs="FiveWs.what[x]")]
       [DeclaredType(Type = typeof(Code))]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
@@ -663,7 +663,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// The hardware or software module of the device to which the version applies
       /// </summary>
-      [FhirElement("component", Order=50)]
+      [FhirElement("component", Order=50, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.Identifier Component
       {
@@ -1342,7 +1342,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Instance identifier
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1400,7 +1400,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Unique Device Identifier (UDI) Barcode string
     /// </summary>
-    [FhirElement("udiCarrier", InSummary=true, Order=120)]
+    [FhirElement("udiCarrier", InSummary=true, Order=120, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Device.UdiCarrierComponent> UdiCarrier
@@ -1414,7 +1414,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | inactive | entered-in-error | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=130)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=130, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.Device.FHIRDeviceStatus> StatusElement
@@ -1446,7 +1446,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// discarded | obsolete | removed
     /// </summary>
-    [FhirElement("statusReason", Order=140)]
+    [FhirElement("statusReason", Order=140, FiveWs="FiveWs.status")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> StatusReason
@@ -1460,7 +1460,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// An identifier that supports traceability to the biological entity that is the source of biological material in the product
     /// </summary>
-    [FhirElement("biologicalSource", Order=150)]
+    [FhirElement("biologicalSource", Order=150, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Identifier BiologicalSource
     {
@@ -1473,7 +1473,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of device manufacturer
     /// </summary>
-    [FhirElement("manufacturer", Order=160)]
+    [FhirElement("manufacturer", Order=160, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString ManufacturerElement
     {
@@ -1504,7 +1504,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date when the device was made
     /// </summary>
-    [FhirElement("manufactureDate", Order=170)]
+    [FhirElement("manufactureDate", Order=170, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime ManufactureDateElement
     {
@@ -1535,7 +1535,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date and time of expiry of this device (if applicable)
     /// </summary>
-    [FhirElement("expirationDate", Order=180)]
+    [FhirElement("expirationDate", Order=180, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime ExpirationDateElement
     {
@@ -1566,7 +1566,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Lot number of manufacture
     /// </summary>
-    [FhirElement("lotNumber", Order=190)]
+    [FhirElement("lotNumber", Order=190, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString LotNumberElement
     {
@@ -1597,7 +1597,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Serial number assigned by the manufacturer
     /// </summary>
-    [FhirElement("serialNumber", Order=200)]
+    [FhirElement("serialNumber", Order=200, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString SerialNumberElement
     {
@@ -1642,7 +1642,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The manufacturer's model number for the device
     /// </summary>
-    [FhirElement("modelNumber", Order=220)]
+    [FhirElement("modelNumber", Order=220, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString ModelNumberElement
     {
@@ -1673,7 +1673,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The part number or catalog number of the device
     /// </summary>
-    [FhirElement("partNumber", Order=230)]
+    [FhirElement("partNumber", Order=230, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PartNumberElement
     {
@@ -1746,7 +1746,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Patient to whom Device is affixed
     /// </summary>
-    [FhirElement("subject", Order=270)]
+    [FhirElement("subject", Order=270, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Practitioner","Person")]
     [DataMember]
@@ -1787,7 +1787,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Organization responsible for device
     /// </summary>
-    [FhirElement("owner", Order=300)]
+    [FhirElement("owner", Order=300, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Organization")]
     [DataMember]
@@ -1802,7 +1802,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Details for human/organization for support
     /// </summary>
-    [FhirElement("contact", Order=310)]
+    [FhirElement("contact", Order=310, FiveWs="FiveWs.source")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.ContactPoint> Contact
@@ -1816,7 +1816,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Where the device is found
     /// </summary>
-    [FhirElement("location", Order=320)]
+    [FhirElement("location", Order=320, FiveWs="FiveWs.where[x]")]
     [CLSCompliant(false)]
     [References("Location")]
     [DataMember]
@@ -1831,7 +1831,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Network address to contact device
     /// </summary>
-    [FhirElement("url", Order=330)]
+    [FhirElement("url", Order=330, FiveWs="FiveWs.where[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/DeviceDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DeviceDefinition.cs
@@ -561,7 +561,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// registered-name | user-friendly-name | patient-reported-name
       /// </summary>
-      [FhirElement("type", Order=50)]
+      [FhirElement("type", Order=50, FiveWs="FiveWs.what[x]")]
       [DeclaredType(Type = typeof(Code))]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
@@ -1770,7 +1770,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// The hardware or software module of the device to which the version applies
       /// </summary>
-      [FhirElement("component", Order=50)]
+      [FhirElement("component", Order=50, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.Identifier Component
       {
@@ -3020,7 +3020,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Instance identifier
     /// </summary>
-    [FhirElement("identifier", Order=100)]
+    [FhirElement("identifier", Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -3048,7 +3048,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The part number or catalog number of the device
     /// </summary>
-    [FhirElement("partNumber", Order=120)]
+    [FhirElement("partNumber", Order=120, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PartNumberElement
     {
@@ -3079,7 +3079,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of device manufacturer
     /// </summary>
-    [FhirElement("manufacturer", Order=130, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("manufacturer", Order=130, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.what[x]")]
     [CLSCompliant(false)]
     [References("Organization")]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirString),typeof(Hl7.Fhir.Model.ResourceReference))]
@@ -3109,7 +3109,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The catalog or model number for the device for example as defined by the manufacturer
     /// </summary>
-    [FhirElement("modelNumber", Order=150)]
+    [FhirElement("modelNumber", Order=150, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString ModelNumberElement
     {
@@ -3266,7 +3266,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Organization responsible for device
     /// </summary>
-    [FhirElement("owner", Order=250)]
+    [FhirElement("owner", Order=250, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Organization")]
     [DataMember]
@@ -3281,7 +3281,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Details for human/organization for support
     /// </summary>
-    [FhirElement("contact", Order=260)]
+    [FhirElement("contact", Order=260, FiveWs="FiveWs.source")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.ContactPoint> Contact

--- a/src/Hl7.Fhir.Core/Model/Generated/DeviceDispense.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DeviceDispense.cs
@@ -256,7 +256,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business identifier for this dispensation
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -302,7 +302,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// preparation | in-progress | cancelled | on-hold | completed | entered-in-error | stopped | declined | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=120)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=120, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -362,7 +362,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// What device was supplied
     /// </summary>
-    [FhirElement("device", InSummary=true, Order=150)]
+    [FhirElement("device", InSummary=true, Order=150, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableReference Device
@@ -376,7 +376,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who the dispense is for
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=160)]
+    [FhirElement("subject", InSummary=true, Order=160, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]
@@ -407,7 +407,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Information that supports the dispensing of the device
     /// </summary>
-    [FhirElement("supportingInformation", Order=180)]
+    [FhirElement("supportingInformation", Order=180, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Resource")]
     [Cardinality(Min=0,Max=-1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/DeviceMetric.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DeviceMetric.cs
@@ -461,7 +461,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Instance identifier
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -475,7 +475,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Identity of metric, for example Heart Rate or PEEP Setting
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=100)]
+    [FhirElement("type", InSummary=true, Order=100, FiveWs="FiveWs.class")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Type
@@ -596,7 +596,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// measurement | setting | calculation | unspecified
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=160)]
+    [FhirElement("category", InSummary=true, Order=160, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/DeviceRequest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DeviceRequest.cs
@@ -71,7 +71,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Device detail
       /// </summary>
-      [FhirElement("code", Order=40)]
+      [FhirElement("code", Order=40, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Code
       {
@@ -84,7 +84,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Value of detail
       /// </summary>
-      [FhirElement("value", Order=50, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("value", Order=50, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.what[x]")]
       [CLSCompliant(false)]
       [AllowedTypes(typeof(Hl7.Fhir.Model.CodeableConcept),typeof(Hl7.Fhir.Model.Quantity),typeof(Hl7.Fhir.Model.Range),typeof(Hl7.Fhir.Model.FhirBoolean))]
       [DataMember]
@@ -191,7 +191,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External Request identifier
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -314,7 +314,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | on-hold | revoked | completed | entered-in-error | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=150)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=150, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.RequestStatus> StatusElement
@@ -346,7 +346,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// proposal | plan | directive | order | original-order | reflex-order | filler-order | instance-order | option
     /// </summary>
-    [FhirElement("intent", InSummary=true, IsModifier=true, Order=160)]
+    [FhirElement("intent", InSummary=true, IsModifier=true, Order=160, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -379,7 +379,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// routine | urgent | asap | stat
     /// </summary>
-    [FhirElement("priority", InSummary=true, Order=170)]
+    [FhirElement("priority", InSummary=true, Order=170, FiveWs="FiveWs.grade")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.RequestPriority> PriorityElement
@@ -442,7 +442,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Device requested
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=190)]
+    [FhirElement("code", InSummary=true, Order=190, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableReference Code
@@ -487,7 +487,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Device details
     /// </summary>
-    [FhirElement("parameter", Order=210)]
+    [FhirElement("parameter", Order=210, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.DeviceRequest.ParameterComponent> Parameter
@@ -501,7 +501,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Focus of request
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=220)]
+    [FhirElement("subject", InSummary=true, Order=220, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group","Location","Device")]
     [Cardinality(Min=1,Max=1)]
@@ -517,7 +517,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Encounter motivating request
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=230)]
+    [FhirElement("encounter", InSummary=true, Order=230, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -532,7 +532,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Desired time or schedule for use
     /// </summary>
-    [FhirElement("occurrence", InSummary=true, Order=240, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("occurrence", InSummary=true, Order=240, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.planned")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period),typeof(Hl7.Fhir.Model.Timing))]
     [DataMember]
@@ -547,7 +547,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When recorded
     /// </summary>
-    [FhirElement("authoredOn", InSummary=true, Order=250)]
+    [FhirElement("authoredOn", InSummary=true, Order=250, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime AuthoredOnElement
     {
@@ -578,7 +578,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who/what submitted the device request
     /// </summary>
-    [FhirElement("requester", InSummary=true, Order=260)]
+    [FhirElement("requester", InSummary=true, Order=260, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Device","Practitioner","PractitionerRole","Organization")]
     [DataMember]
@@ -593,7 +593,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Filler role
     /// </summary>
-    [FhirElement("performerType", InSummary=true, Order=270)]
+    [FhirElement("performerType", InSummary=true, Order=270, FiveWs="FiveWs.actor")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept PerformerType
     {
@@ -606,7 +606,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Requested Filler
     /// </summary>
-    [FhirElement("performer", InSummary=true, Order=280)]
+    [FhirElement("performer", InSummary=true, Order=280, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization","CareTeam","HealthcareService","Patient","Device","RelatedPerson")]
     [DataMember]
@@ -621,7 +621,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Coded/Linked Reason for request
     /// </summary>
-    [FhirElement("reason", InSummary=true, Order=290)]
+    [FhirElement("reason", InSummary=true, Order=290, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason

--- a/src/Hl7.Fhir.Core/Model/Generated/DeviceUsage.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DeviceUsage.cs
@@ -110,7 +110,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External identifier for this record
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -140,7 +140,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | completed | not-done | entered-in-error +
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=110)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=110, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -187,7 +187,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Patient using device
     /// </summary>
-    [FhirElement("patient", InSummary=true, Order=130)]
+    [FhirElement("patient", InSummary=true, Order=130, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]
@@ -234,7 +234,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// How often  the device was used
     /// </summary>
-    [FhirElement("timing", InSummary=true, Order=160, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("timing", InSummary=true, Order=160, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.Timing),typeof(Hl7.Fhir.Model.Period),typeof(Hl7.Fhir.Model.FhirDateTime))]
     [DataMember]
@@ -249,7 +249,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the statement was made (and recorded)
     /// </summary>
-    [FhirElement("dateAsserted", InSummary=true, Order=170)]
+    [FhirElement("dateAsserted", InSummary=true, Order=170, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateAssertedElement
     {
@@ -307,7 +307,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who made the statement
     /// </summary>
-    [FhirElement("informationSource", InSummary=true, Order=200)]
+    [FhirElement("informationSource", InSummary=true, Order=200, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Patient","Practitioner","PractitionerRole","RelatedPerson","Organization")]
     [DataMember]
@@ -322,7 +322,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Code or Reference to device used
     /// </summary>
-    [FhirElement("device", InSummary=true, Order=210)]
+    [FhirElement("device", InSummary=true, Order=210, FiveWs="FiveWs.actor")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableReference Device
@@ -336,7 +336,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why device was used
     /// </summary>
-    [FhirElement("reason", InSummary=true, Order=220)]
+    [FhirElement("reason", InSummary=true, Order=220, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason

--- a/src/Hl7.Fhir.Core/Model/Generated/DiagnosticReport.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DiagnosticReport.cs
@@ -280,7 +280,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business identifier for report
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -310,7 +310,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// registered | partial | preliminary | final +
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=110)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=110, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -343,7 +343,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Service category
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=120)]
+    [FhirElement("category", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -357,7 +357,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name/Code for this diagnostic report
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=130)]
+    [FhirElement("code", InSummary=true, Order=130, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
@@ -371,7 +371,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The subject of the report - usually, but not always, the patient
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=140)]
+    [FhirElement("subject", InSummary=true, Order=140, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group","Device","Location","Organization","Procedure","Practitioner","Medication","Substance","BiologicallyDerivedProduct")]
     [DataMember]
@@ -386,7 +386,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Health care event when test ordered
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=150)]
+    [FhirElement("encounter", InSummary=true, Order=150, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -401,7 +401,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Clinically relevant time/time-period for report
     /// </summary>
-    [FhirElement("effective", InSummary=true, Order=160, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("effective", InSummary=true, Order=160, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period))]
     [DataMember]
@@ -416,7 +416,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// DateTime this version was made
     /// </summary>
-    [FhirElement("issued", InSummary=true, Order=170)]
+    [FhirElement("issued", InSummary=true, Order=170, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.Instant IssuedElement
     {
@@ -447,7 +447,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Responsible Diagnostic Service
     /// </summary>
-    [FhirElement("performer", InSummary=true, Order=180)]
+    [FhirElement("performer", InSummary=true, Order=180, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization","CareTeam")]
     [Cardinality(Min=0,Max=-1)]
@@ -463,7 +463,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Primary result interpreter
     /// </summary>
-    [FhirElement("resultsInterpreter", InSummary=true, Order=190)]
+    [FhirElement("resultsInterpreter", InSummary=true, Order=190, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization","CareTeam")]
     [Cardinality(Min=0,Max=-1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/DocumentManifest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DocumentManifest.cs
@@ -191,7 +191,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Unique Identifier for the set of documents
     /// </summary>
-    [FhirElement("masterIdentifier", InSummary=true, Order=90)]
+    [FhirElement("masterIdentifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.Identifier MasterIdentifier
     {
@@ -204,7 +204,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Other identifiers for the manifest
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -218,7 +218,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// current | superseded | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=110)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=110, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -251,7 +251,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Kind of document set
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=120)]
+    [FhirElement("type", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Type
     {
@@ -264,7 +264,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The subject of the set of documents
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=130)]
+    [FhirElement("subject", InSummary=true, Order=130, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Practitioner","Group","Device")]
     [DataMember]
@@ -279,7 +279,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When this document manifest created
     /// </summary>
-    [FhirElement("created", Order=140)]
+    [FhirElement("created", Order=140, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime CreatedElement
     {
@@ -310,7 +310,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who and/or what authored the DocumentManifest
     /// </summary>
-    [FhirElement("author", InSummary=true, Order=150)]
+    [FhirElement("author", InSummary=true, Order=150, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization","Device","Patient","RelatedPerson")]
     [Cardinality(Min=0,Max=-1)]
@@ -326,7 +326,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Intended to get notified about this set of documents
     /// </summary>
-    [FhirElement("recipient", Order=160)]
+    [FhirElement("recipient", Order=160, FiveWs="FiveWs.cause")]
     [CLSCompliant(false)]
     [References("Patient","Practitioner","PractitionerRole","RelatedPerson","Organization")]
     [Cardinality(Min=0,Max=-1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/DocumentReference.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/DocumentReference.cs
@@ -169,7 +169,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Who attested the composition
       /// </summary>
-      [FhirElement("party", Order=60)]
+      [FhirElement("party", Order=60, FiveWs="FiveWs.witness")]
       [CLSCompliant(false)]
       [References("Patient","RelatedPerson","Practitioner","PractitionerRole","Organization")]
       [DataMember]
@@ -460,7 +460,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Identifier of the attachment binary
       /// </summary>
-      [FhirElement("identifier", InSummary=true, Order=60)]
+      [FhirElement("identifier", InSummary=true, Order=60, FiveWs="FiveWs.identifier")]
       [DataMember]
       public Hl7.Fhir.Model.Identifier Identifier
       {
@@ -574,7 +574,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Other identifiers for the document
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -604,7 +604,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// current | superseded | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=110)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=110, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -637,7 +637,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// preliminary | final | amended | entered-in-error | deprecated
     /// </summary>
-    [FhirElement("docStatus", InSummary=true, Order=120)]
+    [FhirElement("docStatus", InSummary=true, Order=120, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.CompositionStatus> DocStatusElement
@@ -669,7 +669,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Kind of document (LOINC if possible)
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=130)]
+    [FhirElement("type", InSummary=true, Order=130, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Type
     {
@@ -682,7 +682,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Categorization of document
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=140)]
+    [FhirElement("category", InSummary=true, Order=140, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -696,7 +696,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who/what is the subject of the document
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=150)]
+    [FhirElement("subject", InSummary=true, Order=150, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Practitioner","Group","Device","PractitionerRole","Specimen","Organization","Location")]
     [DataMember]
@@ -711,7 +711,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Context of the document  content
     /// </summary>
-    [FhirElement("encounter", Order=160)]
+    [FhirElement("encounter", Order=160, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [Cardinality(Min=0,Max=-1)]
@@ -780,7 +780,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When this document reference was created
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=210)]
+    [FhirElement("date", InSummary=true, Order=210, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.Instant DateElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Encounter.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Encounter.cs
@@ -471,7 +471,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Persons involved in the encounter (including patient)
       /// </summary>
-      [FhirElement("actor", InSummary=true, Order=60)]
+      [FhirElement("actor", InSummary=true, Order=60, FiveWs="FiveWs.who")]
       [CLSCompliant(false)]
       [References("Patient","Group","RelatedPerson","Practitioner","PractitionerRole","Device","HealthcareService")]
       [DataMember]
@@ -600,7 +600,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// The diagnosis or procedure relevant to the encounter
       /// </summary>
-      [FhirElement("condition", InSummary=true, Order=40)]
+      [FhirElement("condition", InSummary=true, Order=40, FiveWs="FiveWs.why[x]")]
       [CLSCompliant(false)]
       [References("Condition","Procedure")]
       [Cardinality(Min=1,Max=1)]
@@ -1066,7 +1066,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Location the encounter takes place
       /// </summary>
-      [FhirElement("location", Order=40)]
+      [FhirElement("location", Order=40, FiveWs="FiveWs.where[x]")]
       [CLSCompliant(false)]
       [References("Location")]
       [Cardinality(Min=1,Max=1)]
@@ -1250,7 +1250,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Identifier(s) by which this encounter is known
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1264,7 +1264,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// planned | in-progress | onhold | completed | cancelled | entered-in-error | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1311,7 +1311,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Classification of patient encounter
     /// </summary>
-    [FhirElement("class", InSummary=true, Order=120)]
+    [FhirElement("class", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.Coding Class
@@ -1339,7 +1339,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Specific type of encounter
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=140)]
+    [FhirElement("type", InSummary=true, Order=140, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Type
@@ -1366,7 +1366,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Indicates the urgency of the encounter
     /// </summary>
-    [FhirElement("priority", Order=160)]
+    [FhirElement("priority", Order=160, FiveWs="FiveWs.grade")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Priority
     {
@@ -1379,7 +1379,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The patient or group present at the encounter
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=170)]
+    [FhirElement("subject", InSummary=true, Order=170, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [DataMember]
@@ -1407,7 +1407,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Episode(s) of care that this encounter should be recorded against
     /// </summary>
-    [FhirElement("episodeOfCare", InSummary=true, Order=190)]
+    [FhirElement("episodeOfCare", InSummary=true, Order=190, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("EpisodeOfCare")]
     [Cardinality(Min=0,Max=-1)]
@@ -1469,7 +1469,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The actual start and end time of the encounter
     /// </summary>
-    [FhirElement("actualPeriod", Order=230)]
+    [FhirElement("actualPeriod", Order=230, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Period ActualPeriod
     {
@@ -1557,7 +1557,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Reason the encounter takes place (core or reference)
     /// </summary>
-    [FhirElement("reason", InSummary=true, Order=270)]
+    [FhirElement("reason", InSummary=true, Order=270, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason

--- a/src/Hl7.Fhir.Core/Model/Generated/Endpoint.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Endpoint.cs
@@ -104,7 +104,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Identifies this endpoint across multiple systems
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -118,7 +118,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | suspended | error | off | entered-in-error | test
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -151,7 +151,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Protocol/Profile/Standard to be used with this endpoint connection
     /// </summary>
-    [FhirElement("connectionType", InSummary=true, Order=110)]
+    [FhirElement("connectionType", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.Coding ConnectionType
@@ -165,7 +165,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// A name that this endpoint can be identified by
     /// </summary>
-    [FhirElement("name", InSummary=true, Order=120)]
+    [FhirElement("name", InSummary=true, Order=120, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString NameElement
     {
@@ -225,7 +225,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Interval the endpoint is expected to be operational
     /// </summary>
-    [FhirElement("period", InSummary=true, Order=150)]
+    [FhirElement("period", InSummary=true, Order=150, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Period Period
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/EnrollmentRequest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/EnrollmentRequest.cs
@@ -150,7 +150,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Responsible practitioner
     /// </summary>
-    [FhirElement("provider", Order=130)]
+    [FhirElement("provider", Order=130, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization")]
     [DataMember]
@@ -165,7 +165,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The subject to be enrolled
     /// </summary>
-    [FhirElement("candidate", Order=140)]
+    [FhirElement("candidate", Order=140, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Patient")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/EnrollmentResponse.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/EnrollmentResponse.cs
@@ -247,7 +247,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Insurer
     /// </summary>
-    [FhirElement("organization", Order=150)]
+    [FhirElement("organization", Order=150, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Organization")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/EpisodeOfCare.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/EpisodeOfCare.cs
@@ -275,7 +275,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Conditions/problems/diagnoses this episode of care is for
       /// </summary>
-      [FhirElement("condition", InSummary=true, Order=40)]
+      [FhirElement("condition", InSummary=true, Order=40, FiveWs="FiveWs.what[x]")]
       [CLSCompliant(false)]
       [References("Condition")]
       [Cardinality(Min=1,Max=1)]
@@ -436,7 +436,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier(s) relevant for this EpisodeOfCare
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -450,7 +450,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// planned | waitlist | active | onhold | finished | cancelled | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -497,7 +497,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Type/class  - e.g. specialist referral, disease management
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=120)]
+    [FhirElement("type", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Type
@@ -525,7 +525,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The patient who is the focus of this episode of care
     /// </summary>
-    [FhirElement("patient", InSummary=true, Order=140)]
+    [FhirElement("patient", InSummary=true, Order=140, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]
@@ -556,7 +556,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Interval during responsibility is assumed
     /// </summary>
-    [FhirElement("period", InSummary=true, Order=160)]
+    [FhirElement("period", InSummary=true, Order=160, FiveWs="FiveWs.init")]
     [DataMember]
     public Hl7.Fhir.Model.Period Period
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/EventDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/EventDefinition.cs
@@ -58,7 +58,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this event definition, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -89,7 +89,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the event definition
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -103,7 +103,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the event definition
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -227,7 +227,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=150)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=150, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -260,7 +260,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=160)]
+    [FhirElement("experimental", InSummary=true, Order=160, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -307,7 +307,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=180)]
+    [FhirElement("date", InSummary=true, Order=180, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -338,7 +338,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=190)]
+    [FhirElement("publisher", InSummary=true, Order=190, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -424,7 +424,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this event definition is defined
     /// </summary>
-    [FhirElement("purpose", Order=240)]
+    [FhirElement("purpose", Order=240, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Evidence.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Evidence.cs
@@ -1853,7 +1853,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this evidence, represented as a globally unique URI
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -1884,7 +1884,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the summary
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1898,7 +1898,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of this summary
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -1976,7 +1976,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=140)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=140, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -2009,7 +2009,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=150)]
+    [FhirElement("date", InSummary=true, Order=150, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -2116,7 +2116,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=190)]
+    [FhirElement("publisher", InSummary=true, Order=190, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/EvidenceReport.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/EvidenceReport.cs
@@ -1193,7 +1193,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this EvidenceReport, represented as a globally unique URI
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -1224,7 +1224,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1271,7 +1271,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Unique identifier for the evidence report
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=120)]
+    [FhirElement("identifier", InSummary=true, Order=120, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1370,7 +1370,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=190)]
+    [FhirElement("publisher", InSummary=true, Order=190, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/EvidenceVariable.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/EvidenceVariable.cs
@@ -1005,7 +1005,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this evidence variable, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -1036,7 +1036,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the evidence variable
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1050,7 +1050,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the evidence variable
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -1205,7 +1205,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=160)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=160, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1238,7 +1238,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=170)]
+    [FhirElement("date", InSummary=true, Order=170, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -1310,7 +1310,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=210)]
+    [FhirElement("publisher", InSummary=true, Order=210, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/ExampleScenario.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ExampleScenario.cs
@@ -1928,7 +1928,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this example scenario, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -1959,7 +1959,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the example scenario
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1973,7 +1973,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the example scenario
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -2035,7 +2035,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=130)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=130, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -2068,7 +2068,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=140)]
+    [FhirElement("experimental", InSummary=true, Order=140, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -2099,7 +2099,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=150)]
+    [FhirElement("date", InSummary=true, Order=150, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -2130,7 +2130,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=160)]
+    [FhirElement("publisher", InSummary=true, Order=160, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -2203,7 +2203,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The purpose of the example, e.g. to illustrate a scenario
     /// </summary>
-    [FhirElement("purpose", Order=200)]
+    [FhirElement("purpose", Order=200, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/ExplanationOfBenefit.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ExplanationOfBenefit.cs
@@ -425,7 +425,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Practitioner or organization
       /// </summary>
-      [FhirElement("provider", Order=50)]
+      [FhirElement("provider", Order=50, FiveWs="FiveWs.actor")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole","Organization")]
       [Cardinality(Min=1,Max=1)]
@@ -1933,7 +1933,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Date or dates of service or product delivery
       /// </summary>
-      [FhirElement("serviced", Order=140, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("serviced", Order=140, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
       [CLSCompliant(false)]
       [AllowedTypes(typeof(Hl7.Fhir.Model.Date),typeof(Hl7.Fhir.Model.Period))]
       [DataMember]
@@ -1948,7 +1948,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Place of service or where product was supplied
       /// </summary>
-      [FhirElement("location", Order=150, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("location", Order=150, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.where[x]")]
       [CLSCompliant(false)]
       [References("Location")]
       [AllowedTypes(typeof(Hl7.Fhir.Model.CodeableConcept),typeof(Hl7.Fhir.Model.Address),typeof(Hl7.Fhir.Model.ResourceReference))]
@@ -3632,7 +3632,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Authorized providers
       /// </summary>
-      [FhirElement("provider", Order=70)]
+      [FhirElement("provider", Order=70, FiveWs="FiveWs.source")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole","Organization")]
       [Cardinality(Min=0,Max=-1)]
@@ -3690,7 +3690,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Date or dates of service or product delivery
       /// </summary>
-      [FhirElement("serviced", Order=110, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("serviced", Order=110, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
       [CLSCompliant(false)]
       [AllowedTypes(typeof(Hl7.Fhir.Model.Date),typeof(Hl7.Fhir.Model.Period))]
       [DataMember]
@@ -3705,7 +3705,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Place of service or where product was supplied
       /// </summary>
-      [FhirElement("location", Order=120, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("location", Order=120, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.where[x]")]
       [CLSCompliant(false)]
       [References("Location")]
       [AllowedTypes(typeof(Hl7.Fhir.Model.CodeableConcept),typeof(Hl7.Fhir.Model.Address),typeof(Hl7.Fhir.Model.ResourceReference))]
@@ -5820,7 +5820,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for the resource
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -5834,7 +5834,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | cancelled | draft | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -5867,7 +5867,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Category or discipline
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=110)]
+    [FhirElement("type", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Type
@@ -5881,7 +5881,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// More granular claim type
     /// </summary>
-    [FhirElement("subType", Order=120)]
+    [FhirElement("subType", Order=120, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept SubType
     {
@@ -5894,7 +5894,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// claim | preauthorization | predetermination
     /// </summary>
-    [FhirElement("use", InSummary=true, Order=130)]
+    [FhirElement("use", InSummary=true, Order=130, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -5927,7 +5927,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The recipient of the products and services
     /// </summary>
-    [FhirElement("patient", InSummary=true, Order=140)]
+    [FhirElement("patient", InSummary=true, Order=140, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]
@@ -5943,7 +5943,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Relevant time frame for the claim
     /// </summary>
-    [FhirElement("billablePeriod", InSummary=true, Order=150)]
+    [FhirElement("billablePeriod", InSummary=true, Order=150, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Period BillablePeriod
     {
@@ -5956,7 +5956,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Response creation date
     /// </summary>
-    [FhirElement("created", InSummary=true, Order=160)]
+    [FhirElement("created", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime CreatedElement
@@ -5988,7 +5988,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Author of the claim
     /// </summary>
-    [FhirElement("enterer", Order=170)]
+    [FhirElement("enterer", Order=170, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole")]
     [DataMember]
@@ -6003,7 +6003,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Party responsible for reimbursement
     /// </summary>
-    [FhirElement("insurer", InSummary=true, Order=180)]
+    [FhirElement("insurer", InSummary=true, Order=180, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Organization")]
     [Cardinality(Min=1,Max=1)]
@@ -6019,7 +6019,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Party responsible for the claim
     /// </summary>
-    [FhirElement("provider", InSummary=true, Order=190)]
+    [FhirElement("provider", InSummary=true, Order=190, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization")]
     [Cardinality(Min=1,Max=1)]
@@ -6131,7 +6131,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Treatment Referral
     /// </summary>
-    [FhirElement("referral", Order=270)]
+    [FhirElement("referral", Order=270, FiveWs="FiveWs.cause")]
     [CLSCompliant(false)]
     [References("ServiceRequest")]
     [DataMember]
@@ -6146,7 +6146,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Servicing Facility
     /// </summary>
-    [FhirElement("facility", Order=280)]
+    [FhirElement("facility", Order=280, FiveWs="FiveWs.where[x]")]
     [CLSCompliant(false)]
     [References("Location")]
     [DataMember]
@@ -6161,7 +6161,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Claim reference
     /// </summary>
-    [FhirElement("claim", Order=290)]
+    [FhirElement("claim", Order=290, FiveWs="FiveWs.why[x]")]
     [CLSCompliant(false)]
     [References("Claim")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/FamilyMemberHistory.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/FamilyMemberHistory.cs
@@ -530,7 +530,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External Id(s) for this record
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -608,7 +608,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// partial | completed | entered-in-error | health-unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=120)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=120, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -654,7 +654,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Patient history is about
     /// </summary>
-    [FhirElement("patient", InSummary=true, Order=140)]
+    [FhirElement("patient", InSummary=true, Order=140, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]
@@ -670,7 +670,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When history was recorded or last updated
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=150)]
+    [FhirElement("date", InSummary=true, Order=150, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -835,7 +835,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why was family member history performed?
     /// </summary>
-    [FhirElement("reason", InSummary=true, Order=230)]
+    [FhirElement("reason", InSummary=true, Order=230, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason

--- a/src/Hl7.Fhir.Core/Model/Generated/Flag.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Flag.cs
@@ -86,7 +86,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business identifier
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -100,7 +100,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | inactive | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -133,7 +133,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Clinical, administrative, etc.
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=110)]
+    [FhirElement("category", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -147,7 +147,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Coded or textual message to display to user
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=120)]
+    [FhirElement("code", InSummary=true, Order=120, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
@@ -161,7 +161,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who/What is flag about?
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=130)]
+    [FhirElement("subject", InSummary=true, Order=130, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Location","Group","Organization","Practitioner","PractitionerRole","PlanDefinition","Medication","Procedure")]
     [Cardinality(Min=1,Max=1)]
@@ -177,7 +177,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Time period when flag is active
     /// </summary>
-    [FhirElement("period", InSummary=true, Order=140)]
+    [FhirElement("period", InSummary=true, Order=140, FiveWs="FiveWs.context")]
     [DataMember]
     public Hl7.Fhir.Model.Period Period
     {
@@ -190,7 +190,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Alert relevant during encounter
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=150)]
+    [FhirElement("encounter", InSummary=true, Order=150, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -205,7 +205,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Flag creator
     /// </summary>
-    [FhirElement("author", InSummary=true, Order=160)]
+    [FhirElement("author", InSummary=true, Order=160, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Device","Organization","Patient","Practitioner","PractitionerRole")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/Goal.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Goal.cs
@@ -163,7 +163,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Reach goal on or before
       /// </summary>
-      [FhirElement("due", InSummary=true, Order=60, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("due", InSummary=true, Order=60, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
       [CLSCompliant(false)]
       [AllowedTypes(typeof(Hl7.Fhir.Model.Date),typeof(Hl7.Fhir.Model.Duration))]
       [DataMember]
@@ -279,7 +279,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External Ids for this goal
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -293,7 +293,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected
     /// </summary>
-    [FhirElement("lifecycleStatus", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("lifecycleStatus", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -339,7 +339,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// E.g. Treatment, dietary, behavioral, etc.
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=120)]
+    [FhirElement("category", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -384,7 +384,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// high-priority | medium-priority | low-priority
     /// </summary>
-    [FhirElement("priority", InSummary=true, Order=140)]
+    [FhirElement("priority", InSummary=true, Order=140, FiveWs="FiveWs.grade")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Priority
     {
@@ -397,7 +397,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Code or text describing goal
     /// </summary>
-    [FhirElement("description", InSummary=true, Order=150)]
+    [FhirElement("description", InSummary=true, Order=150, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Description
@@ -411,7 +411,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who this goal is intended for
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=160)]
+    [FhirElement("subject", InSummary=true, Order=160, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group","Organization")]
     [Cardinality(Min=1,Max=1)]
@@ -427,7 +427,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When goal pursuit begins
     /// </summary>
-    [FhirElement("start", InSummary=true, Order=170, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("start", InSummary=true, Order=170, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.planned")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.Date),typeof(Hl7.Fhir.Model.CodeableConcept))]
     [DataMember]
@@ -456,7 +456,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When goal status took effect
     /// </summary>
-    [FhirElement("statusDate", InSummary=true, Order=190)]
+    [FhirElement("statusDate", InSummary=true, Order=190, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.Date StatusDateElement
     {
@@ -518,7 +518,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who's responsible for creating Goal?
     /// </summary>
-    [FhirElement("source", InSummary=true, Order=210)]
+    [FhirElement("source", InSummary=true, Order=210, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Patient","Practitioner","PractitionerRole","RelatedPerson","CareTeam")]
     [DataMember]
@@ -533,7 +533,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Issues addressed by this goal
     /// </summary>
-    [FhirElement("addresses", Order=220)]
+    [FhirElement("addresses", Order=220, FiveWs="FiveWs.why[x]")]
     [CLSCompliant(false)]
     [References("Condition","Observation","MedicationUsage","MedicationRequest","NutritionOrder","ServiceRequest","RiskAssessment")]
     [Cardinality(Min=0,Max=-1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/GraphDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/GraphDefinition.cs
@@ -972,7 +972,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this graph definition, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -1003,7 +1003,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the graph definition
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=100)]
+    [FhirElement("version", InSummary=true, Order=100, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -1066,7 +1066,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=120)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=120, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1099,7 +1099,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=130)]
+    [FhirElement("experimental", InSummary=true, Order=130, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -1130,7 +1130,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=140)]
+    [FhirElement("date", InSummary=true, Order=140, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -1161,7 +1161,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=150)]
+    [FhirElement("publisher", InSummary=true, Order=150, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -1247,7 +1247,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this graph definition is defined
     /// </summary>
-    [FhirElement("purpose", Order=200)]
+    [FhirElement("purpose", Order=200, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Group.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Group.cs
@@ -476,7 +476,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Unique id
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -490,7 +490,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Whether this group's record is in active use
     /// </summary>
-    [FhirElement("active", InSummary=true, Order=100)]
+    [FhirElement("active", InSummary=true, Order=100, FiveWs="FiveWs.status")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ActiveElement
     {
@@ -521,7 +521,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// person | animal | practitioner | device | medication | substance
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=110)]
+    [FhirElement("type", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -554,7 +554,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Descriptive or actual
     /// </summary>
-    [FhirElement("actual", InSummary=true, Order=120)]
+    [FhirElement("actual", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ActualElement
@@ -586,7 +586,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Kind of Group members
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=130)]
+    [FhirElement("code", InSummary=true, Order=130, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/GuidanceResponse.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/GuidanceResponse.cs
@@ -117,7 +117,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business identifier
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -147,7 +147,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// success | data-requested | data-required | in-progress | failure | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=120)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=120, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -180,7 +180,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Patient the request was performed for
     /// </summary>
-    [FhirElement("subject", Order=130)]
+    [FhirElement("subject", Order=130, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [DataMember]
@@ -195,7 +195,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Encounter during which the response was returned
     /// </summary>
-    [FhirElement("encounter", Order=140)]
+    [FhirElement("encounter", Order=140, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -210,7 +210,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the guidance response was processed
     /// </summary>
-    [FhirElement("occurrenceDateTime", Order=150)]
+    [FhirElement("occurrenceDateTime", Order=150, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime OccurrenceDateTimeElement
     {
@@ -241,7 +241,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Device returning the guidance
     /// </summary>
-    [FhirElement("performer", Order=160)]
+    [FhirElement("performer", Order=160, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Device")]
     [DataMember]
@@ -256,7 +256,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why guidance is needed
     /// </summary>
-    [FhirElement("reason", Order=170)]
+    [FhirElement("reason", Order=170, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason

--- a/src/Hl7.Fhir.Core/Model/Generated/HealthcareService.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/HealthcareService.cs
@@ -588,7 +588,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External identifiers for this item
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -602,7 +602,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Whether this HealthcareService record is in active use
     /// </summary>
-    [FhirElement("active", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("active", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ActiveElement
     {
@@ -648,7 +648,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Broad category of service being performed or delivered
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=120)]
+    [FhirElement("category", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -690,7 +690,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Location(s) where service may be provided
     /// </summary>
-    [FhirElement("location", InSummary=true, Order=150)]
+    [FhirElement("location", InSummary=true, Order=150, FiveWs="FiveWs.where[x]")]
     [CLSCompliant(false)]
     [References("Location")]
     [Cardinality(Min=0,Max=-1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/ImagingSelection.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ImagingSelection.cs
@@ -782,7 +782,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for Imaging Selection
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -796,7 +796,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Associated request
     /// </summary>
-    [FhirElement("basedOn", InSummary=true, Order=100)]
+    [FhirElement("basedOn", InSummary=true, Order=100, FiveWs="FiveWs.cause")]
     [CLSCompliant(false)]
     [References("CarePlan","ServiceRequest","Appointment","AppointmentResponse","Task")]
     [Cardinality(Min=0,Max=-1)]
@@ -812,7 +812,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Subject of the selected instances and / or frames
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=110)]
+    [FhirElement("subject", InSummary=true, Order=110, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group","Device","Location","Organization","Procedure","Practitioner","Medication","Substance","Specimen")]
     [DataMember]
@@ -827,7 +827,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date / Time when the selection of instances was made
     /// </summary>
-    [FhirElement("issued", InSummary=true, Order=120)]
+    [FhirElement("issued", InSummary=true, Order=120, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.Instant IssuedElement
     {
@@ -858,7 +858,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Author (human or machine)
     /// </summary>
-    [FhirElement("performer", InSummary=true, Order=130)]
+    [FhirElement("performer", InSummary=true, Order=130, FiveWs="FiveWs.actor")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.ImagingSelection.PerformerComponent> Performer

--- a/src/Hl7.Fhir.Core/Model/Generated/ImagingStudy.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ImagingStudy.cs
@@ -575,7 +575,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Who performed the series
       /// </summary>
-      [FhirElement("actor", InSummary=true, Order=50)]
+      [FhirElement("actor", InSummary=true, Order=50, FiveWs="FiveWs.actor")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole","Organization","CareTeam","Patient","Device","RelatedPerson","HealthcareService")]
       [Cardinality(Min=1,Max=1)]
@@ -914,7 +914,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Identifiers for the whole study
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -928,7 +928,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// registered | available | cancelled | entered-in-error | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -961,7 +961,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// All of the distinct values for series' modalities
     /// </summary>
-    [FhirElement("modality", InSummary=true, Order=110)]
+    [FhirElement("modality", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Coding> Modality
@@ -975,7 +975,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who or what is the subject of the study
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=120)]
+    [FhirElement("subject", InSummary=true, Order=120, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Device","Group")]
     [Cardinality(Min=1,Max=1)]
@@ -991,7 +991,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Encounter with which this imaging study is associated
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=130)]
+    [FhirElement("encounter", InSummary=true, Order=130, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -1006,7 +1006,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the study was started
     /// </summary>
-    [FhirElement("started", InSummary=true, Order=140)]
+    [FhirElement("started", InSummary=true, Order=140, FiveWs="FiveWs.init")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime StartedElement
     {
@@ -1037,7 +1037,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Request fulfilled
     /// </summary>
-    [FhirElement("basedOn", InSummary=true, Order=150)]
+    [FhirElement("basedOn", InSummary=true, Order=150, FiveWs="FiveWs.cause")]
     [CLSCompliant(false)]
     [References("CarePlan","ServiceRequest","Appointment","AppointmentResponse","Task")]
     [Cardinality(Min=0,Max=-1)]
@@ -1053,7 +1053,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Referring physician
     /// </summary>
-    [FhirElement("referrer", InSummary=true, Order=160)]
+    [FhirElement("referrer", InSummary=true, Order=160, FiveWs="FiveWs.cause")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole")]
     [DataMember]
@@ -1068,7 +1068,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who interpreted images
     /// </summary>
-    [FhirElement("interpreter", InSummary=true, Order=170)]
+    [FhirElement("interpreter", InSummary=true, Order=170, FiveWs="FiveWs.witness")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole")]
     [Cardinality(Min=0,Max=-1)]
@@ -1176,7 +1176,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Where ImagingStudy occurred
     /// </summary>
-    [FhirElement("location", InSummary=true, Order=220)]
+    [FhirElement("location", InSummary=true, Order=220, FiveWs="FiveWs.where[x]")]
     [CLSCompliant(false)]
     [References("Location")]
     [DataMember]
@@ -1191,7 +1191,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why the study was requested / performed
     /// </summary>
-    [FhirElement("reason", InSummary=true, Order=230)]
+    [FhirElement("reason", InSummary=true, Order=230, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason

--- a/src/Hl7.Fhir.Core/Model/Generated/Immunization.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Immunization.cs
@@ -112,7 +112,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Individual or organization who was performing
       /// </summary>
-      [FhirElement("actor", InSummary=true, Order=50)]
+      [FhirElement("actor", InSummary=true, Order=50, FiveWs="FiveWs.actor")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole","Organization")]
       [Cardinality(Min=1,Max=1)]
@@ -913,7 +913,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business identifier
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1007,7 +1007,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// completed | entered-in-error | not-done
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=130)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=130, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1053,7 +1053,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Vaccine product administered
     /// </summary>
-    [FhirElement("vaccineCode", InSummary=true, Order=150)]
+    [FhirElement("vaccineCode", InSummary=true, Order=150, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept VaccineCode
@@ -1144,7 +1144,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who was immunized
     /// </summary>
-    [FhirElement("patient", InSummary=true, Order=190)]
+    [FhirElement("patient", InSummary=true, Order=190, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]
@@ -1160,7 +1160,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Encounter immunization was part of
     /// </summary>
-    [FhirElement("encounter", Order=200)]
+    [FhirElement("encounter", Order=200, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -1175,7 +1175,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Vaccine administration date
     /// </summary>
-    [FhirElement("occurrence", InSummary=true, Order=210, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("occurrence", InSummary=true, Order=210, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.FhirString))]
     [Cardinality(Min=1,Max=1)]
@@ -1191,7 +1191,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the immunization was first captured in the subject's record
     /// </summary>
-    [FhirElement("recorded", Order=220)]
+    [FhirElement("recorded", Order=220, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime RecordedElement
     {
@@ -1222,7 +1222,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Indicates context the data was recorded in
     /// </summary>
-    [FhirElement("primarySource", InSummary=true, Order=230)]
+    [FhirElement("primarySource", InSummary=true, Order=230, FiveWs="FiveWs.source")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean PrimarySourceElement
     {
@@ -1253,7 +1253,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Indicates the source of a  reported record
     /// </summary>
-    [FhirElement("informationSource", Order=240, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("informationSource", Order=240, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Patient","Practitioner","PractitionerRole","RelatedPerson","Organization")]
     [AllowedTypes(typeof(Hl7.Fhir.Model.CodeableConcept),typeof(Hl7.Fhir.Model.ResourceReference))]
@@ -1269,7 +1269,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Where immunization occurred
     /// </summary>
-    [FhirElement("location", Order=250)]
+    [FhirElement("location", Order=250, FiveWs="FiveWs.where[x]")]
     [CLSCompliant(false)]
     [References("Location")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/ImmunizationEvaluation.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ImmunizationEvaluation.cs
@@ -80,7 +80,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business identifier
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -94,7 +94,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// completed | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -127,7 +127,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who this evaluation is for
     /// </summary>
-    [FhirElement("patient", InSummary=true, Order=110)]
+    [FhirElement("patient", InSummary=true, Order=110, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]
@@ -143,7 +143,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date evaluation was performed
     /// </summary>
-    [FhirElement("date", Order=120)]
+    [FhirElement("date", Order=120, FiveWs="FiveWs.init")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/ImmunizationRecommendation.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ImmunizationRecommendation.cs
@@ -644,7 +644,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business identifier
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -722,7 +722,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who this profile is for
     /// </summary>
-    [FhirElement("patient", InSummary=true, Order=120)]
+    [FhirElement("patient", InSummary=true, Order=120, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/ImplementationGuide.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ImplementationGuide.cs
@@ -4460,7 +4460,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this implementation guide, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
@@ -4492,7 +4492,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the implementation guide
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=100)]
+    [FhirElement("version", InSummary=true, Order=100, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -4586,7 +4586,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=130)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=130, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -4619,7 +4619,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=140)]
+    [FhirElement("experimental", InSummary=true, Order=140, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -4650,7 +4650,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=150)]
+    [FhirElement("date", InSummary=true, Order=150, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -4681,7 +4681,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=160)]
+    [FhirElement("publisher", InSummary=true, Order=160, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/InsurancePlan.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/InsurancePlan.cs
@@ -737,7 +737,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Business Identifier for Product
       /// </summary>
-      [FhirElement("identifier", InSummary=true, Order=40)]
+      [FhirElement("identifier", InSummary=true, Order=40, FiveWs="FiveWs.identifier")]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1606,7 +1606,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for Product
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1620,7 +1620,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.PublicationStatus> StatusElement
@@ -1652,7 +1652,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Kind of product
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=110)]
+    [FhirElement("type", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Type

--- a/src/Hl7.Fhir.Core/Model/Generated/InventoryReport.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/InventoryReport.cs
@@ -625,7 +625,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Identifiers for the report
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -639,7 +639,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | requested | active | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/Invoice.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Invoice.cs
@@ -124,7 +124,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Individual who was involved
       /// </summary>
-      [FhirElement("actor", Order=50)]
+      [FhirElement("actor", Order=50, FiveWs="FiveWs.actor")]
       [CLSCompliant(false)]
       [References("Practitioner","Organization","Patient","PractitionerRole","Device","RelatedPerson")]
       [Cardinality(Min=1,Max=1)]
@@ -621,7 +621,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for item
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -635,7 +635,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | issued | balanced | cancelled | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -699,7 +699,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Type of Invoice
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=120)]
+    [FhirElement("type", InSummary=true, Order=120, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Type
     {
@@ -712,7 +712,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Recipient(s) of goods and services
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=130)]
+    [FhirElement("subject", InSummary=true, Order=130, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [DataMember]
@@ -742,7 +742,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Invoice date / posting date
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=150)]
+    [FhirElement("date", InSummary=true, Order=150, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Library.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Library.cs
@@ -58,7 +58,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this library, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -89,7 +89,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the library
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -103,7 +103,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the library
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -227,7 +227,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=150)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=150, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -260,7 +260,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=160)]
+    [FhirElement("experimental", InSummary=true, Order=160, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -291,7 +291,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// logic-library | model-definition | asset-collection | module-definition
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=170)]
+    [FhirElement("type", InSummary=true, Order=170, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Type
@@ -321,7 +321,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=190)]
+    [FhirElement("date", InSummary=true, Order=190, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -352,7 +352,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=200)]
+    [FhirElement("publisher", InSummary=true, Order=200, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -438,7 +438,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this library is defined
     /// </summary>
-    [FhirElement("purpose", Order=250)]
+    [FhirElement("purpose", Order=250, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Linkage.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Linkage.cs
@@ -240,7 +240,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Whether this linkage assertion is active or not
     /// </summary>
-    [FhirElement("active", InSummary=true, Order=90)]
+    [FhirElement("active", InSummary=true, Order=90, FiveWs="FiveWs.status")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ActiveElement
     {
@@ -271,7 +271,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who is responsible for linkages
     /// </summary>
-    [FhirElement("author", InSummary=true, Order=100)]
+    [FhirElement("author", InSummary=true, Order=100, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/List.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/List.cs
@@ -300,7 +300,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business identifier
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -314,7 +314,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// current | retired | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -347,7 +347,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// working | snapshot | changes
     /// </summary>
-    [FhirElement("mode", InSummary=true, IsModifier=true, Order=110)]
+    [FhirElement("mode", InSummary=true, IsModifier=true, Order=110, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -411,7 +411,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// What the purpose of this list is
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=130)]
+    [FhirElement("code", InSummary=true, Order=130, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
     {
@@ -424,7 +424,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// If all resources have the same subject
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=140)]
+    [FhirElement("subject", InSummary=true, Order=140, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group","Device","Location")]
     [DataMember]
@@ -439,7 +439,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Context in which list created
     /// </summary>
-    [FhirElement("encounter", Order=150)]
+    [FhirElement("encounter", Order=150, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -454,7 +454,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the list was prepared
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=160)]
+    [FhirElement("date", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -485,7 +485,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who and/or what defined the list contents (aka Author)
     /// </summary>
-    [FhirElement("source", InSummary=true, Order=170)]
+    [FhirElement("source", InSummary=true, Order=170, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Patient","Device")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/Location.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Location.cs
@@ -566,7 +566,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Unique code or number identifying the location to its users
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -580,7 +580,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | suspended | inactive
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.Location.LocationStatus> StatusElement
@@ -612,7 +612,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The operational status of the location (typically only for a bed/room)
     /// </summary>
-    [FhirElement("operationalStatus", InSummary=true, Order=110)]
+    [FhirElement("operationalStatus", InSummary=true, Order=110, FiveWs="FiveWs.status")]
     [DataMember]
     public Hl7.Fhir.Model.Coding OperationalStatus
     {
@@ -719,7 +719,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// instance | kind
     /// </summary>
-    [FhirElement("mode", InSummary=true, Order=150)]
+    [FhirElement("mode", InSummary=true, Order=150, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.Location.LocationMode> ModeElement
@@ -751,7 +751,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Type of function performed
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=160)]
+    [FhirElement("type", InSummary=true, Order=160, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Type
@@ -792,7 +792,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Physical form of the location
     /// </summary>
-    [FhirElement("physicalType", InSummary=true, Order=190)]
+    [FhirElement("physicalType", InSummary=true, Order=190, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept PhysicalType
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Measure.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Measure.cs
@@ -1178,7 +1178,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this measure, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -1209,7 +1209,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the measure
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1223,7 +1223,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the measure
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -1347,7 +1347,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=150)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=150, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1380,7 +1380,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=160)]
+    [FhirElement("experimental", InSummary=true, Order=160, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -1459,7 +1459,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=190)]
+    [FhirElement("date", InSummary=true, Order=190, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -1490,7 +1490,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=200)]
+    [FhirElement("publisher", InSummary=true, Order=200, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -1576,7 +1576,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this measure is defined
     /// </summary>
-    [FhirElement("purpose", Order=250)]
+    [FhirElement("purpose", Order=250, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/MeasureReport.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/MeasureReport.cs
@@ -1116,7 +1116,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the MeasureReport
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1130,7 +1130,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// complete | pending | error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1163,7 +1163,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// individual | subject-list | summary | data-collection
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=110)]
+    [FhirElement("type", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1228,7 +1228,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// What measure was calculated
     /// </summary>
-    [FhirElement("measure", InSummary=true, Order=130)]
+    [FhirElement("measure", InSummary=true, Order=130, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.Canonical MeasureElement
@@ -1260,7 +1260,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// What individual(s) the report is for
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=140)]
+    [FhirElement("subject", InSummary=true, Order=140, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Practitioner","PractitionerRole","Location","Device","RelatedPerson","Group")]
     [DataMember]
@@ -1275,7 +1275,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the report was generated
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=150)]
+    [FhirElement("date", InSummary=true, Order=150, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -1306,7 +1306,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who is reporting the data
     /// </summary>
-    [FhirElement("reporter", InSummary=true, Order=160)]
+    [FhirElement("reporter", InSummary=true, Order=160, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Location","Organization","Group")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/Medication.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Medication.cs
@@ -427,7 +427,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business identifier for this medication
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -441,7 +441,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Codes that identify this medication
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=100)]
+    [FhirElement("code", InSummary=true, Order=100, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/MedicationAdministration.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/MedicationAdministration.cs
@@ -483,7 +483,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External identifier
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -593,7 +593,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// in-progress | not-done | on-hold | completed | entered-in-error | stopped | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=140)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=140, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -654,7 +654,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// What was administered
     /// </summary>
-    [FhirElement("medication", InSummary=true, Order=170)]
+    [FhirElement("medication", InSummary=true, Order=170, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableReference Medication
@@ -668,7 +668,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who received medication
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=180)]
+    [FhirElement("subject", InSummary=true, Order=180, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [Cardinality(Min=1,Max=1)]
@@ -684,7 +684,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Encounter administered as part of
     /// </summary>
-    [FhirElement("encounter", Order=190)]
+    [FhirElement("encounter", Order=190, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -699,7 +699,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional information to support administration
     /// </summary>
-    [FhirElement("supportingInformation", Order=200)]
+    [FhirElement("supportingInformation", Order=200, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Resource")]
     [Cardinality(Min=0,Max=-1)]
@@ -715,7 +715,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Start and end time of administration
     /// </summary>
-    [FhirElement("occurence", InSummary=true, Order=210, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("occurence", InSummary=true, Order=210, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period))]
     [Cardinality(Min=1,Max=1)]
@@ -731,7 +731,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the MedicationAdministration was first captured in the subject's record
     /// </summary>
-    [FhirElement("recorded", InSummary=true, Order=220)]
+    [FhirElement("recorded", InSummary=true, Order=220, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime RecordedElement
     {
@@ -762,7 +762,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who performed the medication administration and what they did
     /// </summary>
-    [FhirElement("performer", InSummary=true, Order=230)]
+    [FhirElement("performer", InSummary=true, Order=230, FiveWs="FiveWs.actor")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.MedicationAdministration.PerformerComponent> Performer

--- a/src/Hl7.Fhir.Core/Model/Generated/MedicationDispense.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/MedicationDispense.cs
@@ -453,7 +453,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External identifier
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -499,7 +499,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// preparation | in-progress | cancelled | on-hold | completed | entered-in-error | stopped | declined | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=120)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=120, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -590,7 +590,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// What medication was supplied
     /// </summary>
-    [FhirElement("medication", InSummary=true, Order=160)]
+    [FhirElement("medication", InSummary=true, Order=160, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableReference Medication
@@ -604,7 +604,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who the dispense is for
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=170)]
+    [FhirElement("subject", InSummary=true, Order=170, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [Cardinality(Min=1,Max=1)]
@@ -635,7 +635,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Information that supports the dispensing of the medication
     /// </summary>
-    [FhirElement("supportingInformation", Order=190)]
+    [FhirElement("supportingInformation", Order=190, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Resource")]
     [Cardinality(Min=0,Max=-1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/MedicationKnowledge.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/MedicationKnowledge.cs
@@ -2538,7 +2538,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Code that identifies this medication
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=100)]
+    [FhirElement("code", InSummary=true, Order=100, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
     {
@@ -2583,7 +2583,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Creator or owner of the knowledge or information about the medication
     /// </summary>
-    [FhirElement("author", Order=120)]
+    [FhirElement("author", Order=120, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Organization")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/MedicationRequest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/MedicationRequest.cs
@@ -479,7 +479,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Intended performer of dispense
       /// </summary>
-      [FhirElement("dispenser", Order=100)]
+      [FhirElement("dispenser", Order=100, FiveWs="FiveWs.who")]
       [CLSCompliant(false)]
       [References("Organization")]
       [DataMember]
@@ -941,7 +941,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External ids for this request
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1063,7 +1063,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | on-hold | ended | stopped | completed | cancelled | entered-in-error | draft | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=150)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=150, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1140,7 +1140,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// proposal | plan | order | original-order | reflex-order | filler-order | instance-order | option
     /// </summary>
-    [FhirElement("intent", InSummary=true, IsModifier=true, Order=180)]
+    [FhirElement("intent", InSummary=true, IsModifier=true, Order=180, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1173,7 +1173,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Grouping or category of medication request
     /// </summary>
-    [FhirElement("category", Order=190)]
+    [FhirElement("category", Order=190, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -1187,7 +1187,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// routine | urgent | asap | stat
     /// </summary>
-    [FhirElement("priority", InSummary=true, Order=200)]
+    [FhirElement("priority", InSummary=true, Order=200, FiveWs="FiveWs.grade")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.RequestPriority> PriorityElement
@@ -1250,7 +1250,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Medication to be taken
     /// </summary>
-    [FhirElement("medication", InSummary=true, Order=220)]
+    [FhirElement("medication", InSummary=true, Order=220, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableReference Medication
@@ -1264,7 +1264,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who or group medication request is for
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=230)]
+    [FhirElement("subject", InSummary=true, Order=230, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [Cardinality(Min=1,Max=1)]
@@ -1295,7 +1295,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Encounter created as part of encounter/admission/stay
     /// </summary>
-    [FhirElement("encounter", Order=250)]
+    [FhirElement("encounter", Order=250, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -1310,7 +1310,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Information to support fulfilling of the medication
     /// </summary>
-    [FhirElement("supportingInformation", Order=260)]
+    [FhirElement("supportingInformation", Order=260, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Resource")]
     [Cardinality(Min=0,Max=-1)]
@@ -1326,7 +1326,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When request was initially authored
     /// </summary>
-    [FhirElement("authoredOn", InSummary=true, Order=270)]
+    [FhirElement("authoredOn", InSummary=true, Order=270, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime AuthoredOnElement
     {
@@ -1357,7 +1357,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who/What requested the Request
     /// </summary>
-    [FhirElement("requester", InSummary=true, Order=280)]
+    [FhirElement("requester", InSummary=true, Order=280, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization","Patient","RelatedPerson","Device")]
     [DataMember]
@@ -1416,7 +1416,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Intended performer of administration
     /// </summary>
-    [FhirElement("performer", Order=310)]
+    [FhirElement("performer", Order=310, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization","Patient","Device","RelatedPerson","CareTeam","HealthcareService")]
     [DataMember]
@@ -1431,7 +1431,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Person who entered the request
     /// </summary>
-    [FhirElement("recorder", Order=320)]
+    [FhirElement("recorder", Order=320, FiveWs="FiveWs.who")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole")]
     [DataMember]
@@ -1446,7 +1446,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Reason or indication for ordering or not ordering the medication
     /// </summary>
-    [FhirElement("reason", Order=330)]
+    [FhirElement("reason", Order=330, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason

--- a/src/Hl7.Fhir.Core/Model/Generated/MedicationUsage.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/MedicationUsage.cs
@@ -218,7 +218,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External identifier
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -232,7 +232,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// recorded | entered-in-error | draft
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -265,7 +265,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Type of medication usage
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=110)]
+    [FhirElement("category", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -279,7 +279,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// What medication was taken
     /// </summary>
-    [FhirElement("medication", InSummary=true, Order=120)]
+    [FhirElement("medication", InSummary=true, Order=120, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableReference Medication
@@ -293,7 +293,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who is/was taking  the medication
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=130)]
+    [FhirElement("subject", InSummary=true, Order=130, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [Cardinality(Min=1,Max=1)]
@@ -324,7 +324,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The date/time or interval when the medication is/was/will be taken
     /// </summary>
-    [FhirElement("effective", InSummary=true, Order=150, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("effective", InSummary=true, Order=150, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period))]
     [DataMember]
@@ -339,7 +339,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the usage was asserted?
     /// </summary>
-    [FhirElement("dateAsserted", InSummary=true, Order=160)]
+    [FhirElement("dateAsserted", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateAssertedElement
     {
@@ -370,7 +370,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Person or organization that provided the information about the taking of this medication
     /// </summary>
-    [FhirElement("informationSource", Order=170)]
+    [FhirElement("informationSource", Order=170, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Patient","Practitioner","PractitionerRole","RelatedPerson","Organization")]
     [DataMember]
@@ -401,7 +401,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Reason for why the medication is being/was taken
     /// </summary>
-    [FhirElement("reason", Order=190)]
+    [FhirElement("reason", Order=190, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason

--- a/src/Hl7.Fhir.Core/Model/Generated/MessageDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/MessageDefinition.cs
@@ -486,7 +486,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for a given MessageDefinition
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -517,7 +517,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Primary key for the message definition on a given server
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -531,7 +531,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the message definition
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -656,7 +656,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=150)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=150, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -689,7 +689,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=160)]
+    [FhirElement("experimental", InSummary=true, Order=160, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -720,7 +720,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=170)]
+    [FhirElement("date", InSummary=true, Order=170, FiveWs="FiveWs.recorded")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
@@ -752,7 +752,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=180)]
+    [FhirElement("publisher", InSummary=true, Order=180, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -838,7 +838,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this message definition is defined
     /// </summary>
-    [FhirElement("purpose", InSummary=true, Order=230)]
+    [FhirElement("purpose", InSummary=true, Order=230, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/MessageHeader.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/MessageHeader.cs
@@ -177,7 +177,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Intended "real-world" recipient for the data
       /// </summary>
-      [FhirElement("receiver", InSummary=true, Order=70)]
+      [FhirElement("receiver", InSummary=true, Order=70, FiveWs="FiveWs.subject")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole","Organization")]
       [DataMember]
@@ -766,7 +766,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Code for the event this message represents or link to event definition
     /// </summary>
-    [FhirElement("event", InSummary=true, Order=90, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("event", InSummary=true, Order=90, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.what[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.Coding),typeof(Hl7.Fhir.Model.FhirUri))]
     [Cardinality(Min=1,Max=1)]
@@ -782,7 +782,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Message destination application(s)
     /// </summary>
-    [FhirElement("destination", InSummary=true, Order=100)]
+    [FhirElement("destination", InSummary=true, Order=100, FiveWs="FiveWs.subject")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.MessageHeader.MessageDestinationComponent> Destination
@@ -796,7 +796,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Real world sender of the message
     /// </summary>
-    [FhirElement("sender", InSummary=true, Order=110)]
+    [FhirElement("sender", InSummary=true, Order=110, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization")]
     [DataMember]
@@ -811,7 +811,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The source of the data entry
     /// </summary>
-    [FhirElement("enterer", InSummary=true, Order=120)]
+    [FhirElement("enterer", InSummary=true, Order=120, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole")]
     [DataMember]
@@ -826,7 +826,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The source of the decision
     /// </summary>
-    [FhirElement("author", InSummary=true, Order=130)]
+    [FhirElement("author", InSummary=true, Order=130, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole")]
     [DataMember]
@@ -841,7 +841,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Message source application
     /// </summary>
-    [FhirElement("source", InSummary=true, Order=140)]
+    [FhirElement("source", InSummary=true, Order=140, FiveWs="FiveWs.actor")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.MessageHeader.MessageSourceComponent Source
@@ -855,7 +855,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Final responsibility for event
     /// </summary>
-    [FhirElement("responsible", InSummary=true, Order=150)]
+    [FhirElement("responsible", InSummary=true, Order=150, FiveWs="FiveWs.witness")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization")]
     [DataMember]
@@ -870,7 +870,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Cause of event
     /// </summary>
-    [FhirElement("reason", InSummary=true, Order=160)]
+    [FhirElement("reason", InSummary=true, Order=160, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Reason
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/MolecularSequence.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/MolecularSequence.cs
@@ -2793,7 +2793,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Unique ID for this particular sequence. This is a FHIR-defined id
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier

--- a/src/Hl7.Fhir.Core/Model/Generated/NamingSystem.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/NamingSystem.cs
@@ -172,7 +172,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// The unique identifier
       /// </summary>
-      [FhirElement("value", InSummary=true, Order=50)]
+      [FhirElement("value", InSummary=true, Order=50, FiveWs="FiveWs.identifier")]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
       public Hl7.Fhir.Model.FhirString ValueElement
@@ -438,7 +438,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this naming system, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -469,7 +469,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the naming system
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=100)]
+    [FhirElement("version", InSummary=true, Order=100, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -563,7 +563,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=130)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=130, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -596,7 +596,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// codesystem | identifier | root
     /// </summary>
-    [FhirElement("kind", InSummary=true, Order=140)]
+    [FhirElement("kind", InSummary=true, Order=140, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -629,7 +629,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=150)]
+    [FhirElement("date", InSummary=true, Order=150, FiveWs="FiveWs.recorded")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
@@ -661,7 +661,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=160)]
+    [FhirElement("publisher", InSummary=true, Order=160, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -706,7 +706,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who maintains system namespace?
     /// </summary>
-    [FhirElement("responsible", Order=180)]
+    [FhirElement("responsible", Order=180, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString ResponsibleElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/NutritionIntake.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/NutritionIntake.cs
@@ -85,7 +85,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Code that identifies the food or fluid product that was consumed
       /// </summary>
-      [FhirElement("nutritionProduct", InSummary=true, Order=50)]
+      [FhirElement("nutritionProduct", InSummary=true, Order=50, FiveWs="FiveWs.what[x]")]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
       public Hl7.Fhir.Model.CodeableReference NutritionProduct
@@ -586,7 +586,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External identifier
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -696,7 +696,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=140)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=140, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -743,7 +743,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Type of nutrition intake setting/reporting
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=160)]
+    [FhirElement("code", InSummary=true, Order=160, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
     {
@@ -756,7 +756,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who is/was consuming the food or fluid
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=170)]
+    [FhirElement("subject", InSummary=true, Order=170, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [Cardinality(Min=1,Max=1)]
@@ -787,7 +787,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The date/time or interval when the food or fluid is/was consumed
     /// </summary>
-    [FhirElement("occurrence", InSummary=true, Order=190, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("occurrence", InSummary=true, Order=190, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period))]
     [DataMember]
@@ -802,7 +802,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the intake was recorded
     /// </summary>
-    [FhirElement("recorded", InSummary=true, Order=200)]
+    [FhirElement("recorded", InSummary=true, Order=200, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime RecordedElement
     {
@@ -833,7 +833,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Person or organization that provided the information about the consumption of this food or fluid
     /// </summary>
-    [FhirElement("reported", Order=210, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("reported", Order=210, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Patient","RelatedPerson","Practitioner","PractitionerRole","Organization")]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirBoolean),typeof(Hl7.Fhir.Model.ResourceReference))]
@@ -922,7 +922,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Reason for why the food or fluid is /was consumed
     /// </summary>
-    [FhirElement("reason", Order=270)]
+    [FhirElement("reason", Order=270, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason

--- a/src/Hl7.Fhir.Core/Model/Generated/NutritionOrder.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/NutritionOrder.cs
@@ -71,7 +71,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Type of oral diet or diet restrictions that describe what can be consumed orally
       /// </summary>
-      [FhirElement("type", InSummary=true, Order=40)]
+      [FhirElement("type", InSummary=true, Order=40, FiveWs="FiveWs.what[x]")]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.CodeableConcept> Type
@@ -313,7 +313,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Type of nutrient that is being modified
       /// </summary>
-      [FhirElement("modifier", Order=40)]
+      [FhirElement("modifier", Order=40, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Modifier
       {
@@ -575,7 +575,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Type of supplement product requested
       /// </summary>
-      [FhirElement("type", InSummary=true, Order=40)]
+      [FhirElement("type", InSummary=true, Order=40, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Type
       {
@@ -809,7 +809,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Type of enteral or infant formula
       /// </summary>
-      [FhirElement("baseFormulaType", InSummary=true, Order=40)]
+      [FhirElement("baseFormulaType", InSummary=true, Order=40, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept BaseFormulaType
       {
@@ -853,7 +853,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Type of modular component to add to the feeding
       /// </summary>
-      [FhirElement("additiveType", Order=60)]
+      [FhirElement("additiveType", Order=60, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept AdditiveType
       {
@@ -1291,7 +1291,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Identifiers assigned to this order
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1401,7 +1401,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | on-hold | revoked | completed | entered-in-error | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=130)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=130, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1434,7 +1434,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// proposal | plan | directive | order | original-order | reflex-order | filler-order | instance-order | option
     /// </summary>
-    [FhirElement("intent", InSummary=true, IsModifier=true, Order=140)]
+    [FhirElement("intent", InSummary=true, IsModifier=true, Order=140, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1467,7 +1467,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The person who requires the diet, formula or nutritional supplement
     /// </summary>
-    [FhirElement("patient", InSummary=true, Order=150)]
+    [FhirElement("patient", InSummary=true, Order=150, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]
@@ -1483,7 +1483,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The encounter associated with this nutrition order
     /// </summary>
-    [FhirElement("encounter", Order=160)]
+    [FhirElement("encounter", Order=160, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -1498,7 +1498,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date and time the nutrition order was requested
     /// </summary>
-    [FhirElement("dateTime", InSummary=true, Order=170)]
+    [FhirElement("dateTime", InSummary=true, Order=170, FiveWs="FiveWs.recorded")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateTimeElement
@@ -1530,7 +1530,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who ordered the diet, formula or nutritional supplement
     /// </summary>
-    [FhirElement("orderer", InSummary=true, Order=180)]
+    [FhirElement("orderer", InSummary=true, Order=180, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/NutritionProduct.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/NutritionProduct.cs
@@ -760,7 +760,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | inactive | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=90)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=90, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -793,7 +793,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// A category or class of the nutrition product (halal, kosher, gluten free, vegan, etc)
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=100)]
+    [FhirElement("category", InSummary=true, Order=100, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -807,7 +807,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// A code designating a specific type of nutritional product
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=110)]
+    [FhirElement("code", InSummary=true, Order=110, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Observation.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Observation.cs
@@ -309,7 +309,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Type of component observation (code / type)
       /// </summary>
-      [FhirElement("code", InSummary=true, Order=40)]
+      [FhirElement("code", InSummary=true, Order=40, FiveWs="FiveWs.what[x]")]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Code
@@ -498,7 +498,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for observation
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -560,7 +560,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// registered | preliminary | final | amended +
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=130)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=130, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -593,7 +593,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Classification of  type of observation
     /// </summary>
-    [FhirElement("category", Order=140)]
+    [FhirElement("category", Order=140, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -607,7 +607,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Type of observation (code / type)
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=150)]
+    [FhirElement("code", InSummary=true, Order=150, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
@@ -621,7 +621,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who and/or what the observation is about
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=160)]
+    [FhirElement("subject", InSummary=true, Order=160, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group","Device","Location","Organization","Procedure","Practitioner","Medication","Substance","BiologicallyDerivedProduct","NutritionProduct")]
     [DataMember]
@@ -636,7 +636,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// What the observation is about, when it is not about the subject of record
     /// </summary>
-    [FhirElement("focus", InSummary=true, Order=170)]
+    [FhirElement("focus", InSummary=true, Order=170, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Resource")]
     [Cardinality(Min=0,Max=-1)]
@@ -652,7 +652,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Healthcare event during which this observation is made
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=180)]
+    [FhirElement("encounter", InSummary=true, Order=180, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -667,7 +667,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Clinically relevant time/time-period for observation
     /// </summary>
-    [FhirElement("effective", InSummary=true, Order=190, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("effective", InSummary=true, Order=190, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period),typeof(Hl7.Fhir.Model.Timing),typeof(Hl7.Fhir.Model.Instant))]
     [DataMember]
@@ -682,7 +682,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date/Time this version was made available
     /// </summary>
-    [FhirElement("issued", InSummary=true, Order=200)]
+    [FhirElement("issued", InSummary=true, Order=200, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.Instant IssuedElement
     {
@@ -713,7 +713,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who is responsible for the observation
     /// </summary>
-    [FhirElement("performer", InSummary=true, Order=210)]
+    [FhirElement("performer", InSummary=true, Order=210, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization","CareTeam","Patient","RelatedPerson")]
     [Cardinality(Min=0,Max=-1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/ObservationDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ObservationDefinition.cs
@@ -1544,7 +1544,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// General type of observation
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=310)]
+    [FhirElement("category", InSummary=true, Order=310, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -1558,7 +1558,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Type of observation
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=320)]
+    [FhirElement("code", InSummary=true, Order=320, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code

--- a/src/Hl7.Fhir.Core/Model/Generated/OperationDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/OperationDefinition.cs
@@ -1069,7 +1069,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this operation definition, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -1100,7 +1100,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the operation definition
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=100)]
+    [FhirElement("version", InSummary=true, Order=100, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -1194,7 +1194,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=130)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=130, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1227,7 +1227,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// operation | query
     /// </summary>
-    [FhirElement("kind", InSummary=true, Order=140)]
+    [FhirElement("kind", InSummary=true, Order=140, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1260,7 +1260,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=150)]
+    [FhirElement("experimental", InSummary=true, Order=150, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -1291,7 +1291,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=160)]
+    [FhirElement("date", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -1322,7 +1322,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=170)]
+    [FhirElement("publisher", InSummary=true, Order=170, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -1408,7 +1408,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this operation definition is defined
     /// </summary>
-    [FhirElement("purpose", Order=220)]
+    [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Organization.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Organization.cs
@@ -234,7 +234,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Identifies this organization  across multiple systems
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -248,7 +248,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Whether the organization's record is still in active use
     /// </summary>
-    [FhirElement("active", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("active", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ActiveElement
     {
@@ -279,7 +279,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Kind of organization
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=110)]
+    [FhirElement("type", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Type

--- a/src/Hl7.Fhir.Core/Model/Generated/OrganizationAffiliation.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/OrganizationAffiliation.cs
@@ -58,7 +58,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business identifiers that are specific to this role
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -72,7 +72,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Whether this organization affiliation record is in active use
     /// </summary>
-    [FhirElement("active", InSummary=true, Order=100)]
+    [FhirElement("active", InSummary=true, Order=100, FiveWs="FiveWs.status")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ActiveElement
     {
@@ -103,7 +103,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The period during which the participatingOrganization is affiliated with the primary organization
     /// </summary>
-    [FhirElement("period", InSummary=true, Order=110)]
+    [FhirElement("period", InSummary=true, Order=110, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Period Period
     {
@@ -190,7 +190,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The location(s) at which the role occurs
     /// </summary>
-    [FhirElement("location", InSummary=true, Order=170)]
+    [FhirElement("location", InSummary=true, Order=170, FiveWs="FiveWs.where[x]")]
     [CLSCompliant(false)]
     [References("Location")]
     [Cardinality(Min=0,Max=-1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/Patient.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Patient.cs
@@ -660,7 +660,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// An identifier for this patient
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -674,7 +674,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Whether this patient's record is in active use
     /// </summary>
-    [FhirElement("active", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("active", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ActiveElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/PaymentNotice.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/PaymentNotice.cs
@@ -58,7 +58,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for the payment noctice
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -72,7 +72,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | cancelled | draft | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -105,7 +105,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Request reference
     /// </summary>
-    [FhirElement("request", Order=110)]
+    [FhirElement("request", Order=110, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Resource")]
     [DataMember]
@@ -120,7 +120,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Response reference
     /// </summary>
-    [FhirElement("response", Order=120)]
+    [FhirElement("response", Order=120, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Resource")]
     [DataMember]
@@ -135,7 +135,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Creation date
     /// </summary>
-    [FhirElement("created", InSummary=true, Order=130)]
+    [FhirElement("created", InSummary=true, Order=130, FiveWs="FiveWs.recorded")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime CreatedElement
@@ -167,7 +167,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Responsible practitioner
     /// </summary>
-    [FhirElement("provider", Order=140)]
+    [FhirElement("provider", Order=140, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/PaymentReconciliation.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/PaymentReconciliation.cs
@@ -596,7 +596,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for a payment reconciliation
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -610,7 +610,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | cancelled | draft | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -643,7 +643,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Period covered
     /// </summary>
-    [FhirElement("period", InSummary=true, Order=110)]
+    [FhirElement("period", InSummary=true, Order=110, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Period Period
     {
@@ -656,7 +656,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Creation date
     /// </summary>
-    [FhirElement("created", InSummary=true, Order=120)]
+    [FhirElement("created", InSummary=true, Order=120, FiveWs="FiveWs.recorded")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime CreatedElement
@@ -688,7 +688,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Party generating payment
     /// </summary>
-    [FhirElement("paymentIssuer", InSummary=true, Order=130)]
+    [FhirElement("paymentIssuer", InSummary=true, Order=130, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Organization")]
     [DataMember]
@@ -703,7 +703,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Reference to requesting resource
     /// </summary>
-    [FhirElement("request", Order=140)]
+    [FhirElement("request", Order=140, FiveWs="FiveWs.why[x]")]
     [CLSCompliant(false)]
     [References("Task")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/Person.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Person.cs
@@ -395,7 +395,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// A human identifier for this person
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -409,7 +409,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// This person's record is in active use
     /// </summary>
-    [FhirElement("active", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("active", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ActiveElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/PlanDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/PlanDefinition.cs
@@ -2895,7 +2895,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this plan definition, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -2926,7 +2926,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the plan definition
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -2940,7 +2940,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the plan definition
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -3077,7 +3077,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=160)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=160, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -3110,7 +3110,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=170)]
+    [FhirElement("experimental", InSummary=true, Order=170, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -3157,7 +3157,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=190)]
+    [FhirElement("date", InSummary=true, Order=190, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -3188,7 +3188,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=200)]
+    [FhirElement("publisher", InSummary=true, Order=200, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -3274,7 +3274,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this plan definition is defined
     /// </summary>
-    [FhirElement("purpose", Order=250)]
+    [FhirElement("purpose", Order=250, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Practitioner.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Practitioner.cs
@@ -237,7 +237,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// An identifier for the person as this agent
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -251,7 +251,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Whether this practitioner's record is in active use
     /// </summary>
-    [FhirElement("active", InSummary=true, Order=100)]
+    [FhirElement("active", InSummary=true, Order=100, FiveWs="FiveWs.status")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ActiveElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/PractitionerRole.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/PractitionerRole.cs
@@ -457,7 +457,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifiers that are specific to a role/location
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -471,7 +471,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Whether this practitioner role record is in active use
     /// </summary>
-    [FhirElement("active", InSummary=true, Order=100)]
+    [FhirElement("active", InSummary=true, Order=100, FiveWs="FiveWs.status")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ActiveElement
     {
@@ -502,7 +502,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The period during which the practitioner is authorized to perform in these role(s)
     /// </summary>
-    [FhirElement("period", InSummary=true, Order=110)]
+    [FhirElement("period", InSummary=true, Order=110, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Period Period
     {
@@ -573,7 +573,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The location(s) at which this practitioner provides care
     /// </summary>
-    [FhirElement("location", InSummary=true, Order=160)]
+    [FhirElement("location", InSummary=true, Order=160, FiveWs="FiveWs.where[x]")]
     [CLSCompliant(false)]
     [References("Location")]
     [Cardinality(Min=0,Max=-1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/Procedure.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Procedure.cs
@@ -84,7 +84,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Who performed the procedure
       /// </summary>
-      [FhirElement("actor", InSummary=true, Order=50)]
+      [FhirElement("actor", InSummary=true, Order=50, FiveWs="FiveWs.actor")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole","Organization","Patient","RelatedPerson","Device","CareTeam","HealthcareService")]
       [Cardinality(Min=1,Max=1)]
@@ -350,7 +350,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External Identifiers for this procedure
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -460,7 +460,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=140)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=140, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -506,7 +506,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Classification of the procedure
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=160)]
+    [FhirElement("category", InSummary=true, Order=160, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -520,7 +520,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Identification of the procedure
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=170)]
+    [FhirElement("code", InSummary=true, Order=170, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
     {
@@ -533,7 +533,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Individual or entity the procedure was performed on
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=180)]
+    [FhirElement("subject", InSummary=true, Order=180, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group","Device","Practitioner","Organization","Location")]
     [Cardinality(Min=1,Max=1)]
@@ -549,7 +549,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The Encounter during which this Procedure was created
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=190)]
+    [FhirElement("encounter", InSummary=true, Order=190, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -564,7 +564,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the procedure occurred or is occurring
     /// </summary>
-    [FhirElement("occurrence", InSummary=true, Order=200, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("occurrence", InSummary=true, Order=200, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period),typeof(Hl7.Fhir.Model.FhirString),typeof(Hl7.Fhir.Model.Age),typeof(Hl7.Fhir.Model.Range),typeof(Hl7.Fhir.Model.Timing))]
     [DataMember]
@@ -579,7 +579,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the procedure was first captured in the subject's record
     /// </summary>
-    [FhirElement("recorded", InSummary=true, Order=210)]
+    [FhirElement("recorded", InSummary=true, Order=210, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime RecordedElement
     {
@@ -610,7 +610,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who recorded the procedure
     /// </summary>
-    [FhirElement("recorder", InSummary=true, Order=220)]
+    [FhirElement("recorder", InSummary=true, Order=220, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Patient","RelatedPerson","Practitioner","PractitionerRole")]
     [DataMember]
@@ -625,7 +625,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Reported rather than primary record
     /// </summary>
-    [FhirElement("reported", InSummary=true, Order=230, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("reported", InSummary=true, Order=230, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Patient","RelatedPerson","Practitioner","PractitionerRole","Organization")]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirBoolean),typeof(Hl7.Fhir.Model.ResourceReference))]
@@ -655,7 +655,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Where the procedure happened
     /// </summary>
-    [FhirElement("location", InSummary=true, Order=250)]
+    [FhirElement("location", InSummary=true, Order=250, FiveWs="FiveWs.where[x]")]
     [CLSCompliant(false)]
     [References("Location")]
     [DataMember]
@@ -670,7 +670,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The justification that the procedure was performed
     /// </summary>
-    [FhirElement("reason", InSummary=true, Order=260)]
+    [FhirElement("reason", InSummary=true, Order=260, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason

--- a/src/Hl7.Fhir.Core/Model/Generated/Provenance.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Provenance.cs
@@ -144,7 +144,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// The agent that participated in the event
       /// </summary>
-      [FhirElement("who", InSummary=true, Order=60)]
+      [FhirElement("who", InSummary=true, Order=60, FiveWs="FiveWs.actor")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole","Organization","CareTeam","Patient","Device","RelatedPerson")]
       [Cardinality(Min=1,Max=1)]
@@ -462,7 +462,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Target Reference(s) (usually version specific)
     /// </summary>
-    [FhirElement("target", InSummary=true, Order=90)]
+    [FhirElement("target", InSummary=true, Order=90, FiveWs="FiveWs.what[x]")]
     [CLSCompliant(false)]
     [References("Resource")]
     [Cardinality(Min=1,Max=-1)]
@@ -478,7 +478,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the activity occurred
     /// </summary>
-    [FhirElement("occurred", Order=100, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("occurred", Order=100, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.Period),typeof(Hl7.Fhir.Model.FhirDateTime))]
     [DataMember]
@@ -493,7 +493,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the activity was recorded / updated
     /// </summary>
-    [FhirElement("recorded", InSummary=true, Order=110)]
+    [FhirElement("recorded", InSummary=true, Order=110, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.Instant RecordedElement
     {
@@ -556,7 +556,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Where the activity occurred, if relevant
     /// </summary>
-    [FhirElement("location", Order=130)]
+    [FhirElement("location", Order=130, FiveWs="FiveWs.where[x]")]
     [CLSCompliant(false)]
     [References("Location")]
     [DataMember]
@@ -571,7 +571,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Authorization (purposeOfUse) related to the event
     /// </summary>
-    [FhirElement("authorization", Order=140)]
+    [FhirElement("authorization", Order=140, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Authorization
@@ -585,7 +585,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Activity that occurred
     /// </summary>
-    [FhirElement("activity", Order=150)]
+    [FhirElement("activity", Order=150, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Activity
     {
@@ -598,7 +598,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Workflow authorization within which this event occurred
     /// </summary>
-    [FhirElement("basedOn", Order=160)]
+    [FhirElement("basedOn", Order=160, FiveWs="FiveWs.why[x]")]
     [CLSCompliant(false)]
     [References("CarePlan","DeviceRequest","ImmunizationRecommendation","MedicationRequest","NutritionOrder","ServiceRequest","Task")]
     [Cardinality(Min=0,Max=-1)]
@@ -614,7 +614,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Encounter within which this event occurred or which the event is tightly associated
     /// </summary>
-    [FhirElement("encounter", Order=170)]
+    [FhirElement("encounter", Order=170, FiveWs="FiveWs.why[x]")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -629,7 +629,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Actor involved
     /// </summary>
-    [FhirElement("agent", Order=180)]
+    [FhirElement("agent", Order=180, FiveWs="FiveWs.who")]
     [Cardinality(Min=1,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Provenance.AgentComponent> Agent

--- a/src/Hl7.Fhir.Core/Model/Generated/Questionnaire.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Questionnaire.cs
@@ -1460,7 +1460,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this questionnaire, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -1491,7 +1491,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the questionnaire
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1505,7 +1505,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the questionnaire
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -1630,7 +1630,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=150)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=150, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1663,7 +1663,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=160)]
+    [FhirElement("experimental", InSummary=true, Order=160, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -1727,7 +1727,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last formally published
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=180)]
+    [FhirElement("date", InSummary=true, Order=180, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -1758,7 +1758,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=190)]
+    [FhirElement("publisher", InSummary=true, Order=190, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -1844,7 +1844,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this questionnaire is defined
     /// </summary>
-    [FhirElement("purpose", Order=240)]
+    [FhirElement("purpose", Order=240, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/QuestionnaireResponse.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/QuestionnaireResponse.cs
@@ -488,7 +488,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Unique id for this set of answers
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -565,7 +565,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// in-progress | completed | amended | entered-in-error | stopped
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=130)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=130, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -598,7 +598,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The subject of the questions
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=140)]
+    [FhirElement("subject", InSummary=true, Order=140, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Resource")]
     [DataMember]
@@ -613,7 +613,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Encounter created as part of
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=150)]
+    [FhirElement("encounter", InSummary=true, Order=150, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -628,7 +628,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date the answers were gathered
     /// </summary>
-    [FhirElement("authored", InSummary=true, Order=160)]
+    [FhirElement("authored", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime AuthoredElement
     {
@@ -659,7 +659,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The individual or device that received and recorded the answers
     /// </summary>
-    [FhirElement("author", InSummary=true, Order=170)]
+    [FhirElement("author", InSummary=true, Order=170, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Device","Practitioner","PractitionerRole","Patient","RelatedPerson","Organization")]
     [DataMember]
@@ -674,7 +674,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The individual or device that answered the questions
     /// </summary>
-    [FhirElement("source", InSummary=true, Order=180)]
+    [FhirElement("source", InSummary=true, Order=180, FiveWs="FiveWs.source")]
     [CLSCompliant(false)]
     [References("Device","Organization","Patient","Practitioner","PractitionerRole","RelatedPerson")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/RelatedPerson.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/RelatedPerson.cs
@@ -208,7 +208,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// A human identifier for this person
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -222,7 +222,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Whether this related person's record is in active use
     /// </summary>
-    [FhirElement("active", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("active", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ActiveElement
     {
@@ -269,7 +269,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The nature of the relationship
     /// </summary>
-    [FhirElement("relationship", InSummary=true, Order=120)]
+    [FhirElement("relationship", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Relationship
@@ -402,7 +402,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Period of time that this relationship is considered valid
     /// </summary>
-    [FhirElement("period", Order=190)]
+    [FhirElement("period", Order=190, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Period Period
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/RequestGroup.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/RequestGroup.cs
@@ -286,7 +286,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// What goals
       /// </summary>
-      [FhirElement("goal", Order=120)]
+      [FhirElement("goal", Order=120, FiveWs="FiveWs.why[x]")]
       [CLSCompliant(false)]
       [References("Goal")]
       [Cardinality(Min=0,Max=-1)]
@@ -358,7 +358,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Who should perform the action
       /// </summary>
-      [FhirElement("participant", Order=170)]
+      [FhirElement("participant", Order=170, FiveWs="FiveWs.actor")]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.RequestGroup.ParticipantComponent> Participant
@@ -1411,7 +1411,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business identifier
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1534,7 +1534,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | on-hold | revoked | completed | entered-in-error | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=150)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=150, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1567,7 +1567,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// proposal | plan | directive | order | original-order | reflex-order | filler-order | instance-order | option
     /// </summary>
-    [FhirElement("intent", InSummary=true, IsModifier=true, Order=160)]
+    [FhirElement("intent", InSummary=true, IsModifier=true, Order=160, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1600,7 +1600,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// routine | urgent | asap | stat
     /// </summary>
-    [FhirElement("priority", InSummary=true, Order=170)]
+    [FhirElement("priority", InSummary=true, Order=170, FiveWs="FiveWs.grade")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.RequestPriority> PriorityElement
@@ -1632,7 +1632,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// What's being requested/ordered
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=180)]
+    [FhirElement("code", InSummary=true, Order=180, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
     {
@@ -1645,7 +1645,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who the request group is about
     /// </summary>
-    [FhirElement("subject", Order=190)]
+    [FhirElement("subject", Order=190, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [DataMember]
@@ -1660,7 +1660,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Created as part of
     /// </summary>
-    [FhirElement("encounter", Order=200)]
+    [FhirElement("encounter", Order=200, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -1675,7 +1675,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the request group was authored
     /// </summary>
-    [FhirElement("authoredOn", Order=210)]
+    [FhirElement("authoredOn", Order=210, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime AuthoredOnElement
     {
@@ -1706,7 +1706,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Device or practitioner that authored the request group
     /// </summary>
-    [FhirElement("author", Order=220)]
+    [FhirElement("author", Order=220, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Device","Practitioner","PractitionerRole")]
     [DataMember]
@@ -1721,7 +1721,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why the request group is needed
     /// </summary>
-    [FhirElement("reason", Order=230)]
+    [FhirElement("reason", Order=230, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason
@@ -1735,7 +1735,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// What goals
     /// </summary>
-    [FhirElement("goal", Order=240)]
+    [FhirElement("goal", Order=240, FiveWs="FiveWs.why[x]")]
     [CLSCompliant(false)]
     [References("Goal")]
     [Cardinality(Min=0,Max=-1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/ResearchStudy.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ResearchStudy.cs
@@ -220,7 +220,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Identification of product under study
       /// </summary>
-      [FhirElement("productCode", InSummary=true, Order=40)]
+      [FhirElement("productCode", InSummary=true, Order=40, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept ProductCode
       {
@@ -953,7 +953,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Group of participants who were enrolled in study
       /// </summary>
-      [FhirElement("actualGroup", InSummary=true, Order=70)]
+      [FhirElement("actualGroup", InSummary=true, Order=70, FiveWs="FiveWs.subject")]
       [CLSCompliant(false)]
       [References("Group")]
       [DataMember]
@@ -1871,7 +1871,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for study
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -2069,7 +2069,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=190)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=190, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -2156,7 +2156,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Condition being studied
     /// </summary>
-    [FhirElement("condition", InSummary=true, Order=240)]
+    [FhirElement("condition", InSummary=true, Order=240, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Condition
@@ -2224,7 +2224,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the study began and ended
     /// </summary>
-    [FhirElement("period", InSummary=true, Order=290)]
+    [FhirElement("period", InSummary=true, Order=290, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Period Period
     {
@@ -2251,7 +2251,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Organization that initiates and is legally responsible for the study
     /// </summary>
-    [FhirElement("sponsor", InSummary=true, Order=310)]
+    [FhirElement("sponsor", InSummary=true, Order=310, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Organization")]
     [DataMember]
@@ -2266,7 +2266,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Researcher who oversees multiple aspects of the study
     /// </summary>
-    [FhirElement("principalInvestigator", InSummary=true, Order=320)]
+    [FhirElement("principalInvestigator", InSummary=true, Order=320, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole")]
     [DataMember]
@@ -2281,7 +2281,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Facility where study activities are conducted
     /// </summary>
-    [FhirElement("site", InSummary=true, Order=330)]
+    [FhirElement("site", InSummary=true, Order=330, FiveWs="FiveWs.where[x]")]
     [CLSCompliant(false)]
     [References("Location","ResearchStudy","Organization")]
     [Cardinality(Min=0,Max=-1)]
@@ -2367,7 +2367,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// accrual-goal-met | closed-due-to-toxicity | closed-due-to-lack-of-study-progress | temporarily-closed-per-study-design
     /// </summary>
-    [FhirElement("whyStopped", InSummary=true, Order=390)]
+    [FhirElement("whyStopped", InSummary=true, Order=390, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept WhyStopped
     {
@@ -2380,7 +2380,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Target or actual group of participants enrolled in study
     /// </summary>
-    [FhirElement("recruitment", InSummary=true, Order=400)]
+    [FhirElement("recruitment", InSummary=true, Order=400, FiveWs="FiveWs.subject")]
     [DataMember]
     public Hl7.Fhir.Model.ResearchStudy.RecruitmentComponent Recruitment
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/ResearchSubject.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ResearchSubject.cs
@@ -84,7 +84,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// candidate | eligible | follow-up | ineligible | not-registered | off-study | on-study | on-study-intervention | on-study-observation | pending-on-study | potential-candidate | screening | withdrawn
       /// </summary>
-      [FhirElement("subjectState", Order=50)]
+      [FhirElement("subjectState", Order=50, FiveWs="FiveWs.status")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept SubjectState
       {
@@ -97,7 +97,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// SignedUp | Screened | Randomized
       /// </summary>
-      [FhirElement("milestone", Order=60)]
+      [FhirElement("milestone", Order=60, FiveWs="FiveWs.status")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Milestone
       {
@@ -313,7 +313,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for research subject in a study
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -327,7 +327,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/RiskAssessment.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/RiskAssessment.cs
@@ -317,7 +317,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Unique identifier for the assessment
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -361,7 +361,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// registered | preliminary | final | amended +
     /// </summary>
-    [FhirElement("status", InSummary=true, Order=120)]
+    [FhirElement("status", InSummary=true, Order=120, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -394,7 +394,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Evaluation mechanism
     /// </summary>
-    [FhirElement("method", InSummary=true, Order=130)]
+    [FhirElement("method", InSummary=true, Order=130, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Method
     {
@@ -407,7 +407,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Type of assessment
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=140)]
+    [FhirElement("code", InSummary=true, Order=140, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
     {
@@ -420,7 +420,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who/what does assessment apply to?
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=150)]
+    [FhirElement("subject", InSummary=true, Order=150, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group")]
     [Cardinality(Min=1,Max=1)]
@@ -436,7 +436,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Where was assessment performed?
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=160)]
+    [FhirElement("encounter", InSummary=true, Order=160, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -451,7 +451,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When was assessment made?
     /// </summary>
-    [FhirElement("occurrence", InSummary=true, Order=170, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("occurrence", InSummary=true, Order=170, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period))]
     [DataMember]
@@ -481,7 +481,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who did assessment?
     /// </summary>
-    [FhirElement("performer", InSummary=true, Order=190)]
+    [FhirElement("performer", InSummary=true, Order=190, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Patient","Practitioner","PractitionerRole","RelatedPerson","Device")]
     [DataMember]
@@ -496,7 +496,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why the assessment was necessary?
     /// </summary>
-    [FhirElement("reason", Order=200)]
+    [FhirElement("reason", Order=200, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason

--- a/src/Hl7.Fhir.Core/Model/Generated/Schedule.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Schedule.cs
@@ -58,7 +58,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External Ids for this item
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -72,7 +72,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Whether this schedule is in active use
     /// </summary>
-    [FhirElement("active", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("active", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ActiveElement
     {
@@ -103,7 +103,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// High-level category
     /// </summary>
-    [FhirElement("serviceCategory", InSummary=true, Order=110)]
+    [FhirElement("serviceCategory", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> ServiceCategory
@@ -117,7 +117,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Specific service
     /// </summary>
-    [FhirElement("serviceType", InSummary=true, Order=120)]
+    [FhirElement("serviceType", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> ServiceType
@@ -131,7 +131,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Type of specialty needed
     /// </summary>
-    [FhirElement("specialty", InSummary=true, Order=130)]
+    [FhirElement("specialty", InSummary=true, Order=130, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Specialty
@@ -145,7 +145,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Resource(s) that availability information is being provided for
     /// </summary>
-    [FhirElement("actor", InSummary=true, Order=140)]
+    [FhirElement("actor", InSummary=true, Order=140, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Practitioner","PractitionerRole","CareTeam","RelatedPerson","Device","HealthcareService","Location")]
     [Cardinality(Min=1,Max=-1)]
@@ -161,7 +161,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Period of time covered by schedule
     /// </summary>
-    [FhirElement("planningHorizon", InSummary=true, Order=150)]
+    [FhirElement("planningHorizon", InSummary=true, Order=150, FiveWs="FiveWs.planned")]
     [DataMember]
     public Hl7.Fhir.Model.Period PlanningHorizon
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/SearchParameter.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/SearchParameter.cs
@@ -413,7 +413,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this search parameter, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
@@ -445,7 +445,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the search parameter
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=100)]
+    [FhirElement("version", InSummary=true, Order=100, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -539,7 +539,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=130)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=130, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -572,7 +572,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=140)]
+    [FhirElement("experimental", InSummary=true, Order=140, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -603,7 +603,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=150)]
+    [FhirElement("date", InSummary=true, Order=150, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -634,7 +634,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=160)]
+    [FhirElement("publisher", InSummary=true, Order=160, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -721,7 +721,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this search parameter is defined
     /// </summary>
-    [FhirElement("purpose", Order=210)]
+    [FhirElement("purpose", Order=210, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/ServiceRequest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ServiceRequest.cs
@@ -58,7 +58,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Identifiers assigned to this order
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -181,7 +181,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | on-hold | revoked | completed | entered-in-error | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=150)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=150, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -214,7 +214,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// proposal | plan | directive | order +
     /// </summary>
-    [FhirElement("intent", InSummary=true, IsModifier=true, Order=160)]
+    [FhirElement("intent", InSummary=true, IsModifier=true, Order=160, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -247,7 +247,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Classification of service
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=170)]
+    [FhirElement("category", InSummary=true, Order=170, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -261,7 +261,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// routine | urgent | asap | stat
     /// </summary>
-    [FhirElement("priority", InSummary=true, Order=180)]
+    [FhirElement("priority", InSummary=true, Order=180, FiveWs="FiveWs.grade")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.RequestPriority> PriorityElement
@@ -324,7 +324,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// What is being requested/ordered
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=200)]
+    [FhirElement("code", InSummary=true, Order=200, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
     {
@@ -366,7 +366,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Individual or Entity the service is ordered for
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=230)]
+    [FhirElement("subject", InSummary=true, Order=230, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group","Location","Device")]
     [Cardinality(Min=1,Max=1)]
@@ -382,7 +382,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Encounter in which the request was created
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=240)]
+    [FhirElement("encounter", InSummary=true, Order=240, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -397,7 +397,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When service should occur
     /// </summary>
-    [FhirElement("occurrence", InSummary=true, Order=250, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("occurrence", InSummary=true, Order=250, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.planned")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period),typeof(Hl7.Fhir.Model.Timing))]
     [DataMember]
@@ -427,7 +427,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date request signed
     /// </summary>
-    [FhirElement("authoredOn", InSummary=true, Order=270)]
+    [FhirElement("authoredOn", InSummary=true, Order=270, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime AuthoredOnElement
     {
@@ -458,7 +458,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who/what is requesting service
     /// </summary>
-    [FhirElement("requester", InSummary=true, Order=280)]
+    [FhirElement("requester", InSummary=true, Order=280, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization","Patient","RelatedPerson","Device")]
     [DataMember]
@@ -473,7 +473,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Performer role
     /// </summary>
-    [FhirElement("performerType", InSummary=true, Order=290)]
+    [FhirElement("performerType", InSummary=true, Order=290, FiveWs="FiveWs.actor")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept PerformerType
     {
@@ -486,7 +486,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Requested performer
     /// </summary>
-    [FhirElement("performer", InSummary=true, Order=300)]
+    [FhirElement("performer", InSummary=true, Order=300, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization","CareTeam","HealthcareService","Patient","Device","RelatedPerson")]
     [Cardinality(Min=0,Max=-1)]
@@ -502,7 +502,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Requested location
     /// </summary>
-    [FhirElement("location", InSummary=true, Order=310)]
+    [FhirElement("location", InSummary=true, Order=310, FiveWs="FiveWs.actor")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Location
@@ -516,7 +516,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Explanation/Justification for procedure or service
     /// </summary>
-    [FhirElement("reason", InSummary=true, Order=320)]
+    [FhirElement("reason", InSummary=true, Order=320, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason

--- a/src/Hl7.Fhir.Core/Model/Generated/Slot.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Slot.cs
@@ -98,7 +98,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External Ids for this item
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -112,7 +112,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// A broad categorization of the service that is to be performed during this appointment
     /// </summary>
-    [FhirElement("serviceCategory", InSummary=true, Order=100)]
+    [FhirElement("serviceCategory", InSummary=true, Order=100, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> ServiceCategory
@@ -126,7 +126,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The type of appointments that can be booked into this slot (ideally this would be an identifiable service - which is at a location, rather than the location itself). If provided then this overrides the value provided on the availability resource
     /// </summary>
-    [FhirElement("serviceType", InSummary=true, Order=110)]
+    [FhirElement("serviceType", InSummary=true, Order=110, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> ServiceType
@@ -140,7 +140,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The specialty of a practitioner that would be required to perform the service requested in this appointment
     /// </summary>
-    [FhirElement("specialty", InSummary=true, Order=120)]
+    [FhirElement("specialty", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Specialty
@@ -154,7 +154,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The style of appointment or patient that may be booked in the slot (not service type)
     /// </summary>
-    [FhirElement("appointmentType", InSummary=true, Order=130)]
+    [FhirElement("appointmentType", InSummary=true, Order=130, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> AppointmentType
@@ -217,7 +217,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date/Time that the slot is to begin
     /// </summary>
-    [FhirElement("start", InSummary=true, Order=160)]
+    [FhirElement("start", InSummary=true, Order=160, FiveWs="FiveWs.planned")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.Instant StartElement
@@ -249,7 +249,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date/Time that the slot is to conclude
     /// </summary>
-    [FhirElement("end", InSummary=true, Order=170)]
+    [FhirElement("end", InSummary=true, Order=170, FiveWs="FiveWs.planned")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.Instant EndElement

--- a/src/Hl7.Fhir.Core/Model/Generated/Specimen.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Specimen.cs
@@ -105,7 +105,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Who collected the specimen
       /// </summary>
-      [FhirElement("collector", InSummary=true, Order=40)]
+      [FhirElement("collector", InSummary=true, Order=40, FiveWs="FiveWs.actor")]
       [CLSCompliant(false)]
       [References("Practitioner","PractitionerRole","Patient","RelatedPerson")]
       [DataMember]
@@ -120,7 +120,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Collection time
       /// </summary>
-      [FhirElement("collected", InSummary=true, Order=50, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("collected", InSummary=true, Order=50, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.init")]
       [CLSCompliant(false)]
       [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period))]
       [DataMember]
@@ -135,7 +135,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// How long it took to collect specimen
       /// </summary>
-      [FhirElement("duration", InSummary=true, Order=60)]
+      [FhirElement("duration", InSummary=true, Order=60, FiveWs="FiveWs.init")]
       [DataMember]
       public Hl7.Fhir.Model.Duration Duration
       {
@@ -641,7 +641,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Where the container is
       /// </summary>
-      [FhirElement("location", Order=60)]
+      [FhirElement("location", Order=60, FiveWs="FiveWs.where[x]")]
       [CLSCompliant(false)]
       [References("Location")]
       [DataMember]
@@ -848,7 +848,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External Identifier
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -862,7 +862,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Identifier assigned by the lab
     /// </summary>
-    [FhirElement("accessionIdentifier", InSummary=true, Order=100)]
+    [FhirElement("accessionIdentifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.Identifier AccessionIdentifier
     {
@@ -875,7 +875,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// available | unavailable | unsatisfactory | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=110)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=110, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.Specimen.SpecimenStatus> StatusElement
@@ -907,7 +907,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Kind of material that forms the specimen
     /// </summary>
-    [FhirElement("type", InSummary=true, Order=120)]
+    [FhirElement("type", InSummary=true, Order=120, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Type
     {
@@ -920,7 +920,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Where the specimen came from. This may be from patient(s), from a location (e.g., the source of an environmental sample), or a sampling of a substance, a biologically-derived product, or a device
     /// </summary>
-    [FhirElement("subject", InSummary=true, Order=130)]
+    [FhirElement("subject", InSummary=true, Order=130, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient","Group","Device","BiologicallyDerivedProduct","Substance","Location")]
     [DataMember]
@@ -935,7 +935,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The time when specimen is received by the testing laboratory
     /// </summary>
-    [FhirElement("receivedTime", InSummary=true, Order=140)]
+    [FhirElement("receivedTime", InSummary=true, Order=140, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime ReceivedTimeElement
     {
@@ -982,7 +982,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why the specimen was collected
     /// </summary>
-    [FhirElement("request", Order=160)]
+    [FhirElement("request", Order=160, FiveWs="FiveWs.why[x]")]
     [CLSCompliant(false)]
     [References("ServiceRequest")]
     [Cardinality(Min=0,Max=-1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/StructureDefinition.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/StructureDefinition.cs
@@ -780,7 +780,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this structure definition, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
@@ -812,7 +812,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the structure definition
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -826,7 +826,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the structure definition
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -920,7 +920,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=140)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=140, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -953,7 +953,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=150)]
+    [FhirElement("experimental", InSummary=true, Order=150, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -984,7 +984,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=160)]
+    [FhirElement("date", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -1015,7 +1015,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=170)]
+    [FhirElement("publisher", InSummary=true, Order=170, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -1101,7 +1101,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this structure definition is defined
     /// </summary>
-    [FhirElement("purpose", Order=220)]
+    [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/StructureMap.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/StructureMap.cs
@@ -2521,7 +2521,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this structure map, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
@@ -2553,7 +2553,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the structure map
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -2567,7 +2567,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the structure map
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -2661,7 +2661,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=140)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=140, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -2694,7 +2694,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=150)]
+    [FhirElement("experimental", InSummary=true, Order=150, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -2725,7 +2725,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=160)]
+    [FhirElement("date", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -2756,7 +2756,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=170)]
+    [FhirElement("publisher", InSummary=true, Order=170, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -2842,7 +2842,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this structure map is defined
     /// </summary>
-    [FhirElement("purpose", Order=220)]
+    [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Subscription.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Subscription.cs
@@ -370,7 +370,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifiers (business identifier)
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -415,7 +415,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// requested | active | error | off | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=110)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=110, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -448,7 +448,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Reference to the subscription topic being subscribed to
     /// </summary>
-    [FhirElement("topic", InSummary=true, Order=120)]
+    [FhirElement("topic", InSummary=true, Order=120, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.Canonical TopicElement
@@ -480,7 +480,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Contact details for source (e.g. troubleshooting)
     /// </summary>
-    [FhirElement("contact", InSummary=true, Order=130)]
+    [FhirElement("contact", InSummary=true, Order=130, FiveWs="FiveWs.subject")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.ContactPoint> Contact
@@ -494,7 +494,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When to automatically delete the subscription
     /// </summary>
-    [FhirElement("end", InSummary=true, Order=140)]
+    [FhirElement("end", InSummary=true, Order=140, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Instant EndElement
     {
@@ -525,7 +525,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Description of why this subscription was created
     /// </summary>
-    [FhirElement("reason", InSummary=true, Order=150)]
+    [FhirElement("reason", InSummary=true, Order=150, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString ReasonElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/SubscriptionStatus.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/SubscriptionStatus.cs
@@ -315,7 +315,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// requested | active | error | off | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, Order=90)]
+    [FhirElement("status", InSummary=true, Order=90, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.SubscriptionState> StatusElement
@@ -347,7 +347,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// handshake | heartbeat | event-notification | query-status | query-event
     /// </summary>
-    [FhirElement("type", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("type", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.what[x]")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -456,7 +456,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Reference to the Subscription responsible for this notification
     /// </summary>
-    [FhirElement("subscription", InSummary=true, Order=140)]
+    [FhirElement("subscription", InSummary=true, Order=140, FiveWs="FiveWs.why[x]")]
     [CLSCompliant(false)]
     [References("Subscription")]
     [Cardinality(Min=1,Max=1)]

--- a/src/Hl7.Fhir.Core/Model/Generated/SubscriptionTopic.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/SubscriptionTopic.cs
@@ -1265,7 +1265,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Logical canonical URL to reference this SubscriptionTopic (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
@@ -1297,7 +1297,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for SubscriptionTopic
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1311,7 +1311,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the SubscriptionTopic
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -1405,7 +1405,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=140)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=140, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1438,7 +1438,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// If for testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, IsModifier=true, Order=150)]
+    [FhirElement("experimental", InSummary=true, IsModifier=true, Order=150, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -1469,7 +1469,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date status first applied
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=160)]
+    [FhirElement("date", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -1500,7 +1500,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The name of the individual or organization that published the SubscriptionTopic
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=170)]
+    [FhirElement("publisher", InSummary=true, Order=170, FiveWs="FiveWs.author")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -1586,7 +1586,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this SubscriptionTopic is defined
     /// </summary>
-    [FhirElement("purpose", Order=220)]
+    [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/Substance.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Substance.cs
@@ -221,7 +221,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Unique identifier
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -267,7 +267,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | inactive | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=110)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=110, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.Substance.FHIRSubstanceStatus> StatusElement
@@ -299,7 +299,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// What class/type of substance this is
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=120)]
+    [FhirElement("category", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> Category
@@ -313,7 +313,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// What substance this is
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=130)]
+    [FhirElement("code", InSummary=true, Order=130, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.CodeableReference Code

--- a/src/Hl7.Fhir.Core/Model/Generated/SupplyDelivery.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/SupplyDelivery.cs
@@ -367,7 +367,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When event occurred
     /// </summary>
-    [FhirElement("occurrence", InSummary=true, Order=160, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("occurrence", InSummary=true, Order=160, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.done[x]")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period),typeof(Hl7.Fhir.Model.Timing))]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/SupplyRequest.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/SupplyRequest.cs
@@ -123,7 +123,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Item detail
       /// </summary>
-      [FhirElement("code", Order=40)]
+      [FhirElement("code", Order=40, FiveWs="FiveWs.what[x]")]
       [DataMember]
       public Hl7.Fhir.Model.CodeableConcept Code
       {
@@ -136,7 +136,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Value of detail
       /// </summary>
-      [FhirElement("value", Order=50, Choice=ChoiceType.DatatypeChoice)]
+      [FhirElement("value", Order=50, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.what[x]")]
       [CLSCompliant(false)]
       [AllowedTypes(typeof(Hl7.Fhir.Model.CodeableConcept),typeof(Hl7.Fhir.Model.Quantity),typeof(Hl7.Fhir.Model.Range),typeof(Hl7.Fhir.Model.FhirBoolean))]
       [DataMember]
@@ -243,7 +243,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for SupplyRequest
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -257,7 +257,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | suspended +
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.SupplyRequest.SupplyRequestStatus> StatusElement
@@ -305,7 +305,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The kind of supply (central, non-stock, etc.)
     /// </summary>
-    [FhirElement("category", InSummary=true, Order=120)]
+    [FhirElement("category", InSummary=true, Order=120, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Category
     {
@@ -318,7 +318,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// routine | urgent | asap | stat
     /// </summary>
-    [FhirElement("priority", InSummary=true, Order=130)]
+    [FhirElement("priority", InSummary=true, Order=130, FiveWs="FiveWs.grade")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.RequestPriority> PriorityElement
@@ -378,7 +378,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Ordered item details
     /// </summary>
-    [FhirElement("parameter", Order=160)]
+    [FhirElement("parameter", Order=160, FiveWs="FiveWs.what[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.SupplyRequest.ParameterComponent> Parameter
@@ -392,7 +392,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the request should be fulfilled
     /// </summary>
-    [FhirElement("occurrence", InSummary=true, Order=170, Choice=ChoiceType.DatatypeChoice)]
+    [FhirElement("occurrence", InSummary=true, Order=170, Choice=ChoiceType.DatatypeChoice, FiveWs="FiveWs.planned")]
     [CLSCompliant(false)]
     [AllowedTypes(typeof(Hl7.Fhir.Model.FhirDateTime),typeof(Hl7.Fhir.Model.Period),typeof(Hl7.Fhir.Model.Timing))]
     [DataMember]
@@ -407,7 +407,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the request was made
     /// </summary>
-    [FhirElement("authoredOn", InSummary=true, Order=180)]
+    [FhirElement("authoredOn", InSummary=true, Order=180, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime AuthoredOnElement
     {
@@ -438,7 +438,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Individual making the request
     /// </summary>
-    [FhirElement("requester", InSummary=true, Order=190)]
+    [FhirElement("requester", InSummary=true, Order=190, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization","Patient","RelatedPerson","Device","CareTeam")]
     [DataMember]
@@ -453,7 +453,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who is intended to fulfill the request
     /// </summary>
-    [FhirElement("supplier", InSummary=true, Order=200)]
+    [FhirElement("supplier", InSummary=true, Order=200, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Organization","HealthcareService")]
     [Cardinality(Min=0,Max=-1)]
@@ -469,7 +469,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The reason why the supply item was requested
     /// </summary>
-    [FhirElement("reason", Order=210)]
+    [FhirElement("reason", Order=210, FiveWs="FiveWs.why[x]")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableReference> Reason

--- a/src/Hl7.Fhir.Core/Model/Generated/Task.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/Task.cs
@@ -648,7 +648,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Task Instance Identifier
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -769,7 +769,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | requested | received | accepted | +
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=150)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=150, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -828,7 +828,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// unknown | proposal | plan | order | original-order | reflex-order | filler-order | instance-order | option
     /// </summary>
-    [FhirElement("intent", InSummary=true, Order=180)]
+    [FhirElement("intent", InSummary=true, Order=180, FiveWs="FiveWs.class")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -861,7 +861,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// routine | urgent | asap | stat
     /// </summary>
-    [FhirElement("priority", Order=190)]
+    [FhirElement("priority", Order=190, FiveWs="FiveWs.grade")]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
     public Code<Hl7.Fhir.Model.RequestPriority> PriorityElement
@@ -893,7 +893,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Task Type
     /// </summary>
-    [FhirElement("code", InSummary=true, Order=200)]
+    [FhirElement("code", InSummary=true, Order=200, FiveWs="FiveWs.what[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept Code
     {
@@ -937,7 +937,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// What task is acting on
     /// </summary>
-    [FhirElement("focus", InSummary=true, Order=220)]
+    [FhirElement("focus", InSummary=true, Order=220, FiveWs="FiveWs.what[x]")]
     [CLSCompliant(false)]
     [References("Resource")]
     [DataMember]
@@ -952,7 +952,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Beneficiary of the Task
     /// </summary>
-    [FhirElement("for", InSummary=true, Order=230)]
+    [FhirElement("for", InSummary=true, Order=230, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Resource")]
     [DataMember]
@@ -967,7 +967,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Healthcare event during which this task originated
     /// </summary>
-    [FhirElement("encounter", InSummary=true, Order=240)]
+    [FhirElement("encounter", InSummary=true, Order=240, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -982,7 +982,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Start and end time of execution
     /// </summary>
-    [FhirElement("executionPeriod", InSummary=true, Order=250)]
+    [FhirElement("executionPeriod", InSummary=true, Order=250, FiveWs="FiveWs.done[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Period ExecutionPeriod
     {
@@ -995,7 +995,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Task Creation Date
     /// </summary>
-    [FhirElement("authoredOn", Order=260)]
+    [FhirElement("authoredOn", Order=260, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime AuthoredOnElement
     {
@@ -1057,7 +1057,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who is asking for task to be done
     /// </summary>
-    [FhirElement("requester", InSummary=true, Order=280)]
+    [FhirElement("requester", InSummary=true, Order=280, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Device","Organization","Patient","Practitioner","PractitionerRole","RelatedPerson")]
     [DataMember]
@@ -1072,7 +1072,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Requested performer
     /// </summary>
-    [FhirElement("performerType", Order=290)]
+    [FhirElement("performerType", Order=290, FiveWs="FiveWs.actor")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.CodeableConcept> PerformerType
@@ -1086,7 +1086,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Responsible individual
     /// </summary>
-    [FhirElement("owner", InSummary=true, Order=300)]
+    [FhirElement("owner", InSummary=true, Order=300, FiveWs="FiveWs.actor")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole","Organization","CareTeam","HealthcareService","Patient","Device","RelatedPerson")]
     [DataMember]
@@ -1101,7 +1101,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Where task occurs
     /// </summary>
-    [FhirElement("location", InSummary=true, Order=310)]
+    [FhirElement("location", InSummary=true, Order=310, FiveWs="FiveWs.where[x]")]
     [CLSCompliant(false)]
     [References("Location")]
     [DataMember]
@@ -1116,7 +1116,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why task is needed
     /// </summary>
-    [FhirElement("reasonCode", Order=320)]
+    [FhirElement("reasonCode", Order=320, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.CodeableConcept ReasonCode
     {
@@ -1129,7 +1129,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why task is needed
     /// </summary>
-    [FhirElement("reasonReference", Order=330)]
+    [FhirElement("reasonReference", Order=330, FiveWs="FiveWs.why[x]")]
     [CLSCompliant(false)]
     [References("Resource")]
     [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/TerminologyCapabilities.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/TerminologyCapabilities.cs
@@ -1890,7 +1890,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this terminology capabilities, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -1921,7 +1921,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the terminology capabilities
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -1935,7 +1935,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the terminology capabilities
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -2028,7 +2028,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=140)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=140, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -2061,7 +2061,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=150)]
+    [FhirElement("experimental", InSummary=true, Order=150, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -2092,7 +2092,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=160)]
+    [FhirElement("date", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
@@ -2124,7 +2124,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=170)]
+    [FhirElement("publisher", InSummary=true, Order=170, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -2210,7 +2210,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this terminology capabilities is defined
     /// </summary>
-    [FhirElement("purpose", Order=220)]
+    [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/TestReport.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/TestReport.cs
@@ -1568,7 +1568,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// External identifier
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=90)]
+    [FhirElement("identifier", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.Identifier Identifier
     {
@@ -1612,7 +1612,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// completed | in-progress | waiting | stopped | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=110)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=110, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -1756,7 +1756,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the TestScript was executed and this TestReport was generated
     /// </summary>
-    [FhirElement("issued", InSummary=true, Order=160)]
+    [FhirElement("issued", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime IssuedElement
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/TestScript.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/TestScript.cs
@@ -4738,7 +4738,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this test script, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -4769,7 +4769,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the test script
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -4783,7 +4783,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the test script
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -4877,7 +4877,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=140)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=140, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -4910,7 +4910,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=150)]
+    [FhirElement("experimental", InSummary=true, Order=150, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -4941,7 +4941,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=160)]
+    [FhirElement("date", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -4972,7 +4972,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=170)]
+    [FhirElement("publisher", InSummary=true, Order=170, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -5058,7 +5058,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this test script is defined
     /// </summary>
-    [FhirElement("purpose", Order=220)]
+    [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/ValueSet.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ValueSet.cs
@@ -71,7 +71,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Fixed date for references with no specified version (transitive)
       /// </summary>
-      [FhirElement("lockedDate", InSummary=true, Order=40)]
+      [FhirElement("lockedDate", InSummary=true, Order=40, FiveWs="FiveWs.init")]
       [DataMember]
       public Hl7.Fhir.Model.Date LockedDateElement
       {
@@ -2591,7 +2591,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Canonical identifier for this value set, represented as a URI (globally unique)
     /// </summary>
-    [FhirElement("url", InSummary=true, Order=90)]
+    [FhirElement("url", InSummary=true, Order=90, FiveWs="FiveWs.identifier")]
     [DataMember]
     public Hl7.Fhir.Model.FhirUri UrlElement
     {
@@ -2622,7 +2622,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Additional identifier for the value set (business identifier)
     /// </summary>
-    [FhirElement("identifier", InSummary=true, Order=100)]
+    [FhirElement("identifier", InSummary=true, Order=100, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -2636,7 +2636,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business version of the value set
     /// </summary>
-    [FhirElement("version", InSummary=true, Order=110)]
+    [FhirElement("version", InSummary=true, Order=110, FiveWs="FiveWs.version")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString VersionElement
     {
@@ -2729,7 +2729,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// draft | active | retired | unknown
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=140)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=140, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -2762,7 +2762,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// For testing purposes, not real usage
     /// </summary>
-    [FhirElement("experimental", InSummary=true, Order=150)]
+    [FhirElement("experimental", InSummary=true, Order=150, FiveWs="FiveWs.class")]
     [DataMember]
     public Hl7.Fhir.Model.FhirBoolean ExperimentalElement
     {
@@ -2793,7 +2793,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Date last changed
     /// </summary>
-    [FhirElement("date", InSummary=true, Order=160)]
+    [FhirElement("date", InSummary=true, Order=160, FiveWs="FiveWs.recorded")]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateElement
     {
@@ -2824,7 +2824,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Name of the publisher (organization or individual)
     /// </summary>
-    [FhirElement("publisher", InSummary=true, Order=170)]
+    [FhirElement("publisher", InSummary=true, Order=170, FiveWs="FiveWs.witness")]
     [DataMember]
     public Hl7.Fhir.Model.FhirString PublisherElement
     {
@@ -2941,7 +2941,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Why this value set is defined
     /// </summary>
-    [FhirElement("purpose", Order=230)]
+    [FhirElement("purpose", Order=230, FiveWs="FiveWs.why[x]")]
     [DataMember]
     public Hl7.Fhir.Model.Markdown Purpose
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/VerificationResult.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/VerificationResult.cs
@@ -117,7 +117,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Reference to the primary source
       /// </summary>
-      [FhirElement("who", Order=40)]
+      [FhirElement("who", Order=40, FiveWs="FiveWs.who")]
       [CLSCompliant(false)]
       [References("Organization","Practitioner","PractitionerRole")]
       [DataMember]

--- a/src/Hl7.Fhir.Core/Model/Generated/VisionPrescription.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/VisionPrescription.cs
@@ -864,7 +864,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Business Identifier for vision prescription
     /// </summary>
-    [FhirElement("identifier", Order=90)]
+    [FhirElement("identifier", Order=90, FiveWs="FiveWs.identifier")]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
     public List<Hl7.Fhir.Model.Identifier> Identifier
@@ -878,7 +878,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// active | cancelled | draft | entered-in-error
     /// </summary>
-    [FhirElement("status", InSummary=true, IsModifier=true, Order=100)]
+    [FhirElement("status", InSummary=true, IsModifier=true, Order=100, FiveWs="FiveWs.status")]
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
@@ -943,7 +943,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who prescription is for
     /// </summary>
-    [FhirElement("patient", InSummary=true, Order=120)]
+    [FhirElement("patient", InSummary=true, Order=120, FiveWs="FiveWs.subject")]
     [CLSCompliant(false)]
     [References("Patient")]
     [Cardinality(Min=1,Max=1)]
@@ -959,7 +959,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Created during encounter / admission / stay
     /// </summary>
-    [FhirElement("encounter", Order=130)]
+    [FhirElement("encounter", Order=130, FiveWs="FiveWs.context")]
     [CLSCompliant(false)]
     [References("Encounter")]
     [DataMember]
@@ -974,7 +974,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When prescription was authorized
     /// </summary>
-    [FhirElement("dateWritten", InSummary=true, Order=140)]
+    [FhirElement("dateWritten", InSummary=true, Order=140, FiveWs="FiveWs.recorded")]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
     public Hl7.Fhir.Model.FhirDateTime DateWrittenElement
@@ -1006,7 +1006,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Who authorized the vision prescription
     /// </summary>
-    [FhirElement("prescriber", InSummary=true, Order=150)]
+    [FhirElement("prescriber", InSummary=true, Order=150, FiveWs="FiveWs.author")]
     [CLSCompliant(false)]
     [References("Practitioner","PractitionerRole")]
     [Cardinality(Min=1,Max=1)]


### PR DESCRIPTION
## Description
This PR replaces PR https://github.com/FirelyTeam/firely-net-sdk/pull/1932. 

This PR contains:
- A list of auto generated files using CodeGen (with guidance of @GinoCanessa)
- Unit test `ValidateFiveWs`


## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes