### PR TITLE
Symbol packages are also uploaded to NuGet

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -256,7 +256,7 @@ stages:
               condition: and(succeeded(), endswith(variables['Build.SourceBranch'], '-dstu2')) 
               inputs:
                   command: push
-                  packagesToPush: '$(Agent.BuildDirectory)/NuGetPackages/*DSTU2*.nupkg'
+                  packagesToPush: '$(Agent.BuildDirectory)/NuGetPackages/*DSTU2*.*nupkg'
                   nuGetFeedType: external
                   publishFeedCredentials: NuGet
                   verbosityPush: normal    
@@ -267,7 +267,7 @@ stages:
               condition: and(succeeded(), endswith(variables['Build.SourceBranch'], '-stu3')) 
               inputs:
                 command: push
-                packagesToPush: '$(Agent.BuildDirectory)/NuGetPackages/*.nupkg'
+                packagesToPush: '$(Agent.BuildDirectory)/NuGetPackages/*.*nupkg'
                 nuGetFeedType: external
                 publishFeedCredentials: NuGet
                 verbosityPush: normal  
@@ -278,7 +278,7 @@ stages:
               condition: and(succeeded(), endswith(variables['Build.SourceBranch'], '-r4')) 
               inputs:
                 command: push
-                packagesToPush: '$(Agent.BuildDirectory)/NuGetPackages/*R4*.nupkg'
+                packagesToPush: '$(Agent.BuildDirectory)/NuGetPackages/*R4*.*nupkg'
                 nuGetFeedType: external
                 publishFeedCredentials: NuGet
                 verbosityPush: normal  
@@ -289,7 +289,7 @@ stages:
               condition: and(succeeded(), endswith(variables['Build.SourceBranch'], '-r4B')) 
               inputs:
                 command: push
-                packagesToPush: '$(Agent.BuildDirectory)/NuGetPackages/*R4B*.nupkg'
+                packagesToPush: '$(Agent.BuildDirectory)/NuGetPackages/*R4B*.*nupkg'
                 nuGetFeedType: external
                 publishFeedCredentials: NuGet
                 verbosityPush: normal  
@@ -300,7 +300,7 @@ stages:
               condition: and(succeeded(), endswith(variables['Build.SourceBranch'], '-r5')) 
               inputs:
                 command: push
-                packagesToPush: '$(Agent.BuildDirectory)/NuGetPackages/*R5*.nupkg'
+                packagesToPush: '$(Agent.BuildDirectory)/NuGetPackages/*R5*.*nupkg'
                 nuGetFeedType: external
                 publishFeedCredentials: NuGet
                 verbosityPush: normal 


### PR DESCRIPTION
## Description
The pattern for uploading NuGet packages has been broadened, so that symbol packages are also uploaded.

## Related issues
Resolves #2094 

## Testing
Check after a release if the symbols packages are uploaded as well.

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes