### PR TITLE
Catch InvalidOperationException when FhirClient encounters non-FHIR Json/XML in the response - STU3

### DIFF
--- a/src/Hl7.Fhir.Core/Rest/BaseFhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/BaseFhirClient.cs
@@ -1006,7 +1006,7 @@ namespace Hl7.Fhir.Rest
                 if (!typedEntryResponse.IsSuccessful())
                 {
                     Enum.TryParse(typedEntryResponse.Status, out HttpStatusCode code);
-                    throw FhirOperationException.BuildFhirOperationException(code, response.Resource);
+                    throw FhirOperationException.BuildFhirOperationException(code, response.Resource, typedEntryResponse.GetBodyAsText());
                 }
 
             }


### PR DESCRIPTION
Fixes: #2020