### PR TITLE
Treat warnings as errors

### DIFF
--- a/src/firely-net-sdk.props
+++ b/src/firely-net-sdk.props
@@ -7,7 +7,7 @@
 	<!-- Solution-wide properties for NuGet packaging -->
 	<PropertyGroup>
 		<VersionPrefix>4.0.0</VersionPrefix>
-		<VersionSuffix>beta2</VersionSuffix>
+		<VersionSuffix>beta3</VersionSuffix>
 		<Authors>Firely (info@fire.ly) and contributors</Authors>
 		<Company>Firely (https://fire.ly)</Company>
 		<Copyright>Copyright 2013-2022 Firely.  Contains materials (C) HL7 International</Copyright>

--- a/src/firely-net-sdk.props
+++ b/src/firely-net-sdk.props
@@ -38,6 +38,7 @@
 		<LangVersion>9.0</LangVersion>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Configurations>Debug;Release;FullDebug</Configurations>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'FullDebug'  ">


### PR DESCRIPTION
## Description
To enhance our code, we added the compiler option `TreatWarningsAsErrors`

## Related issues
Resolves issue #2034.

See also PR FirelyTeam/firely-net-common/pull/192

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes