### PR TITLE
Make LegacyFhirClient obsolete

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
@@ -64,7 +64,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         private static void CreateItems()
         {
-            var client = new LegacyFhirClient(testEndpoint);
+            var client = new FhirClient(testEndpoint);
 
             client.Settings.PreferredFormat = ResourceFormat.Json;
             client.Settings.PreferredReturn = Prefer.ReturnRepresentation;
@@ -137,9 +137,10 @@ namespace Hl7.Fhir.Tests.Rest
         }
 
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void FetchConformance()
         {
-            LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
+            var client = new LegacyFhirClient(testEndpoint);
             TestConformance(client);
         }
 
@@ -178,6 +179,7 @@ namespace Hl7.Fhir.Tests.Rest
         }
 
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void PatchClient()
         {
             using var client = new LegacyFhirClient(testEndpoint);
@@ -202,6 +204,7 @@ namespace Hl7.Fhir.Tests.Rest
         }
 
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void CondionalPatchClient()
         {
             using var client = new LegacyFhirClient(testEndpoint);
@@ -245,9 +248,10 @@ namespace Hl7.Fhir.Tests.Rest
         }
 
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void ReadWithFormat()
         {
-            LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
+            var client = new LegacyFhirClient(testEndpoint);
             testReadWithFormat(client);
         }
 
@@ -270,9 +274,10 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest")]
         [ExpectedException(typeof(FhirOperationException))]
+        [Obsolete]
         public void ReadWrongResourceType()
         {
-            LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
+            var client = new LegacyFhirClient(testEndpoint);
             var loc = client.Read<Patient>("Location/" + locationId);
         }
 
@@ -290,9 +295,10 @@ namespace Hl7.Fhir.Tests.Rest
         }
 
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public async T.Task Read()
         {
-            LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
+            var client = new LegacyFhirClient(testEndpoint);
             await testReadClientAsync(client);
         }
 
@@ -343,9 +349,10 @@ namespace Hl7.Fhir.Tests.Rest
         }
 
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void ReadRelative()
         {
-            LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
+            var client = new LegacyFhirClient(testEndpoint);
             testReadRelative(client);
 
         }
@@ -435,9 +442,10 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod, Ignore]   // Something does not work with the gzip
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void Search()
         {
-            LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
+            var client = new LegacyFhirClient(testEndpoint);
             Bundle result;
 
             client.Settings.CompressRequestBody = true;
@@ -529,9 +537,10 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod, TestCategory("FhirClient")]
         [ExpectedException(typeof(ArgumentException))]
+        [Obsolete]
         public void SearchInvalidCriteria()
         {
-            LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
+            var client = new LegacyFhirClient(testEndpoint);
             testSearchInvalidCriteria(client);
         }
 
@@ -604,9 +613,10 @@ namespace Hl7.Fhir.Tests.Rest
 
 
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void Paging()
         {
-            LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
+            var client = new LegacyFhirClient(testEndpoint);
 
             testPaging(client);
         }
@@ -652,9 +662,10 @@ namespace Hl7.Fhir.Tests.Rest
 
 
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void PagingInJson()
         {
-            LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
+            var client = new LegacyFhirClient(testEndpoint);
             testPagingInJson(client);
         }
 
@@ -703,9 +714,10 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void CreateAndFullRepresentation()
         {
-            LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
+            var client = new LegacyFhirClient(testEndpoint);
             testCreateAndFullRepresentation(client);
         }
 
@@ -753,9 +765,10 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public async T.Task CreateEditDelete()
         {
-            LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
+            var client = new LegacyFhirClient(testEndpoint);
             client.OnBeforeRequest += Compression_OnBeforeWebRequestZipOrDeflate;
             await testCreateEditDeleteAsync(client);
         }
@@ -829,10 +842,11 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         //Test for github issue https://github.com/FirelyTeam/firely-net-sdk/issues/145
         public void Create_ObservationWithValueAsSimpleQuantity_ReadReturnsValueAsQuantity()
         {
-            LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
+            var client = new LegacyFhirClient(testEndpoint);
             testCreateObservationWithQuantity(client);
         }
 
@@ -945,9 +959,10 @@ namespace Hl7.Fhir.Tests.Rest
         /// and counts them in the WholeSystemHistory
         /// </summary>
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest"), Ignore]     // Keeps on failing periodically. Grahames server?
+        [Obsolete]
         public async T.Task History()
         {
-            LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
+            var client = new LegacyFhirClient(testEndpoint);
             await testHistoryAsync(client);
         }
 
@@ -1017,6 +1032,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void TestWithParam()
         {
             var client = new LegacyFhirClient(testEndpoint);
@@ -1040,9 +1056,10 @@ namespace Hl7.Fhir.Tests.Rest
         }
 
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void ManipulateMeta()
         {
-            LegacyFhirClient client = new LegacyFhirClient("http://test.fhir.org/r4");
+            var client = new LegacyFhirClient("http://test.fhir.org/r4");
             testManipulateMeta(client);
         }
 
@@ -1171,6 +1188,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void TestSearchUsingPostMultipleIncludesShouldNotThrowArgumentException()
         {
             // This test case proves issue https://github.com/FirelyTeam/firely-net-sdk/issues/1206 is fixed. 
@@ -1207,6 +1225,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void TestSearchByPersonaCode()
         {
             var client = new LegacyFhirClient(testEndpoint);
@@ -1232,6 +1251,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void TestSearchUsingPostByPersonaCode()
         {
             var client = new LegacyFhirClient(_endpointSupportingSearchUsingPost);
@@ -1256,9 +1276,10 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public async T.Task CreateDynamic()
         {
-            LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
+            var client = new LegacyFhirClient(testEndpoint);
             await testCreateDynamicHttpClientAsync(client);
         }
 
@@ -1291,9 +1312,10 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void CallsCallbacks()
         {
-            LegacyFhirClient client = new LegacyFhirClient(testEndpoint);
+            var client = new LegacyFhirClient(testEndpoint);
             client.Settings.ParserSettings.AllowUnrecognizedEnums = true;
 
             bool calledBefore = false;
@@ -1395,6 +1417,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void RequestFullResource()
         {
             var client = new LegacyFhirClient(testEndpoint);
@@ -1433,6 +1456,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]   // Currently ignoring, as spark.furore.com returns Status 500.
+        [Obsolete]
         public void TestReceiveHtmlIsHandled()
         {
             var client = new LegacyFhirClient("http://test.fhir.org/r4");        // an address that returns html
@@ -1468,6 +1492,7 @@ namespace Hl7.Fhir.Tests.Rest
 
 
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void TestRefresh()
         {
             var client = new LegacyFhirClient(testEndpoint);
@@ -1500,6 +1525,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [Ignore]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void TestReceiveErrorStatusWithHtmlIsHandled()
         {
             var client = new LegacyFhirClient("http://test.fhir.org/r4/");        // an address that returns Status 500 with HTML in its body
@@ -1560,6 +1586,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void TestReceiveErrorStatusWithOperationOutcomeIsHandled()
         {
             var client = new LegacyFhirClient("http://test.fhir.org/r4/");  // an address that returns Status 404 with an OperationOutcome
@@ -1617,6 +1644,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod, Ignore]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        [Obsolete]
         public void FhirVersionIsChecked()
         {
             var testEndpointDSTU2 = new Uri("http://spark-dstu2.furore.com/fhir");
@@ -1674,9 +1702,10 @@ namespace Hl7.Fhir.Tests.Rest
         }
 
         [TestMethod, TestCategory("IntegrationTest"), TestCategory("FhirClient")]
+        [Obsolete]
         public void TestAuthenticationOnBefore()
         {
-            LegacyFhirClient validationFhirClient = new LegacyFhirClient(testEndpoint);
+            var validationFhirClient = new LegacyFhirClient(testEndpoint);
             validationFhirClient.OnBeforeRequest += (object sender, BeforeRequestEventArgs e) =>
             {
                 e.RawRequest.Headers["Authorization"] = "Bearer bad-bearer";
@@ -1713,6 +1742,7 @@ namespace Hl7.Fhir.Tests.Rest
         /// Test for showing issue https://github.com/FirelyTeam/firely-net-sdk/issues/128
         /// </summary>
         [TestMethod, TestCategory("IntegrationTest"), TestCategory("FhirClient")]
+        [Obsolete]
         public void TestCreatingBinaryResource()
         {
             byte[] arr = File.ReadAllBytes(TestDataHelper.GetFullPathForExample(@"fhir-logo.png"));
@@ -1774,9 +1804,10 @@ namespace Hl7.Fhir.Tests.Rest
 
         [Ignore]
         [TestMethod, TestCategory("IntegrationTest"), TestCategory("FhirClient")]
+        [Obsolete]
         public void TestOperationEverything()
         {
-            LegacyFhirClient client = new LegacyFhirClient("http://test.fhir.org/r4", new FhirClientSettings() { UseFormatParameter = true, PreferredFormat = ResourceFormat.Json });
+            var client = new LegacyFhirClient("http://test.fhir.org/r4", new FhirClientSettings() { UseFormatParameter = true, PreferredFormat = ResourceFormat.Json });
             testOpEverything(client);
         }
 

--- a/src/Hl7.Fhir.Core.Tests/Rest/OperationsTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/OperationsTests.cs
@@ -7,14 +7,11 @@
  */
 
 using Hl7.Fhir.Model;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Rest.Legacy;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
 
 namespace Hl7.Fhir.Tests.Rest
 {
@@ -24,12 +21,13 @@ namespace Hl7.Fhir.Tests.Rest
     {
         string testEndpoint = FhirClientTests.testEndpoint.OriginalString;
 
-        [TestMethod] 
+        [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public void InvokeTestPatientGetEverything()
         {
             var client = new LegacyFhirClient(testEndpoint);
-            patientGetEverything(client);            
+            patientGetEverything(client);
         }
 
         [TestMethod]
@@ -56,6 +54,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public void InvokeExpandExistingValueSet()
         {
             var client = new LegacyFhirClient(FhirClientTests.TerminologyEndpoint);
@@ -69,7 +68,7 @@ namespace Hl7.Fhir.Tests.Rest
             using (var client = new FhirClient(FhirClientTests.TerminologyEndpoint))
             {
                 expandExistingValueset(client);
-            };            
+            };
         }
 
         private static void expandExistingValueset(BaseFhirClient client)
@@ -80,6 +79,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public void InvokeExpandParameterValueSet()
         {
             var client = new LegacyFhirClient(FhirClientTests.TerminologyEndpoint);
@@ -88,12 +88,12 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
-        public void InvokeExpandParameterValueSetHttpClient ()
+        public void InvokeExpandParameterValueSetHttpClient()
         {
             using (var client = new FhirClient(FhirClientTests.TerminologyEndpoint))
             {
                 expandParameterValueSet(client);
-            }            
+            }
         }
 
         private static void expandParameterValueSet(BaseFhirClient client)
@@ -122,6 +122,7 @@ namespace Hl7.Fhir.Tests.Rest
         /// </summary>
         [TestMethod]  // Server returns internal server error
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public void InvokeLookupCoding()
         {
             var client = new LegacyFhirClient(FhirClientTests.TerminologyEndpoint);
@@ -150,6 +151,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod] // Server returns internal server error
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public void InvokeLookupCode()
         {
             var client = new LegacyFhirClient(FhirClientTests.TerminologyEndpoint);
@@ -163,7 +165,7 @@ namespace Hl7.Fhir.Tests.Rest
             using (var client = new FhirClient(FhirClientTests.TerminologyEndpoint))
             {
                 lookUpCode(client);
-            };            
+            };
         }
 
         private static void lookUpCode(BaseFhirClient client)
@@ -176,6 +178,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public void InvokeValidateCodeById()
         {
             var client = new LegacyFhirClient(FhirClientTests.TerminologyEndpoint);
@@ -202,6 +205,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public void InvokeValidateCodeByCanonical()
         {
             var client = new LegacyFhirClient(FhirClientTests.TerminologyEndpoint);
@@ -210,12 +214,12 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
-        public void InvokeValidateCodeByCanonicalHttpClient ()
+        public void InvokeValidateCodeByCanonicalHttpClient()
         {
             using (var client = new FhirClient(FhirClientTests.TerminologyEndpoint))
             {
                 validateCodeByCanonical(client);
-            }            
+            }
         }
 
 
@@ -230,6 +234,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public void InvokeValidateCodeWithVS()
         {
             var client = new LegacyFhirClient(FhirClientTests.TerminologyEndpoint);
@@ -243,7 +248,7 @@ namespace Hl7.Fhir.Tests.Rest
             using (var client = new FhirClient(FhirClientTests.TerminologyEndpoint))
             {
                 validateCodeWithVS(client);
-            };           
+            };
         }
 
         private static void validateCodeWithVS(BaseFhirClient client)
@@ -259,6 +264,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public void InvokeResourceValidation()
         {
             var client = new LegacyFhirClient(testEndpoint);
@@ -272,7 +278,7 @@ namespace Hl7.Fhir.Tests.Rest
             using (var client = new FhirClient(testEndpoint))
             {
                 validateResource(client);
-            }            
+            }
         }
 
         private static void validateResource(BaseFhirClient client)
@@ -280,11 +286,12 @@ namespace Hl7.Fhir.Tests.Rest
             var pat = client.Read<Patient>("Patient/pat1");
             var vresult = client.ValidateResource(pat, null,
                 new FhirUri("http://hl7.org/fhir/StructureDefinition/Patient"));
-            Assert.IsTrue(vresult.Success);          
+            Assert.IsTrue(vresult.Success);
         }
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public async System.Threading.Tasks.Task InvokeTestPatientGetEverythingAsync()
         {
             string _endpoint = "https://api.hspconsortium.org/rpineda/open";
@@ -300,7 +307,7 @@ namespace Hl7.Fhir.Tests.Rest
             using (var client = new FhirClient(_endpoint))
             {
                 await patientEverythingAsync(client).ConfigureAwait(false);
-            }           
+            }
         }
 
         private static async System.Threading.Tasks.Task patientEverythingAsync(BaseFhirClient client)

--- a/src/Hl7.Fhir.Core.Tests/Rest/ReadAsyncTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/ReadAsyncTests.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Hl7.Fhir.Model;
+﻿using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Rest.Legacy;
 using Hl7.Fhir.Tests.Rest;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Hl7.Fhir.Core.AsyncTests
 {
@@ -18,10 +17,10 @@ namespace Hl7.Fhir.Core.AsyncTests
         [ClassInitialize]
         public static void ClassInitialize(TestContext context)
         {
-            var client = new LegacyFhirClient(_endpoint);
+            var client = new FhirClient(_endpoint);
             client.Settings.PreferredFormat = ResourceFormat.Json;
             client.Settings.PreferredReturn = Prefer.ReturnRepresentation;
-            
+
 
 
             var pat = new Patient()
@@ -64,11 +63,12 @@ namespace Hl7.Fhir.Core.AsyncTests
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public async System.Threading.Tasks.Task Read_UsingResourceIdentity_ResultReturned()
         {
             var client = new LegacyFhirClient(_endpoint);
             client.Settings.PreferredFormat = ResourceFormat.Json;
-            client.Settings.PreferredReturn = Prefer.ReturnRepresentation;          
+            client.Settings.PreferredReturn = Prefer.ReturnRepresentation;
 
             await readUsingResourceId(client);
         }
@@ -82,7 +82,7 @@ namespace Hl7.Fhir.Core.AsyncTests
                 client.Settings.PreferredFormat = ResourceFormat.Json;
                 client.Settings.PreferredReturn = Prefer.ReturnRepresentation;
                 await readUsingResourceId(client);
-            }          
+            }
         }
 
 
@@ -98,12 +98,13 @@ namespace Hl7.Fhir.Core.AsyncTests
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public async System.Threading.Tasks.Task Read_UsingLocationString_ResultReturned()
         {
             var client = new LegacyFhirClient(_endpoint);
             client.Settings.PreferredFormat = ResourceFormat.Json;
             client.Settings.PreferredReturn = Prefer.ReturnRepresentation;
-            
+
 
             await readUsingLocationString(client);
         }
@@ -117,7 +118,7 @@ namespace Hl7.Fhir.Core.AsyncTests
                 client.Settings.PreferredFormat = ResourceFormat.Json;
                 client.Settings.PreferredReturn = Prefer.ReturnRepresentation;
                 await readUsingLocationString(client);
-            }            
+            }
         }
 
         private static async System.Threading.Tasks.Task readUsingLocationString(BaseFhirClient client)

--- a/src/Hl7.Fhir.Core.Tests/Rest/RequesterTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/RequesterTests.cs
@@ -54,6 +54,7 @@ namespace Hl7.Fhir.Test
         #region EntryRequest To Webclient
 
         [TestMethod]
+        [Obsolete]
         public void TestPreferSetting()
         {
             var entry = _Entry;
@@ -66,7 +67,7 @@ namespace Hl7.Fhir.Test
             settings.PreferredReturn = Prefer.RespondAsync;
             request = entry.ToHttpWebRequest(_endpoint, settings);
             Assert.AreEqual("respond-async", request.Headers["Prefer"]);
-            
+
             settings.PreferredReturn = null;
             request = entry.ToHttpWebRequest(_endpoint, settings);
             Assert.IsNull(request.Headers["Prefer"]);
@@ -75,11 +76,11 @@ namespace Hl7.Fhir.Test
             settings.PreferredReturn = Prefer.OperationOutcome;
             request = entry.ToHttpWebRequest(_endpoint, settings);
             Assert.AreEqual("handling=lenient", request.Headers["Prefer"]);
-            
+
             settings.PreferredReturn = Prefer.RespondAsync;
             request = entry.ToHttpWebRequest(_endpoint, settings);
             Assert.AreEqual("handling=lenient, respond-async", request.Headers["Prefer"]);
-            
+
             settings.PreferredReturn = Prefer.ReturnRepresentation;
             settings.PreferredParameterHandling = null;
             request = entry.ToHttpWebRequest(_endpoint, settings);
@@ -87,23 +88,25 @@ namespace Hl7.Fhir.Test
         }
 
         [TestMethod]
+        [Obsolete]
         public void TestRequestedBodyContent()
         {
             var entry = _Entry;
             entry.RequestBodyContent = Encoding.UTF8.GetBytes("Test body");
             var settings = _Settings;
-            
+
             ExceptionAssert.Throws<InvalidOperationException>(() => entry.ToHttpWebRequest(_endpoint, settings));
-            
+
             entry.Method = HTTPVerb.POST;
             var request = entry.ToHttpWebRequest(_endpoint, settings);
         }
 
         [TestMethod]
+        [Obsolete]
         public void TestFormatParameters()
         {
             var entry = _Entry;
-            var settings = _Settings;           
+            var settings = _Settings;
 
             settings.UseFormatParameter = true;
             var request = entry.ToHttpWebRequest(_endpoint, settings);
@@ -111,6 +114,7 @@ namespace Hl7.Fhir.Test
         }
 
         [TestMethod]
+        [Obsolete]
         public void TestEntryRequestHeaders()
         {
             var entry = _Entry;
@@ -132,6 +136,7 @@ namespace Hl7.Fhir.Test
         }
 
         [TestMethod]
+        [Obsolete]
         public void TestSetAgent()
         {
             var entry = _Entry;
@@ -147,7 +152,7 @@ namespace Hl7.Fhir.Test
             {
                 Assert.AreEqual(".NET FhirClient for FHIR testAgent", request.UserAgent);
             }
-            catch(Exception)
+            catch (Exception)
             {
                 Assert.AreEqual(EntryToHttpExtensions.SetUserAgentUsingDirectHeaderManipulation, false);
             }
@@ -192,6 +197,7 @@ namespace Hl7.Fhir.Test
         }
 
         [TestMethod]
+        [Obsolete]
         public void TestRequestedBodyContentHttpClient()
         {
             var entry = _Entry;
@@ -402,7 +408,7 @@ namespace Hl7.Fhir.Test
                 AllowUnrecognizedEnums = false,
                 DisallowXsiAttributesOnRoot = true,
                 PermissiveParsing = false
-            };  
+            };
 
             var bundleresponse = typedresponse.ToBundleEntry(settings);
 
@@ -416,4 +422,4 @@ namespace Hl7.Fhir.Test
         #endregion
     }
 }
- 
+

--- a/src/Hl7.Fhir.Core.Tests/Rest/SearchAsyncTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/SearchAsyncTests.cs
@@ -17,6 +17,7 @@ namespace Hl7.Fhir.Core.AsyncTests
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public async Task Search_UsingSearchParams_SearchReturned()
         {
             var client = new LegacyFhirClient(_endpoint);
@@ -62,6 +63,7 @@ namespace Hl7.Fhir.Core.AsyncTests
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public async Task SearchUsingPost_UsingSearchParams_SearchReturned()
         {
             var client = new LegacyFhirClient(_endpointSupportingSearchUsingPost);
@@ -109,6 +111,7 @@ namespace Hl7.Fhir.Core.AsyncTests
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public void SearchSync_UsingSearchParams_SearchReturned()
         {
             var client = new LegacyFhirClient(_endpoint);
@@ -157,6 +160,7 @@ namespace Hl7.Fhir.Core.AsyncTests
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public void SearchUsingPostSync_UsingSearchParams_SearchReturned()
         {
             var client = new LegacyFhirClient(_endpointSupportingSearchUsingPost);
@@ -188,6 +192,7 @@ namespace Hl7.Fhir.Core.AsyncTests
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public async Task SearchMultiple_UsingSearchParams_SearchReturned()
         {
             var client = new LegacyFhirClient(_endpoint);
@@ -243,6 +248,7 @@ namespace Hl7.Fhir.Core.AsyncTests
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public async Task SearchUsingPostMultiple_UsingSearchParams_SearchReturned()
         {
             var client = new LegacyFhirClient(_endpointSupportingSearchUsingPost);
@@ -299,6 +305,7 @@ namespace Hl7.Fhir.Core.AsyncTests
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public async Task SearchWithCriteria_SyncContinue_SearchReturned()
         {
             var client = new LegacyFhirClient(_endpoint);
@@ -343,6 +350,7 @@ namespace Hl7.Fhir.Core.AsyncTests
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public async Task SearchUsingPostWithCriteria_SyncContinue_SearchReturned()
         {
             var client = new LegacyFhirClient(_endpointSupportingSearchUsingPost);
@@ -387,6 +395,7 @@ namespace Hl7.Fhir.Core.AsyncTests
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public async Task SearchWithCriteria_AsyncContinue_SearchReturned()
         {
             var client = new LegacyFhirClient(_endpoint);
@@ -433,6 +442,7 @@ namespace Hl7.Fhir.Core.AsyncTests
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public async Task SearchUsingPostWithCriteria_AsyncContinue_SearchReturned()
         {
             var client = new LegacyFhirClient(_endpointSupportingSearchUsingPost);

--- a/src/Hl7.Fhir.Core.Tests/Rest/UpdateRefreshDeleteAsyncTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/UpdateRefreshDeleteAsyncTests.cs
@@ -1,12 +1,11 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Rest.Legacy;
 using Hl7.Fhir.Tests;
 using Hl7.Fhir.Tests.Rest;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
 
 namespace Hl7.Fhir.Core.AsyncTests
 {
@@ -16,15 +15,16 @@ namespace Hl7.Fhir.Core.AsyncTests
 
         [TestMethod]
         [TestCategory("IntegrationTest")]
+        [Obsolete]
         public async System.Threading.Tasks.Task UpdateDelete_UsingResourceIdentity_ResultReturned()
         {
             var client = new LegacyFhirClient(_endpoint);
             client.Settings.PreferredFormat = ResourceFormat.Json;
-            client.Settings.PreferredReturn = Prefer.ReturnRepresentation;            
+            client.Settings.PreferredReturn = Prefer.ReturnRepresentation;
 
             await updateDelete(client);
         }
-        
+
         [TestMethod]
         [TestCategory("IntegrationTest")]
         public async System.Threading.Tasks.Task UpdateDelete_UsingResourceIdentity_ResultReturnedHttpClient()
@@ -34,7 +34,7 @@ namespace Hl7.Fhir.Core.AsyncTests
                 client.Settings.PreferredFormat = ResourceFormat.Json;
                 client.Settings.PreferredReturn = Prefer.ReturnRepresentation;
                 await updateDelete(client);
-            }           
+            }
         }
 
 

--- a/src/Hl7.Fhir.Core/Rest/Legacy/LegacyFhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/Legacy/LegacyFhirClient.cs
@@ -15,7 +15,7 @@ using System.Net;
 
 namespace Hl7.Fhir.Rest.Legacy
 {
-    [Obsolete("Use the class FhirClient instead.")]       // Obsoleted on 20220210 by Marco Visser
+    [Obsolete("Use the class FhirClient instead. Will be removed in the next major release.")]       // Obsoleted on 20220210 by Marco Visser
     public partial class LegacyFhirClient : BaseFhirClient
     {
         /// <summary>

--- a/src/Hl7.Fhir.Core/Rest/Legacy/LegacyFhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/Legacy/LegacyFhirClient.cs
@@ -15,6 +15,7 @@ using System.Net;
 
 namespace Hl7.Fhir.Rest.Legacy
 {
+    [Obsolete("Use the class FhirClient instead.")]       // Obsoleted on 20220210 by Marco Visser
     public partial class LegacyFhirClient : BaseFhirClient
     {
         /// <summary>
@@ -144,7 +145,7 @@ namespace Hl7.Fhir.Rest.Legacy
             get => Settings.PreferredParameterHandling;
             set => Settings.PreferredParameterHandling = value;
         }
-        
+
         /// <summary>
         /// This will do 2 things:
         /// 1. Add the header Accept-Encoding: gzip, deflate
@@ -188,9 +189,9 @@ namespace Hl7.Fhir.Rest.Legacy
         /// no longer available. Use LastBody, LastBodyAsText and LastBodyAsResource to get access to the received body (if any)</remarks>
         [Obsolete("LastResponse was already disposed, so no point in having them around", true)]
         public HttpWebResponse LastResponse;
-        
+
         #endregion
-        
+
 
         /// <summary>
         /// Called just before the Http call is done
@@ -224,7 +225,7 @@ namespace Hl7.Fhir.Rest.Legacy
             OnAfterResponse?.Invoke(this, new AfterResponseEventArgs(webResponse, body));
         }
     }
-    
+
     public class BeforeRequestEventArgs : EventArgs
     {
         public BeforeRequestEventArgs(HttpWebRequest rawRequest, byte[] body)

--- a/src/Hl7.Fhir.Specification.Tests/Source/TerminologyTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/TerminologyTests.cs
@@ -926,7 +926,7 @@ namespace Hl7.Fhir.Specification.Tests
         private static bool hasWarnings(Parameters outcome) =>
             isSuccess(outcome) && outcome.GetSingleValue<FhirString>("message") is not null;
 
-        private static string? getMessage(Parameters outcome) =>
+        private static string getMessage(Parameters outcome) =>
             outcome.GetSingleValue<FhirString>("message")?.Value;
 
         #endregion


### PR DESCRIPTION
## Description
- Make the class `LegacyFhirClient` obsolete, This will be removed in the next major release
- Solving some compiler messages

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes