### PR TITLE
Changes to improve performance of Bundle validation

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/StructureDefinitionSerializationInfoTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/StructureDefinitionSerializationInfoTests.cs
@@ -1,6 +1,6 @@
 ﻿using Hl7.Fhir.Specification;
 using Hl7.Fhir.Specification.Source;
-using Hl7.Fhir.Validation;
+using Hl7.Fhir.Specification.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Hl7.Fhir.Serialization.Tests
@@ -18,7 +18,7 @@ namespace Hl7.Fhir.Serialization.Tests
                 );
         }
 
-        static IResourceResolver source = null;
+        private static IResourceResolver source = null;
 
         [TestMethod]
         public void TestCanLocateTypes() => SerializationInfoTestHelpers.TestCanLocateTypes(new StructureDefinitionSummaryProvider(source));

--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -22,7 +22,7 @@ using T = System.Threading.Tasks;
 namespace Hl7.Fhir.Specification.Tests
 {
     [Trait("Category", "Validation")]
-    public class BasicValidationTests : IClassFixture<ValidationFixture>
+    public partial class BasicValidationTests : IClassFixture<ValidationFixture>
     {
         private readonly IResourceResolver _source;
         private readonly IAsyncResourceResolver _asyncSource;
@@ -1268,25 +1268,6 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.True(visitResolver.Visited(patientReference), "no attempt was made to resolve the example patient");
             Assert.True(0 == outcome.Warnings, $"Found {outcome.Warnings} warnings");
 
-        }
-
-        class VisitResolver : IResourceResolver
-        {
-            private List<string> _visits = new List<string>();
-
-            public Resource ResolveByCanonicalUri(string uri)
-            {
-                _visits.Add(uri);
-                return null;
-            }
-
-            public Resource ResolveByUri(string uri)
-            {
-                _visits.Add(uri);
-                return null;
-            }
-
-            internal bool Visited(string uri) => _visits.Contains(uri);
         }
 
         private class ClearSnapshotResolver : IResourceResolver

--- a/src/Hl7.Fhir.Specification.Tests/Validation/SliceValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/SliceValidationTests.cs
@@ -39,7 +39,7 @@ namespace Hl7.Fhir.Specification.Tests
             //var xml = FhirSerializer.SerializeResourceToXml(sd);
             //File.WriteAllText(@"c:\temp\sdout.xml", xml);
 
-            return BucketFactory.CreateRoot(nav, _resolver, _validator);
+            return BucketFactory.CreateRoot(nav, _resolver, _validator, new ValidationState());
         }
 
         /*

--- a/src/Hl7.Fhir.Specification.Tests/Validation/TargetProfileValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/TargetProfileValidationTests.cs
@@ -1,0 +1,98 @@
+﻿using FluentAssertions;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Source;
+using Hl7.Fhir.Utility;
+using Hl7.Fhir.Validation;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Hl7.Fhir.Specification.Tests
+{
+    [Trait("Category", "Validation")]
+    public class TargetProfileValidationTests
+    {
+        private class TestResolver : IResourceResolver
+        {
+            public static string Url = "http://test.org/fhir/Organization/3141";
+
+            private static Organization dummy = new() { Id = "3141", Name = "Dummy" };
+
+            public Resource ResolveByCanonicalUri(string uri) => ResolveByUri(uri);
+            public Resource ResolveByUri(string uri) =>
+                uri == Url ? dummy : null;
+        }
+
+
+        [Fact]
+        public void AvoidsRedoingProfileValidation()
+        {
+            var all = new Bundle() { Type = Bundle.BundleType.Batch };
+            var org1 = new Organization() { Id = "org1", Name = "Organization 1" };
+            var org2 = new Organization() { Id = "org2", Name = "Organization 2", Meta = new() { Profile = new[] { TestProfileArtifactSource.PROFILED_ORG_URL } } };
+
+            all.Entry.Add(new() { FullUrl = refr("org1"), Resource = org1 });
+            all.Entry.Add(new() { FullUrl = refr("org2"), Resource = org2 });
+
+            var bothRef = new List<ResourceReference>()
+            {
+                new ResourceReference("#refme"),
+                new ResourceReference(refr("org1")),
+                new ResourceReference(refr("org2")),
+                new ResourceReference("http://test.org/fhir/Organization/3141")
+            };
+
+            var pat1 = new Patient()
+            {
+                Meta = new() { Profile = new[] { "http://validationtest.org/fhir/StructureDefinition/PatientWithReferences" } },
+                Id = "pat1",
+                GeneralPractitioner = bothRef,
+                ManagingOrganization = new(refr("org1")),
+                BirthDate = new("2011crap")
+            };
+
+            pat1.Contained.Add(new Organization { Id = "refme", Name = "referred" });
+
+            var pat2 = new Patient()
+            {
+                Meta = new() { Profile = new[] { "http://validationtest.org/fhir/StructureDefinition/PatientWithReferences" } },
+                Id = "pat2",
+                GeneralPractitioner = bothRef,
+                ManagingOrganization = new(refr("org2"))
+            };
+
+            pat2.Contained.Add(new Organization { Id = "refme", Name = "referred" });
+
+            all.Entry.Add(new() { FullUrl = refr("pat1"), Resource = pat1 });
+            all.Entry.Add(new() { FullUrl = refr("pat2"), Resource = pat2 });
+
+            var visitResolver = new TestResolver();
+
+            var cr = new SnapshotSource(
+                      new CachedResolver(
+                        new MultiResolver(
+                          new TestProfileArtifactSource(),
+                          new ZipSource("specification.zip"),
+                          visitResolver)));
+
+            var validatorSettings = new ValidationSettings
+            {
+                GenerateSnapshot = true,
+                ResourceResolver = cr,
+                ResolveExternalReferences = true
+            };
+            var validator = new Validator(validatorSettings);
+
+            var result = validator.Validate(all);
+            result.Success.Should().Be(false);
+            result.Errors.Should().Be(1);
+            result.ToString().Should().Contain("does not match regex");
+
+            var validationState = result.Annotation<ValidationState>();
+
+            validationState.Global.ResourcesValidated.Value.Should().Be(16);
+            validationState.Instance.InternalValidations.Count.Should().Be(8);
+
+            static string refr(string x) => "http://test.org/fhir/" + x;
+        }
+    }
+}

--- a/src/Hl7.Fhir.Specification.Tests/Validation/VisitResolver.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/VisitResolver.cs
@@ -1,0 +1,32 @@
+﻿using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Source;
+using System.Collections.Generic;
+
+namespace Hl7.Fhir.Specification.Tests
+{
+    public class VisitResolver : IResourceResolver
+    {
+        private readonly Resource _example;
+        public List<string> Visits = new();
+
+        public VisitResolver(Resource example = null)
+        {
+            _example = example;
+        }
+
+        public Resource ResolveByCanonicalUri(string uri)
+        {
+            Visits.Add(uri);
+            return _example;
+        }
+
+        public Resource ResolveByUri(string uri)
+        {
+            Visits.Add(uri);
+            return _example;
+        }
+
+        internal bool Visited(string uri) => Visits.Contains(uri);
+    }
+}
+

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/BaseBucket.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/BaseBucket.cs
@@ -7,18 +7,20 @@ namespace Hl7.Fhir.Validation
 {
     internal abstract class BaseBucket : IBucket
     {
-        internal protected BaseBucket(ElementDefinition definition)
+        protected internal BaseBucket(ElementDefinition definition, ValidationState state)
         {
             Name = definition.Path + (definition.SliceName != null ? $":{definition.SliceName}" : null);
             Cardinality = Cardinality.FromElementDefinition(definition);
+            State = state;
         }
 
         public string Name { get; private set; }
         public Cardinality Cardinality { get; private set; }
         public IList<ITypedElement> Members { get; private set; } = new List<ITypedElement>();
+        protected ValidationState State { get; }
 
         public abstract bool Add(ITypedElement instance);
-  
+
         public virtual OperationOutcome Validate(Validator validator, ITypedElement errorLocation)
         {
             var outcome = new OperationOutcome();

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/BindingDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/BindingDiscriminator.cs
@@ -8,9 +8,6 @@
 
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
-using Hl7.Fhir.Utility;
-using Hl7.FhirPath;
-using System.Linq;
 
 namespace Hl7.Fhir.Validation
 {
@@ -29,7 +26,7 @@ namespace Hl7.Fhir.Validation
         public readonly ElementDefinition.ElementDefinitionBindingComponent Binding;
         public readonly string Context;
 
-        protected override bool MatchInternal(ITypedElement instance)
+        protected override bool MatchInternal(ITypedElement instance, ValidationState _)
         {
             var result = Validator.ValidateBinding(Binding, instance, ErrorLocation, Context);
             return result.Success;

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/BucketFactory.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/BucketFactory.cs
@@ -15,18 +15,18 @@ namespace Hl7.Fhir.Validation
 {
     internal static class BucketFactory
     {
-        public static IBucket CreateRoot(ElementDefinitionNavigator root, IResourceResolver resolver, Validator validator)
+        public static IBucket CreateRoot(ElementDefinitionNavigator root, IResourceResolver resolver, Validator validator, ValidationState state)
         {
             // Create a single bucket
-            var entryBucket = new ElementBucket(root, validator);
+            var entryBucket = new ElementBucket(root, validator, state);
 
             if (root.Current.Slicing == null)
                 return entryBucket;
             else
-                return CreateGroup(root, resolver, validator, entryBucket);
+                return CreateGroup(root, resolver, validator, entryBucket, state);
         }
 
-        public static IBucket CreateGroup(ElementDefinitionNavigator root, IResourceResolver resolver, Validator validator, IBucket entryBucket)
+        public static IBucket CreateGroup(ElementDefinitionNavigator root, IResourceResolver resolver, Validator validator, IBucket entryBucket, ValidationState state)
         {
             var discriminatorSpecs = root.Current.Slicing.Discriminator.ToArray();  // copy, since root will move after this
             var location = root.Current.Path;
@@ -48,16 +48,16 @@ namespace Hl7.Fhir.Validation
                     {
                         throw new IncorrectElementDefinitionException($"There is nothing to discriminate on at {location}.");
                     }
-                    subBucket = new DiscriminatorBucket(root, validator, discriminators.ToArray());
+                    subBucket = new DiscriminatorBucket(root, validator, discriminators.ToArray(), state);
                 }
                 else
                     // Discriminator-less matching
-                    subBucket = new ConstraintsBucket(root, validator);
+                    subBucket = new ConstraintsBucket(root, validator, state);
 
                 if (root.Current.Slicing == null)
                     subs.Add(subBucket);
                 else
-                    subs.Add(CreateGroup(root, resolver, validator, subBucket));
+                    subs.Add(CreateGroup(root, resolver, validator, subBucket, state));
             }
 
             root.ReturnToBookmark(bm);

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/CombinedDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/CombinedDiscriminator.cs
@@ -22,6 +22,6 @@ namespace Hl7.Fhir.Validation
         public CombinedDiscriminator(IEnumerable<IDiscriminator> components) =>
                 Components = components.ToArray();
 
-        public bool Matches(ITypedElement candidate) => Components.All(c => c.Matches(candidate));
+        public bool Matches(ITypedElement candidate, ValidationState state) => Components.All(c => c.Matches(candidate, state));
     }
 }

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/ComprehensiveDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/ComprehensiveDiscriminator.cs
@@ -18,7 +18,7 @@ namespace Hl7.Fhir.Validation
     /// </summary>
     internal class ComprehensiveDiscriminator : IDiscriminator
     {
-        public bool Matches(ITypedElement candidate) => true;
+        public bool Matches(ITypedElement candidate, ValidationState _) => true;
     }
 }
 

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/ConstraintsBucket.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/ConstraintsBucket.cs
@@ -6,10 +6,9 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Navigation;
-using Hl7.Fhir.Support;
-using Hl7.Fhir.ElementModel;
 
 namespace Hl7.Fhir.Validation
 {
@@ -21,21 +20,25 @@ namespace Hl7.Fhir.Validation
         /// </summary>
         /// <param name="sliceConstraints">The set of constraints that are the criterium for membership of the slice.</param>
         /// <param name="validator">A validator instance that will be invoked to validate the child constraints.</param>
-        public ConstraintsBucket(ElementDefinitionNavigator sliceConstraints, Validator validator) : base(sliceConstraints.Current)
+        /// <param name="state">The validation state to forward to all nested validations in this bucket.</param>
+        public ConstraintsBucket(
+            ElementDefinitionNavigator sliceConstraints,
+            Validator validator,
+            ValidationState state) : base(sliceConstraints.Current, state)
         {
             // Keep a copy of the constraints for this slice, so we can use them to validate the instances against later.
             SliceConstraints = sliceConstraints.ShallowCopy();
 
             Validator = validator;
         }
-    
+
         public ElementDefinitionNavigator SliceConstraints { get; private set; }
 
         public Validator Validator { get; private set; }
 
         public override bool Add(ITypedElement candidate)
         {
-            OperationOutcome outcome = Validator.Validate(candidate, SliceConstraints);
+            OperationOutcome outcome = Validator.ValidateInternal(candidate, SliceConstraints, State);
 
             if (outcome.Success)
             {

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/ElementBucket.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/ElementBucket.cs
@@ -6,16 +6,16 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Support;
-using Hl7.Fhir.ElementModel;
 
 namespace Hl7.Fhir.Validation
 {
     internal class ElementBucket : BaseBucket
     {
-        public ElementBucket(ElementDefinitionNavigator root, Validator validator) : base(root.Current)
+        public ElementBucket(ElementDefinitionNavigator root, Validator validator, ValidationState state) : base(root.Current, state)
         {
             Root = root.ShallowCopy();
             Validator = validator;
@@ -36,9 +36,9 @@ namespace Hl7.Fhir.Validation
         {
             var outcome = base.Validate(validator, errorLocation);
 
-            foreach(var member in Members)
+            foreach (var member in Members)
             {
-                outcome.Include(Validator.Validate(member, Root));
+                outcome.Include(Validator.ValidateInternal(member, Root, State));
             }
 
             return outcome;

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/ExistsDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/ExistsDiscriminator.cs
@@ -24,7 +24,7 @@ namespace Hl7.Fhir.Validation
 
         public string Path { get; }
 
-        public bool Matches(ITypedElement candidate)
+        public bool Matches(ITypedElement candidate, ValidationState _)
         {
             ITypedElement[] values = candidate.Select(Path).ToArray();
 

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/IDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/IDiscriminator.cs
@@ -12,6 +12,6 @@ namespace Hl7.Fhir.Validation
 {
     internal interface IDiscriminator
     {
-        bool Matches(ITypedElement candidate);
+        bool Matches(ITypedElement candidate, ValidationState state);
     }
 }

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/PathBasedDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/PathBasedDiscriminator.cs
@@ -9,7 +9,6 @@
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Utility;
 using Hl7.FhirPath;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace Hl7.Fhir.Validation
@@ -23,7 +22,7 @@ namespace Hl7.Fhir.Validation
 
         public readonly string Path;
 
-        public bool Matches(ITypedElement candidate)
+        public bool Matches(ITypedElement candidate, ValidationState state)
         {
             ITypedElement[] values = candidate.Select(Path).ToArray();
 
@@ -34,9 +33,9 @@ namespace Hl7.Fhir.Validation
             else if (values.Length == 0)
                 return false;
             else
-                return MatchInternal(values.Single());
+                return MatchInternal(values.Single(), state);
         }
 
-        abstract protected bool MatchInternal(ITypedElement candidate);
+        protected abstract bool MatchInternal(ITypedElement candidate, ValidationState state);
     }
 }

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/PatternDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/PatternDiscriminator.cs
@@ -22,7 +22,7 @@ namespace Hl7.Fhir.Validation
         public readonly Validator Validator;
         public readonly Element Pattern;
 
-        protected override bool MatchInternal(ITypedElement instance)
+        protected override bool MatchInternal(ITypedElement instance, ValidationState _)
         {
             var result = Validator.ValidatePattern(Pattern, instance);
             return result.Success;

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/ProfileDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/ProfileDiscriminator.cs
@@ -23,13 +23,17 @@ namespace Hl7.Fhir.Validation
         public readonly Validator Validator;
         public readonly string[] Profiles;
 
-        protected override bool MatchInternal(ITypedElement instance) =>
-            Profiles.Any(profile => validates(instance, profile));
+        protected override bool MatchInternal(ITypedElement instance, ValidationState state) =>
+            Profiles.Any(profile => validates(instance, profile, state));
 
-        private bool validates(ITypedElement instance, string profile)
+        private bool validates(ITypedElement instance, string profile, ValidationState state)
         {
             var validator = Validator.NewInstance();
-            var result = validator.Validate(instance, profile);
+            var result = validator.ValidateInternal(instance,
+                                            declaredTypeProfile: null,
+                                            statedCanonicals: new[] { profile },
+                                            statedProfiles: null,
+                                            state: state);
             return result.Success;
         }
     }

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/TypeDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/TypeDiscriminator.cs
@@ -25,7 +25,7 @@ namespace Hl7.Fhir.Validation
 
         // This discriminator matches if the type in the instance is *compatible* with ANY of the 
         // possible multiple types in the ElementDefinition.Type.Code (since Type repeats).
-        protected override bool MatchInternal(ITypedElement instance) =>
+        protected override bool MatchInternal(ITypedElement instance, ValidationState _) =>
             Types.Any(type => ModelInfo.IsInstanceTypeFor(type, instance.InstanceType));
     }
 }

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/ValueDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/ValueDiscriminator.cs
@@ -22,7 +22,7 @@ namespace Hl7.Fhir.Validation
         public readonly Validator Validator;
         public readonly Element FixedValue;
 
-        protected override bool MatchInternal(ITypedElement instance)
+        protected override bool MatchInternal(ITypedElement instance, ValidationState _)
         {
             var result = Validator.ValidateFixed(FixedValue, instance);
             return result.Success;

--- a/src/Hl7.Fhir.Specification/Validation/TypeRefValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/TypeRefValidationExtensions.cs
@@ -19,7 +19,7 @@ namespace Hl7.Fhir.Validation
 {
     internal static class TypeRefValidationExtensions
     {
-        internal static OperationOutcome ValidateType(this Validator validator, ElementDefinition definition, ScopedNode instance)
+        internal static OperationOutcome ValidateType(this Validator validator, ElementDefinition definition, ScopedNode instance, ValidationState state)
         {
             var outcome = new OperationOutcome();
 
@@ -51,7 +51,7 @@ namespace Hl7.Fhir.Validation
                         // Instance typename must be one of the applicable types in the choice
                         if (applicableChoices.Any())
                         {
-                            outcome.Include(validator.ValidateTypeReferences(applicableChoices, instance));
+                            outcome.Include(validator.ValidateTypeReferences(applicableChoices, instance, state));
                         }
                         else
                         {
@@ -71,7 +71,7 @@ namespace Hl7.Fhir.Validation
             else if (choices.Count() == 1)
             {
                 // Only one type present in list of typerefs, all of the typerefs are candidates
-                outcome.Include(validator.ValidateTypeReferences(typeRefs, instance));
+                outcome.Include(validator.ValidateTypeReferences(typeRefs, instance, state));
             }
 
             return outcome;
@@ -79,7 +79,7 @@ namespace Hl7.Fhir.Validation
 
 
         internal static OperationOutcome ValidateTypeReferences(this Validator validator,
-            IEnumerable<ElementDefinition.TypeRefComponent> typeRefs, ScopedNode instance, bool validateProfiles = true)
+            IEnumerable<ElementDefinition.TypeRefComponent> typeRefs, ScopedNode instance, ValidationState state, bool validateProfiles = true)
         {
             //TODO: It's more efficient to do the non-reference types FIRST, since ANY match would be ok,
             //and validating non-references is cheaper
@@ -87,12 +87,16 @@ namespace Hl7.Fhir.Validation
             //better separate the fetching of the instance from the validation, so we do not run the rest of the validation (multiple times!)
             //when a reference cannot be resolved.  (this happens in a choice type where there are multiple references with multiple profiles)
 
-            IEnumerable<Func<OperationOutcome>> validations = typeRefs.Select(tr => createValidatorForTypeRef(validator, instance, tr, validateProfiles));
+            IEnumerable<Func<OperationOutcome>> validations = typeRefs.Select(tr => createValidatorForTypeRef(validator, instance, tr, validateProfiles, state));
             return validator.Combine(BatchValidationMode.Any, instance, validations);
         }
 
-        private static Func<OperationOutcome> createValidatorForTypeRef(Validator validator, ScopedNode instance, ElementDefinition.TypeRefComponent tr,
-            bool validateProfiles)
+        private static Func<OperationOutcome> createValidatorForTypeRef(
+            Validator validator,
+            ScopedNode instance,
+            ElementDefinition.TypeRefComponent tr,
+            bool validateProfiles,
+            ValidationState state)
         {
             return validate;
 
@@ -103,18 +107,22 @@ namespace Hl7.Fhir.Validation
                 if (validateProfiles)
                 {
                     // First, call Validate() for the current element (the reference itself) against the profile
-                    result.Add(validator.Validate(instance, tr.GetDeclaredProfiles(), statedCanonicals: null, statedProfiles: null));
+                    result.Add(validator.ValidateInternal(instance, tr.GetDeclaredProfiles(), statedCanonicals: null, statedProfiles: null, state: state));
                 }
 
                 // If this is a reference, also validate the reference against the targetProfile
                 if (ModelInfo.FhirTypeNameToFhirType(tr.Code) == FHIRAllTypes.Reference)
-                    result.Add(validator.ValidateResourceReference(instance, tr));
+                    result.Add(validator.ValidateResourceReference(instance, tr, state));
 
                 return result;
             }
         }
 
-        internal static OperationOutcome ValidateResourceReference(this Validator validator, ScopedNode instance, ElementDefinition.TypeRefComponent typeRef)
+        internal static OperationOutcome ValidateResourceReference(
+            this Validator validator,
+            ScopedNode instance,
+            ElementDefinition.TypeRefComponent typeRef,
+            ValidationState state)
         {
             var outcome = new OperationOutcome();
 
@@ -122,7 +130,6 @@ namespace Hl7.Fhir.Validation
 
             if (reference == null)       // No reference found -> this is always valid
                 return outcome;
-
 
             // Try to resolve the reference *within* the current instance (Bundle, resource with contained resources) first
             var referencedResource = validator.resolveReference(instance, reference,
@@ -165,12 +172,24 @@ namespace Hl7.Fhir.Validation
 
                 if (encounteredKind != ElementDefinition.AggregationMode.Referenced)
                 {
-                    childResult = validator.Validate(referencedResource, typeRef.TargetProfile, statedProfiles: null, statedCanonicals: null);
+                    childResult = validator.ValidateInternal(referencedResource,
+                                                             typeRef.TargetProfile,
+                                                             statedProfiles: null,
+                                                             statedCanonicals: null,
+                                                             state: state);
                 }
                 else
                 {
                     var newValidator = validator.NewInstance();
-                    childResult = newValidator.Validate(referencedResource, typeRef.TargetProfile, statedProfiles: null, statedCanonicals: null);
+                    var newState = state.NewInstanceScope();
+
+                    newState.Instance.ExternalUrl = reference;
+                    childResult = newState.Global.ExternalValidations.Start(reference, typeRef.TargetProfile,
+                        () => newValidator.ValidateInternal(referencedResource,
+                                                        typeRef.TargetProfile,
+                                                        statedProfiles: null,
+                                                        statedCanonicals: null,
+                                                        state: newState));
                 }
 
                 // Prefix each path with the referring resource's path to keep the locations

--- a/src/Hl7.Fhir.Specification/Validation/ValidationLogger.cs
+++ b/src/Hl7.Fhir.Specification/Validation/ValidationLogger.cs
@@ -1,0 +1,81 @@
+﻿/* 
+ * Copyright (c) 2016, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Support;
+using System;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Hl7.Fhir.Validation
+{
+    /// <summary>
+    /// This class is used to track which resources/contained resources/bundled resources are already
+    /// validated, and what the previous result was. Since it keeps track of running validations, it
+    /// can also be used to detect loops.
+    /// </summary>
+    internal class ValidationLogger
+    {
+        private enum ValidationStatus
+        {
+            Started,
+            Success,
+            Failure
+        }
+
+        private class Entry
+        {
+            public Entry(string location, string profileUrl, ValidationStatus status)
+            {
+                Location = location;
+                ProfileUrl = profileUrl;
+                Status = status;
+            }
+
+            public string Location;
+            public string ProfileUrl;
+            public ValidationStatus Status;
+        }
+
+        private readonly Dictionary<string, Entry> _data = new();
+
+        public OperationOutcome Start(string location, string profileUrl, Func<OperationOutcome> validator)
+        {
+            var key = $"{location}:{profileUrl}";
+
+            if (_data.TryGetValue(key, out var existing))
+            {
+                if (existing.Status == ValidationStatus.Started)
+                    throw new InvalidOperationException($"Detected a loop: instance data inside '{location}' refers back to itself.");
+
+                // If the validation has been run before, return an outcome with the same result.
+                // Note: we don't keep a copy of the original outcome since it has been included in the
+                // total result (at the first run) and keeping them around costs a lot of memory.
+                var repeatedOutcome = new OperationOutcome();
+                if (existing.Status == ValidationStatus.Failure)
+                    repeatedOutcome.AddIssue("Validation of this resource has been performed before with a failure result.",
+                        Issue.PROCESSING_REPEATED_ERROR);
+
+                return repeatedOutcome;
+            }
+            else
+            {
+                // This validation is run for the first time
+                var newEntry = new Entry(location, profileUrl, ValidationStatus.Started);
+                _data.Add(key, newEntry);
+
+                var result = validator();
+                newEntry.Status = result.Success ? ValidationStatus.Success : ValidationStatus.Failure;
+                return result;
+            }
+        }
+
+        public int Count => _data.Values.Count;
+    }
+}

--- a/src/Hl7.Fhir.Specification/Validation/ValidationState.cs
+++ b/src/Hl7.Fhir.Specification/Validation/ValidationState.cs
@@ -1,0 +1,66 @@
+﻿/* 
+ * Copyright (c) 2016, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+
+#nullable enable
+
+namespace Hl7.Fhir.Validation
+{
+    internal class Counter
+    {
+        public int Increase() => Value += 1;
+
+        public int Value { get; private set; }
+    }
+
+
+    /// <summary>
+    /// Hold the state relevant to a single run of the validator.
+    /// </summary>
+    internal class ValidationState
+    {
+        /// <summary>
+        /// State to be kept for one full run of the validator.
+        /// </summary>
+        public class GlobalState
+        {
+            /// <summary>
+            /// This keeps track of all validations done on external resources
+            /// referenced from the original root resource passed to the Validate() call.
+            /// </summary>
+            public ValidationLogger ExternalValidations { get; set; } = new();
+
+            public Counter ResourcesValidated { get; set; } = new();
+        }
+
+        public GlobalState Global { get; private set; } = new();
+
+        /// <summary>
+        /// State to be kept for an instance encountered during validation
+        /// (e.g. if the resource under validation references an external resource,
+        /// the validation of that resource will have its own <see cref="InstanceState"/>.
+        /// </summary>
+        public class InstanceState
+        {
+            /// <summary>
+            /// The URL where the current instance was retrieved (if known).
+            /// </summary>
+            public string? ExternalUrl { get; set; }
+
+            public ValidationLogger InternalValidations { get; set; } = new();
+        }
+
+        public InstanceState Instance { get; private set; } = new();
+
+        public ValidationState NewInstanceScope() =>
+            new()
+            {
+                Global = Global
+            };
+    }
+}


### PR DESCRIPTION
Added state to keep track of which (nested/contained)resources have already been validated.

Avoiding duplicate validation will keep bundle validation perf reasonable (we hope).