### PR TITLE
Extensions on Binding are not merged from the differential to the snapshot (R4)

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/ElementDefinitionPropertyProxy.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/ElementDefinitionPropertyProxy.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using Hl7.Fhir.Model;
+using System;
+using System.Collections;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace Hl7.Fhir.Specification.Tests
+{
+    /// <summary>
+    /// Proxy for accessing an element definition property by name using reflection.
+    /// The property can also be a specific item from a property list.
+    /// The property name is specified in the constructor.
+    /// 
+    /// The name is either the name of the property (e.g. "Binding") or the name of the property list
+    /// with a item selector (e.g. "Constraint[Key:dom-2]").
+    /// </summary>
+    internal class ElementDefinitionPropertyProxy
+    {
+        private string _propertyName;
+        private string _selectorPropertyName;
+        private string _selectorValue;
+        private PropertyInfo _propertyInfo;
+        private PropertyInfo _selectorPropertyInfo;
+
+        public ElementDefinitionPropertyProxy(string propertyName)
+        {
+            getPropertyInfo(propertyName);
+        }
+
+        /// <summary>
+        /// Create a new instance of the property.
+        /// If the property is a list then an instance of the list item type is created as well.
+        /// </summary>
+        /// <param name="element">Optional element to initialize the new list item with.</param>
+        /// <returns></returns>
+        public object CreateInstance(Element element)
+        {
+            var instance = Activator.CreateInstance(_propertyInfo.PropertyType);
+
+            if (_selectorPropertyInfo == null)
+                return instance; // Primitive property
+
+            // Create item for property list
+            var item = (Element)Activator.CreateInstance(_propertyInfo.PropertyType.GenericTypeArguments[0]);
+
+            // Initialize with specified element
+            element?.CopyTo(item);
+
+            // Set key value
+            _selectorPropertyInfo.SetValue(item, _selectorValue);
+
+            // Add item to property list
+            if (instance is IList items)
+                items.Add(item);
+
+            return instance;
+        }
+
+        /// <summary>
+        /// Set the value of the property.
+        /// </summary>
+        /// <param name="instance">Instance to set the property value for.</param>
+        /// <param name="value">The value to set.</param>
+        public void SetValue(object instance, object value)
+        {
+            _propertyInfo.SetValue(instance, value);
+        }
+
+        /// <summary>
+        /// Get the value of property (typed as Element).
+        /// </summary>
+        /// <param name="instance">Instance to get the property value from.</param>
+        /// <returns>The property value as an Element type.</returns>
+        public Element GetValueAsElement(object instance)
+        {
+            if (_selectorPropertyInfo == null)
+                return (Element)_propertyInfo.GetValue(instance);
+
+            if (_propertyInfo.GetValue(instance, null) is not IList items)
+                return null;
+
+            foreach (var item in items)
+            {
+                var value = _selectorPropertyInfo.GetValue(item)?.ToString();
+
+                if (_selectorValue.Equals(value))
+                    return (Element)item;
+            }
+
+            return null;
+        }
+
+        private void getPropertyInfo(string propertyName)
+        {
+            parsePropertyName(propertyName);
+
+            _propertyInfo = typeof(ElementDefinition).GetProperty(_propertyName);
+            _propertyInfo.Should().NotBeNull(); // Check property exists
+
+            // ReSharper disable once PossibleNullReferenceException
+            if (!isList(_propertyInfo.PropertyType))
+            {
+                _propertyInfo.PropertyType.IsAssignableTo(typeof(Element)).Should().BeTrue(); // Property type should be derived from Element
+                return;
+            }
+
+            _propertyInfo.PropertyType.GenericTypeArguments[0].IsAssignableTo(typeof(Element)).Should().BeTrue(); // Property type should be derived from Element
+
+            _selectorPropertyInfo = _propertyInfo.PropertyType.GenericTypeArguments[0].GetProperty(_selectorPropertyName);
+            _selectorPropertyInfo.Should().NotBeNull(); // Check property exists
+        }
+
+        private void parsePropertyName(string propertyName)
+        {
+            _propertyName = propertyName;
+
+            var regex = new Regex("(.*)\\[(.*):(.*)\\]|(.*)");
+            var result = regex.Match(propertyName);
+
+            if (!result.Success || result.Groups[4].Success)
+                return;
+
+            _propertyName = result.Groups[1].Value;
+            _selectorPropertyName = result.Groups[2].Value;
+            _selectorValue = result.Groups[3].Value;
+        }
+
+        private static bool isList(Type type) => typeof(IList).IsAssignableFrom(type);
+    }
+}

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -9467,5 +9467,149 @@ namespace Hl7.Fhir.Specification.Tests
             public StructureDefinition BaseStructureDefinition { get; }
             public ElementDefinition BaseElementDefinition { get; }
         }
+
+        public static IEnumerable<object[]> ElementDefinitionPropertyExtensionTestCasesR4
+        {
+            get
+            {
+                // Modify an existing Binding extension
+                yield return new object[] { FHIRAllTypes.AllergyIntolerance, "AllergyIntolerance.code", "Binding",
+                    new[] {
+                        new Extension("http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName", new FhirString("AllergyIntoleranceCode")) },
+                    new[] {
+                        new Extension("http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName", new FhirString("Test")) }};
+
+                // Adding a new Binding extension
+                yield return new object[] { FHIRAllTypes.AllergyIntolerance, "AllergyIntolerance.code", "Binding",
+                    new[] {
+                        new Extension("http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName", new FhirString("AllergyIntoleranceCode")) },
+                    new[] {
+                        new Extension("http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding", new FhirBoolean(true)) }};
+
+                // Adding a new Constraint extension
+                yield return new object[] { FHIRAllTypes.AllergyIntolerance, "AllergyIntolerance", "Constraint[Key:dom-2]",
+                    Array.Empty<Extension>(),
+                    new[] {
+                        new Extension("http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice", new FhirBoolean(true)) }};
+
+                // Modifying an existing Constraint extension
+                yield return new object[] { FHIRAllTypes.AllergyIntolerance, "AllergyIntolerance", "Constraint[Key:dom-6]",
+                    new[] {
+                        new Extension("http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice", new FhirBoolean(true)),
+                        new Extension("http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation", new Markdown("When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time.")) },
+                    new[] {
+                        new Extension("http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice", new FhirBoolean(false)) }};
+            }
+        }
+
+        /// <summary>
+        /// Tests whether element definition property extensions in the differential are properly merged by the snapshot generator.
+        /// </summary>
+        /// <param name="profileType">The profile type under test (e.g. FHIRAllTypes.AllergyIntolerance).</param>
+        /// <param name="elementId">The element id of the profile to check (e.g. "AllergyIntolerance.code")</param>
+        /// <param name="propertyName">The name of the element definition property for which to add or modify the extension in the differential (e.g. "Binding").</param>
+        /// <param name="baseExtensions">The extensions that are defined in the base profile for this property.</param>
+        /// <param name="diffExtensions">The extensions to define in the differential for this property.</param>
+        /// <returns></returns>
+        [DataTestMethod]
+        [DynamicData(nameof(ElementDefinitionPropertyExtensionTestCasesR4), DynamicDataSourceType.Property)]
+        public async T.Task ElementDefinitionPropertyExtensionTest(FHIRAllTypes profileType, string elementId, string propertyName, Extension[] baseExtensions, Extension[] diffExtensions)
+        {
+            // Arrange
+            var uri = ModelInfo.CanonicalUriForFhirCoreType(profileType);
+            var zipSource = ZipSource.CreateValidationSource();
+            var generator = new SnapshotGenerator(zipSource, SnapshotGeneratorSettings.CreateDefault());
+            var propertyProxy = new ElementDefinitionPropertyProxy(propertyName);
+
+            var sd = await _testResolver.FindStructureDefinitionAsync(uri); // Find base profile
+            var snapElementDefinition = sd.Snapshot.Element.SingleOrDefault(x => x.ElementId == elementId); // Find specified element in snapshot of base profile
+            snapElementDefinition.Should().NotBeNull();
+            var snapElementDefinitionProperty = propertyProxy.GetValueAsElement(snapElementDefinition); // Get the property from the snapshot element (typed)
+
+            if (snapElementDefinitionProperty != null)
+            {
+                logExtensions("Base extensions", baseExtensions);
+
+                snapElementDefinitionProperty.Extension.Should().HaveCount(baseExtensions.Length); // Check extensions in element
+                snapElementDefinitionProperty.Extension.OrderBy(x => x.Url).Should().Equal(baseExtensions.OrderBy(x => x.Url), (e1, e2) => e1.IsExactly(e2));
+            }
+            else
+            {
+                baseExtensions.Should().BeNull();
+            }
+
+            var diffElementDefinition = new ElementDefinition(elementId) { ElementId = elementId }; // Create element for differential
+            propertyProxy.SetValue(diffElementDefinition, propertyProxy.CreateInstance(snapElementDefinitionProperty)); // Set property for differential element
+            var diffElementDefinitionProperty = propertyProxy.GetValueAsElement(diffElementDefinition); // Get the property from the differential element (typed)
+
+            // Add extensions for the element definition properties in the differential
+            foreach (Extension diffExtension in diffExtensions)
+            {
+                var extension = diffElementDefinitionProperty.Extension.SingleOrDefault(x => x.Url == diffExtension.Url);
+
+                if (extension != null)
+                {
+                    var index = diffElementDefinitionProperty.Extension.IndexOf(extension);
+                    diffElementDefinitionProperty.Extension[index] = diffExtension; // Modification on base extension
+                }
+                else
+                {
+                    diffElementDefinitionProperty.Extension.AddRange(diffExtensions); // New extension (i.e. does not exist in base)
+                }
+            }
+
+            var profile = new StructureDefinition() // Create derived profile
+            {
+                Type = profileType.GetLiteral(),
+                BaseDefinition = uri,
+                Name = "My" + elementId,
+                Url = uri + "Test",
+                Differential = new StructureDefinition.DifferentialComponent()
+                {
+                    Element = new List<ElementDefinition>() { diffElementDefinition }
+                }
+            };
+
+            // Act
+            var elements = await generator.GenerateAsync(profile);
+
+            // Assert
+            var element = elements.SingleOrDefault(x => x.ElementId == diffElementDefinition.ElementId);
+            element.Should().NotBeNull();
+            var elementProperty = propertyProxy.GetValueAsElement(element);
+
+            var expectedExtensions = new List<Extension>(diffElementDefinitionProperty.Extension); // Determine expected extensions
+
+            foreach (Extension snapExtension in snapElementDefinitionProperty.Extension)
+            {
+                if (expectedExtensions.SingleOrDefault(x => x.Url == snapExtension.Url) == null)
+                    expectedExtensions.Add(snapExtension); // Extension from snapshot element property should be in expected extensions
+            }
+
+            logExtensions("Expected extensions", expectedExtensions);
+            logExtensions("Actual extensions", elementProperty.Extension);
+
+            elementProperty.Extension.Should().HaveCount(expectedExtensions.Count);
+            elementProperty.Extension.OrderBy(x => x.Url).Should().Equal(expectedExtensions.OrderBy(x => x.Url), (e1, e2) => e1.IsExactly(e2));
+        }
+
+        private void logExtensions(string title, IEnumerable<Extension> extensions, int level = 1)
+        {
+            Debug.WriteLine(title);
+
+            if (!extensions.Any())
+            {
+                Debug.WriteLine($"{new string(' ', level * 3)}none");
+                return;
+            }
+
+            foreach (Extension extension in extensions)
+            {
+                if (extension.Extension != null && extension.Extension.Count > 0)
+                    logExtensions(extension.Url, extension.Extension, level + 1);
+                else
+                    Debug.WriteLine($"{new string(' ', level * 3)}{extension.Url} : {extension.Value}");
+            }
+        }
     }
 }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -353,6 +353,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                         snap.StrengthElement = mergePrimitiveElement(snap.StrengthElement, diff.StrengthElement);
                         snap.DescriptionElement = mergePrimitiveElement(snap.DescriptionElement, diff.DescriptionElement);
                         snap.ValueSetElement = mergeComplexAttribute(snap.ValueSetElement, diff.ValueSetElement);
+                        snap.Extension = mergeExtensions(snap.Extension, diff.Extension);
                         onConstraint(result);
                     }
                 }


### PR DESCRIPTION
## Description
Extensions on Binding are not merged from the differential to the snapshot.

## Related issues
Fixes #2091 

## Testing
Unit test ElementDefinitionPropertyExtensionTest.

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes