### PR TITLE
Extensions on Binding and Constraint are not merged from the differential to the snapshot (STU3)

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/ElementDefinitionPropertyProxy.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/ElementDefinitionPropertyProxy.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using Hl7.Fhir.Model;
+using System;
+using System.Collections;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace Hl7.Fhir.Specification.Tests
+{
+    /// <summary>
+    /// Proxy for accessing a element definition property by name using reflection.
+    /// The property can also be a specific item from a property list.
+    /// The property name is specified in the constructor.
+    /// 
+    /// The name is either the name of the property (e.g. "Binding") or the name of the property list
+    /// with a item selector (e.g. "Constraint[Key:dom-2]").
+    /// </summary>
+    internal class ElementDefinitionPropertyProxy
+    {
+        private string _propertyName;
+        private string _selectorPropertyName;
+        private string _selectorValue;
+        private PropertyInfo _propertyInfo;
+        private PropertyInfo _selectorPropertyInfo;
+
+        public ElementDefinitionPropertyProxy(string propertyName)
+        {
+            getPropertyInfo(propertyName);
+        }
+
+        /// <summary>
+        /// Create a new instance of the property.
+        /// If the property is a list then an instance of the list item type is created as well.
+        /// </summary>
+        /// <param name="element">Optional element to initialize the new list item with.</param>
+        /// <returns></returns>
+        public object CreateInstance(Element element)
+        {
+            var instance = Activator.CreateInstance(_propertyInfo.PropertyType);
+
+            if (_selectorPropertyInfo == null)
+                return instance; // Primitive property
+
+            // Create item for property list
+            var item = (Element)Activator.CreateInstance(_propertyInfo.PropertyType.GenericTypeArguments[0]);
+
+            // Initialize with specified element
+            element?.CopyTo(item);
+
+            // Set key value
+            _selectorPropertyInfo.SetValue(item, _selectorValue);
+
+            // Add item to property list
+            if (instance is IList items)
+                items.Add(item);
+
+            return instance;
+        }
+
+        /// <summary>
+        /// Set the value of the property.
+        /// </summary>
+        /// <param name="instance">Instance to set the property value for.</param>
+        /// <param name="value">The value to set.</param>
+        public void SetValue(object instance, object value)
+        {
+            _propertyInfo.SetValue(instance, value);
+        }
+
+        /// <summary>
+        /// Get the value of property (typed as Element).
+        /// </summary>
+        /// <param name="instance">Instance to get the property value from.</param>
+        /// <returns>The property value as an Element type.</returns>
+        public Element GetValueAsElement(object instance)
+        {
+            if (_selectorPropertyInfo == null)
+                return (Element)_propertyInfo.GetValue(instance);
+
+            if (_propertyInfo.GetValue(instance, null) is not IList items)
+                return null;
+
+            foreach (var item in items)
+            {
+                var value = _selectorPropertyInfo.GetValue(item)?.ToString();
+
+                if (_selectorValue.Equals(value))
+                    return (Element)item;
+            }
+
+            return null;
+        }
+
+        private void getPropertyInfo(string propertyName)
+        {
+            parsePropertyName(propertyName);
+
+            _propertyInfo = typeof(ElementDefinition).GetProperty(_propertyName);
+            _propertyInfo.Should().NotBeNull(); // Check property exists
+
+            // ReSharper disable once PossibleNullReferenceException
+            if (!isList(_propertyInfo.PropertyType))
+            {
+                _propertyInfo.PropertyType.IsAssignableTo(typeof(Element)).Should().BeTrue(); // Property type should be derived from Element
+                return;
+            }
+
+            _propertyInfo.PropertyType.GenericTypeArguments[0].IsAssignableTo(typeof(Element)).Should().BeTrue(); // Property type should be derived from Element
+
+            _selectorPropertyInfo = _propertyInfo.PropertyType.GenericTypeArguments[0].GetProperty(_selectorPropertyName);
+            _selectorPropertyInfo.Should().NotBeNull(); // Check property exists
+        }
+
+        private void parsePropertyName(string propertyName)
+        {
+            _propertyName = propertyName;
+
+            var regex = new Regex("(.*)\\[(.*):(.*)\\]|(.*)");
+            var result = regex.Match(propertyName);
+
+            if (!result.Success || result.Groups[4].Success)
+                return;
+
+            _propertyName = result.Groups[1].Value;
+            _selectorPropertyName = result.Groups[2].Value;
+            _selectorValue = result.Groups[3].Value;
+        }
+
+        private static bool isList(Type type) => typeof(IList).IsAssignableFrom(type);
+    }
+}

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/ElementDefinitionPropertyProxy.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/ElementDefinitionPropertyProxy.cs
@@ -8,7 +8,7 @@ using System.Text.RegularExpressions;
 namespace Hl7.Fhir.Specification.Tests
 {
     /// <summary>
-    /// Proxy for accessing a element definition property by name using reflection.
+    /// Proxy for accessing an element definition property by name using reflection.
     /// The property can also be a specific item from a property list.
     /// The property name is specified in the constructor.
     /// 

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -7919,7 +7919,7 @@ namespace Hl7.Fhir.Specification.Tests
         /// <param name="elementId">The element id of the profile to check (e.g. "AllergyIntolerance.code")</param>
         /// <param name="propertyName">The name of the element definition property for which to add or modify the extension in the differential (e.g. "Binding").</param>
         /// <param name="baseExtensions">The extensions that are defined in the base profile for this property.</param>
-        /// <param name="diffExtensions">The etxnsions to define in the differential for this property.</param>
+        /// <param name="diffExtensions">The extensions to define in the differential for this property.</param>
         /// <returns></returns>
         [DataTestMethod]
         [DynamicData(nameof(ElementDefinitionPropertyExtensionTestCasesStu3), DynamicDataSourceType.Property)]

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -7886,5 +7886,140 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsNull(elem.CommonTypeCode());
         }
 
+        public static IEnumerable<object[]> ElementDefinitionPropertyExtensionTestCasesStu3
+        {
+            get
+            {
+                // Modify an existing Binding extension
+                yield return new object[] { FHIRAllTypes.AllergyIntolerance, "AllergyIntolerance.code", "Binding",
+                    new[] {
+                        new Extension("http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName", new FhirString("AllergyIntoleranceCode")) },
+                    new[] {
+                        new Extension("http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName", new FhirString("Test")) }};
+
+                // Adding a new Binding extension
+                yield return new object[] { FHIRAllTypes.AllergyIntolerance, "AllergyIntolerance.code", "Binding",
+                    new[] {
+                        new Extension("http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName", new FhirString("AllergyIntoleranceCode")) },
+                    new[] {
+                        new Extension("http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding", new FhirBoolean(true)) }};
+
+                // Adding a new Constraint extension
+                yield return new object[] { FHIRAllTypes.AllergyIntolerance, "AllergyIntolerance", "Constraint[Key:dom-2]",
+                    Array.Empty<Extension>(),
+                    new[] {
+                        new Extension("http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice", new FhirBoolean(true)) }};
+            }
+        }
+
+        /// <summary>
+        /// Tests whether element definition property extensions in the differential are properly merged by the snapshot generator.
+        /// </summary>
+        /// <param name="profileType">The profile type under test (e.g. FHIRAllTypes.AllergyIntolerance).</param>
+        /// <param name="elementId">The element id of the profile to check (e.g. "AllergyIntolerance.code")</param>
+        /// <param name="propertyName">The name of the element definition property for which to add or modify the extension in the differential (e.g. "Binding").</param>
+        /// <param name="baseExtensions">The extensions that are defined in the base profile for this property.</param>
+        /// <param name="diffExtensions">The etxnsions to define in the differential for this property.</param>
+        /// <returns></returns>
+        [DataTestMethod]
+        [DynamicData(nameof(ElementDefinitionPropertyExtensionTestCasesStu3), DynamicDataSourceType.Property)]
+        public async T.Task ElementDefinitionPropertyExtensionTest(FHIRAllTypes profileType, string elementId, string propertyName, Extension[] baseExtensions, Extension[] diffExtensions)
+        {
+            // Arrange
+            var uri = ModelInfo.CanonicalUriForFhirCoreType(profileType);
+            var zipSource = ZipSource.CreateValidationSource();
+            var generator = new SnapshotGenerator(zipSource, SnapshotGeneratorSettings.CreateDefault());
+            var propertyProxy = new ElementDefinitionPropertyProxy(propertyName);
+
+            var sd = await _testResolver.FindStructureDefinitionAsync(uri); // Find base profile
+            var snapElementDefinition = sd.Snapshot.Element.SingleOrDefault(x => x.ElementId == elementId); // Find specified element in snapshot of base profile
+            snapElementDefinition.Should().NotBeNull();
+            var snapElementDefinitionProperty = propertyProxy.GetValueAsElement(snapElementDefinition); // Get the property from the snapshot element (typed)
+
+            if (snapElementDefinitionProperty != null)
+            {
+                logExtensions("Base extensions", baseExtensions);
+
+                snapElementDefinitionProperty.Extension.Should().HaveCount(baseExtensions.Length); // Check extensions in element
+                snapElementDefinitionProperty.Extension.OrderBy(x => x.Url).Should().Equal(baseExtensions.OrderBy(x => x.Url), (e1, e2) => e1.IsExactly(e2));
+            }
+            else
+            {
+                baseExtensions.Should().BeNull();
+            }
+
+            var diffElementDefinition = new ElementDefinition(elementId) { ElementId = elementId }; // Create element for differential
+            propertyProxy.SetValue(diffElementDefinition, propertyProxy.CreateInstance(snapElementDefinitionProperty)); // Set property for differential element
+            var diffElementDefinitionProperty = propertyProxy.GetValueAsElement(diffElementDefinition); // Get the property from the differential element (typed)
+
+            // Add extensions for the element definition properties in the differential
+            foreach (Extension diffExtension in diffExtensions)
+            {
+                var extension = diffElementDefinitionProperty.Extension.SingleOrDefault(x => x.Url == diffExtension.Url);
+
+                if (extension != null)
+                {
+                    var index = diffElementDefinitionProperty.Extension.IndexOf(extension);
+                    diffElementDefinitionProperty.Extension[index] = diffExtension; // Modification on base extension
+                }
+                else
+                {
+                    diffElementDefinitionProperty.Extension.AddRange(diffExtensions); // New extension (i.e. does not exist in base)
+                }
+            }
+
+            var profile = new StructureDefinition() // Create derived profile
+            {
+                Type = profileType.GetLiteral(),
+                BaseDefinition = uri,
+                Name = "My" + elementId,
+                Url = uri + "Test",
+                Differential = new StructureDefinition.DifferentialComponent()
+                {
+                    Element = new List<ElementDefinition>() { diffElementDefinition }
+                }
+            };
+
+            // Act
+            var elements = await generator.GenerateAsync(profile);
+
+            // Assert
+            var element = elements.SingleOrDefault(x => x.ElementId == diffElementDefinition.ElementId);
+            element.Should().NotBeNull();
+            var elementProperty = propertyProxy.GetValueAsElement(element);
+
+            var expectedExtensions = new List<Extension>(diffElementDefinitionProperty.Extension); // Determine expected extensions
+
+            foreach (Extension snapExtension in snapElementDefinitionProperty.Extension)
+            {
+                if (expectedExtensions.SingleOrDefault(x => x.Url == snapExtension.Url) == null)
+                    expectedExtensions.Add(snapExtension); // Extension from snapshot element property should be in expected extensions
+            }
+
+            logExtensions("Expected extensions", expectedExtensions);
+            logExtensions("Actual extensions", elementProperty.Extension);
+
+            elementProperty.Extension.Should().HaveCount(expectedExtensions.Count);
+            elementProperty.Extension.OrderBy(x => x.Url).Should().Equal(expectedExtensions.OrderBy(x => x.Url), (e1, e2) => e1.IsExactly(e2));
+        }
+
+        private void logExtensions(string title, IEnumerable<Extension> extensions, int level = 1)
+        {
+            Debug.WriteLine(title);
+
+            if (!extensions.Any())
+            {
+                Debug.WriteLine($"{new string(' ', level * 3)}none");
+                return;
+            }
+            
+            foreach (Extension extension in extensions)
+            {
+                if (extension.Extension != null && extension.Extension.Count > 0)
+                    logExtensions(extension.Url, extension.Extension, level + 1);
+                else
+                    Debug.WriteLine($"{new string(' ', level * 3)}{extension.Url} : {extension.Value}");
+            }
+        }
     }
 }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -144,10 +144,11 @@ namespace Hl7.Fhir.Specification.Snapshot
                 // Constraints are cumulative, so they are always "new" (hence a constant false for the comparer)
                 // [WMR 20160917] Note: constraint keys must be unique. The validator will detect duplicate keys, so the derived
                 // profile author can correct the conflicting constraint key.
-                // [WMR 20160918] MUST merge indentical constraints, otherwise each derived profile accumulates
+                // [WMR 20160918] MUST merge identical constraints, otherwise each derived profile accumulates
                 // additional identical constraints inherited from e.g. BackboneElement.
                 // snap.Constraint = mergeCollection(snap.Constraint, diff.Constraint, (a, b) => false);
-                snap.Constraint = mergeCollection(snap.Constraint, diff.Constraint, (a, b) => a.IsExactly(b));
+                // [Backported from R4] Use of mergeConstraints.
+                snap.Constraint = mergeConstraints(snap.Constraint, diff.Constraint);
 
                 // [WMR 20160907] merge conditions
                 snap.ConditionElement = mergeCollection(snap.ConditionElement, diff.ConditionElement, (a, b) => a.Value == b.Value);
@@ -173,9 +174,9 @@ namespace Hl7.Fhir.Specification.Snapshot
                 // [WMR 20160817] TODO: Merge extensions
                 // Debug.WriteLineIf(diff.Extension != null && diff.GetChangedByDiff() == null, "[ElementDefnMerger] Warning: Extension merging is not supported yet...");
 
-                // TODO: What happens to extensions present on an ElementDefinition that is overriding another?
-                // [WMR 20160907] Merge extensions... match on url, diff completely overrides snapshot
-                snap.Extension = mergeCollection(snap.Extension, diff.Extension, (s, d) => s.Url == d.Url);
+                // [WMR 20160907] Merge extensions, match on url
+                // [Backported from R4] Use of mergeExtensions
+                snap.Extension = mergeExtensions(snap.Extension, diff.Extension);
 
                 // [EK 20170301] Added this after comparison with Java generated snapshot
                 snap.RepresentationElement = mergeCollection(snap.RepresentationElement, diff.RepresentationElement, (s, d) => s.IsExactly(d));
@@ -194,6 +195,15 @@ namespace Hl7.Fhir.Specification.Snapshot
             void onConstraint(Element snap)
             {
                 _generator?.OnConstraint(snap);
+            }
+
+            /// <summary>Notify clients about a snapshot collection element with differential constraints.</summary>
+            void onConstraint<T>(List<T> snap) where T : Element
+            {
+                foreach (var item in snap)
+                {
+                    onConstraint(item);
+                }
             }
 
             /// <summary>
@@ -230,7 +240,9 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                         result.ObjectValue = diffText;
                     }
-
+                    // Also merge extensions on primitives
+                    // [Backported from R4] 
+                    result.Extension = mergeExtensions(snap?.Extension, diff.Extension);
                     onConstraint(result);
                     return result;
                 }
@@ -291,7 +303,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                     if (int.TryParse(snap.Value, out var sv) &&
                         int.TryParse(diff.Value, out var dv))
                     {
-                        // compare them if they are both numerics
+                        // compare them if they are both numeric
                         return dv < sv ? deepCopyAndRaiseOnConstraint(diff) : snap;
                     }
 
@@ -370,27 +382,90 @@ namespace Hl7.Fhir.Specification.Snapshot
                 return result;
             }
 
-            List<T> mergeCollection<T>(List<T> snap, List<T> diff, Func<T, T, bool> elemComparer) where T : Element
+            // [Backported from R4] Does not include InitializeConstraintSource!
+            List<ElementDefinition.ConstraintComponent> mergeConstraints(
+                List<ElementDefinition.ConstraintComponent> snap,
+                List<ElementDefinition.ConstraintComponent> diff)
             {
-                if (!diff.IsNullOrEmpty() && !diff.IsExactly(snap))
+                var result = snap;
+                if (!diff.IsNullOrEmpty())
                 {
-                    var result = snap == null ? new List<T>() : new List<T>(snap.DeepCopy());
-
-                    // Just add new elements to the result, never replace existing ones
-                    foreach (var element in diff)
+                    if (snap.IsNullOrEmpty())
                     {
-                        if (!result.Any(e => elemComparer(e, element)))
+                        result = (List<ElementDefinition.ConstraintComponent>)diff.DeepCopy();
+                        onConstraint(result);
+                    }
+                    else if (!diff.IsExactly(snap))
+                    {
+                        result = new List<ElementDefinition.ConstraintComponent>(snap.DeepCopy());
+                        // Properly merge matching collection items
+                        foreach (var diffItem in diff)
                         {
-                            var newElement = (T)element.DeepCopy();
-                            onConstraint(newElement);
-                            result.Add(newElement);
+                            // [WMR 20190723] FIX #1052: WRONG! Initializing .source breaks matching...
+                            // Instead, match element constraints on id
+                            //var idx = snap.FindIndex(e => matchExactly(e, diffItem));
+                            var idx = snap.FindIndex(e => isEqualString(e.Key, diffItem.Key));
+
+                            ElementDefinition.ConstraintComponent mergedItem;
+                            if (idx < 0)
+                            {
+                                // No match; add diff item
+                                mergedItem = (ElementDefinition.ConstraintComponent)diffItem.DeepCopy();
+                                result.Add(mergedItem);
+                            }
+                            else
+                            {
+                                // Match; merge diff with snap
+                                var snapItem = result[idx];
+                                mergedItem = mergeComplexAttribute(snapItem, diffItem);
+                                result[idx] = mergedItem;
+                            }
+                            onConstraint(mergedItem);
                         }
                     }
-
-                    return result;
                 }
-                else
-                    return snap;
+                return result;
+            }
+
+            // Merge two collections
+            // Differential collection items replace/overwrite matching snapshot collection items
+            // [Backported from R4] 
+            List<T> mergeCollection<T>(List<T> snap, List<T> diff, Func<T, T, bool> matchItems) where T : Element
+            {
+                var result = snap;
+                if (!diff.IsNullOrEmpty())
+                {
+                    if (snap.IsNullOrEmpty())
+                    {
+                        result = (List<T>)diff.DeepCopy();
+                        onConstraint(result);
+                    }
+                    else if (!diff.IsExactly(snap))
+                    {
+                        result = new List<T>(snap.DeepCopy());
+                        // Properly merge matching collection items
+                        foreach (var diffItem in diff)
+                        {
+                            var idx = snap.FindIndex(e => matchItems(e, diffItem));
+                            T mergedItem;
+                            if (idx < 0)
+                            {
+                                // No match; add diff item
+                                mergedItem = (T)diffItem.DeepCopy();
+                                result.Add(mergedItem);
+                            }
+                            else
+                            {
+                                // Match; merge diff with snap
+                                var snapItem = result[idx];
+                                mergedItem = mergeComplexAttribute(snapItem, diffItem);
+                                result[idx] = mergedItem;
+                            }
+                            onConstraint(mergedItem);
+                        }
+                    }
+                }
+                return result;
             }
 
 
@@ -411,11 +486,17 @@ namespace Hl7.Fhir.Specification.Snapshot
                         snap.StrengthElement = mergePrimitiveAttribute(snap.StrengthElement, diff.StrengthElement);
                         snap.DescriptionElement = mergePrimitiveAttribute(snap.DescriptionElement, diff.DescriptionElement);
                         snap.ValueSet = mergeComplexAttribute(snap.ValueSet, diff.ValueSet);
+                        snap.Extension = mergeExtensions(snap.Extension, diff.Extension);
                         onConstraint(result);
                     }
                 }
                 return result;
             }
+
+            // Merge differential extensions with snapshot extensions
+            // Match extensions on url
+            List<Extension> mergeExtensions(List<Extension> snap, List<Extension> diff)
+                => mergeCollection(snap, diff, matchExtensions);
 
             string mergeId(ElementDefinition snap, ElementDefinition diff, bool mergeElementId)
             {
@@ -460,7 +541,9 @@ namespace Hl7.Fhir.Specification.Snapshot
                 return c.Display == d.Display;
             }
 
+            static bool matchExtensions(Extension x, Extension y) => !(x is null) && !(y is null) && (x.Url == y.Url);
+
+            static bool isEqualString(string x, string y) => StringComparer.Ordinal.Equals(x, y);
         }
     }
-
 }


### PR DESCRIPTION
## Description
Extensions on Binding and Constraint are not merged from the differential to the snapshot.

## Related issues
Fixes #2091.

## Testing
Unit test ElementDefinitionPropertyExtensionTest.

## Considerations
I have backported some code from R4 to fix the problem for Constraint extensions.

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes