### PR TITLE
3-way merge of cardinality of an element

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Hl7.Fhir.Specification.Tests.csproj
+++ b/src/Hl7.Fhir.Specification.Tests/Hl7.Fhir.Specification.Tests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\firely-net-sdk.props" />
   <Import Project="..\firely-net-sdk.targets" />
-  <Import Project="..\firely-net-sdk-tests.props"/>
+  <Import Project="..\firely-net-sdk-tests.props" />
 
   <PropertyGroup>
     <AssemblyName>Hl7.Fhir.Specification.Tests</AssemblyName>   

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -88,28 +88,39 @@ namespace Hl7.Fhir.Specification.Tests
             };
         }
 
-        [TestMethod]
-        public void TestMergeMax()
+        [DataTestMethod]
+        [DataRow(null, "1", "1")]
+        [DataRow("1", null, "1")]
+        [DataRow("1", "1", "1")]
+        [DataRow("1", "*", "1")]
+        [DataRow("2", "*", "2")]
+        [DataRow("*", "*", "*")]
+        [DataRow("*", "2", "2")]
+        [DataRow("*", null, "*")]
+        [DataRow(null, "*", "*")]
+        [DataRow("3", "2", "2")]
+        [DataRow("2", "3", "2")]
+        public void TestMergeMax(string snap, string diff, string expected)
         {
             var sg = new SnapshotGenerator.ElementDefnMerger();
 
-            test(null, "1", "1");
-            test("1", null, "1");
-            test("1", "1", "1");
-            test("1", "*", "1");
-            test("2", "*", "2");
-            test("*", "*", "*");
-            test("*", "2", "2");
-            test("*", null, "*");
-            test(null, "*", "*");
-            test("3", "2", "2");
-            test("2", "3", "2");
+            var actual = sg.mergeMax(new FhirString(snap), new FhirString(diff));
+            Assert.AreEqual(expected, actual.Value);
+        }
 
-            void test(string snap, string diff, string expected)
-            {
-                var actual = sg.mergeMax(new FhirString(snap), new FhirString(diff));
-                Assert.AreEqual(expected, actual.Value);
-            }
+        [DataTestMethod]
+        [DataRow(null, null, null)]
+        [DataRow(null, 1, 1)]
+        [DataRow(1, null, 1)]
+        [DataRow(1, 2, 2)]
+        [DataRow(2, 1, 2)]
+        [DataRow(1, 1, 1)]
+        public void TestMinMax(int? snap, int? diff, int? expected)
+        {
+            var sg = new SnapshotGenerator.ElementDefnMerger();
+
+            var actual = sg.mergeMin(new UnsignedInt(snap), new UnsignedInt(diff));
+            Assert.AreEqual(expected, actual.Value);
         }
 
         [TestMethod]

--- a/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Issue-1981/Issue-1981-Patient.StructureDefinition.xml
+++ b/src/Hl7.Fhir.Specification.Tests/TestData/snapshot-test/Issue-1981/Issue-1981-Patient.StructureDefinition.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <url value="https://example.org/fhir/StructureDefinition/issue-1981-patient" />
+  <name value="MyPatient" />
+  <status value="draft" />
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="Patient" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Patient" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Patient.extension">
+      <path value="Patient.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+      <min value="0" />
+    </element>
+    <element id="Patient.extension:birthPlace">
+      <path value="Patient.extension" />
+      <sliceName value="birthPlace" />
+      <min value="0" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/birthPlace" />
+      </type>
+      <isModifier value="false" />
+    </element>
+  </differential>
+</StructureDefinition>

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -6,14 +6,13 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Navigation;
+using Hl7.Fhir.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Hl7.Fhir.Model;
-using Hl7.Fhir.Specification.Navigation;
-using Hl7.Fhir.Support;
 using System.Reflection;
-using Hl7.Fhir.Utility;
 
 namespace Hl7.Fhir.Specification.Snapshot
 {
@@ -105,7 +104,8 @@ namespace Hl7.Fhir.Specification.Snapshot
                 // Mappings are cumulative, but keep unique on full contents
                 snap.Mapping = mergeCollection(snap.Mapping, diff.Mapping, (a, b) => a.IsExactly(b));
 
-                snap.MinElement = mergePrimitiveAttribute(snap.MinElement, diff.MinElement);
+                //snap.MinElement = mergePrimitiveAttribute(snap.MinElement, diff.MinElement);
+                snap.MinElement = mergeMin(snap.MinElement, diff.MinElement);
                 //snap.MaxElement = mergePrimitiveAttribute(snap.MaxElement, diff.MaxElement);
                 snap.MaxElement = mergeMax(snap.MaxElement, diff.MaxElement);
 
@@ -132,7 +132,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                 snap.MinValue = mergeComplexAttribute(snap.MinValue, diff.MinValue);
                 snap.MaxValue = mergeComplexAttribute(snap.MaxValue, diff.MaxValue);
-                
+
                 // [WMR 20160909] merge defaultValue and meaningWhenMissing, to handle core definitions; validator can detect invalid constraints
                 snap.DefaultValue = mergeComplexAttribute(snap.DefaultValue, diff.DefaultValue);
                 snap.MeaningWhenMissingElement = mergePrimitiveAttribute(snap.MeaningWhenMissingElement, diff.MeaningWhenMissingElement);
@@ -224,8 +224,8 @@ namespace Hl7.Fhir.Specification.Snapshot
                             // [WMR 20160719] Handle snap == null
                             // diffText = (snap.ObjectValue as string) + "\r\n" + diffText.Substring(3);
                             var prefix = snap != null ? snap.ObjectValue as string : null;
-                            diffText = string.IsNullOrEmpty(prefix) ? 
-                                diffText.Substring(3) 
+                            diffText = string.IsNullOrEmpty(prefix) ?
+                                diffText.Substring(3)
                                 : prefix + "\r\n" + diffText.Substring(3);
                         }
 
@@ -238,6 +238,28 @@ namespace Hl7.Fhir.Specification.Snapshot
                 else
                     return snap;
             }
+
+            internal UnsignedInt mergeMin(UnsignedInt snap, UnsignedInt diff)
+            {
+                if (snap.IsNullOrEmpty() && !diff.IsNullOrEmpty())
+                {
+                    return deepCopyAndRaiseOnConstraint(diff);
+                }
+
+                if (!diff.IsNullOrEmpty())
+                {
+                    var snapMin = snap.Value;
+                    var diffMin = diff.Value;
+
+                    if (diffMin > snapMin)
+                    {
+                        return deepCopyAndRaiseOnConstraint(diff);
+                    }
+                }
+
+                return snap;
+            }
+
 
             // The diamond problem is especially painful for min/max -
             // most datatypes roots have a cardinality of 0..*, so
@@ -255,7 +277,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                     // Now, diff has a numeric limit
                     // So, if snap has no limit, take the diff
-                    if(snap.Value == "*")
+                    if (snap.Value == "*")
                         return deepCopyAndRaiseOnConstraint(diff);
 
                     // snap and diff both have a numeric value
@@ -265,7 +287,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                         // compare them if they are both numerics
                         return dv < sv ? deepCopyAndRaiseOnConstraint(diff) : snap;
                     }
-                    
+
                     // one of the two values cannot be parsed, just don't
                     // do anything to not break it any further.
                     return snap;
@@ -278,9 +300,9 @@ namespace Hl7.Fhir.Specification.Snapshot
                     return snap;
             }
 
-            private FhirString deepCopyAndRaiseOnConstraint(FhirString elt)
+            private T deepCopyAndRaiseOnConstraint<T>(T elt) where T : PrimitiveType
             {
-                var result = (FhirString)elt.DeepCopy();
+                var result = (T)elt.DeepCopy();
                 onConstraint(result);
                 return result;
             }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -239,15 +239,23 @@ namespace Hl7.Fhir.Specification.Snapshot
                     return snap;
             }
 
+            /// <summary>
+            /// Merge the Min element of the differential into the snapshot. The most contrained will win: so the maximum of both values.
+            /// </summary>
+            /// <param name="snap"></param>
+            /// <param name="diff"></param>
+            /// <returns></returns>
             internal UnsignedInt mergeMin(UnsignedInt snap, UnsignedInt diff)
             {
                 if (snap.IsNullOrEmpty() && !diff.IsNullOrEmpty())
                 {
+                    // no snap element, but diff element: return the diff:
                     return deepCopyAndRaiseOnConstraint(diff);
                 }
 
                 if (!diff.IsNullOrEmpty())
                 {
+                    // a snap element and diff element exist
                     var snapMin = snap.Value;
                     var diffMin = diff.Value;
 
@@ -256,7 +264,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                         return deepCopyAndRaiseOnConstraint(diff);
                     }
                 }
-
+                // in all other cases, return the snap
                 return snap;
             }
 

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -1159,8 +1159,12 @@ namespace Hl7.Fhir.Specification.Snapshot
                             var rebasedRootElem = (ElementDefinition)typeRootElem.DeepCopy();
                             rebasedRootElem.Path = diff.Path;
                             // MV 20210727: copy cardinality from base (so do not use the cardinality of the type). See issue #1824
-                            rebasedRootElem.Min = diff.Current.Min;
-                            rebasedRootElem.Max = diff.Current.Max;
+                            //rebasedRootElem.Min = diff.Current.Min;
+                            //rebasedRootElem.Max = diff.Current.Max;
+
+                            // NEW 20220224:
+                            rebasedRootElem.Min = mostConstrainedMin(rebasedRootElem.Min, diff.Current.Min);
+                            rebasedRootElem.Max = mostConstrainedMax(rebasedRootElem.Max, diff.Current.Max);
 
                             // Merge the type profile root element; no need to expand children
                             mergeElementDefinition(snap.Current, rebasedRootElem, false);
@@ -1180,6 +1184,24 @@ namespace Hl7.Fhir.Specification.Snapshot
             }
 
             return true;
+
+            int? mostConstrainedMin(int? a, int? b)
+            {
+                if (a is null) return b;
+                if (b is null) return a;
+
+                return Math.Max(a.Value, b.Value);
+            }
+
+            string mostConstrainedMax(string a, string b)
+            {
+                if (string.IsNullOrEmpty(a) || a == "*") return b;
+                if (string.IsNullOrEmpty(b) || b == "*") return a;
+
+                var left = int.Parse(a);
+                var right = int.Parse(b);
+                return Math.Min(left, right).ToString();
+            }
         }
 
         // [WMR 20170209] HACK

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -1158,13 +1158,12 @@ namespace Hl7.Fhir.Specification.Snapshot
                             // Rebase before merging
                             var rebasedRootElem = (ElementDefinition)typeRootElem.DeepCopy();
                             rebasedRootElem.Path = diff.Path;
-                            // MV 20210727: copy cardinality from base (so do not use the cardinality of the type). See issue #1824
-                            //rebasedRootElem.Min = diff.Current.Min;
-                            //rebasedRootElem.Max = diff.Current.Max;
 
-                            // NEW 20220224:
-                            rebasedRootElem.Min = mostConstrainedMin(rebasedRootElem.Min, diff.Current.Min);
-                            rebasedRootElem.Max = mostConstrainedMax(rebasedRootElem.Max, diff.Current.Max);
+                            var sg = new ElementDefnMerger();
+                            // merge the min of the external profile type with the diff. Most constrained wins (the maximum of both values)
+                            rebasedRootElem.MinElement = sg.mergeMin(rebasedRootElem.MinElement, diff.Current.MinElement);
+                            // merge the min of the external profile type with the diff. Most constrained wins (the minumum of both values) 
+                            rebasedRootElem.MaxElement = sg.mergeMax(rebasedRootElem.MaxElement, diff.Current.MaxElement);
 
                             // Merge the type profile root element; no need to expand children
                             mergeElementDefinition(snap.Current, rebasedRootElem, false);
@@ -1184,24 +1183,6 @@ namespace Hl7.Fhir.Specification.Snapshot
             }
 
             return true;
-
-            int? mostConstrainedMin(int? a, int? b)
-            {
-                if (a is null) return b;
-                if (b is null) return a;
-
-                return Math.Max(a.Value, b.Value);
-            }
-
-            string mostConstrainedMax(string a, string b)
-            {
-                if (string.IsNullOrEmpty(a) || a == "*") return b;
-                if (string.IsNullOrEmpty(b) || b == "*") return a;
-
-                var left = int.Parse(a);
-                var right = int.Parse(b);
-                return Math.Min(left, right).ToString();
-            }
         }
 
         // [WMR 20170209] HACK

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -1159,6 +1159,10 @@ namespace Hl7.Fhir.Specification.Snapshot
                             var rebasedRootElem = (ElementDefinition)typeRootElem.DeepCopy();
                             rebasedRootElem.Path = diff.Path;
 
+                            // MV 20220224: we have here actually a 3-way merge of the cardinality: merge of the snapshot in progress (1), differential (2) and 
+                            // the external profile type (3). We do first a merge with the profile type and the differential and then the differential 
+                            // will be merged into the snapshot.
+
                             var sg = new ElementDefnMerger();
                             // merge the min of the external profile type with the diff. Most constrained wins (the maximum of both values)
                             rebasedRootElem.MinElement = sg.mergeMin(rebasedRootElem.MinElement, diff.Current.MinElement);


### PR DESCRIPTION
## Description
In PR #1826 we introduced a bug in existing functionality. We resolved that now by a 3-way merge of the cardinality of
- snapshot
- differential
- external profile type

The most constrained value will win. Let's say we have the following cardinalities on an element:
- snapshot: `0..*`
- differential: `1..*`
- external profile type (like an extension): `1..1`

Then the result cardinality of the element would be: `1..1`

This behavior is also applied to the "normal" merge of `Min`: in the past the Min value of the differential was copied to the snapshot (when it exists). Now  both Min values (snap and diff) are compared first, and the highest value wins.

## Related issues
Resolves #1981.

## Testing
- `SnapshotGeneratorTest2.TestMinMax`
- `SnapshotGeneratorTest2.CardinalityOfExtension`

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes