### PR TITLE
Signing the NuGet Packages

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -119,13 +119,27 @@ stages:
         configurationToPack: $(buildConfiguration)
         nobuild: true
         verbosityPack: Normal
-        
+     
+    - powershell: |
+        #Convert the Secure password that's presented as plain text back into a secure string
+        $pwd = ConvertTo-SecureString -String $(CodeSigningPassword) -Force -AsPlainText
+
+        #Create PFX file from Certificate Variable
+        New-Item Temp-Certificate.pfx -Value $(FirelyCodeSignerCertificate)
+
+        #Import the PFX certificate from the newly created file and password. Read the thumbprint into variable
+        $Thumbprint = (Import-PfxCertificate -CertStoreLocation Cert:\CurrentUser\My -FilePath Temp-Certificate.pfx -Password $pwd).Thumbprint
+
+        Write-Host $Thumbprint
+
+        #Rest of Script below or set environment variable for rest of Pipeline
+        Write-Host "##vso[task.setvariable variable=Thumbprint]$Thumbprint"
     - task: DotNetCoreCLI@2
       displayName: Code signing of packages
       inputs:
         command: custom
         custom:  nuget 
-        arguments: sign $(Build.ArtifactStagingDirectory)\*.nupkg --certificate-path $(FirelyCodeSignerCertificate) --timestamper http://timestamp.digicert.com --certificate-password $(CodeSigningPassword) 
+        arguments: sign $(Build.ArtifactStagingDirectory)\*.nupkg --certificate-path Temp-Certificate.pfx --timestamper http://timestamp.digicert.com --certificate-password $(CodeSigningPassword) 
     
     - task: PublishBuildArtifacts@1
       displayName: Publish Artifact

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -119,35 +119,13 @@ stages:
         configurationToPack: $(buildConfiguration)
         nobuild: true
         verbosityPack: Normal
-     
-    - powershell: |
-        #Convert the Secure password that's presented as plain text back into a secure string
-        $pwd = ConvertTo-SecureString -String "$(CodeSigningPassword)" -Force -AsPlainText
 
-        #Create PFX file from Certificate Variable
-        New-Item Temp-Certificate.pfx -Value $(FirelyCodeSignerCertificate)
+    - template: templates/codesign-nuget-packages.yml
+      parameters:
+        certificateValue: $(FirelyCodeSignerCertificate)
+        certificatePasswordValue: $(CodeSigningPassword)
+        packagePaths: $(Build.ArtifactStagingDirectory)\*.nupkg
 
-        #Import the PFX certificate from the newly created file and password. Read the thumbprint into variable
-        $Thumbprint = (Import-PfxCertificate -CertStoreLocation Cert:\CurrentUser\My -FilePath Temp-Certificate.pfx -Password $pwd).Thumbprint
-
-        Write-Host "##vso[task.setvariable variable=Thumbprint]$Thumbprint"
-
-        #Remove the pfx file, the certificate is now imported
-        Remove-Item Temp-Certificate.pfx
-      displayName: 'Import Code Signing certificate'
-
-    - task: DotNetCoreCLI@2
-      displayName: 'Code signing of packages'
-      inputs:
-        command: custom
-        custom:  nuget 
-        arguments: sign $(Build.ArtifactStagingDirectory)\*.nupkg --certificate-fingerprint $(Thumbprint) --timestamper http://timestamp.digicert.com 
-
-    - powershell: |
-        #Delete the certificate by thumbprint, so it cannot be used elsewhere.
-        Get-ChildItem Cert:\CurrentUser\My\$(Thumbprint) | Remove-Item
-      displayName: 'Remove the certificate from cert store'
-    
     - task: PublishBuildArtifacts@1
       displayName: Publish Artifact
       inputs:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -137,7 +137,7 @@ stages:
       inputs:
         command: custom
         custom:  nuget 
-        arguments: sign $(Build.ArtifactStagingDirectory)\*.nupkg --certificate-path Temp-Certificate.pfx --timestamper http://timestamp.digicert.com --certificate-password $(certpassword) 
+        arguments: sign $(Build.ArtifactStagingDirectory)\*.nupkg --certificate-path Temp-Certificate.pfx --timestamper http://timestamp.digicert.com --certificate-password "$(CodeSigningPassword)" 
     
     - task: PublishBuildArtifacts@1
       displayName: Publish Artifact

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -122,18 +122,18 @@ stages:
      
     - powershell: |
         #Convert the Secure password that's presented as plain text back into a secure string
-        $pwd = ConvertTo-SecureString -String $(CodeSigningPassword) -Force -AsPlainText
+        #$pwd = ConvertTo-SecureString -String $(CodeSigningPassword) -Force -AsPlainText
 
         #Create PFX file from Certificate Variable
         New-Item Temp-Certificate.pfx -Value $(FirelyCodeSignerCertificate)
 
         #Import the PFX certificate from the newly created file and password. Read the thumbprint into variable
-        $Thumbprint = (Import-PfxCertificate -CertStoreLocation Cert:\CurrentUser\My -FilePath Temp-Certificate.pfx -Password $pwd).Thumbprint
+        #$Thumbprint = (Import-PfxCertificate -CertStoreLocation Cert:\CurrentUser\My -FilePath Temp-Certificate.pfx -Password $pwd).Thumbprint
 
-        Write-Host $Thumbprint
+        #Write-Host $Thumbprint
 
         #Rest of Script below or set environment variable for rest of Pipeline
-        Write-Host "##vso[task.setvariable variable=Thumbprint]$Thumbprint"
+        #Write-Host "##vso[task.setvariable variable=Thumbprint]$Thumbprint"
     - task: DotNetCoreCLI@2
       displayName: Code signing of packages
       inputs:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -120,7 +120,7 @@ stages:
         nobuild: true
         verbosityPack: Normal
 
-    - template: templates/codesign-nuget-packages.yml
+    - template: codesign-nuget-packages.yml@templates
       parameters:
         certificateValue: $(FirelyCodeSignerCertificate)
         certificatePasswordValue: $(CodeSigningPassword)

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -72,7 +72,7 @@ stages:
       inputs:
         command: build
         projects: ./Hl7.Fhir.sln
-        arguments: --configuration $(buildConfiguration) --no-restore
+        arguments: --configuration $(buildConfiguration) --no-restore /p:ContinuousIntegrationBuild=true 
 
     - task: DotNetCoreCLI@2
       displayName: Create Test artifacts

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -124,20 +124,29 @@ stages:
         #Convert the Secure password that's presented as plain text back into a secure string
         $pwd = ConvertTo-SecureString -String "$(CodeSigningPassword)" -Force -AsPlainText
 
-        Write-Host $(CodeSigningPassword)
-        Write-Host $pwd
-
         #Create PFX file from Certificate Variable
-        New-Item $(Build.ArtifactStagingDirectory)\Temp-Certificate.pfx -Value $(FirelyCodeSignerCertificate)
+        New-Item Temp-Certificate.pfx -Value $(FirelyCodeSignerCertificate)
 
-        #Rest of Script below or set environment variable for rest of Pipeline
-        Write-Host "##vso[task.setvariable variable=certpassword]$pwd"
-    #- task: DotNetCoreCLI@2
-    #  displayName: Code signing of packages
-    #  inputs:
-    #    command: custom
-    #    custom:  nuget 
-    #    arguments: sign $(Build.ArtifactStagingDirectory)\*.nupkg --certificate-path Temp-Certificate.pfx --timestamper http://timestamp.digicert.com --certificate-password "$(CodeSigningPassword)" 
+        #Import the PFX certificate from the newly created file and password. Read the thumbprint into variable
+        $Thumbprint = (Import-PfxCertificate -CertStoreLocation Cert:\CurrentUser\My -FilePath Temp-Certificate.pfx -Password $pwd).Thumbprint
+
+        Write-Host "##vso[task.setvariable variable=Thumbprint]$Thumbprint"
+
+        #Remove the pfx file, the certificate is now imported
+        Remove-Item Temp-Certificate.pfx
+      displayName: 'Import Code Signing certificate'
+
+    - task: DotNetCoreCLI@2
+      displayName: 'Code signing of packages'
+      inputs:
+        command: custom
+        custom:  nuget 
+        arguments: sign $(Build.ArtifactStagingDirectory)\*.nupkg --certificate-fingerprint $(Thumbprint) --timestamper http://timestamp.digicert.com 
+
+    - powershell: |
+        #Delete the certificate by thumbprint, so it cannot be used elsewhere.
+        Get-ChildItem Cert:\CurrentUser\My\$(Thumbprint) | Remove-Item
+      displayName: 'Remove the certificate from cert store'
     
     - task: PublishBuildArtifacts@1
       displayName: Publish Artifact

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -122,24 +122,22 @@ stages:
      
     - powershell: |
         #Convert the Secure password that's presented as plain text back into a secure string
-        #$pwd = ConvertTo-SecureString -String $(CodeSigningPassword) -Force -AsPlainText
+        $pwd = ConvertTo-SecureString -String "$(CodeSigningPassword)" -Force -AsPlainText
+
+        Write-Host $(CodeSigningPassword)
+        Write-Host $pwd
 
         #Create PFX file from Certificate Variable
         New-Item Temp-Certificate.pfx -Value $(FirelyCodeSignerCertificate)
 
-        #Import the PFX certificate from the newly created file and password. Read the thumbprint into variable
-        #$Thumbprint = (Import-PfxCertificate -CertStoreLocation Cert:\CurrentUser\My -FilePath Temp-Certificate.pfx -Password $pwd).Thumbprint
-
-        #Write-Host $Thumbprint
-
         #Rest of Script below or set environment variable for rest of Pipeline
-        #Write-Host "##vso[task.setvariable variable=Thumbprint]$Thumbprint"
+        Write-Host "##vso[task.setvariable variable=certpassword]$pwd"
     - task: DotNetCoreCLI@2
       displayName: Code signing of packages
       inputs:
         command: custom
         custom:  nuget 
-        arguments: sign $(Build.ArtifactStagingDirectory)\*.nupkg --certificate-path Temp-Certificate.pfx --timestamper http://timestamp.digicert.com --certificate-password $(CodeSigningPassword) 
+        arguments: sign $(Build.ArtifactStagingDirectory)\*.nupkg --certificate-path Temp-Certificate.pfx --timestamper http://timestamp.digicert.com --certificate-password $(certpassword) 
     
     - task: PublishBuildArtifacts@1
       displayName: Publish Artifact

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -16,6 +16,7 @@ trigger:
 name: $(date:yyyyMMdd)$(rev:.r)
 
 variables:
+- group: CodeSigning
 - template: build-variables.yml
 - template: pipeline-variables.yml
   
@@ -118,6 +119,13 @@ stages:
         configurationToPack: $(buildConfiguration)
         nobuild: true
         verbosityPack: Normal
+    - task: DotNetCoreCLI@2
+      displayName: Code signing of packages
+      inputs:
+        command: custom
+        custom:  nuget sign $(Build.ArtifactStagingDirectory)\*.nupkg --certificate-path $(FirelyCodeSignerCertificate) --timestamper http://timestamp.digicert.com --certificate-password $(CodeSigningPassword) 
+      
+    
     - task: PublishBuildArtifacts@1
       displayName: Publish Artifact
       inputs:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -128,16 +128,16 @@ stages:
         Write-Host $pwd
 
         #Create PFX file from Certificate Variable
-        New-Item Temp-Certificate.pfx -Value $(FirelyCodeSignerCertificate)
+        New-Item $(Build.ArtifactStagingDirectory)\Temp-Certificate.pfx -Value $(FirelyCodeSignerCertificate)
 
         #Rest of Script below or set environment variable for rest of Pipeline
         Write-Host "##vso[task.setvariable variable=certpassword]$pwd"
-    - task: DotNetCoreCLI@2
-      displayName: Code signing of packages
-      inputs:
-        command: custom
-        custom:  nuget 
-        arguments: sign $(Build.ArtifactStagingDirectory)\*.nupkg --certificate-path Temp-Certificate.pfx --timestamper http://timestamp.digicert.com --certificate-password "$(CodeSigningPassword)" 
+    #- task: DotNetCoreCLI@2
+    #  displayName: Code signing of packages
+    #  inputs:
+    #    command: custom
+    #    custom:  nuget 
+    #    arguments: sign $(Build.ArtifactStagingDirectory)\*.nupkg --certificate-path Temp-Certificate.pfx --timestamper http://timestamp.digicert.com --certificate-password "$(CodeSigningPassword)" 
     
     - task: PublishBuildArtifacts@1
       displayName: Publish Artifact

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -119,12 +119,13 @@ stages:
         configurationToPack: $(buildConfiguration)
         nobuild: true
         verbosityPack: Normal
+        
     - task: DotNetCoreCLI@2
       displayName: Code signing of packages
       inputs:
         command: custom
-        custom:  nuget sign $(Build.ArtifactStagingDirectory)\*.nupkg --certificate-path $(FirelyCodeSignerCertificate) --timestamper http://timestamp.digicert.com --certificate-password $(CodeSigningPassword) 
-      
+        custom:  nuget 
+        arguments: sign $(Build.ArtifactStagingDirectory)\*.nupkg --certificate-path $(FirelyCodeSignerCertificate) --timestamper http://timestamp.digicert.com --certificate-password $(CodeSigningPassword) 
     
     - task: PublishBuildArtifacts@1
       displayName: Publish Artifact

--- a/build/build-variables.yml
+++ b/build/build-variables.yml
@@ -3,7 +3,7 @@
 # Variables used during builds.
 
 variables:
-  NET_CORE_SDK: 5.0.x
+  NET_CORE_SDK: 6.0.x
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   TEST_TARGETFRAMEWORK: net5.0
   buildConfiguration: Release


### PR DESCRIPTION
## Description
The produced nuget packages are now signed by a code signing certificate of Firely.

The public key is installed at NuGet for the organization Firely, and the private key is stored at a Azure Key Vault, together with the password for this key. To access those secrets in the Azure Key Vault a Variable Group `CodeSigning` has been created in the Devops project `firely-net-sdk`.

The signing itself is done by a Firely template, which can be found [here](https://github.com/FirelyTeam/azure-pipeline-templates/blob/master/codesign-nuget-packages.yml).

Also the flag `/p:ContinuousIntegrationBuild=true` has been added to the build to make the compilation deterministic.

## Related issues
Resolves issue #2041 

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes