### PR TITLE
Use IssueComponent.Expression instead of IssueComponent.Location

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Model/ModelTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Model/ModelTests.cs
@@ -6,17 +6,13 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+using FluentAssertions;
+using Hl7.Fhir.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Text;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Hl7.Fhir.Model;
 using System.Xml.Linq;
-using System.ComponentModel.DataAnnotations;
-using Hl7.Fhir.Validation;
-using Hl7.Fhir.Serialization;
-using FluentAssertions;
 
 namespace Hl7.Fhir.Tests.Model
 {
@@ -36,14 +32,14 @@ namespace Hl7.Fhir.Tests.Model
         }
 
         [TestMethod]
-        public void OperationOutcomeLocation()
+        public void OperationOutcomeExpression()
         {
             OperationOutcome oo = new OperationOutcome();
             oo.Issue.Add(new OperationOutcome.IssueComponent()
             {
-                Location = new string[] { "yes" }
+                Expression = new string[] { "this" }
             });
-            Assert.AreEqual(1, oo.Issue[0].Location.Count());
+            Assert.AreEqual(1, oo.Issue[0].Expression.Count());
         }
 
         [TestMethod]
@@ -72,7 +68,7 @@ namespace Hl7.Fhir.Tests.Model
         [TestMethod]
         public void TestTryToDateTimeOffset()
         {
-            var fdt = new FhirDateTime(new DateTimeOffset(2021, 3, 18, 12, 22, 35, 999, new TimeSpan(-4, 0, 0)));           
+            var fdt = new FhirDateTime(new DateTimeOffset(2021, 3, 18, 12, 22, 35, 999, new TimeSpan(-4, 0, 0)));
             Assert.AreEqual("2021-03-18T12:22:35.999-04:00", fdt.Value);
 
             Assert.IsTrue(fdt.TryToDateTimeOffset(out var dto1));
@@ -87,7 +83,7 @@ namespace Hl7.Fhir.Tests.Model
             fdt = new FhirDateTime("2021-03-18T12:22:35.999Z");
             Assert.IsTrue(fdt.TryToDateTimeOffset(out var dto3));
             Assert.AreEqual("2021-03-18T12:22:35.9990000+00:00", dto3.ToString("o"));
-            
+
             fdt = new FhirDateTime("2021-03-18T12:22:35.1234+04:00");
             Assert.IsTrue(fdt.TryToDateTimeOffset(out var dto4));
             Assert.AreEqual("2021-03-18T12:22:35.1234000+04:00", dto4.ToString("o"));
@@ -100,7 +96,7 @@ namespace Hl7.Fhir.Tests.Model
         [TestMethod]
         public void TodayTests()
         {
-            var todayLocal = Date.Today(); 
+            var todayLocal = Date.Today();
             Assert.AreEqual(DateTimeOffset.Now.ToString("yyy-MM-dd"), todayLocal.Value);
 
             var todayUtc = Date.UtcToday();
@@ -135,7 +131,7 @@ namespace Hl7.Fhir.Tests.Model
                 var uriEncodedUrl = string.Format(urlFormat, Uri.EscapeDataString(param1), Uri.EscapeDataString(param2));
                 Assert.AreEqual(manuallyEncodedUrl, uriEncodedUrl);
                 var uri = new Uri(manuallyEncodedUrl, UriKind.RelativeOrAbsolute);
-                var bundle = new Bundle {SelfLink = uri};
+                var bundle = new Bundle { SelfLink = uri };
                 if (uri.IsAbsoluteUri)
                 {
                     Assert.AreEqual(uri.AbsoluteUri, bundle.SelfLink.AbsoluteUri);
@@ -454,7 +450,7 @@ namespace Hl7.Fhir.Tests.Model
             Assert.IsNull(ns.UrlElement);
 
             ns.UniqueId.Add(new NamingSystem.UniqueIdComponent { Value = "http://nu.nl" });
-            ns.UniqueId.Add(new NamingSystem.UniqueIdComponent { Value = "http://dan.nl", Preferred=true });
+            ns.UniqueId.Add(new NamingSystem.UniqueIdComponent { Value = "http://dan.nl", Preferred = true });
 
             Assert.AreEqual("http://dan.nl", ns.Url);
             Assert.AreEqual("http://dan.nl", ns.UrlElement.Value);
@@ -621,7 +617,7 @@ namespace Hl7.Fhir.Tests.Model
             Assert.IsTrue(ModelInfo.CheckMinorVersionCompatibility("3.0.1"));
             Assert.IsTrue(ModelInfo.CheckMinorVersionCompatibility("3.0"));
             Assert.IsTrue(ModelInfo.CheckMinorVersionCompatibility("3.0.2"));
-            Assert.IsFalse(ModelInfo.CheckMinorVersionCompatibility("3"));            
+            Assert.IsFalse(ModelInfo.CheckMinorVersionCompatibility("3"));
         }
 
         [TestMethod]

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -1032,7 +1032,7 @@ namespace Hl7.Fhir.Specification.Tests
             }
             if (location != null && location.Length > 0)
             {
-                Assert.IsTrue(location.SequenceEqual(issue.Location));
+                Assert.IsTrue(location.SequenceEqual(issue.Expression));
             }
         }
 
@@ -1619,7 +1619,7 @@ namespace Hl7.Fhir.Specification.Tests
                 if (issue.Details.Text != null) sb.AppendFormat(" Text : '{0}'", issue.Details.Text);
             }
             if (issue.Diagnostics != null) { sb.AppendFormat(" Profile: '{0}'", issue.Diagnostics); }
-            if (issue.Location != null) { sb.AppendFormat(" Path: '{0}'", string.Join(" | ", issue.Location)); }
+            if (issue.Expression != null) { sb.AppendFormat(" Path: '{0}'", string.Join(" | ", issue.Expression)); }
 
             Debug.Print(sb.ToString());
         }

--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -199,7 +199,7 @@ namespace Hl7.Fhir.Specification.Tests
                 {
                     new OperationOutcome.IssueComponent
                     {
-                        Location = new string[]{"active.extension"},
+                        Expression = new string[]{"active.extension"},
                         Severity = OperationOutcome.IssueSeverity.Error,
                         Details = new CodeableConcept
                         {
@@ -208,7 +208,7 @@ namespace Hl7.Fhir.Specification.Tests
                     },
                     new OperationOutcome.IssueComponent
                     {
-                        Location = new string[]{"active.extension"},
+                        Expression = new string[]{"active.extension"},
                         Severity = OperationOutcome.IssueSeverity.Error,
                         Details = new CodeableConcept
                         {
@@ -224,7 +224,7 @@ namespace Hl7.Fhir.Specification.Tests
                 {
                     new OperationOutcome.IssueComponent
                     {
-                        Location = new string[]{"active.value"},
+                        Expression = new string[]{"active.value"},
                         Severity = OperationOutcome.IssueSeverity.Error,
                         Details = new CodeableConcept
                         {
@@ -233,7 +233,7 @@ namespace Hl7.Fhir.Specification.Tests
                     },
                     new OperationOutcome.IssueComponent
                     {
-                        Location = new string[]{"active.extension"},
+                        Expression = new string[]{"active.extension"},
                         Severity = OperationOutcome.IssueSeverity.Error,
                         Details = new CodeableConcept
                         {

--- a/src/Hl7.Fhir.Specification/Schema/Binding.cs
+++ b/src/Hl7.Fhir.Specification/Schema/Binding.cs
@@ -149,7 +149,12 @@ namespace Hl7.Fhir.Specification.Schema
 
 
                 var outcome = (await svc.ValueSetValidateCode(parameters).ConfigureAwait(false)).ToOperationOutcome();
-                foreach (var issue in outcome.Issue) issue.Expression = new string[] { location };
+                foreach (var issue in outcome.Issue)
+                {
+                    issue.Expression = new string[] { location };
+                    // Location is deprecated, but we set this for backwards compatibility
+                    issue.Location = new string[] { location };
+                }
                 return outcome;
             }
             catch (FhirOperationException tse)

--- a/src/Hl7.Fhir.Specification/Schema/Binding.cs
+++ b/src/Hl7.Fhir.Specification/Schema/Binding.cs
@@ -138,7 +138,7 @@ namespace Hl7.Fhir.Specification.Schema
                 Coding coding = null, CodeableConcept cc = null, bool? abstractAllowed = null, string context = null)
         {
             try
-            {                
+            {
                 var parameters = new ValidateCodeParameters()
                     .WithValueSet(canonical)
                     .WithCode(code: code, system: system, display: display, context: context)
@@ -149,14 +149,14 @@ namespace Hl7.Fhir.Specification.Schema
 
 
                 var outcome = (await svc.ValueSetValidateCode(parameters).ConfigureAwait(false)).ToOperationOutcome();
-                foreach (var issue in outcome.Issue) issue.Location = new string[] { location };
+                foreach (var issue in outcome.Issue) issue.Expression = new string[] { location };
                 return outcome;
             }
             catch (FhirOperationException tse)
             {
-                string message = (cc?.Coding == null || cc.Coding.Count == 1) 
+                string message = (cc?.Coding == null || cc.Coding.Count == 1)
                     ? $"Terminology service failed while validating code '{code ?? coding?.Code ?? cc?.Coding[0]?.Code}' (system '{system ?? coding?.System ?? cc?.Coding[0]?.System}'): {tse.Message}"
-                    : $"Terminology service failed while validating the codes: {tse.Message}";            
+                    : $"Terminology service failed while validating the codes: {tse.Message}";
 
                 return Issue.TERMINOLOGY_SERVICE_FAILED
                         .NewOutcomeWithIssue(message, location);

--- a/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
@@ -72,7 +72,9 @@ namespace Hl7.Fhir.Validation
                         Code = issue.Type,
                         Details = issue.ToCodeableConcept(text),
                         Diagnostics = constraintElement.GetFhirPathConstraint(), // Putting the fhirpath expression of the invariant in the diagnostics
-                        Expression = new string[] { instance.Location }
+                        Expression = new string[] { instance.Location },
+                        // Location is deprecated, but we set this for backwards compatibility
+                        Location = new string[] { instance.Location }
                     };
                     outcomeIssue.Details.Coding.Add(new Coding(structureDefinitionUrl, constraintElement.Key, constraintElement.Human));
                     outcome.AddIssue(outcomeIssue);

--- a/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
@@ -72,7 +72,7 @@ namespace Hl7.Fhir.Validation
                         Code = issue.Type,
                         Details = issue.ToCodeableConcept(text),
                         Diagnostics = constraintElement.GetFhirPathConstraint(), // Putting the fhirpath expression of the invariant in the diagnostics
-                        Location = new string[] { instance.Location }
+                        Expression = new string[] { instance.Location }
                     };
                     outcomeIssue.Details.Coding.Add(new Coding(structureDefinitionUrl, constraintElement.Key, constraintElement.Human));
                     outcome.AddIssue(outcomeIssue);

--- a/src/Hl7.Fhir.Specification/Validation/TypeRefValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/TypeRefValidationExtensions.cs
@@ -195,7 +195,11 @@ namespace Hl7.Fhir.Validation
                 // Prefix each path with the referring resource's path to keep the locations
                 // interpretable
                 foreach (var issue in childResult.Issue)
+                {
                     issue.Expression = issue.Expression.Concat(new string[] { instance.Location });
+                    // Location is deprecated, but we set this for backwards compatibility
+                    issue.Location = issue.Expression.Concat(new string[] { instance.Location });
+                }
 
                 outcome.Include(childResult);
             }

--- a/src/Hl7.Fhir.Specification/Validation/TypeRefValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/TypeRefValidationExtensions.cs
@@ -195,7 +195,7 @@ namespace Hl7.Fhir.Validation
                 // Prefix each path with the referring resource's path to keep the locations
                 // interpretable
                 foreach (var issue in childResult.Issue)
-                    issue.Location = issue.Location.Concat(new string[] { instance.Location });
+                    issue.Expression = issue.Expression.Concat(new string[] { instance.Location });
 
                 outcome.Include(childResult);
             }


### PR DESCRIPTION
## Description
 `IssueComponent.Location` is deprecated. We use now  `IssueComponent.Expression`

## Related issues
Resolves #1692.

## Testing
Existing tests

## See also
PR FirelyTeam/firely-net-common/pull/196

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes