### PR TITLE
Signing of NuGet packages is not done anymore at PR builds

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -119,12 +119,13 @@ stages:
         configurationToPack: $(buildConfiguration)
         nobuild: true
         verbosityPack: Normal
-
-    - template: codesign-nuget-packages.yml@templates
-      parameters:
-        certificateValue: $(FirelyCodeSignerCertificate)
-        certificatePasswordValue: $(CodeSigningPassword)
-        packagePaths: $(Build.ArtifactStagingDirectory)\*.nupkg
+    
+    - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+      - template: codesign-nuget-packages.yml@templates
+        parameters:
+          certificateValue: $(FirelyCodeSignerCertificate)
+          certificatePasswordValue: $(CodeSigningPassword)
+          packagePaths: $(Build.ArtifactStagingDirectory)\*.nupkg
 
     - task: PublishBuildArtifacts@1
       displayName: Publish Artifact


### PR DESCRIPTION
## Description
Signing of the NuGet Packages is not done anymore for Pull Requests. Because externals that are creating PRs cannot access our secrets, like code certificates or signing passwords, which is a good thing ;) 

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes