### PR TITLE
Support providing the HttpClient direct to the FhirClient

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/FhirClientTests.cs
@@ -1385,7 +1385,7 @@ namespace Hl7.Fhir.Tests.Rest
 
         [TestMethod]
         [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
-        public void CallsCallbacksHttpClient()
+        public void CallsCallbacksHttpClientHandler()
         {
             using (var handler = new HttpClientEventHandler())
             {
@@ -1430,6 +1430,94 @@ namespace Hl7.Fhir.Tests.Rest
 
                 // And use another on the same handler to ensure that it wasn't disposed :O
                 using (FhirClient client = new FhirClient(testEndpoint, messageHandler: handler))
+                {
+                    client.Settings.ParserSettings.AllowUnrecognizedEnums = true;
+
+                    bool calledBefore = false;
+                    HttpStatusCode? status = null;
+                    byte[] body = null;
+                    byte[] bodyOut = null;
+
+                    handler.OnBeforeRequest += (sender, e) =>
+                    {
+                        calledBefore = true;
+                        bodyOut = e.Body;
+                    };
+
+                    handler.OnAfterResponse += (sender, e) =>
+                    {
+                        body = e.Body;
+                        status = e.RawResponse.StatusCode;
+                    };
+
+                    var pat = client.Read<Patient>("Patient/" + patientId);
+                    Assert.IsTrue(calledBefore);
+                    Assert.IsNotNull(status);
+                    Assert.IsNotNull(body);
+
+                    var bodyText = HttpUtil.DecodeBody(body, Encoding.UTF8);
+
+                    Assert.IsTrue(bodyText.Contains("<Patient"));
+
+                    calledBefore = false;
+                    client.Update(pat); // create cannot be called with an ID (which was retrieved)
+                    Assert.IsTrue(calledBefore);
+                    Assert.IsNotNull(bodyOut);
+
+                    bodyText = HttpUtil.DecodeBody(body, Encoding.UTF8);
+                    Assert.IsTrue(bodyText.Contains("<Patient"));
+                }
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("FhirClient"), TestCategory("IntegrationTest")]
+        public void CallsCallbacksHttpClient()
+        {
+            using (var handler = new HttpClientEventHandler())
+            using (var httpClient = new HttpClient(handler))
+            {
+                using (FhirClient client = new FhirClient(testEndpoint, httpClient: httpClient))
+                {
+                    client.Settings.ParserSettings.AllowUnrecognizedEnums = true;
+
+                    bool calledBefore = false;
+                    HttpStatusCode? status = null;
+                    byte[] body = null;
+                    byte[] bodyOut = null;
+
+                    handler.OnBeforeRequest += (sender, e) =>
+                    {
+                        calledBefore = true;
+                        bodyOut = e.Body;
+                    };
+
+                    handler.OnAfterResponse += (sender, e) =>
+                    {
+                        body = e.Body;
+                        status = e.RawResponse.StatusCode;
+                    };
+
+                    var pat = client.Read<Patient>("Patient/" + patientId);
+                    Assert.IsTrue(calledBefore);
+                    Assert.IsNotNull(status);
+                    Assert.IsNotNull(body);
+
+                    var bodyText = HttpUtil.DecodeBody(body, Encoding.UTF8);
+
+                    Assert.IsTrue(bodyText.Contains("<Patient"));
+
+                    calledBefore = false;
+                    client.Update(pat); // create cannot be called with an ID (which was retrieved)
+                    Assert.IsTrue(calledBefore);
+                    Assert.IsNotNull(bodyOut);
+
+                    bodyText = HttpUtil.DecodeBody(body, Encoding.UTF8);
+                    Assert.IsTrue(bodyText.Contains("<Patient"));
+                }
+
+                // And use another on the same handler to ensure that it wasn't disposed :O
+                using (FhirClient client = new FhirClient(testEndpoint, httpClient: httpClient))
                 {
                     client.Settings.ParserSettings.AllowUnrecognizedEnums = true;
 

--- a/src/Hl7.Fhir.Core/Rest/FhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/FhirClient.cs
@@ -26,8 +26,7 @@ namespace Hl7.Fhir.Rest
         /// If the endpoint does not end with a slash (/), it will be added.
         /// </summary>
         /// <remarks>
-        /// If the messageHandler, or httpClient is provided then it must be disposed by the caller
-        /// Only one of the messageHandler or httpClient can be provided
+        /// If the messageHandler is provided then it must be disposed by the caller
         /// </remarks>
         /// <param name="endpoint">
         /// The URL of the server to connect to.<br/>
@@ -56,8 +55,7 @@ namespace Hl7.Fhir.Rest
         /// If the endpoint does not end with a slash (/), it will be added.
         /// </summary>
         /// <remarks>
-        /// If the messageHandler, or httpClient is provided then it must be disposed by the caller
-        /// Only one of the messageHandler or httpClient can be provided
+        /// The httpClient must be disposed by the caller
         /// </remarks>
         /// <param name="endpoint">
         /// The URL of the server to connect to.<br/>
@@ -79,6 +77,9 @@ namespace Hl7.Fhir.Rest
         /// Creates a new client using a default endpoint
         /// If the endpoint does not end with a slash (/), it will be added.
         /// </summary>
+        /// <remarks>
+        /// If the messageHandler is provided then it must be disposed by the caller
+        /// </remarks>
         /// <param name="endpoint">
         /// The URL of the server to connect to.<br/>
         /// If the trailing '/' is not present, then it will be appended automatically
@@ -95,6 +96,9 @@ namespace Hl7.Fhir.Rest
         /// Creates a new client using a default endpoint
         /// If the endpoint does not end with a slash (/), it will be added.
         /// </summary>
+        /// <remarks>
+        /// The httpClient must be disposed by the caller
+        /// </remarks>
         /// <param name="endpoint">
         /// The URL of the server to connect to.<br/>
         /// If the trailing '/' is not present, then it will be appended automatically

--- a/src/Hl7.Fhir.Core/Rest/FhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/FhirClient.cs
@@ -19,7 +19,7 @@ namespace Hl7.Fhir.Rest
 {
     public partial class FhirClient : BaseFhirClient
     {
-//disables warning that OnBeforeRequest and OnAfterResponse are never used.
+        //disables warning that OnBeforeRequest and OnAfterResponse are never used.
 #pragma warning disable CS0067
 
         /// <summary>
@@ -27,7 +27,8 @@ namespace Hl7.Fhir.Rest
         /// If the endpoint does not end with a slash (/), it will be added.
         /// </summary>
         /// <remarks>
-        /// If the messageHandler is provided then it must be disposed by the caller
+        /// If the messageHandler, or httpClient is provided then it must be disposed by the caller
+        /// Only one of the messageHandler or httpClient can be provided
         /// </remarks>
         /// <param name="endpoint">
         /// The URL of the server to connect to.<br/>
@@ -35,16 +36,27 @@ namespace Hl7.Fhir.Rest
         /// </param>
         /// <param name="settings"></param>
         /// <param name="messageHandler"></param>
+        /// <param name="httpClient"></param>
         /// <param name="provider"></param>
-        public FhirClient(Uri endpoint, FhirClientSettings settings = null, HttpMessageHandler messageHandler = null, IStructureDefinitionSummaryProvider provider = null) : base(endpoint, settings, provider)
+        public FhirClient(Uri endpoint, FhirClientSettings settings = null, HttpMessageHandler messageHandler = null, HttpClient httpClient = null, IStructureDefinitionSummaryProvider provider = null) : base(endpoint, settings, provider)
         {
-            // If user does not supply message handler, add decompression strategy in default handler.
-            var handler = messageHandler ?? new HttpClientHandler()
+            HttpClientRequester requester;
+            if (httpClient != null)
             {
-                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-            };
+                if (messageHandler != null) throw new ArgumentException("Must not provide both messageHandler and httpClient parameters", nameof(messageHandler));
 
-            var requester = new HttpClientRequester(Endpoint, Settings, handler, messageHandler == null);
+                requester = new HttpClientRequester(Endpoint, Settings, httpClient);
+            }
+            else
+            {
+                // If user does not supply message handler, create our own and add decompression strategy in default handler.
+                var handler = messageHandler ?? new HttpClientHandler()
+                {
+                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+                };
+
+                requester = new HttpClientRequester(Endpoint, Settings, handler, messageHandler == null);
+            }
             Requester = requester;
 
             // Expose default request headers to user.
@@ -62,9 +74,10 @@ namespace Hl7.Fhir.Rest
         /// </param>
         /// <param name="settings"></param>
         /// <param name="messageHandler"></param>
+        /// <param name="httpClient"></param>
         /// <param name="provider"></param>
-        public FhirClient(string endpoint, FhirClientSettings settings = null, HttpMessageHandler messageHandler = null, IStructureDefinitionSummaryProvider provider = null)
-            : this(new Uri(endpoint), settings, messageHandler, provider)
+        public FhirClient(string endpoint, FhirClientSettings settings = null, HttpMessageHandler messageHandler = null, HttpClient httpClient = null, IStructureDefinitionSummaryProvider provider = null)
+            : this(new Uri(endpoint), settings, messageHandler, httpClient, provider)
         {
         }
 


### PR DESCRIPTION
## Description
Support providing the HttpClient direct to the FhirClient instead of the HttpClientHandler (as another alternative)

This then supports creating unit tests as described here for webapi based projects
https://www.hanselman.com/blog/minimal-apis-in-net-6-but-where-are-the-unit-tests


## Related issues
Resolves/Contributes to #2046 #2036 (may be able to now push the HttpClientFactory work to the callers, and not be required in the FirelySDK at all)

## Testing
Additional unit test included (and also included in my server to verify that can unit test as shown)
