### PR TITLE
STU3: Do not dispose of a shared HttpMessageHandler passed into the constructor

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
@@ -38,14 +38,14 @@ namespace Hl7.Fhir.Tests.Rest
         //public static Uri testEndpoint = new Uri("http://fhirtest.uhn.ca/baseDstu3");
         //public static Uri testEndpoint = new Uri("http://localhost:49911/fhir");
         //public static Uri testEndpoint = new Uri("http://sqlonfhir-stu3.azurewebsites.net/fhir");
-        public static Uri testEndpoint = new Uri("https://server.fire.ly/r4");
+        public static Uri testEndpoint = new Uri("https://server.fire.ly/r3");
 
         //public static Uri _endpointSupportingSearchUsingPost = new Uri("http://localhost:49911/fhir");
         public static Uri _endpointSupportingSearchUsingPost = new Uri("http://localhost:4080");
         //public static Uri _endpointSupportingSearchUsingPost = new Uri("https://vonk.fire.ly/r3");
 
         public static Uri TerminologyEndpoint = new Uri("https://r4.ontoserver.csiro.au/fhir");
-        // public static Uri TerminologyEndpoint = new Uri("http://test.fhir.org/r4");
+        // public static Uri TerminologyEndpoint = new Uri("http://test.fhir.org/r3");
 
         private static string patientId = "pat1" + ModelInfo.Version;
         private static string locationId = "loc1" + ModelInfo.Version;

--- a/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
@@ -1,7 +1,7 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2014, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
- * 
+ *
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
@@ -38,13 +38,14 @@ namespace Hl7.Fhir.Tests.Rest
         //public static Uri testEndpoint = new Uri("http://fhirtest.uhn.ca/baseDstu3");
         //public static Uri testEndpoint = new Uri("http://localhost:49911/fhir");
         //public static Uri testEndpoint = new Uri("http://sqlonfhir-stu3.azurewebsites.net/fhir");
-        public static Uri testEndpoint = new Uri("https://server.fire.ly/r3");
+        public static Uri testEndpoint = new Uri("https://server.fire.ly/r4");
 
-        //public static Uri _endpointSupportingSearchUsingPost = new Uri("http://localhost:49911/fhir"); 
+        //public static Uri _endpointSupportingSearchUsingPost = new Uri("http://localhost:49911/fhir");
         public static Uri _endpointSupportingSearchUsingPost = new Uri("http://localhost:4080");
         //public static Uri _endpointSupportingSearchUsingPost = new Uri("https://vonk.fire.ly/r3");
 
-        public static Uri TerminologyEndpoint = new Uri("https://stu3.ontoserver.csiro.au/fhir");
+        public static Uri TerminologyEndpoint = new Uri("https://r4.ontoserver.csiro.au/fhir");
+        // public static Uri TerminologyEndpoint = new Uri("http://test.fhir.org/r4");
 
         private static string patientId = "pat1" + ModelInfo.Version;
         private static string locationId = "loc1" + ModelInfo.Version;
@@ -315,7 +316,7 @@ namespace Hl7.Fhir.Tests.Rest
                 await testReadClientAsync(client);
             }
         }
-        
+
         private async T.Task testReadClientAsync(BaseFhirClient client)
         {
             var loc = client.Read<Location>("Location/" + locationId);
@@ -387,7 +388,7 @@ namespace Hl7.Fhir.Tests.Rest
 		public void ReadRelativeAsync()
 		{
 			FhirClient client = new FhirClient(testEndpoint);
-            testRelativeAsyncClient(client);			
+            testRelativeAsyncClient(client);
 		}
 
         [TestMethod, TestCategory("FhirClient")]
@@ -610,6 +611,44 @@ namespace Hl7.Fhir.Tests.Rest
 
             Assert.IsNotNull(result);
             Assert.IsTrue(result.Entry.Count > 0);
+        }
+
+        public void SearchAsyncHttpClient()
+        {
+            using(TestClient client = new TestClient(testEndpoint))
+            {
+                Bundle result;
+
+                result = client.SearchAsync<DiagnosticReport>().Result;
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.Entry.Count() > 10, "Test should use testdata with more than 10 reports");
+
+                result = client.SearchAsync<DiagnosticReport>(pageSize: 10).Result;
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.Entry.Count <= 10);
+
+                var withSubject =
+                    result.Entry.ByResourceType<DiagnosticReport>().FirstOrDefault(dr => dr.Resource.Subject != null);
+                Assert.IsNotNull(withSubject, "Test should use testdata with a report with a subject");
+
+                ResourceIdentity ri = new ResourceIdentity(withSubject.Id);
+
+                result = client.SearchByIdAsync<DiagnosticReport>(ri.Id,
+                            includes: new string[] { "DiagnosticReport.subject" }).Result;
+                Assert.IsNotNull(result);
+
+                Assert.AreEqual(2, result.Entry.Count);  // should have subject too
+
+                Assert.IsNotNull(result.Entry.Single(entry => new ResourceIdentity(entry.Id).Collection ==
+                            typeof(DiagnosticReport).GetCollectionName()));
+                Assert.IsNotNull(result.Entry.Single(entry => new ResourceIdentity(entry.Id).Collection ==
+                            typeof(Patient).GetCollectionName()));
+
+                result = client.SearchAsync<Patient>(new string[] { "name=Everywoman", "name=Eve" }).Result;
+
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.Entry.Count > 0);
+            }
         }
 #endif
 
@@ -912,7 +951,7 @@ namespace Hl7.Fhir.Tests.Rest
                 Name = "Furore",
                 Identifier = new List<Identifier> { new Identifier("http://hl7.org/test/1", "3141") },
                 Telecom = new List<ContactPoint> { new ContactPoint { System = ContactPoint.ContactPointSystem.Phone, Value = "+31-20-3467171" } }
-            };          
+            };
 
             var fe = client.CreateAsync<Organization>(furore).Result;
 
@@ -926,9 +965,9 @@ namespace Hl7.Fhir.Tests.Rest
             var fe2 = client.UpdateAsync(fe).Result;
 
             Assert.IsNotNull(fe2);
-            Assert.AreEqual(fe.Id, fe2.Id);        
+            Assert.AreEqual(fe.Id, fe2.Id);
 
-         
+
 
             fe.Identifier.Add(new Identifier("http://hl7.org/test/3", "3141592"));
             var fe3 = client.UpdateAsync(fe2).Result;
@@ -952,7 +991,7 @@ namespace Hl7.Fhir.Tests.Rest
 
 
         /// <summary>
-        /// This test will fail if the system records AuditEvents 
+        /// This test will fail if the system records AuditEvents
         /// and counts them in the WholeSystemHistory
         /// </summary>
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest"), Ignore]     // Keeps on failing periodically. Grahames server?
@@ -964,7 +1003,7 @@ namespace Hl7.Fhir.Tests.Rest
 
 
         /// <summary>
-        /// This test will fail if the system records AuditEvents 
+        /// This test will fail if the system records AuditEvents
         /// and counts them in the WholeSystemHistory
         /// </summary>
         [TestMethod, TestCategory("FhirClient"), TestCategory("IntegrationTest"), Ignore]     // Keeps on failing periodically. Grahames server?
@@ -998,7 +1037,7 @@ namespace Hl7.Fhir.Tests.Rest
             history = client.TypeHistory("Patient", timestampBeforeCreationAndDeletions.ToUniversalTime());
             Assert.IsNotNull(history);
             DebugDumpBundle(history);
-            Assert.AreEqual(4, history.Entry.Count());   // there's a race condition here, sometimes this is 5. 
+            Assert.AreEqual(4, history.Entry.Count());   // there's a race condition here, sometimes this is 5.
             Assert.AreEqual(3, history.Entry.Where(entry => entry.Resource != null).Count());
             Assert.AreEqual(1, history.Entry.Where(entry => entry.IsDeleted()).Count());
 
@@ -1184,8 +1223,8 @@ namespace Hl7.Fhir.Tests.Rest
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
         public void TestSearchUsingPostMultipleIncludesShouldNotThrowArgumentException()
         {
-            // This test case proves issue https://github.com/FirelyTeam/firely-net-sdk/issues/1206 is fixed. 
-            // Previoulsly EntryToHttpExtensions.setBodyAndContentType used a Dictionary which required the 
+            // This test case proves issue https://github.com/FirelyTeam/firely-net-sdk/issues/1206 is fixed.
+            // Previoulsly EntryToHttpExtensions.setBodyAndContentType used a Dictionary which required the
             // name part of the parameters to be unique.
             // Fixed by using IEnumerable<KeyValuePair<string, string>> instead of Dictionary<string, string>
             var client = new LegacyFhirClient(testEndpoint);
@@ -1197,8 +1236,8 @@ namespace Hl7.Fhir.Tests.Rest
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
         public void TestSearchUsingPostMultipleIncludesShouldNotThrowArgumentExceptionHttpClient()
         {
-            // This test case proves issue https://github.com/FirelyTeam/firely-net-sdk/issues/1206 is fixed. 
-            // Previoulsly EntryToHttpExtensions.setBodyAndContentType used a Dictionary which required the 
+            // This test case proves issue https://github.com/FirelyTeam/firely-net-sdk/issues/1206 is fixed.
+            // Previoulsly EntryToHttpExtensions.setBodyAndContentType used a Dictionary which required the
             // name part of the parameters to be unique.
             // Fixed by using IEnumerable<KeyValuePair<string, string>> instead of Dictionary<string, string>
             var client = new FhirClient(testEndpoint);
@@ -1347,43 +1386,85 @@ namespace Hl7.Fhir.Tests.Rest
         public void CallsCallbacksHttpClient()
         {
             using (var handler = new HttpClientEventHandler())
-            using (FhirClient client = new FhirClient(testEndpoint, messageHandler: handler))
             {
-                client.Settings.ParserSettings.AllowUnrecognizedEnums = true;
-
-                bool calledBefore = false;
-                HttpStatusCode? status = null;
-                byte[] body = null;
-                byte[] bodyOut = null;
-
-                handler.OnBeforeRequest += (sender, e) =>
+                using (FhirClient client = new FhirClient(testEndpoint, messageHandler: handler))
                 {
-                    calledBefore = true;
-                    bodyOut = e.Body;
-                };
+                    client.Settings.ParserSettings.AllowUnrecognizedEnums = true;
 
-                handler.OnAfterResponse += (sender, e) =>
+                    bool calledBefore = false;
+                    HttpStatusCode? status = null;
+                    byte[] body = null;
+                    byte[] bodyOut = null;
+
+                    handler.OnBeforeRequest += (sender, e) =>
+                    {
+                        calledBefore = true;
+                        bodyOut = e.Body;
+                    };
+
+                    handler.OnAfterResponse += (sender, e) =>
+                    {
+                        body = e.Body;
+                        status = e.RawResponse.StatusCode;
+                    };
+
+                    var pat = client.Read<Patient>("Patient/" + patientId);
+                    Assert.IsTrue(calledBefore);
+                    Assert.IsNotNull(status);
+                    Assert.IsNotNull(body);
+
+                    var bodyText = HttpUtil.DecodeBody(body, Encoding.UTF8);
+
+                    Assert.IsTrue(bodyText.Contains("<Patient"));
+
+                    calledBefore = false;
+                    client.Update(pat); // create cannot be called with an ID (which was retrieved)
+                    Assert.IsTrue(calledBefore);
+                    Assert.IsNotNull(bodyOut);
+
+                    bodyText = HttpUtil.DecodeBody(body, Encoding.UTF8);
+                    Assert.IsTrue(bodyText.Contains("<Patient"));
+                }
+
+                // And use another on the same handler to ensure that it wasn't disposed :O
+                using (FhirClient client = new FhirClient(testEndpoint, messageHandler: handler))
                 {
-                    body = e.Body;
-                    status = e.RawResponse.StatusCode;
-                };
+                    client.Settings.ParserSettings.AllowUnrecognizedEnums = true;
 
-                var pat = client.Read<Patient>("Patient/" + patientId);
-                Assert.IsTrue(calledBefore);
-                Assert.IsNotNull(status);
-                Assert.IsNotNull(body);
+                    bool calledBefore = false;
+                    HttpStatusCode? status = null;
+                    byte[] body = null;
+                    byte[] bodyOut = null;
 
-                var bodyText = HttpUtil.DecodeBody(body, Encoding.UTF8);
+                    handler.OnBeforeRequest += (sender, e) =>
+                    {
+                        calledBefore = true;
+                        bodyOut = e.Body;
+                    };
 
-                Assert.IsTrue(bodyText.Contains("<Patient"));
+                    handler.OnAfterResponse += (sender, e) =>
+                    {
+                        body = e.Body;
+                        status = e.RawResponse.StatusCode;
+                    };
 
-                calledBefore = false;
-                client.Update(pat); // create cannot be called with an ID (which was retrieved)
-                Assert.IsTrue(calledBefore);
-                Assert.IsNotNull(bodyOut);
+                    var pat = client.Read<Patient>("Patient/" + patientId);
+                    Assert.IsTrue(calledBefore);
+                    Assert.IsNotNull(status);
+                    Assert.IsNotNull(body);
 
-                bodyText = HttpUtil.DecodeBody(body, Encoding.UTF8);
-                Assert.IsTrue(bodyText.Contains("<Patient"));
+                    var bodyText = HttpUtil.DecodeBody(body, Encoding.UTF8);
+
+                    Assert.IsTrue(bodyText.Contains("<Patient"));
+
+                    calledBefore = false;
+                    client.Update(pat); // create cannot be called with an ID (which was retrieved)
+                    Assert.IsTrue(calledBefore);
+                    Assert.IsNotNull(bodyOut);
+
+                    bodyText = HttpUtil.DecodeBody(body, Encoding.UTF8);
+                    Assert.IsTrue(bodyText.Contains("<Patient"));
+                }
             }
         }
 

--- a/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
@@ -44,7 +44,7 @@ namespace Hl7.Fhir.Tests.Rest
         public static Uri _endpointSupportingSearchUsingPost = new Uri("http://localhost:4080");
         //public static Uri _endpointSupportingSearchUsingPost = new Uri("https://vonk.fire.ly/r3");
 
-        public static Uri TerminologyEndpoint = new Uri("https://r4.ontoserver.csiro.au/fhir");
+        public static Uri TerminologyEndpoint = new Uri("https://stu3.ontoserver.csiro.au/fhir");
         // public static Uri TerminologyEndpoint = new Uri("http://test.fhir.org/r3");
 
         private static string patientId = "pat1" + ModelInfo.Version;

--- a/src/Hl7.Fhir.Core/Rest/FhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/FhirClient.cs
@@ -41,7 +41,7 @@ namespace Hl7.Fhir.Rest
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
             };
 
-            var requester = new HttpClientRequester(Endpoint, Settings, handler);
+            var requester = new HttpClientRequester(Endpoint, Settings, handler, messageHandler == null);
             Requester = requester;
 
             // Expose default request headers to user.

--- a/src/Hl7.Fhir.Core/Rest/FhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/FhirClient.cs
@@ -1,7 +1,7 @@
-﻿/* 
+﻿/*
 * Copyright (c) 2014, Firely (info@fire.ly) and contributors
 * See the file CONTRIBUTORS for details.
-* 
+*
 * This file is licensed under the BSD 3-Clause license
 * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
 */
@@ -21,11 +21,14 @@ namespace Hl7.Fhir.Rest
     {
 //disables warning that OnBeforeRequest and OnAfterResponse are never used.
 #pragma warning disable CS0067
-        
+
         /// <summary>
         /// Creates a new client using a default endpoint
         /// If the endpoint does not end with a slash (/), it will be added.
         /// </summary>
+        /// <remarks>
+        /// If the messageHandler is provided then it must be disposed by the caller
+        /// </remarks>
         /// <param name="endpoint">
         /// The URL of the server to connect to.<br/>
         /// If the trailing '/' is not present, then it will be appended automatically
@@ -122,7 +125,7 @@ namespace Hl7.Fhir.Rest
         }
 
         /// <summary>
-        /// Should calls to Create, Update and transaction operations return the whole updated content, 
+        /// Should calls to Create, Update and transaction operations return the whole updated content,
         /// or an OperationOutcome?
         /// </summary>
         /// <remarks>Refer to specification section 2.1.0.5 (Managing Return Content)</remarks>
@@ -157,7 +160,7 @@ namespace Hl7.Fhir.Rest
             set => Settings.PreferCompressedResponses = value;
         }
         /// <summary>
-        /// Compress any Request bodies 
+        /// Compress any Request bodies
         /// (warning, if a server does not handle compressed requests you will get a 415 response)
         /// </summary>
         [Obsolete("Use the FhirClient.Settings property or the settings argument in the constructor instead")]
@@ -201,6 +204,6 @@ namespace Hl7.Fhir.Rest
         }
     }
 
-   
+
 }
 


### PR DESCRIPTION
## Description
When creating the new `HttpClient` inside the constructor indicate that if it is a shared MessageHandler and therefore that it should not be disposing it when it is finished with it.
As the change in the common lib has a default parameter this is not a truly breaking change, and in the R4 (version level) functionality the public surface has not changed this is not tagged as a breaking change.

## Related issues
Resolves #2029

## Testing
The unit test `CallsCallbacksHttpClient` was used to verify this functionality, as it fails when the fix is not applied.

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes