### PR TITLE
Initialization of empty element constraint sources can be skipped for snapshot generator output intended for the differential

### DIFF
--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -282,7 +282,7 @@ namespace Hl7.Fhir.Specification.Snapshot
         public ElementDefinition MergeElementDefinition(ElementDefinition snap, ElementDefinition diff, bool mergeElementId)
         {
             var result = (ElementDefinition)snap.DeepCopy();
-            ElementDefnMerger.Merge(this, result, diff, mergeElementId, _stack.CurrentProfileUri);
+            ElementDefnMerger.Merge(this, result, diff, mergeElementId, _stack.CurrentProfileUri, _settings.IntendedUse);
             return result;
         }
 
@@ -1034,7 +1034,7 @@ namespace Hl7.Fhir.Specification.Snapshot
         {
 
             // [WMR 20170421] Add parameter to control when (not) to inherit Element.id
-            ElementDefnMerger.Merge(this, snap, diff, mergeElementId, _stack.CurrentProfileUri);
+            ElementDefnMerger.Merge(this, snap, diff, mergeElementId, _stack.CurrentProfileUri, _settings.IntendedUse);
         }
 
         // [WMR 20160720] Merge custom element type profiles, e.g. Patient.name with type.profile = "MyHumanName"
@@ -2311,7 +2311,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 // Otherwise, cloning & expanding the result will pick up incorrect root element from original... WRONG!
 #endif
                 // [WMR 20190723] FIX #1052: Initialize ElementDefinition.constraint.source
-                ElementDefnMerger.InitializeConstraintSource(snapRoot.Constraint, sd.Url);
+                ElementDefnMerger.InitializeConstraintSource(snapRoot.Constraint, sd.Url, _settings.IntendedUse);
 
                 // Debug.Print($"[{nameof(SnapshotGenerator)}.{nameof(getSnapshotRootElement)}] {nameof(profileUri)} = '{profileUri}' - use root element definition from differential: #{clonedDiffRoot.GetHashCode()}");
                 return snapRoot;

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorSettings.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGeneratorSettings.cs
@@ -45,6 +45,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             other.GenerateExtensionsOnConstraints = GenerateExtensionsOnConstraints;
             other.GenerateAnnotationsOnConstraints = GenerateAnnotationsOnConstraints;
             other.GenerateElementIds = GenerateElementIds;
+            other.IntendedUse = IntendedUse;
             // other.MergeTypeProfiles = MergeTypeProfiles;
         }
 
@@ -80,6 +81,13 @@ namespace Hl7.Fhir.Specification.Snapshot
 
         /// <summary>Enable this setting to automatically generate missing element id values.</summary>
         public bool GenerateElementIds { get; set; } = true;
+
+        /// <summary>
+        /// Indicates the intended use of the snapshot generator output: snapshot or differential.
+        /// Snapshot generator business logic may vary depending on the intended use.
+        /// The default value is set to a backwards compatible setting (i.e. snapshot and differential).
+        /// </summary>
+        public SnapshotIntendedUse IntendedUse { get; set; } = SnapshotIntendedUse.BackwardsCompatible;
 
         // [WMR 20161004] Always try to merge element type profiles
 

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotIntendedUse.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotIntendedUse.cs
@@ -1,0 +1,9 @@
+﻿namespace Hl7.Fhir.Specification.Snapshot
+{
+    public enum SnapshotIntendedUse
+    {
+        Snapshot = 1 << 0,
+        Differential = 1 << 1,
+        BackwardsCompatible = Snapshot | Differential
+    }
+}


### PR DESCRIPTION
## Description
Added SnapshotIntendedUse enum and IntendedUse property to SnapshotGeneratorSettings so that initialization of empty element constraint sources can be skipped for snapshot generator output intended for the differential.

## Related issues
Fixes #2111 

## Testing
Unit test ElementConstraintSourceTest was added.

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes