### PR TITLE
Changes to improve performance of Bundle validation (R4) 

### DIFF
--- a/src/Hl7.Fhir.ElementModel.Tests/ElementNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Tests/ElementNodeTests.cs
@@ -9,19 +9,19 @@
 // To introduce the DSTU2 FHIR specification
 //extern alias dstu2;
 
-using System;
 using Hl7.Fhir.ElementModel;
-using Hl7.Fhir.Utility;
-using System.Linq;
-using Hl7.Fhir.Serialization;
-using System.IO;
-using Hl7.Fhir.Specification;
 using Hl7.Fhir.Model;
-using Hl7.Fhir.Tests;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Hl7.Fhir.Specification.Source;
-using System.Threading.Tasks;
+using Hl7.Fhir.Serialization;
+using Hl7.Fhir.Specification;
 using Hl7.Fhir.Specification.Snapshot;
+using Hl7.Fhir.Specification.Source;
+using Hl7.Fhir.Tests;
+using Hl7.Fhir.Utility;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Tasks = System.Threading.Tasks;
 
 namespace Hl7.FhirPath.Tests
@@ -41,7 +41,7 @@ namespace Hl7.FhirPath.Tests
 
             var activeNode = patientRoot.Add(_provider, "active", true);
             activeNode.Add(_provider, "id", "myId1");
-               
+
             activeNode.AddAnnotation("a string annotation");
             var ext1 = activeNode.Add(_provider, "extension");
             ext1.Add(_provider, "value", 4, "integer");
@@ -320,10 +320,10 @@ namespace Hl7.FhirPath.Tests
             Assert.IsTrue(activeChild.Annotations<string>().Single() == "a string annotation");
 
             var identifierSystemChild = newElement["identifier"][0]["system"].Single();
-            
+
             // check whether we really have a clone by changing the copy
             identifierSystemChild.Value = "http://dan.nl";
-            Assert.AreEqual("http://nu.nl",patient["identifier"][0]["system"].Single().Value);
+            Assert.AreEqual("http://nu.nl", patient["identifier"][0]["system"].Single().Value);
         }
 
         [TestMethod]
@@ -386,7 +386,7 @@ namespace Hl7.FhirPath.Tests
 
             public CustomResourceResolver()
             {
-                _zipSource = new ZipSource("specification.zip");
+                _zipSource = ZipSource.CreateValidationSource();
                 _resolver = new CachedResolver(new MultiResolver(_zipSource, new DirectorySource("TestData/TestSd")));
             }
 

--- a/src/Hl7.Fhir.ElementModel.Tests/ScopedNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Tests/ScopedNodeTests.cs
@@ -17,7 +17,7 @@ namespace Hl7.Fhir.ElementModel.Tests
     [TestClass]
     public class ScopedNodeTests
     {
-        ScopedNode? _bundleNode;
+        private ScopedNode? _bundleNode;
 
         [TestInitialize]
         public void SetupSource()
@@ -249,7 +249,7 @@ namespace Hl7.Fhir.ElementModel.Tests
             public CCDAResourceResolver()
             {
                 _cache = new Dictionary<string, StructureDefinition>();
-                _zipSource = new ZipSource("specification.zip");
+                _zipSource = ZipSource.CreateValidationSource();
                 _coreResolver = new CachedResolver(new MultiResolver(_zipSource, new DirectorySource("TestData/TestSd")));
             }
 

--- a/src/Hl7.Fhir.Specification.Tests/DiscriminatorInterpreterTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/DiscriminatorInterpreterTests.cs
@@ -17,7 +17,7 @@ namespace Hl7.Fhir.Specification.Tests
                 new SnapshotSource(
                 new MultiResolver(
                     new DirectorySource(@"TestData\validation"),
-                    new ZipSource("specification.zip"))));
+                    ZipSource.CreateValidationSource())));
         }
 
         [ClassInitialize]

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -76,7 +76,7 @@ namespace Hl7.Fhir.Specification.Tests
             // [WMR 20170810] Order is important!
             // Specify source first to override core defs from
             // TestData\snapshot-test\profiles-resources.xml and profiles-types.xml
-            _zipSource = new ZipSource("specification.zip");
+            _zipSource = ZipSource.CreateValidationSource();
             _testResolver = new CachedResolver(new MultiResolver(_zipSource, _source));
         }
 

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -32,7 +32,6 @@ using Hl7.Fhir.Specification.Snapshot;
 using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Support;
 using Hl7.Fhir.Utility;
-using Hl7.Fhir.Validation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
@@ -53,12 +52,11 @@ namespace Hl7.Fhir.Specification.Tests
     public class SnapshotGeneratorTest2
 #endif
     {
-        SnapshotGenerator _generator;
-        ZipSource _zipSource;
-        CachedResolver _testResolver;
-        TimingSource _source;
-
-        readonly SnapshotGeneratorSettings _settings = new SnapshotGeneratorSettings()
+        private SnapshotGenerator _generator;
+        private ZipSource _zipSource;
+        private CachedResolver _testResolver;
+        private TimingSource _source;
+        private readonly SnapshotGeneratorSettings _settings = new SnapshotGeneratorSettings()
         {
             // Throw on unresolved profile references; must include in TestData folder
             GenerateSnapshotForExternalProfiles = true,
@@ -491,7 +489,7 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
-        static bool isExpandableElement(ElementDefinition element)
+        private static bool isExpandableElement(ElementDefinition element)
         {
 #if HACK_STU3_RECURSION
             // [WMR 20170328] DEBUG HACK
@@ -529,9 +527,9 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         // [WMR 20180116] Returns true for complex datatypes and resources, or false otherwise
-        static bool isComplexDataTypeOrResource(string typeName) => !ModelInfo.IsPrimitive(typeName);
+        private static bool isComplexDataTypeOrResource(string typeName) => !ModelInfo.IsPrimitive(typeName);
 
-        static bool isComplexDataTypeOrResource(FHIRAllTypes type) => !ModelInfo.IsPrimitive(type);
+        private static bool isComplexDataTypeOrResource(FHIRAllTypes type) => !ModelInfo.IsPrimitive(type);
 
 
         // [WMR 20180115] NEW - Use alternative (iterative) approach for full expansion
@@ -668,7 +666,7 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
-        static void beforeExpandElementHandler_DEBUG(object sender, SnapshotExpandElementEventArgs e)
+        private static void beforeExpandElementHandler_DEBUG(object sender, SnapshotExpandElementEventArgs e)
         {
             Debug.Print($"[beforeExpandElementHandler_DEBUG] #{e.Element.GetHashCode()} '{e.Element.Path}' - HasChildren = {e.HasChildren} - MustExpand = {e.MustExpand}");
         }
@@ -724,7 +722,7 @@ namespace Hl7.Fhir.Specification.Tests
             dumpBasePaths(expanded);
         }
 
-        void assertContainsElement(StructureDefinition sd, string path, string name = null, string elementId = null)
+        private void assertContainsElement(StructureDefinition sd, string path, string name = null, string elementId = null)
         {
             Assert.IsNotNull(sd);
 
@@ -737,7 +735,7 @@ namespace Hl7.Fhir.Specification.Tests
             assertContainsElement(sd.Snapshot, path, name, elementId);
         }
 
-        void assertContainsElement(IElementList elements, string path, string name = null, string elementId = null)
+        private void assertContainsElement(IElementList elements, string path, string name = null, string elementId = null)
         {
             var label = elements is StructureDefinition.DifferentialComponent ? "differential" : "snapshot";
             Assert.IsNotNull(elements);
@@ -763,10 +761,10 @@ namespace Hl7.Fhir.Specification.Tests
             return expanded;
         }
 
-        static void insertElementsBefore(StructureDefinition structure, ElementDefinition insertBefore, params ElementDefinition[] inserts)
+        private static void insertElementsBefore(StructureDefinition structure, ElementDefinition insertBefore, params ElementDefinition[] inserts)
             => insertElementsBefore(structure.Differential.Element, insertBefore, inserts);
 
-        static void insertElementsBefore(List<ElementDefinition> elements, ElementDefinition insertBefore, params ElementDefinition[] inserts)
+        private static void insertElementsBefore(List<ElementDefinition> elements, ElementDefinition insertBefore, params ElementDefinition[] inserts)
         {
             var idx = elements.FindIndex(e => e.Path == insertBefore.Path && e.SliceName == insertBefore.SliceName);
             Assert.AreNotEqual(-1, idx, $"Warning! insertBefore element is missing. Path = '{insertBefore.Path}', Name = '{insertBefore.SliceName}'.");
@@ -778,10 +776,10 @@ namespace Hl7.Fhir.Specification.Tests
             elements.InsertRange(idx, inserts);
         }
 
-        static void insertElementsBefore(StructureDefinition structure, string insertBeforePath, int elemIndex, params ElementDefinition[] inserts)
+        private static void insertElementsBefore(StructureDefinition structure, string insertBeforePath, int elemIndex, params ElementDefinition[] inserts)
             => insertElementsBefore(structure.Differential.Element, insertBeforePath, elemIndex, inserts);
 
-        static void insertElementsBefore(List<ElementDefinition> elements, string insertBeforePath, int elemIndex, params ElementDefinition[] inserts)
+        private static void insertElementsBefore(List<ElementDefinition> elements, string insertBeforePath, int elemIndex, params ElementDefinition[] inserts)
         {
             var idx = -1;
             do
@@ -1134,7 +1132,7 @@ namespace Hl7.Fhir.Specification.Tests
             assertIssue(outcome.Issue[2], Issue.UNAVAILABLE_REFERENCED_PROFILE, "http://example.org/fhir/StructureDefinition/MyCodeableConcept");
         }
 
-        static void assertIssue(OperationOutcome.IssueComponent issue, Issue expected, string diagnostics = null, params string[] location)
+        private static void assertIssue(OperationOutcome.IssueComponent issue, Issue expected, string diagnostics = null, params string[] location)
         {
             Assert.IsNotNull(issue);
             Assert.AreEqual(expected.Type, issue.Code);
@@ -1222,7 +1220,7 @@ namespace Hl7.Fhir.Specification.Tests
             return (areEqual, expanded);
         }
 
-        IEnumerable<StructureDefinition> findConstraintStrucDefs()
+        private IEnumerable<StructureDefinition> findConstraintStrucDefs()
         {
 #if true
             if (_source.Source is DirectorySource dirSource)
@@ -1617,7 +1615,7 @@ namespace Hl7.Fhir.Specification.Tests
 
         // [WMR 20160722] For debugging purposes
         [Conditional("DEBUG")]
-        void dumpReferences(StructureDefinition sd, bool differential = false)
+        private void dumpReferences(StructureDefinition sd, bool differential = false)
         {
             if (sd != null)
             {
@@ -1652,12 +1650,12 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
-        static IEnumerable<string> enumerateDistinctTypeProfiles(IList<ElementDefinition> elements)
+        private static IEnumerable<string> enumerateDistinctTypeProfiles(IList<ElementDefinition> elements)
         {
             return elements.SelectMany(e => e.Type).SelectMany(t => t.Profile).Distinct();
         }
 
-        static string formatElementPathName(ElementDefinition elem) =>
+        private static string formatElementPathName(ElementDefinition elem) =>
             elem == null
                 ? null
                 : !string.IsNullOrEmpty(elem.SliceName) ?
@@ -1665,7 +1663,7 @@ namespace Hl7.Fhir.Specification.Tests
                     : elem.Path;
 
         [Conditional("DEBUG")]
-        static void dumpBaseElems(IEnumerable<ElementDefinition> elements)
+        private static void dumpBaseElems(IEnumerable<ElementDefinition> elements)
         {
             Debug.Print(string.Join(Environment.NewLine,
                 elements.Select(e =>
@@ -1692,7 +1690,7 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [Conditional("DEBUG")]
-        void dumpBasePaths(StructureDefinition sd)
+        private void dumpBasePaths(StructureDefinition sd)
         {
             if (sd != null && sd.Snapshot != null)
             {
@@ -1710,10 +1708,10 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [Conditional("DEBUG")]
-        void dumpOutcome(OperationOutcome outcome) => dumpIssues(outcome?.Issue);
+        private void dumpOutcome(OperationOutcome outcome) => dumpIssues(outcome?.Issue);
 
         [Conditional("DEBUG")]
-        void dumpIssues(List<OperationOutcome.IssueComponent> issues)
+        private void dumpIssues(List<OperationOutcome.IssueComponent> issues)
         {
             if (issues != null && issues.Count > 0)
             {
@@ -1727,7 +1725,7 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [Conditional("DEBUG")]
-        void dumpIssue(OperationOutcome.IssueComponent issue, int index)
+        private void dumpIssue(OperationOutcome.IssueComponent issue, int index)
         {
             StringBuilder sb = new StringBuilder();
             sb.AppendFormat("* Issue #{0}: Severity = '{1}' Code = '{2}'", index, issue.Severity, issue.Code);
@@ -2258,7 +2256,7 @@ namespace Hl7.Fhir.Specification.Tests
         // [WMR 20170714] NEW
         // Annotated Base Element for backbone elements is not included in base structuredefinition ?
 
-        static StructureDefinition MyTestObservation => new StructureDefinition()
+        private static StructureDefinition MyTestObservation => new StructureDefinition()
         {
             Type = FHIRAllTypes.Observation.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Observation),
@@ -2327,7 +2325,7 @@ namespace Hl7.Fhir.Specification.Tests
 
 
         // [WMR 20160816] Test custom annotations containing associated base definitions
-        class BaseDefAnnotation
+        private class BaseDefAnnotation
         {
             public BaseDefAnnotation(ElementDefinition baseElemDef, StructureDefinition baseStructDef)
             {
@@ -2338,12 +2336,12 @@ namespace Hl7.Fhir.Specification.Tests
             public StructureDefinition BaseStructureDefinition { get; private set; }
         }
 
-        static ElementDefinition GetBaseElementAnnotation(ElementDefinition elemDef)
+        private static ElementDefinition GetBaseElementAnnotation(ElementDefinition elemDef)
         {
             return elemDef?.Annotation<BaseDefAnnotation>()?.BaseElementDefinition;
         }
 
-        void profileHandler(object sender, SnapshotBaseProfileEventArgs e)
+        private void profileHandler(object sender, SnapshotBaseProfileEventArgs e)
         {
             var profile = e.Profile;
             // Assert.IsTrue(sd.Url != profile.Url || sd.IsExactly(profile));
@@ -2356,7 +2354,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual(profile.BaseDefinition, baseProfile.Url);
         }
 
-        static void elementHandler(object sender, SnapshotElementEventArgs e)
+        private static void elementHandler(object sender, SnapshotElementEventArgs e)
         {
             var elem = e.Element;
             Assert.IsNotNull(elem);
@@ -2380,7 +2378,7 @@ namespace Hl7.Fhir.Specification.Tests
             Debug.WriteLine(ann?.BaseElementDefinition != null ? $" (old Base: #{ann.BaseElementDefinition.GetHashCode()} '{ann.BaseElementDefinition.Path}')" : "");
         }
 
-        void constraintHandler(object sender, SnapshotConstraintEventArgs e)
+        private void constraintHandler(object sender, SnapshotConstraintEventArgs e)
         {
             if (e.Element is ElementDefinition elem)
             {
@@ -2391,7 +2389,7 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
-        static void assertBaseDefs(StructureDefinition sd, SnapshotGeneratorSettings settings)
+        private static void assertBaseDefs(StructureDefinition sd, SnapshotGeneratorSettings settings)
         {
             Assert.IsNotNull(sd);
             Assert.IsNotNull(sd.Snapshot);
@@ -2399,7 +2397,7 @@ namespace Hl7.Fhir.Specification.Tests
             assertBaseDefs(sd.Snapshot.Element, settings);
         }
 
-        static void assertBaseDefs(List<ElementDefinition> elems, SnapshotGeneratorSettings settings)
+        private static void assertBaseDefs(List<ElementDefinition> elems, SnapshotGeneratorSettings settings)
         {
             Assert.IsNotNull(elems);
             Assert.IsTrue(elems.Count > 0);
@@ -2461,7 +2459,7 @@ namespace Hl7.Fhir.Specification.Tests
         // Utility function to compare element and base element
         // Path, Base and CHANGED_BY_DIFF_EXT extension are excluded from comparison
         // Returns true if the element has no other constraints on base
-        static bool isAlmostExactly(ElementDefinition elem, ElementDefinition baseElem, bool ignoreTypeProfile = false)
+        private static bool isAlmostExactly(ElementDefinition elem, ElementDefinition baseElem, bool ignoreTypeProfile = false)
         {
             var elemClone = (ElementDefinition)elem.DeepCopy();
             var baseClone = (ElementDefinition)baseElem.DeepCopy();
@@ -2492,7 +2490,7 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         // Returns true if the specified element or any of its' components contain the CHANGED_BY_DIFF_EXT extension
-        static bool hasChanges(ElementDefinition elem)
+        private static bool hasChanges(ElementDefinition elem)
         {
             return isChanged(elem)
                 || hasChanges(elem.AliasElement)
@@ -2530,7 +2528,7 @@ namespace Hl7.Fhir.Specification.Tests
                 || hasChanges(elem.Type);
         }
 
-        static string getChangeDescription(ElementDefinition element)
+        private static string getChangeDescription(ElementDefinition element)
         {
             if (isChanged(element.Slicing)) { return "Slicing"; }       // Moved to front
             if (hasChanges(element.Type)) { return "Type"; }            // Moved to front
@@ -2573,8 +2571,8 @@ namespace Hl7.Fhir.Specification.Tests
             return isChanged(element) ? "Element" : string.Empty;           // Moved to back
         }
 
-        static bool hasChanges<T>(IList<T> elements) where T : Element => elements != null ? elements.Any(e => isChanged(e)) : false;
-        static bool isChanged(Element elem) => elem != null && elem.IsConstrainedByDiff();
+        private static bool hasChanges<T>(IList<T> elements) where T : Element => elements != null ? elements.Any(e => isChanged(e)) : false;
+        private static bool isChanged(Element elem) => elem != null && elem.IsConstrainedByDiff();
 
         [TestMethod]
         public async T.Task TestExpandCoreElement()
@@ -2658,7 +2656,7 @@ namespace Hl7.Fhir.Specification.Tests
             await testExpandResources(coreResourceUrls.ToArray());
         }
 
-        async T.Task testExpandResources(string[] profileUris)
+        private async T.Task testExpandResources(string[] profileUris)
         {
             var sw = new Stopwatch();
             int count = profileUris.Length;
@@ -2674,7 +2672,7 @@ namespace Hl7.Fhir.Specification.Tests
             _source.ShowDuration(count, sw.Elapsed);
         }
 
-        async T.Task<bool> testExpandResource(string url)
+        private async T.Task<bool> testExpandResource(string url)
         {
             Debug.Print("[testExpandResource] url = '{0}'", url);
             var sd = await _testResolver.FindStructureDefinitionAsync(url);
@@ -2698,7 +2696,7 @@ namespace Hl7.Fhir.Specification.Tests
             return result;
         }
 
-        IEnumerable<T> enumerateBundleStream<T>(Stream stream) where T : Resource
+        private IEnumerable<T> enumerateBundleStream<T>(Stream stream) where T : Resource
         {
             using (var reader = XmlReader.Create(stream))
             {
@@ -2746,9 +2744,9 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsTrue(result);
         }
 
-        struct ProfileInfo { public string Url; public string BaseDefinition; }
+        private struct ProfileInfo { public string Url; public string BaseDefinition; }
 
-        async T.Task expandStructuresBasedOn(IAsyncResourceResolver resolver, ProfileInfo[] profileInfo, string baseUrl)
+        private async T.Task expandStructuresBasedOn(IAsyncResourceResolver resolver, ProfileInfo[] profileInfo, string baseUrl)
         {
             var derivedStructures = profileInfo.Where(pi => pi.BaseDefinition == baseUrl);
             if (derivedStructures.Any())
@@ -2764,7 +2762,7 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
-        async T.Task updateSnapshot(StructureDefinition sd)
+        private async T.Task updateSnapshot(StructureDefinition sd)
         {
             Assert.IsNotNull(sd);
             Debug.Print("Profile: '{0}' : '{1}'".FormatWith(sd.Url, sd.BaseDefinition));
@@ -2777,7 +2775,7 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         // Verify ElementDefinition.Base components
-        bool verifyElementBase(StructureDefinition original, StructureDefinition expanded)
+        private bool verifyElementBase(StructureDefinition original, StructureDefinition expanded)
         {
             var originalElems = original.HasSnapshot ? original.Snapshot.Element : new List<ElementDefinition>();
             var expandedElems = expanded.HasSnapshot ? expanded.Snapshot.Element : new List<ElementDefinition>();
@@ -2908,7 +2906,7 @@ namespace Hl7.Fhir.Specification.Tests
             return verified;
         }
 
-        static bool verifyBasePath(ElementDefinition elem, ElementDefinition orgElem, string path = "")
+        private static bool verifyBasePath(ElementDefinition elem, ElementDefinition orgElem, string path = "")
         {
             bool result = false;
 
@@ -2975,7 +2973,7 @@ namespace Hl7.Fhir.Specification.Tests
             assertPatientTelecomReslice(snapNav);
         }
 
-        void assertPatientTelecomReslice(ElementDefinitionNavigator nav)
+        private void assertPatientTelecomReslice(ElementDefinitionNavigator nav)
         {
             Assert.IsTrue(nav.MoveToFirstChild());  // Patient
 
@@ -3077,7 +3075,7 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         // Ewout: type slices cannot contain renamed elements!
-        static StructureDefinition ObservationTypeSliceProfile => new StructureDefinition()
+        private static StructureDefinition ObservationTypeSliceProfile => new StructureDefinition()
         {
             Type = FHIRAllTypes.Observation.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Observation),
@@ -3118,10 +3116,10 @@ namespace Hl7.Fhir.Specification.Tests
         };
 
         [Conditional("DEBUG")]
-        void dumpElements(IEnumerable<ElementDefinition> elements, string header = null) => dumpElements(elements.ToList(), header);
+        private void dumpElements(IEnumerable<ElementDefinition> elements, string header = null) => dumpElements(elements.ToList(), header);
 
         [Conditional("DEBUG")]
-        void dumpElements(List<ElementDefinition> elements, string header = null)
+        private void dumpElements(List<ElementDefinition> elements, string header = null)
         {
             Debug.WriteLineIf(!string.IsNullOrEmpty(header), header);
             for (int i = 0; i < elements.Count; i++)
@@ -3240,7 +3238,7 @@ namespace Hl7.Fhir.Specification.Tests
             assertIssue(outcome.Issue[0], Issue.UNAVAILABLE_REFERENCED_PROFILE, profile.BaseDefinition);
         }
 
-        static StructureDefinition ObservationTypeResliceProfile => new StructureDefinition()
+        private static StructureDefinition ObservationTypeResliceProfile => new StructureDefinition()
         {
             Type = FHIRAllTypes.Observation.GetLiteral(),
             BaseDefinition = ObservationTypeSliceProfile.Url,
@@ -3336,7 +3334,7 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         // Choice type constraint, with element renaming
-        static StructureDefinition ObservationTypeConstraintProfile => new StructureDefinition()
+        private static StructureDefinition ObservationTypeConstraintProfile => new StructureDefinition()
         {
             Type = FHIRAllTypes.Observation.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Observation),
@@ -3750,7 +3748,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsTrue(nav.Current.MinValue is Integer i && i.Value == 0);
         }
 
-        static StructureDefinition ClosedExtensionSliceObservationProfile => new StructureDefinition()
+        private static StructureDefinition ClosedExtensionSliceObservationProfile => new StructureDefinition()
         {
             Type = FHIRAllTypes.Observation.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Observation),
@@ -3825,7 +3823,7 @@ namespace Hl7.Fhir.Specification.Tests
         [TestMethod]
         public async T.Task TestObservationProfileWithExtensions_ExpandAll() => await testObservationProfileWithExtensions(true);
 
-        async T.Task testObservationProfileWithExtensions(bool expandAll)
+        private async T.Task testObservationProfileWithExtensions(bool expandAll)
         {
             // Same as TestObservationProfileWithExtensions, but with full expansion of all complex elements (inc. extensions!)
 
@@ -3934,7 +3932,7 @@ namespace Hl7.Fhir.Specification.Tests
             verifyProfileExtensionBaseElement(coreObsExtensionElem);
         }
 
-        void verifyProfileExtensionBaseElement(ElementDefinition extElem)
+        private void verifyProfileExtensionBaseElement(ElementDefinition extElem)
         {
             var baseElem = extElem.Annotation<BaseDefAnnotation>().BaseElementDefinition;
             Assert.IsNotNull(baseElem);
@@ -4177,7 +4175,7 @@ namespace Hl7.Fhir.Specification.Tests
         // - Patient.identifier:B/2               => Patient.identifier:B in MyPatient
         // - Patient.identifier:C                 => Patient.identifier in MyPatient
 
-        static StructureDefinition SlicedPatientProfile => new StructureDefinition()
+        private static StructureDefinition SlicedPatientProfile => new StructureDefinition()
         {
             Type = FHIRAllTypes.Patient.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient),
@@ -4295,7 +4293,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual("2", nav.Current.Max);
         }
 
-        static StructureDefinition NationalPatientProfile => new StructureDefinition()
+        private static StructureDefinition NationalPatientProfile => new StructureDefinition()
         {
             Type = FHIRAllTypes.Patient.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient),
@@ -4318,7 +4316,7 @@ namespace Hl7.Fhir.Specification.Tests
             }
         };
 
-        static StructureDefinition SlicedNationalPatientProfile => new StructureDefinition()
+        private static StructureDefinition SlicedNationalPatientProfile => new StructureDefinition()
         {
             Type = FHIRAllTypes.Patient.GetLiteral(),
             BaseDefinition = NationalPatientProfile.Url,
@@ -4513,7 +4511,7 @@ namespace Hl7.Fhir.Specification.Tests
 #endif
         }
 
-        static StructureDefinition ReslicedNationalPatientProfile => new StructureDefinition()
+        private static StructureDefinition ReslicedNationalPatientProfile => new StructureDefinition()
         {
             Type = FHIRAllTypes.Patient.GetLiteral(),
             BaseDefinition = NationalPatientProfile.Url,
@@ -4913,9 +4911,9 @@ namespace Hl7.Fhir.Specification.Tests
 
         }
 
-        static void dumpMappings(ElementDefinition elem) => dumpMappings(elem.Mapping, $"Mappings for {elem.Path}:");
+        private static void dumpMappings(ElementDefinition elem) => dumpMappings(elem.Mapping, $"Mappings for {elem.Path}:");
 
-        static void dumpMappings(IList<ElementDefinition.MappingComponent> mappings, string header = null)
+        private static void dumpMappings(IList<ElementDefinition.MappingComponent> mappings, string header = null)
         {
             Debug.WriteLineIf(header != null, header);
             foreach (var mapping in mappings)
@@ -4926,7 +4924,7 @@ namespace Hl7.Fhir.Specification.Tests
 
         // Ewout: type slices cannot contain renamed elements!
 
-        static StructureDefinition PatientNonTypeSliceProfile => new StructureDefinition()
+        private static StructureDefinition PatientNonTypeSliceProfile => new StructureDefinition()
         {
             Type = FHIRAllTypes.Patient.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient),
@@ -4971,7 +4969,7 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         // Ewout: type slices cannot contain renamed elements!
-        static StructureDefinition ObservationSimpleQuantityProfile => new StructureDefinition()
+        private static StructureDefinition ObservationSimpleQuantityProfile => new StructureDefinition()
         {
             Type = FHIRAllTypes.Observation.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Observation),
@@ -5155,7 +5153,7 @@ namespace Hl7.Fhir.Specification.Tests
 
         // [WMR 20170424] For debugging ElementIdGenerator
 
-        static StructureDefinition TestQuestionnaireProfile => new StructureDefinition()
+        private static StructureDefinition TestQuestionnaireProfile => new StructureDefinition()
         {
             Type = FHIRAllTypes.Questionnaire.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Questionnaire),
@@ -5341,7 +5339,7 @@ namespace Hl7.Fhir.Specification.Tests
 
         }
 
-        static StructureDefinition TestPatientTypeSliceProfile => new StructureDefinition()
+        private static StructureDefinition TestPatientTypeSliceProfile => new StructureDefinition()
         {
             Type = FHIRAllTypes.Patient.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient),
@@ -5409,7 +5407,7 @@ namespace Hl7.Fhir.Specification.Tests
 
         // [WMR 20170616] NEW - Test custom element IDs
 
-        static StructureDefinition TestSlicedPatientWithCustomIdProfile => new StructureDefinition()
+        private static StructureDefinition TestSlicedPatientWithCustomIdProfile => new StructureDefinition()
         {
             Type = FHIRAllTypes.Patient.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient),
@@ -5645,7 +5643,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual("land", baseElem.Alias.FirstOrDefault());
         }
 
-        void dumpBaseDefId(StructureDefinition sd)
+        private void dumpBaseDefId(StructureDefinition sd)
         {
             Debug.Print("===== " + sd.Name);
             Debug.Print($"{"Path",50}| {"Base Path",49}| {"Base StructureDefinition",69}| {"Element Id",49}| {"Base Element Id",49}");
@@ -5666,12 +5664,12 @@ namespace Hl7.Fhir.Specification.Tests
 
         // [WMR 20170424] For debugging ElementIdGenerator
 
-        const string PatientIdentifierProfileUri = @"http://example.org/fhir/StructureDefinition/PatientIdentifierProfile";
-        const string PatientProfileWithIdentifierProfileUri = @"http://example.org/fhir/StructureDefinition/PatientProfileWithIdentifierProfile";
-        const string PatientIdentifierTypeValueSetUri = @"http://example.org/fhir/ValueSet/PatientIdentifierTypeValueSet";
+        private const string PatientIdentifierProfileUri = @"http://example.org/fhir/StructureDefinition/PatientIdentifierProfile";
+        private const string PatientProfileWithIdentifierProfileUri = @"http://example.org/fhir/StructureDefinition/PatientProfileWithIdentifierProfile";
+        private const string PatientIdentifierTypeValueSetUri = @"http://example.org/fhir/ValueSet/PatientIdentifierTypeValueSet";
 
         // Identifier profile with valueset binding on child element Identifier.type
-        static StructureDefinition PatientIdentifierProfile => new StructureDefinition()
+        private static StructureDefinition PatientIdentifierProfile => new StructureDefinition()
         {
             Type = FHIRAllTypes.Identifier.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Identifier),
@@ -5698,7 +5696,7 @@ namespace Hl7.Fhir.Specification.Tests
 
         // Patient profile with type profile constraint on Patient.identifier
         // Snapshot should pick up the valueset binding on Identifier.type
-        static StructureDefinition PatientProfileWithIdentifierProfile => new StructureDefinition()
+        private static StructureDefinition PatientProfileWithIdentifierProfile => new StructureDefinition()
         {
             Type = FHIRAllTypes.Patient.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient),
@@ -5761,7 +5759,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsFalse(nav.MoveToChild("type"));
         }
 
-        static StructureDefinition QuestionnaireResponseWithSlice => new StructureDefinition()
+        private static StructureDefinition QuestionnaireResponseWithSlice => new StructureDefinition()
         {
             Type = FHIRAllTypes.QuestionnaireResponse.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.QuestionnaireResponse),
@@ -5867,7 +5865,7 @@ namespace Hl7.Fhir.Specification.Tests
         // When expanding MyVitalSigns, the annotated base elements also include local diff constraints... WRONG!
         // As a result, Forge will not detect the existing local constraints (no yellow pen, excluded from output).
 
-        static StructureDefinition MyDerivedObservation => new StructureDefinition()
+        private static StructureDefinition MyDerivedObservation => new StructureDefinition()
         {
             Type = FHIRAllTypes.Observation.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Observation),
@@ -5931,7 +5929,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual(coreMethodElem.Short, baseElem.Short);
         }
 
-        static StructureDefinition MyMoreDerivedObservation => new StructureDefinition()
+        private static StructureDefinition MyMoreDerivedObservation => new StructureDefinition()
         {
             Type = FHIRAllTypes.Observation.GetLiteral(),
             BaseDefinition = MyDerivedObservation.Url,
@@ -6015,7 +6013,7 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         // [WMR 20170718] Test for slicing issue
-        static StructureDefinition MySlicedDocumentReference => new StructureDefinition()
+        private static StructureDefinition MySlicedDocumentReference => new StructureDefinition()
         {
             Type = FHIRAllTypes.Observation.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.DocumentReference),
@@ -6110,7 +6108,7 @@ namespace Hl7.Fhir.Specification.Tests
         // [WMR 20170718] NEW
         // Accept and handle derived profile constraints on existing slice entry in base profile
 
-        static StructureDefinition MySlicedBasePatient => new StructureDefinition()
+        private static StructureDefinition MySlicedBasePatient => new StructureDefinition()
         {
             Type = FHIRAllTypes.Patient.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient),
@@ -6137,7 +6135,7 @@ namespace Hl7.Fhir.Specification.Tests
             }
         };
 
-        static StructureDefinition MyMoreDerivedPatient => new StructureDefinition()
+        private static StructureDefinition MyMoreDerivedPatient => new StructureDefinition()
         {
             Type = FHIRAllTypes.Patient.GetLiteral(),
             BaseDefinition = MySlicedBasePatient.Url,
@@ -6237,7 +6235,7 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
-        static StructureDefinition MedicationStatementWithSimpleQuantitySlice => new StructureDefinition()
+        private static StructureDefinition MedicationStatementWithSimpleQuantitySlice => new StructureDefinition()
         {
             Type = FHIRAllTypes.MedicationStatement.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.MedicationStatement),
@@ -6310,10 +6308,10 @@ namespace Hl7.Fhir.Specification.Tests
         // [WMR 20170925] BUG: Stefan Lang - Forge displays both valueString and value[x]
         // https://trello.com/c/XI8krV6j
 
-        const string SL_HumanNameTitleSuffixUri = @"http://example.org/fhir/StructureDefinition/SL-HumanNameTitleSuffix";
+        private const string SL_HumanNameTitleSuffixUri = @"http://example.org/fhir/StructureDefinition/SL-HumanNameTitleSuffix";
 
         // Extension on complex datatype HumanName
-        static StructureDefinition SL_HumanNameTitleSuffix => new StructureDefinition()
+        private static StructureDefinition SL_HumanNameTitleSuffix => new StructureDefinition()
         {
             Type = FHIRAllTypes.Extension.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Extension),
@@ -6346,7 +6344,7 @@ namespace Hl7.Fhir.Specification.Tests
         };
 
         // Profile on complex datatype HumanName with extension element
-        static StructureDefinition SL_HumanNameBasis => new StructureDefinition()
+        private static StructureDefinition SL_HumanNameBasis => new StructureDefinition()
         {
             Type = FHIRAllTypes.HumanName.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.HumanName),
@@ -6376,7 +6374,7 @@ namespace Hl7.Fhir.Specification.Tests
         };
 
         // Profile on Patient referencing custom HumanName datatype profile
-        static StructureDefinition SL_PatientBasis => new StructureDefinition()
+        private static StructureDefinition SL_PatientBasis => new StructureDefinition()
         {
             Type = FHIRAllTypes.Patient.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient),
@@ -6403,11 +6401,10 @@ namespace Hl7.Fhir.Specification.Tests
             }
         };
 
-
-        const string SL_NameSuffixValueSetUri = @"http://fhir.de/ValueSet/deuev/anlage-7-namenszusaetze";
+        private const string SL_NameSuffixValueSetUri = @"http://fhir.de/ValueSet/deuev/anlage-7-namenszusaetze";
 
         // Derived profile on Patient
-        static StructureDefinition SL_PatientDerived => new StructureDefinition()
+        private static StructureDefinition SL_PatientDerived => new StructureDefinition()
         {
             Type = FHIRAllTypes.Patient.GetLiteral(),
             BaseDefinition = SL_PatientBasis.Url,
@@ -7740,7 +7737,7 @@ namespace Hl7.Fhir.Specification.Tests
         {
             // #827: Verify that derived profiles inherit extensions on value element of primitive types
 
-            var src = new Fhir.Validation.TestProfileArtifactSource();
+            var src = new TestProfileArtifactSource();
             var testResolver = new CachedResolver(
                 new MultiResolver(
                     _zipSource, //new ZipSource("specification.zip"),
@@ -7956,7 +7953,7 @@ namespace Hl7.Fhir.Specification.Tests
 
         // [WMR 20190826] Verify correct handling of implicit type slicing through element renaming
 
-        static readonly StructureDefinition ExtensionWithImplicitTypeSlice = new StructureDefinition()
+        private static readonly StructureDefinition ExtensionWithImplicitTypeSlice = new StructureDefinition()
         {
             Type = FHIRAllTypes.Extension.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Extension),
@@ -8032,7 +8029,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsFalse(nav.MoveToNext("valueString"));
         }
 
-        StructureDefinition PatientWithExtensionWithImplicitTypeSlice = new StructureDefinition()
+        private StructureDefinition PatientWithExtensionWithImplicitTypeSlice = new StructureDefinition()
         {
             Type = FHIRAllTypes.Patient.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient),
@@ -8132,7 +8129,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsFalse(nav.MoveToNext("valueString"));
         }
 
-        StructureDefinition PatientWithExtensionWithImplicitTypeSliceMixed = new StructureDefinition()
+        private StructureDefinition PatientWithExtensionWithImplicitTypeSliceMixed = new StructureDefinition()
         {
             Type = FHIRAllTypes.Patient.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient),
@@ -8242,7 +8239,7 @@ namespace Hl7.Fhir.Specification.Tests
 
         // [WMR 20190826] Verify correct handling of verbose type slicing w/o renaming
 
-        static readonly StructureDefinition ExtensionWithVerboseTypeSlice = new StructureDefinition()
+        private static readonly StructureDefinition ExtensionWithVerboseTypeSlice = new StructureDefinition()
         {
             Type = FHIRAllTypes.Extension.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Extension),
@@ -8320,7 +8317,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsFalse(nav.MoveToNext("valueString"));
         }
 
-        StructureDefinition PatientWithExtensionWithVerboseTypeSlice = new StructureDefinition()
+        private StructureDefinition PatientWithExtensionWithVerboseTypeSlice = new StructureDefinition()
         {
             Type = FHIRAllTypes.Patient.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient),
@@ -8418,7 +8415,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsFalse(nav.MoveToNext("valueString"));
         }
 
-        StructureDefinition PatientWithExtensionWithVerboseTypeSliceMixed = new StructureDefinition()
+        private StructureDefinition PatientWithExtensionWithVerboseTypeSliceMixed = new StructureDefinition()
         {
             Type = FHIRAllTypes.Patient.GetLiteral(),
             BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient),
@@ -8795,7 +8792,7 @@ namespace Hl7.Fhir.Specification.Tests
         // fixedUri should inherit values from base profile
         // i.e. do NOT replace with canonical url of derived profile...!
 
-        static void AssertExtensionUrlChildElement(ElementDefinitionNavigator nav, string url)
+        private static void AssertExtensionUrlChildElement(ElementDefinitionNavigator nav, string url)
         {
             var bm = nav.Bookmark();
             Assert.IsTrue(nav.MoveToChild("url"));
@@ -8803,7 +8800,7 @@ namespace Hl7.Fhir.Specification.Tests
             nav.ReturnToBookmark(bm);
         }
 
-        static void AssertExtensionUrlElement(ElementDefinitionNavigator nav, string url)
+        private static void AssertExtensionUrlElement(ElementDefinitionNavigator nav, string url)
         {
             Assert.IsTrue(nav.Path.ToLowerInvariant().EndsWith("extension.url"));
             var fixedValue = nav.Current.Fixed;

--- a/src/Hl7.Fhir.Specification.Tests/StructureDefinitionSerializationInfoTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/StructureDefinitionSerializationInfoTests.cs
@@ -1,6 +1,6 @@
 ﻿using Hl7.Fhir.Specification;
 using Hl7.Fhir.Specification.Source;
-using Hl7.Fhir.Validation;
+using Hl7.Fhir.Specification.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Hl7.Fhir.Serialization.Tests
@@ -18,7 +18,7 @@ namespace Hl7.Fhir.Serialization.Tests
                 );
         }
 
-        static IResourceResolver source = null;
+        private static IResourceResolver source = null;
 
         [TestMethod]
         public void TestCanLocateTypes() => SerializationInfoTestHelpers.TestCanLocateTypes(new StructureDefinitionSummaryProvider(source));

--- a/src/Hl7.Fhir.Specification.Tests/StructureDefinitionWalkerTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/StructureDefinitionWalkerTests.cs
@@ -18,7 +18,7 @@ namespace Hl7.Fhir.Specification.Tests
                 new SnapshotSource(
                 new MultiResolver(
                     new DirectorySource(@"TestData\validation"),
-                    new ZipSource("specification.zip"))));
+                    ZipSource.CreateValidationSource())));
         }
 
         [ClassInitialize]

--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -23,7 +23,7 @@ using T = System.Threading.Tasks;
 namespace Hl7.Fhir.Specification.Tests
 {
     [Trait("Category", "Validation")]
-    public class BasicValidationTests : IClassFixture<ValidationFixture>
+    public partial class BasicValidationTests : IClassFixture<ValidationFixture>
     {
         private readonly IResourceResolver _source;
         private readonly IAsyncResourceResolver _asyncSource;
@@ -1388,25 +1388,6 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.True(visitResolver.Visited(patientReference), "no attempt was made to resolve the example patient");
             Assert.True(0 == outcome.Warnings, $"Found {outcome.Warnings} warnings");
 
-        }
-
-        class VisitResolver : IResourceResolver
-        {
-            private List<string> _visits = new List<string>();
-
-            public Resource ResolveByCanonicalUri(string uri)
-            {
-                _visits.Add(uri);
-                return null;
-            }
-
-            public Resource ResolveByUri(string uri)
-            {
-                _visits.Add(uri);
-                return null;
-            }
-
-            internal bool Visited(string uri) => _visits.Contains(uri);
         }
 
         private class ClearSnapshotResolver : IResourceResolver

--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -752,7 +752,7 @@ namespace Hl7.Fhir.Specification.Tests
             var source =
                     new MultiResolver(
                         new DirectorySource(@"TestData\validation"),
-                        new ZipSource("specification.zip"));
+                        ZipSource.CreateValidationSource());
 
             var ctx = new ValidationSettings()
             {
@@ -1059,7 +1059,7 @@ namespace Hl7.Fhir.Specification.Tests
                         // new DirectorySource(Path.Combine("TestData", "validation")),
                         // new TestProfileArtifactSource(),
                         memResolver,
-                        new ZipSource("specification.zip"))));
+                        ZipSource.CreateValidationSource())));
 
             var ctx = new ValidationSettings()
             {
@@ -1127,7 +1127,7 @@ namespace Hl7.Fhir.Specification.Tests
                     new BasicValidationTests.BundleExampleResolver(@"TestData\validation"),
                     new DirectorySource(@"TestData\validation"),
                     new TestProfileArtifactSource(),
-                    new ZipSource("specification.zip")));
+                    ZipSource.CreateValidationSource()));
 
             var nrOfParrallelTasks = 50;
             var results = new ConcurrentBag<OperationOutcome>();

--- a/src/Hl7.Fhir.Specification.Tests/Validation/ProfileAssertionTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/ProfileAssertionTests.cs
@@ -1,13 +1,10 @@
 ﻿using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Validation;
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using T=System.Threading.Tasks;
 using Xunit;
+using T = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Specification.Tests
 {
@@ -25,7 +22,7 @@ namespace Hl7.Fhir.Specification.Tests
                         new BasicValidationTests.BundleExampleResolver(Path.Combine("TestData", "validation")),
                         new DirectorySource(Path.Combine("TestData", "validation")),
                         new TestProfileArtifactSource(),
-                        new ZipSource("specification.zip")));
+                        ZipSource.CreateValidationSource()));
 
             var ctx = new ValidationSettings()
             {
@@ -91,7 +88,7 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
 
-// We don't want to rewrite ProfileAssertion right now...
+        // We don't want to rewrite ProfileAssertion right now...
 #pragma warning disable CS0618 // Type or member is obsolete
         private StructureDefinition resolve(string uri) => _resolver.FindStructureDefinition(uri);
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -182,11 +179,11 @@ namespace Hl7.Fhir.Specification.Tests
             assertion.AddStatedProfile(ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Observation));
             assertion.AddStatedProfile("http://validationtest.org/fhir/StructureDefinition/WeightHeightObservation");
             assertion.AddStatedProfile("http://hl7.org/fhir/StructureDefinition/devicemetricobservation");
-            
+
             var report = assertion.Validate();
             Assert.True(report.Success);
             Assert.Equal(2, assertion.MinimalProfiles.Count());
-            Assert.Equal( assertion.MinimalProfiles, assertion.StatedProfiles.Skip(1));
+            Assert.Equal(assertion.MinimalProfiles, assertion.StatedProfiles.Skip(1));
 
             assertion.SetDeclaredType(FHIRAllTypes.Procedure);
             report = assertion.Validate();

--- a/src/Hl7.Fhir.Specification.Tests/Validation/ProfilePreprocessorTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/ProfilePreprocessorTests.cs
@@ -19,12 +19,12 @@ namespace Hl7.Fhir.Specification.Tests.Validation
         public async T.Task RunSnapshotMultiThreaded()
         {
             // Arrange
-            var source = new CachedResolver(new ZipSource("specification.zip"));
+            var source = new CachedResolver(ZipSource.CreateValidationSource());
             var generator = new SnapshotGenerator(source);
 
             OperationOutcome GenerateSnapshot(StructureDefinition sd)
             {
-// We don't want to update ProfilePreprocessor right now
+                // We don't want to update ProfilePreprocessor right now
 #pragma warning disable CS0618 // Type or member is obsolete
                 generator.Update(sd);
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Hl7.Fhir.Specification.Tests/Validation/SliceValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/SliceValidationTests.cs
@@ -39,7 +39,7 @@ namespace Hl7.Fhir.Specification.Tests
             //var xml = FhirSerializer.SerializeResourceToXml(sd);
             //File.WriteAllText(@"c:\temp\sdout.xml", xml);
 
-            return BucketFactory.CreateRoot(nav, _resolver, _validator);
+            return BucketFactory.CreateRoot(nav, _resolver, _validator, new ValidationState());
         }
 
         /*

--- a/src/Hl7.Fhir.Specification.Tests/Validation/TargetProfileValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/TargetProfileValidationTests.cs
@@ -71,7 +71,7 @@ namespace Hl7.Fhir.Specification.Tests
                       new CachedResolver(
                         new MultiResolver(
                           new TestProfileArtifactSource(),
-                          new ZipSource("specification.zip"),
+                          ZipSource.CreateValidationSource(),
                           visitResolver)));
 
             var validatorSettings = new ValidationSettings

--- a/src/Hl7.Fhir.Specification.Tests/Validation/TargetProfileValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/TargetProfileValidationTests.cs
@@ -26,7 +26,7 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public void AvoidsRedoingProfileValidation()
         {
-            var all = new Bundle() { Type = Bundle.BundleType.Batch };
+            var all = new Bundle() { Type = Bundle.BundleType.Collection };
             var org1 = new Organization() { Id = "org1", Name = "Organization 1" };
             var org2 = new Organization() { Id = "org2", Name = "Organization 2", Meta = new() { Profile = new[] { TestProfileArtifactSource.PROFILED_ORG_URL } } };
 

--- a/src/Hl7.Fhir.Specification.Tests/Validation/TargetProfileValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/TargetProfileValidationTests.cs
@@ -1,0 +1,98 @@
+﻿using FluentAssertions;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Source;
+using Hl7.Fhir.Utility;
+using Hl7.Fhir.Validation;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Hl7.Fhir.Specification.Tests
+{
+    [Trait("Category", "Validation")]
+    public class TargetProfileValidationTests
+    {
+        private class TestResolver : IResourceResolver
+        {
+            public static string Url = "http://test.org/fhir/Organization/3141";
+
+            private static Organization dummy = new() { Id = "3141", Name = "Dummy" };
+
+            public Resource ResolveByCanonicalUri(string uri) => ResolveByUri(uri);
+            public Resource ResolveByUri(string uri) =>
+                uri == Url ? dummy : null;
+        }
+
+
+        [Fact]
+        public void AvoidsRedoingProfileValidation()
+        {
+            var all = new Bundle() { Type = Bundle.BundleType.Batch };
+            var org1 = new Organization() { Id = "org1", Name = "Organization 1" };
+            var org2 = new Organization() { Id = "org2", Name = "Organization 2", Meta = new() { Profile = new[] { TestProfileArtifactSource.PROFILED_ORG_URL } } };
+
+            all.Entry.Add(new() { FullUrl = refr("org1"), Resource = org1 });
+            all.Entry.Add(new() { FullUrl = refr("org2"), Resource = org2 });
+
+            var bothRef = new List<ResourceReference>()
+            {
+                new ResourceReference("#refme"),
+                new ResourceReference(refr("org1")),
+                new ResourceReference(refr("org2")),
+                new ResourceReference("http://test.org/fhir/Organization/3141")
+            };
+
+            var pat1 = new Patient()
+            {
+                Meta = new() { Profile = new[] { "http://validationtest.org/fhir/StructureDefinition/PatientWithReferences" } },
+                Id = "pat1",
+                GeneralPractitioner = bothRef,
+                ManagingOrganization = new(refr("org1")),
+                BirthDate = new("2011crap")
+            };
+
+            pat1.Contained.Add(new Organization { Id = "refme", Name = "referred" });
+
+            var pat2 = new Patient()
+            {
+                Meta = new() { Profile = new[] { "http://validationtest.org/fhir/StructureDefinition/PatientWithReferences" } },
+                Id = "pat2",
+                GeneralPractitioner = bothRef,
+                ManagingOrganization = new(refr("org2"))
+            };
+
+            pat2.Contained.Add(new Organization { Id = "refme", Name = "referred" });
+
+            all.Entry.Add(new() { FullUrl = refr("pat1"), Resource = pat1 });
+            all.Entry.Add(new() { FullUrl = refr("pat2"), Resource = pat2 });
+
+            var visitResolver = new TestResolver();
+
+            var cr = new SnapshotSource(
+                      new CachedResolver(
+                        new MultiResolver(
+                          new TestProfileArtifactSource(),
+                          new ZipSource("specification.zip"),
+                          visitResolver)));
+
+            var validatorSettings = new ValidationSettings
+            {
+                GenerateSnapshot = true,
+                ResourceResolver = cr,
+                ResolveExternalReferences = true
+            };
+            var validator = new Validator(validatorSettings);
+
+            var result = validator.Validate(all);
+            result.Success.Should().Be(false);
+            result.Errors.Should().Be(1);
+            result.ToString().Should().Contain("does not match regex");
+
+            var validationState = result.Annotation<ValidationState>();
+
+            validationState.Global.ResourcesValidated.Value.Should().Be(16);
+            validationState.Instance.InternalValidations.Count.Should().Be(8);
+
+            static string refr(string x) => "http://test.org/fhir/" + x;
+        }
+    }
+}

--- a/src/Hl7.Fhir.Specification.Tests/Validation/VisitResolver.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/VisitResolver.cs
@@ -1,0 +1,32 @@
+﻿using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Source;
+using System.Collections.Generic;
+
+namespace Hl7.Fhir.Specification.Tests
+{
+    public class VisitResolver : IResourceResolver
+    {
+        private readonly Resource _example;
+        public List<string> Visits = new();
+
+        public VisitResolver(Resource example = null)
+        {
+            _example = example;
+        }
+
+        public Resource ResolveByCanonicalUri(string uri)
+        {
+            Visits.Add(uri);
+            return _example;
+        }
+
+        public Resource ResolveByUri(string uri)
+        {
+            Visits.Add(uri);
+            return _example;
+        }
+
+        internal bool Visited(string uri) => Visits.Contains(uri);
+    }
+}
+

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/BaseBucket.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/BaseBucket.cs
@@ -7,18 +7,20 @@ namespace Hl7.Fhir.Validation
 {
     internal abstract class BaseBucket : IBucket
     {
-        internal protected BaseBucket(ElementDefinition definition)
+        protected internal BaseBucket(ElementDefinition definition, ValidationState state)
         {
             Name = definition.Path + (definition.SliceName != null ? $":{definition.SliceName}" : null);
             Cardinality = Cardinality.FromElementDefinition(definition);
+            State = state;
         }
 
         public string Name { get; private set; }
         public Cardinality Cardinality { get; private set; }
         public IList<ITypedElement> Members { get; private set; } = new List<ITypedElement>();
+        protected ValidationState State { get; }
 
         public abstract bool Add(ITypedElement instance);
-  
+
         public virtual OperationOutcome Validate(Validator validator, ITypedElement errorLocation)
         {
             var outcome = new OperationOutcome();

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/BindingDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/BindingDiscriminator.cs
@@ -8,9 +8,6 @@
 
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
-using Hl7.Fhir.Utility;
-using Hl7.FhirPath;
-using System.Linq;
 
 namespace Hl7.Fhir.Validation
 {
@@ -29,7 +26,7 @@ namespace Hl7.Fhir.Validation
         public readonly ElementDefinition.ElementDefinitionBindingComponent Binding;
         public readonly string Context;
 
-        protected override bool MatchInternal(ITypedElement instance)
+        protected override bool MatchInternal(ITypedElement instance, ValidationState _)
         {
             var result = Validator.ValidateBinding(Binding, instance, ErrorLocation, Context);
             return result.Success;

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/BucketFactory.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/BucketFactory.cs
@@ -15,18 +15,18 @@ namespace Hl7.Fhir.Validation
 {
     internal static class BucketFactory
     {
-        public static IBucket CreateRoot(ElementDefinitionNavigator root, IResourceResolver resolver, Validator validator)
+        public static IBucket CreateRoot(ElementDefinitionNavigator root, IResourceResolver resolver, Validator validator, ValidationState state)
         {
             // Create a single bucket
-            var entryBucket = new ElementBucket(root, validator);
+            var entryBucket = new ElementBucket(root, validator, state);
 
             if (root.Current.Slicing == null)
                 return entryBucket;
             else
-                return CreateGroup(root, resolver, validator, entryBucket);
+                return CreateGroup(root, resolver, validator, entryBucket, state);
         }
 
-        public static IBucket CreateGroup(ElementDefinitionNavigator root, IResourceResolver resolver, Validator validator, IBucket entryBucket)
+        public static IBucket CreateGroup(ElementDefinitionNavigator root, IResourceResolver resolver, Validator validator, IBucket entryBucket, ValidationState state)
         {
             var discriminatorSpecs = root.Current.Slicing.Discriminator.ToArray();  // copy, since root will move after this
             var location = root.Current.Path;
@@ -48,16 +48,16 @@ namespace Hl7.Fhir.Validation
                     {
                         throw new IncorrectElementDefinitionException($"There is nothing to discriminate on at {location}.");
                     }
-                    subBucket = new DiscriminatorBucket(root, validator, discriminators.ToArray());
+                    subBucket = new DiscriminatorBucket(root, validator, discriminators.ToArray(), state);
                 }
                 else
                     // Discriminator-less matching
-                    subBucket = new ConstraintsBucket(root, validator);
+                    subBucket = new ConstraintsBucket(root, validator, state);
 
                 if (root.Current.Slicing == null)
                     subs.Add(subBucket);
                 else
-                    subs.Add(CreateGroup(root, resolver, validator, subBucket));
+                    subs.Add(CreateGroup(root, resolver, validator, subBucket, state));
             }
 
             root.ReturnToBookmark(bm);

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/CombinedDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/CombinedDiscriminator.cs
@@ -22,6 +22,6 @@ namespace Hl7.Fhir.Validation
         public CombinedDiscriminator(IEnumerable<IDiscriminator> components) =>
                 Components = components.ToArray();
 
-        public bool Matches(ITypedElement candidate) => Components.All(c => c.Matches(candidate));
+        public bool Matches(ITypedElement candidate, ValidationState state) => Components.All(c => c.Matches(candidate, state));
     }
 }

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/ComprehensiveDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/ComprehensiveDiscriminator.cs
@@ -18,7 +18,7 @@ namespace Hl7.Fhir.Validation
     /// </summary>
     internal class ComprehensiveDiscriminator : IDiscriminator
     {
-        public bool Matches(ITypedElement candidate) => true;
+        public bool Matches(ITypedElement candidate, ValidationState _) => true;
     }
 }
 

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/ConstraintsBucket.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/ConstraintsBucket.cs
@@ -6,10 +6,9 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Navigation;
-using Hl7.Fhir.Support;
-using Hl7.Fhir.ElementModel;
 
 namespace Hl7.Fhir.Validation
 {
@@ -21,21 +20,25 @@ namespace Hl7.Fhir.Validation
         /// </summary>
         /// <param name="sliceConstraints">The set of constraints that are the criterium for membership of the slice.</param>
         /// <param name="validator">A validator instance that will be invoked to validate the child constraints.</param>
-        public ConstraintsBucket(ElementDefinitionNavigator sliceConstraints, Validator validator) : base(sliceConstraints.Current)
+        /// <param name="state">The validation state to forward to all nested validations in this bucket.</param>
+        public ConstraintsBucket(
+            ElementDefinitionNavigator sliceConstraints,
+            Validator validator,
+            ValidationState state) : base(sliceConstraints.Current, state)
         {
             // Keep a copy of the constraints for this slice, so we can use them to validate the instances against later.
             SliceConstraints = sliceConstraints.ShallowCopy();
 
             Validator = validator;
         }
-    
+
         public ElementDefinitionNavigator SliceConstraints { get; private set; }
 
         public Validator Validator { get; private set; }
 
         public override bool Add(ITypedElement candidate)
         {
-            OperationOutcome outcome = Validator.Validate(candidate, SliceConstraints);
+            OperationOutcome outcome = Validator.ValidateInternal(candidate, SliceConstraints, State);
 
             if (outcome.Success)
             {

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/ElementBucket.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/ElementBucket.cs
@@ -6,16 +6,16 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Support;
-using Hl7.Fhir.ElementModel;
 
 namespace Hl7.Fhir.Validation
 {
     internal class ElementBucket : BaseBucket
     {
-        public ElementBucket(ElementDefinitionNavigator root, Validator validator) : base(root.Current)
+        public ElementBucket(ElementDefinitionNavigator root, Validator validator, ValidationState state) : base(root.Current, state)
         {
             Root = root.ShallowCopy();
             Validator = validator;
@@ -36,9 +36,9 @@ namespace Hl7.Fhir.Validation
         {
             var outcome = base.Validate(validator, errorLocation);
 
-            foreach(var member in Members)
+            foreach (var member in Members)
             {
-                outcome.Include(Validator.Validate(member, Root));
+                outcome.Include(Validator.ValidateInternal(member, Root, State));
             }
 
             return outcome;

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/ExistsDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/ExistsDiscriminator.cs
@@ -24,7 +24,7 @@ namespace Hl7.Fhir.Validation
 
         public string Path { get; }
 
-        public bool Matches(ITypedElement candidate)
+        public bool Matches(ITypedElement candidate, ValidationState _)
         {
             ITypedElement[] values = candidate.Select(Path).ToArray();
 

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/IDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/IDiscriminator.cs
@@ -12,6 +12,6 @@ namespace Hl7.Fhir.Validation
 {
     internal interface IDiscriminator
     {
-        bool Matches(ITypedElement candidate);
+        bool Matches(ITypedElement candidate, ValidationState state);
     }
 }

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/PathBasedDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/PathBasedDiscriminator.cs
@@ -9,7 +9,6 @@
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Utility;
 using Hl7.FhirPath;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace Hl7.Fhir.Validation
@@ -23,7 +22,7 @@ namespace Hl7.Fhir.Validation
 
         public readonly string Path;
 
-        public bool Matches(ITypedElement candidate)
+        public bool Matches(ITypedElement candidate, ValidationState state)
         {
             ITypedElement[] values = candidate.Select(Path).ToArray();
 
@@ -34,9 +33,9 @@ namespace Hl7.Fhir.Validation
             else if (values.Length == 0)
                 return false;
             else
-                return MatchInternal(values.Single());
+                return MatchInternal(values.Single(), state);
         }
 
-        abstract protected bool MatchInternal(ITypedElement candidate);
+        protected abstract bool MatchInternal(ITypedElement candidate, ValidationState state);
     }
 }

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/PatternDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/PatternDiscriminator.cs
@@ -22,7 +22,7 @@ namespace Hl7.Fhir.Validation
         public readonly Validator Validator;
         public readonly Element Pattern;
 
-        protected override bool MatchInternal(ITypedElement instance)
+        protected override bool MatchInternal(ITypedElement instance, ValidationState _)
         {
             var result = Validator.ValidatePattern(Pattern, instance);
             return result.Success;

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/ProfileDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/ProfileDiscriminator.cs
@@ -23,13 +23,17 @@ namespace Hl7.Fhir.Validation
         public readonly Validator Validator;
         public readonly string[] Profiles;
 
-        protected override bool MatchInternal(ITypedElement instance) =>
-            Profiles.Any(profile => validates(instance, profile));
+        protected override bool MatchInternal(ITypedElement instance, ValidationState state) =>
+            Profiles.Any(profile => validates(instance, profile, state));
 
-        private bool validates(ITypedElement instance, string profile)
+        private bool validates(ITypedElement instance, string profile, ValidationState state)
         {
             var validator = Validator.NewInstance();
-            var result = validator.Validate(instance, profile);
+            var result = validator.ValidateInternal(instance,
+                                            declaredTypeProfile: null,
+                                            statedCanonicals: new[] { profile },
+                                            statedProfiles: null,
+                                            state: state);
             return result.Success;
         }
     }

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/TypeDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/TypeDiscriminator.cs
@@ -25,7 +25,7 @@ namespace Hl7.Fhir.Validation
 
         // This discriminator matches if the type in the instance is *compatible* with ANY of the 
         // possible multiple types in the ElementDefinition.Type.Code (since Type repeats).
-        protected override bool MatchInternal(ITypedElement instance) =>
+        protected override bool MatchInternal(ITypedElement instance, ValidationState _) =>
             Types.Any(type => ModelInfo.IsInstanceTypeFor(type, instance.InstanceType));
     }
 }

--- a/src/Hl7.Fhir.Specification/Validation/Slicing/ValueDiscriminator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Slicing/ValueDiscriminator.cs
@@ -22,7 +22,7 @@ namespace Hl7.Fhir.Validation
         public readonly Validator Validator;
         public readonly Element FixedValue;
 
-        protected override bool MatchInternal(ITypedElement instance)
+        protected override bool MatchInternal(ITypedElement instance, ValidationState _)
         {
             var result = Validator.ValidateFixed(FixedValue, instance);
             return result.Success;

--- a/src/Hl7.Fhir.Specification/Validation/ValidationLogger.cs
+++ b/src/Hl7.Fhir.Specification/Validation/ValidationLogger.cs
@@ -1,0 +1,81 @@
+﻿/* 
+ * Copyright (c) 2016, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Support;
+using System;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Hl7.Fhir.Validation
+{
+    /// <summary>
+    /// This class is used to track which resources/contained resources/bundled resources are already
+    /// validated, and what the previous result was. Since it keeps track of running validations, it
+    /// can also be used to detect loops.
+    /// </summary>
+    internal class ValidationLogger
+    {
+        private enum ValidationStatus
+        {
+            Started,
+            Success,
+            Failure
+        }
+
+        private class Entry
+        {
+            public Entry(string location, string profileUrl, ValidationStatus status)
+            {
+                Location = location;
+                ProfileUrl = profileUrl;
+                Status = status;
+            }
+
+            public string Location;
+            public string ProfileUrl;
+            public ValidationStatus Status;
+        }
+
+        private readonly Dictionary<string, Entry> _data = new();
+
+        public OperationOutcome Start(string location, string profileUrl, Func<OperationOutcome> validator)
+        {
+            var key = $"{location}:{profileUrl}";
+
+            if (_data.TryGetValue(key, out var existing))
+            {
+                if (existing.Status == ValidationStatus.Started)
+                    throw new InvalidOperationException($"Detected a loop: instance data inside '{location}' refers back to itself.");
+
+                // If the validation has been run before, return an outcome with the same result.
+                // Note: we don't keep a copy of the original outcome since it has been included in the
+                // total result (at the first run) and keeping them around costs a lot of memory.
+                var repeatedOutcome = new OperationOutcome();
+                if (existing.Status == ValidationStatus.Failure)
+                    repeatedOutcome.AddIssue("Validation of this resource has been performed before with a failure result.",
+                        Issue.PROCESSING_REPEATED_ERROR);
+
+                return repeatedOutcome;
+            }
+            else
+            {
+                // This validation is run for the first time
+                var newEntry = new Entry(location, profileUrl, ValidationStatus.Started);
+                _data.Add(key, newEntry);
+
+                var result = validator();
+                newEntry.Status = result.Success ? ValidationStatus.Success : ValidationStatus.Failure;
+                return result;
+            }
+        }
+
+        public int Count => _data.Values.Count;
+    }
+}

--- a/src/Hl7.Fhir.Specification/Validation/ValidationState.cs
+++ b/src/Hl7.Fhir.Specification/Validation/ValidationState.cs
@@ -1,0 +1,66 @@
+﻿/* 
+ * Copyright (c) 2016, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+
+#nullable enable
+
+namespace Hl7.Fhir.Validation
+{
+    internal class Counter
+    {
+        public int Increase() => Value += 1;
+
+        public int Value { get; private set; }
+    }
+
+
+    /// <summary>
+    /// Hold the state relevant to a single run of the validator.
+    /// </summary>
+    internal class ValidationState
+    {
+        /// <summary>
+        /// State to be kept for one full run of the validator.
+        /// </summary>
+        public class GlobalState
+        {
+            /// <summary>
+            /// This keeps track of all validations done on external resources
+            /// referenced from the original root resource passed to the Validate() call.
+            /// </summary>
+            public ValidationLogger ExternalValidations { get; set; } = new();
+
+            public Counter ResourcesValidated { get; set; } = new();
+        }
+
+        public GlobalState Global { get; private set; } = new();
+
+        /// <summary>
+        /// State to be kept for an instance encountered during validation
+        /// (e.g. if the resource under validation references an external resource,
+        /// the validation of that resource will have its own <see cref="InstanceState"/>.
+        /// </summary>
+        public class InstanceState
+        {
+            /// <summary>
+            /// The URL where the current instance was retrieved (if known).
+            /// </summary>
+            public string? ExternalUrl { get; set; }
+
+            public ValidationLogger InternalValidations { get; set; } = new();
+        }
+
+        public InstanceState Instance { get; private set; } = new();
+
+        public ValidationState NewInstanceScope() =>
+            new()
+            {
+                Global = Global
+            };
+    }
+}

--- a/src/Hl7.Fhir.Specification/Validation/Validator.cs
+++ b/src/Hl7.Fhir.Specification/Validation/Validator.cs
@@ -83,41 +83,57 @@ namespace Hl7.Fhir.Validation
             };
         }
 
-
         public OperationOutcome Validate(ITypedElement instance)
         {
-            return Validate(instance, declaredTypeProfile: null, statedCanonicals: null, statedProfiles: null).RemoveDuplicateMessages();
+            var state = new ValidationState();
+            var result = ValidateInternal(instance, declaredTypeProfile: null, statedCanonicals: null, statedProfiles: null, state: state)
+                .RemoveDuplicateMessages();
+            result.SetAnnotation(state);
+            return result;
         }
 
-        public OperationOutcome Validate(ITypedElement instance, params string[] definitionUris)
-        {
-            return Validate(instance, (IEnumerable<string>)definitionUris).RemoveDuplicateMessages(); ;
-        }
+        public OperationOutcome Validate(ITypedElement instance, params string[] definitionUris) =>
+            Validate(instance, (IEnumerable<string>)definitionUris);
 
         public OperationOutcome Validate(ITypedElement instance, IEnumerable<string> definitionUris)
         {
-            return Validate(instance, declaredTypeProfile: null, statedCanonicals: definitionUris, statedProfiles: null).RemoveDuplicateMessages(); ;
+            var state = new ValidationState();
+            var result = ValidateInternal(instance, declaredTypeProfile: null, statedCanonicals: definitionUris, statedProfiles: null, state: state)
+                .RemoveDuplicateMessages();
+            result.SetAnnotation(state);
+            return result;
         }
 
-        public OperationOutcome Validate(ITypedElement instance, params StructureDefinition[] structureDefinitions)
-        {
-            return Validate(instance, (IEnumerable<StructureDefinition>)structureDefinitions).RemoveDuplicateMessages();
-        }
+        public OperationOutcome Validate(ITypedElement instance, params StructureDefinition[] structureDefinitions) =>
+            Validate(instance, (IEnumerable<StructureDefinition>)structureDefinitions);
 
         public OperationOutcome Validate(ITypedElement instance, IEnumerable<StructureDefinition> structureDefinitions)
         {
-            return Validate(instance, declaredTypeProfile: null, statedCanonicals: null, statedProfiles: structureDefinitions).RemoveDuplicateMessages(); ;
+            var state = new ValidationState();
+            var result = ValidateInternal(
+                instance,
+                declaredTypeProfile: null,
+                statedCanonicals: null,
+                statedProfiles: structureDefinitions,
+                state: state).RemoveDuplicateMessages();
+            result.SetAnnotation(state);
+            return result;
         }
 
         // This is the one and only main entry point for all external validation calls (i.e. invoked by the user of the API)
-        internal OperationOutcome Validate(ITypedElement instance, string declaredTypeProfile, IEnumerable<string> statedCanonicals, IEnumerable<StructureDefinition> statedProfiles)
+        internal OperationOutcome ValidateInternal(
+            ITypedElement instance,
+            string declaredTypeProfile,
+            IEnumerable<string> statedCanonicals,
+            IEnumerable<StructureDefinition> statedProfiles,
+            ValidationState state)
         {
             var processor = new ProfilePreprocessor(profileResolutionNeeded, snapshotGenerationNeeded, instance, declaredTypeProfile, statedProfiles, statedCanonicals, Settings.ResourceMapping);
             var outcome = processor.Process();
 
             // Note: only start validating if the profiles are complete and consistent
             if (outcome.Success)
-                outcome.Add(Validate(instance, processor.Result));
+                outcome.Add(ValidateInternal(instance, processor.Result, state));
 
             return outcome;
 
@@ -128,26 +144,23 @@ namespace Hl7.Fhir.Validation
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
-        internal OperationOutcome Validate(ITypedElement instance, ElementDefinitionNavigator definition)
-        {
-            return Validate(instance, new[] { definition }).RemoveDuplicateMessages(); ;
-        }
+        internal OperationOutcome ValidateInternal(ITypedElement instance, ElementDefinitionNavigator definition, ValidationState state)
+            => ValidateInternal(instance, new[] { definition }, state).RemoveDuplicateMessages();
 
 
         // This is the one and only main internal entry point for all validations, which in its term
         // will call step 1 in the validator, the function validateElement
-        internal OperationOutcome Validate(ITypedElement elementNav, IEnumerable<ElementDefinitionNavigator> definitions)
+        internal OperationOutcome ValidateInternal(ITypedElement elementNav, IEnumerable<ElementDefinitionNavigator> definitions, ValidationState state)
         {
             var outcome = new OperationOutcome();
-
-            var instance = elementNav as ScopedNode ?? new ScopedNode(elementNav);
+            var instance = elementNav.ToScopedNode();
 
             try
             {
                 var allDefinitions = definitions.ToList();
 
                 if (allDefinitions.Count() == 1)
-                    outcome.Add(validateElement(allDefinitions.Single(), instance));
+                    outcome.Add(startValidation(allDefinitions.Single(), instance, state));
                 else
                 {
                     var validators = allDefinitions.Select(nav => createValidator(nav));
@@ -162,17 +175,36 @@ namespace Hl7.Fhir.Validation
             return outcome;
 
             Func<OperationOutcome> createValidator(ElementDefinitionNavigator nav) =>
-                () => validateElement(nav, instance);
+                () => startValidation(nav, instance, state);
 
         }
 
-        private OperationOutcome validateElement(ElementDefinitionNavigator definition, ScopedNode instance)
+        private OperationOutcome startValidation(ElementDefinitionNavigator definition, ScopedNode instance, ValidationState state)
+        {
+            // If we are starting a validation of a referenceable element (resource, contained resource, nested resource),
+            // make sure we keep track of it, so we can detect loops and avoid validating the same resource multiple times.
+            if (instance.AtResource && definition.AtRoot)
+            {
+                state.Global.ResourcesValidated.Increase();
+                var location = state.Instance.ExternalUrl is string extu
+                    ? extu + "#" + instance.Location
+                    : instance.Location;
+
+                return state.Instance.InternalValidations.Start(location, definition.StructureDefinition.Url,
+                    () => validateElement(definition, instance, state));
+            }
+            else
+            {
+                return validateElement(definition, instance, state);
+            }
+        }
+
+        private OperationOutcome validateElement(ElementDefinitionNavigator definition, ScopedNode instance, ValidationState state)
         {
             var outcome = new OperationOutcome();
 
             try
             {
-
                 // If navigator cannot be moved to content, there's really nothing to validate against.
                 if (definition.AtRoot && !definition.MoveToFirstChild())
                 {
@@ -218,13 +250,13 @@ namespace Hl7.Fhir.Validation
                         // TODO: Check whether this is even true when the <type> has a profile?
                         // Note: the snapshot is *not* exhaustive if the declared type is a base FHIR type (like Resource),
                         // in which case there may be additional children (verified in the next step)
-                        outcome.Add(this.ValidateChildConstraints(definition, instance, allowAdditionalChildren: allowAdditionalChildren));
+                        outcome.Add(this.ValidateChildConstraints(definition, instance, allowAdditionalChildren: allowAdditionalChildren, state));
 
                         // Special case: if we are located at a nested resource (i.e. contained or Bundle.entry.resource),
                         // we need to validate based on the actual type of the instance
                         if (isInlineChildren && elementConstraints.IsResourcePlaceholder())
                         {
-                            outcome.Add(this.ValidateType(elementConstraints, instance));
+                            outcome.Add(this.ValidateType(elementConstraints, instance, state));
                         }
                     }
 
@@ -233,8 +265,8 @@ namespace Hl7.Fhir.Validation
                         // No inline-children, so validation depends on the presence of a <type> or <contentReference>
                         if (elementConstraints.Type != null || elementConstraints.ContentReference != null)
                         {
-                            outcome.Add(this.ValidateType(elementConstraints, instance));
-                            outcome.Add(ValidateNameReference(elementConstraints, definition, instance));
+                            outcome.Add(this.ValidateType(elementConstraints, instance, state));
+                            outcome.Add(ValidateNameReference(elementConstraints, definition, instance, state));
                         }
                         else
                             Trace(outcome, "ElementDefinition has no child, nor does it specify a type or contentReference to validate the instance data against", Issue.PROFILE_ELEMENTDEF_CONTAINS_NO_TYPE_OR_NAMEREF, instance);
@@ -351,7 +383,11 @@ namespace Hl7.Fhir.Validation
             return outcome;
         }
 
-        internal OperationOutcome ValidateNameReference(ElementDefinition definition, ElementDefinitionNavigator allDefinitions, ScopedNode instance)
+        internal OperationOutcome ValidateNameReference(
+            ElementDefinition definition,
+            ElementDefinitionNavigator allDefinitions,
+            ScopedNode instance,
+            ValidationState state)
         {
             var outcome = new OperationOutcome();
 
@@ -362,7 +398,7 @@ namespace Hl7.Fhir.Validation
                 var referencedPositionNav = allDefinitions.ShallowCopy();
 
                 if (referencedPositionNav.JumpToNameReference(definition.ContentReference))
-                    outcome.Include(Validate(instance, referencedPositionNav));
+                    outcome.Include(ValidateInternal(instance, referencedPositionNav, state));
                 else
                     Trace(outcome, $"ElementDefinition uses a non-existing nameReference '{definition.ContentReference}'", Issue.PROFILE_ELEMENTDEF_INVALID_NAMEREFERENCE, instance);
 


### PR DESCRIPTION
Added state to keep track of which (nested/contained)resources have already been validated.

Avoiding duplicate validation will keep bundle validation perf reasonable (we hope).