### PR TITLE
Remove unused #if NET40

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Hl7.Fhir.Core.Tests.csproj
+++ b/src/Hl7.Fhir.Core.Tests/Hl7.Fhir.Core.Tests.csproj
@@ -19,10 +19,6 @@
     <PackageReference Include="System.AppContext" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
-  </ItemGroup>
-
   <ItemGroup>
     <Content Include="TestData\**\*.xml;TestData\**\*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Hl7.Fhir.Core.Tests/TestDataHelper.cs
+++ b/src/Hl7.Fhir.Core.Tests/TestDataHelper.cs
@@ -1,13 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using System.IO.Compression;
-using System.Reflection;
-using System.Text;
-#if NET40
-using System.Linq;
-using ICSharpCode.SharpZipLib.Zip;
-#endif
 
 namespace Hl7.Fhir.Tests
 {
@@ -18,7 +10,7 @@ namespace Hl7.Fhir.Tests
             //string location = typeof(TestDataHelper).GetTypeInfo().Assembly.Location;
             //var path = Path.GetDirectoryName(location);
             //return Path.Combine(path, "TestData", filename);
-            return Path.Combine("TestData",filename);
+            return Path.Combine("TestData", filename);
         }
 
         public static string ReadTestData(string filename)
@@ -27,68 +19,10 @@ namespace Hl7.Fhir.Tests
             return File.ReadAllText(file);
         }
 
-#if NET40
-        public static ZipArchive ReadTestZip(string filename)
-        {
-            string file = GetFullPathForExample(filename);
-            return new ZipArchive(new ZipFile(file));
-        }
-#else
         public static ZipArchive ReadTestZip(string filename)
         {
             string file = GetFullPathForExample(filename);
             return ZipFile.OpenRead(file);
         }
-#endif
     }
-
-#if NET40
-    internal class ZipArchiveEntry
-    {
-        private ZipFile _zip;
-        private ZipEntry _zipEntry;
-
-        public ZipArchiveEntry(ZipEntry zipEntry, ZipFile zipFile)
-        {
-            _zipEntry = zipEntry;
-            _zip = zipFile;
-        }
-
-        public string Name
-        {
-            get
-            {
-                return _zipEntry.Name;
-            }
-        }
-
-        public Stream Open()
-        {
-            return _zip.GetInputStream(_zipEntry);
-        }
-    }
-
-    internal class ZipArchive : IDisposable
-    {
-        private ZipFile _zip;
-
-        public ZipArchive(ZipFile zip)
-        {
-            _zip = zip;
-        }
-
-        public IEnumerable<ZipArchiveEntry> Entries
-        {
-            get
-            {
-                return _zip.Cast<ZipEntry>().Select(e => new ZipArchiveEntry(e, _zip));
-            }
-        }
-
-        public void Dispose()
-        {
-            ((IDisposable)_zip).Dispose();
-        }
-    }
-#endif
 }

--- a/src/Hl7.Fhir.Core.Tests/Validation/ValidationTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Validation/ValidationTests.cs
@@ -86,31 +86,19 @@ namespace Hl7.Fhir.Tests.Validation
             var oidWithZero = "urn:oid:1.2.0.3.4";
 
             FhirUri uri = new(oidUrl);
-#if NET40
-            Validator.ValidateObject(uri, new ValidationContext(uri, null, null), true);
-#else
             Validator.ValidateObject(uri, new ValidationContext(uri), true);
-#endif
 
             uri = new FhirUri(illOidUrl);
             validateErrorOrFail(uri);
 
             uri = new FhirUri(uuidUrl);
-#if NET40
-            Validator.ValidateObject(uri, new ValidationContext(uri, null, null), true);
-#else
             Validator.ValidateObject(uri, new ValidationContext(uri), true);
-#endif
 
             uri = new FhirUri(illUuidUrl);
             validateErrorOrFail(uri);
 
             uri = new FhirUri(oidWithZero);
-#if NET40
-            Validator.ValidateObject(uri, new ValidationContext(uri, null, null), true);
-#else
             Validator.ValidateObject(uri, new ValidationContext(uri), true);
-#endif
 
             Assert.IsTrue(Uri.Equals(new Uri("http://nu.nl"), new Uri("http://nu.nl")));
         }

--- a/src/Hl7.Fhir.Core/Rest/FhirClientSearch.cs
+++ b/src/Hl7.Fhir.Core/Rest/FhirClientSearch.cs
@@ -9,7 +9,6 @@
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Utility;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -18,8 +17,8 @@ namespace Hl7.Fhir.Rest
 {
     public abstract partial class BaseFhirClient
     {
-        #pragma warning disable CS1584 // XML comment has syntactically incorrect cref attribute
-        #pragma warning disable CS1658 // Warning is overriding an error
+#pragma warning disable CS1584 // XML comment has syntactically incorrect cref attribute
+#pragma warning disable CS1658 // Warning is overriding an error
 
         #region Search Execution
 
@@ -509,7 +508,7 @@ namespace Hl7.Fhir.Rest
             return SearchByIdUsingPostAsync(ModelInfo.GetFhirTypeNameForType(typeof(TResource)), id, includes, pageSize, revIncludes);
         }
 
-       
+
         public Task<Bundle> SearchByIdUsingPostAsync<TResource>(string id, string[] includes = null, int? pageSize = null,
              string[] revIncludes = null) where TResource : Resource, new()
         {
@@ -688,16 +687,10 @@ namespace Hl7.Fhir.Rest
             {
                 // Return a null bundle, can not return simply null because this is a task
                 Bundle nullValue = null;
-#if NET40
-                TaskCompletionSource<Bundle> completionSource = new TaskCompletionSource<Bundle>();
-                completionSource.SetResult(nullValue);
-
-                return completionSource.Task;
-#else
                 return System.Threading.Tasks.Task.FromResult(nullValue);
-#endif
             }
         }
+
         /// <summary>
         /// Uses the FHIR paging mechanism to go navigate around a series of paged result Bundles
         /// </summary>
@@ -748,13 +741,13 @@ namespace Hl7.Fhir.Rest
 
         private (string path, IncludeModifier modifier)[] stringToIncludeTuple(string[] includes)
         {
-            if(includes != null && includes.Any())
+            if (includes != null && includes.Any())
                 return includes.Select(i => (i, IncludeModifier.None)).ToArray();
             else
                 return new (string path, IncludeModifier modifier)[] { };
         }
     }
-        #endregion
+    #endregion
     public enum PageDirection
     {
         First,
@@ -762,5 +755,5 @@ namespace Hl7.Fhir.Rest
         Next,
         Last
     }
-   
+
 }

--- a/src/Hl7.Fhir.Serialization.Tests/RoundtripTest.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/RoundtripTest.cs
@@ -6,42 +6,38 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
-using System.IO;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Diagnostics;
 using Hl7.Fhir.Model;
-using System.IO.Compression;
 using Hl7.Fhir.Specification;
 using Hl7.Fhir.Specification.Source;
-using System.Collections.Generic;
-using System;
 using Hl7.Fhir.Tests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
 using Tasks = System.Threading.Tasks;
-using System.Linq;
-#if NET40
-using ICSharpCode.SharpZipLib.Zip;
-using System.Linq;
-#endif
 
 namespace Hl7.Fhir.Serialization.Tests
 {
     [TestClass]
     public class RoundtripTest
-    { 
+    {
         [TestMethod]
         [TestCategory("LongRunner")]
         public void FullRoundtripOfAllExamplesXmlPoco()
         {
-            FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml", 
-                "Roundtripping xml->json->xml", usingPoco: true, provider:null);
+            FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml",
+                "Roundtripping xml->json->xml", usingPoco: true, provider: null);
         }
-        
+
         [TestMethod]
         [TestCategory("LongRunner")]
         public async Tasks.Task FullRoundtripOfAllExamplesXmlPocoAsync()
         {
-            await FullRoundtripOfAllExamplesAsync("examples.zip", "FHIRRoundTripTestXml", 
-                "Roundtripping xml->json->xml", usingPoco: true, provider:null);
+            await FullRoundtripOfAllExamplesAsync("examples.zip", "FHIRRoundTripTestXml",
+                "Roundtripping xml->json->xml", usingPoco: true, provider: null);
         }
 
         [TestMethod]
@@ -51,7 +47,7 @@ namespace Hl7.Fhir.Serialization.Tests
             FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
                 "Roundtripping json->xml->json", usingPoco: true, provider: null);
         }
-        
+
         [TestMethod]
         [TestCategory("LongRunner")]
         public async Tasks.Task FullRoundtripOfAllExamplesJsonPocoAsync()
@@ -67,7 +63,7 @@ namespace Hl7.Fhir.Serialization.Tests
             FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml",
                 "Roundtripping xml->json->xml", usingPoco: false, provider: new PocoStructureDefinitionSummaryProvider());
         }
-        
+
         [TestMethod]
         [TestCategory("LongRunner")]
         public async Tasks.Task FullRoundtripOfAllExamplesXmlNavPocoProviderAsync()
@@ -83,7 +79,7 @@ namespace Hl7.Fhir.Serialization.Tests
             FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
                 "Roundtripping json->xml->json", usingPoco: false, provider: new PocoStructureDefinitionSummaryProvider());
         }
-        
+
         [TestMethod]
         [TestCategory("LongRunner")]
         public async Tasks.Task FullRoundtripOfAllExamplesJsonNavPocoProviderAsync()
@@ -100,7 +96,7 @@ namespace Hl7.Fhir.Serialization.Tests
             FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml",
                 "Roundtripping xml->json->xml", usingPoco: false, provider: new StructureDefinitionSummaryProvider(source));
         }
-        
+
         [TestMethod]
         [TestCategory("LongRunner")]
         public async Tasks.Task FullRoundtripOfAllExamplesXmlNavSdProviderAsync()
@@ -118,7 +114,7 @@ namespace Hl7.Fhir.Serialization.Tests
             FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
                 "Roundtripping json->xml->json", usingPoco: false, provider: new StructureDefinitionSummaryProvider(source));
         }
-        
+
         [TestMethod]
         [TestCategory("LongRunner")]
         public async Tasks.Task FullRoundtripOfAllExamplesJsonNavSdProviderAsync()
@@ -130,97 +126,11 @@ namespace Hl7.Fhir.Serialization.Tests
 
         private static string GetFullPathForExample(string filename) => Path.Combine("TestData", filename);
 
-#if NET40
-        public static ZipArchive ReadTestZip(string filename)
-        {
-            string file = GetFullPathForExample(filename);
-            return new ZipArchive(new ZipFile(file));
-        }
-
-        public class ZipArchiveEntry
-        {
-            private ZipFile _zip;
-            private ZipEntry _zipEntry;
-
-            public ZipArchiveEntry(ZipEntry zipEntry, ZipFile zipFile)
-            {
-                _zipEntry = zipEntry;
-                _zip = zipFile;
-            }
-
-            public string Name
-            {
-                get
-                {
-                    return _zipEntry.Name;
-                }
-            }
-
-            public Stream Open()
-            {
-                return _zip.GetInputStream(_zipEntry);
-            }
-        }
-
-        public class ZipArchive : IDisposable
-        {
-            private ZipFile _zip;
-
-            public ZipArchive(ZipFile zip)
-            {
-                _zip = zip;
-            }
-
-            public IEnumerable<ZipArchiveEntry> Entries
-            {
-                get
-                {
-                    return _zip.Cast<ZipEntry>().Select(e => new ZipArchiveEntry(e, _zip));
-                }
-            }
-
-            public void Dispose()
-            {
-                ((IDisposable)_zip).Dispose();
-            }
-
-            public void ExtractToDirectory(string directory)
-            {
-                byte[] buffer = new byte[4096];
-
-                foreach (ZipEntry entry in _zip)
-                {
-                    using (Stream entryStream = _zip.GetInputStream(entry))
-                    {
-                        string fullPath = Path.Combine(directory, entry.Name.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar));
-                        FileInfo entryFileInfo = new FileInfo(fullPath);
-
-                        if (!Directory.Exists(entryFileInfo.DirectoryName))
-                        {
-                            Directory.CreateDirectory(entryFileInfo.DirectoryName);
-                        }
-
-                        using (FileStream entryOutputStream = File.Create(fullPath))
-                        {
-                            int bytesRead = entryStream.Read(buffer, 0, 4096);
-
-                            while (bytesRead > 0)
-                            {
-                                entryOutputStream.Write(buffer, 0, bytesRead);
-                                bytesRead = entryStream.Read(buffer, 0, 4096);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-#else
         public static ZipArchive ReadTestZip(string filename)
         {
             string file = GetFullPathForExample(filename);
             return ZipFile.OpenRead(file);
         }
-#endif
 
         public static void FullRoundtripOfAllExamples(string zipname, string dirname, string label, bool usingPoco, IStructureDefinitionSummaryProvider provider)
         {
@@ -234,7 +144,7 @@ namespace Hl7.Fhir.Serialization.Tests
             createEmptyDir(baseTestPath);
             doRoundTrip(examples, baseTestPath, usingPoco, provider);
         }
-        
+
         public static async Tasks.Task FullRoundtripOfAllExamplesAsync(string zipname, string dirname, string label, bool usingPoco, IStructureDefinitionSummaryProvider provider)
         {
             ZipArchive examples = ReadTestZip(zipname);
@@ -274,7 +184,7 @@ namespace Hl7.Fhir.Serialization.Tests
             if (Directory.Exists(baseTestPath)) Directory.Delete(baseTestPath, true);
             Directory.CreateDirectory(baseTestPath);
         }
-        
+
         private static void doRoundTrip(ZipArchive examplesZip, string baseTestPath, bool usingPoco, IStructureDefinitionSummaryProvider provider)
         {
             var examplePath = Path.Combine(baseTestPath, "input");
@@ -409,7 +319,7 @@ namespace Hl7.Fhir.Serialization.Tests
                     else
                         convertResourceNav(file, outputFile, provider);
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     errors.Add($"{exampleName}{ext}: " + ex.Message);
                 }
@@ -447,7 +357,7 @@ namespace Hl7.Fhir.Serialization.Tests
                     else
                         await convertResourceNavAsync(file, outputFile, provider);
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     errors.Add($"{exampleName}{ext}: " + ex.Message);
                 }
@@ -549,7 +459,7 @@ namespace Hl7.Fhir.Serialization.Tests
                 await File.WriteAllTextAsync(outputFile, xml);
             }
         }
-        
+
         private static void convertResourceNav(string inputFile, string outputFile, IStructureDefinitionSummaryProvider provider)
         {
             if (inputFile.EndsWith(".xml"))
@@ -562,8 +472,8 @@ namespace Hl7.Fhir.Serialization.Tests
             else
             {
                 var json = File.ReadAllText(inputFile);
-                var nav = JsonParsingHelpers.ParseToTypedElement(json, provider, 
-                    settings: new FhirJsonParsingSettings { AllowJsonComments = true, PermissiveParsing = true } );
+                var nav = JsonParsingHelpers.ParseToTypedElement(json, provider,
+                    settings: new FhirJsonParsingSettings { AllowJsonComments = true, PermissiveParsing = true });
                 var xml = nav.ToXml();
                 File.WriteAllText(outputFile, xml);
             }
@@ -581,8 +491,8 @@ namespace Hl7.Fhir.Serialization.Tests
             else
             {
                 var json = await File.ReadAllTextAsync(inputFile);
-                var nav = await JsonParsingHelpers.ParseToTypedElementAsync(json, provider, 
-                    settings: new FhirJsonParsingSettings { AllowJsonComments = true, PermissiveParsing = true } );
+                var nav = await JsonParsingHelpers.ParseToTypedElementAsync(json, provider,
+                    settings: new FhirJsonParsingSettings { AllowJsonComments = true, PermissiveParsing = true });
                 var xml = await nav.ToXmlAsync();
                 await File.WriteAllTextAsync(outputFile, xml);
             }

--- a/src/Hl7.Fhir.Serialization.Tests/StreamXmlResources.cs
+++ b/src/Hl7.Fhir.Serialization.Tests/StreamXmlResources.cs
@@ -7,9 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-#if NET40
-using ICSharpCode.SharpZipLib.Zip;
-#endif
 
 namespace Hl7.Fhir.Support.Tests.Serialization
 {
@@ -123,15 +120,6 @@ namespace Hl7.Fhir.Support.Tests.Serialization
             // ZipDeflateStream does not support seeking (forward-only stream)
             // Therefore this only works for the XmlNavigatorStream, as the ctor does NOT (need to) call Reset()
             // JsonNavigatorStream cannot support zip streams; ctor needs to call Reset after scanning resourceType
-#if NET40
-            using (var archive = new ZipFile(ZipSource.SpecificationZipFileName))
-            {
-                var entry = archive.Cast<ZipEntry>().FirstOrDefault(e => e.Name == "profiles-resources.xml");
-                Assert.IsNotNull(entry);
-
-                using (var entryStream = archive.GetInputStream(entry))
-                {
-#else
             using var archive = ZipFile.Open(ZipSource.SpecificationZipFileName, ZipArchiveMode.Read);
             var entry = archive.Entries.FirstOrDefault(e => e.Name == "profiles-resources.xml");
             Assert.IsNotNull(entry);
@@ -144,7 +132,6 @@ namespace Hl7.Fhir.Support.Tests.Serialization
                 Assert.IsTrue(navStream.IsBundle);
                 Assert.AreEqual(ResourceType.Bundle.GetLiteral(), navStream.ResourceType);
             };
-#endif
         }
     }
 }

--- a/src/Hl7.Fhir.Specification/Specification/Source/Summary/ArtifactSummaryExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/Summary/ArtifactSummaryExtensions.cs
@@ -10,9 +10,7 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Support;
 using Hl7.Fhir.Utility;
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace Hl7.Fhir.Specification.Source
@@ -58,7 +56,7 @@ namespace Hl7.Fhir.Specification.Source
 
             var version = values.Length == 2 ? values[1] : string.Empty;
 
-            return summaries.ConformanceResources().Where(r => r.GetConformanceCanonicalUrl() == values[0] && 
+            return summaries.ConformanceResources().Where(r => r.GetConformanceCanonicalUrl() == values[0] &&
                                                                (string.IsNullOrEmpty(version) || r.GetConformanceVersion() == version));
         }
 
@@ -104,10 +102,10 @@ namespace Hl7.Fhir.Specification.Source
         public static ArtifactSummary ResolveNamingSystem(this IEnumerable<ArtifactSummary> summaries, string uniqueId)
             => summaries.FindNamingSystems(uniqueId).SingleOrDefault(NamingSystemUrlConflictExceptionFactory);
 
-/// <summary>Resolve the <see cref="ArtifactSummary"/> for the <see cref="CodeSystem"/> resource with the specified ValueSet uri.</summary>
+        /// <summary>Resolve the <see cref="ArtifactSummary"/> for the <see cref="CodeSystem"/> resource with the specified ValueSet uri.</summary>
         public static ArtifactSummary ResolveCodeSystem(this IEnumerable<ArtifactSummary> summaries, string uri)
             => summaries.FindCodeSystems(uri).SingleOrDefault(CodeSystemConflictExceptionFactory);
-            
+
         /// <summary>Resolve the <see cref="ArtifactSummary"/> for the <see cref="ConceptMap"/> resource with the specified source and/or target uri(s).</summary>
         public static ArtifactSummary ResolveConceptMap(this IEnumerable<ArtifactSummary> summaries, string sourceUri = null, string targetUri = null)
             => summaries.FindConceptMaps(sourceUri, targetUri).SingleOrDefault(ConceptMapUrlConflictExceptionFactory);
@@ -252,107 +250,4 @@ namespace Hl7.Fhir.Specification.Source
 
         #endregion
     }
-
-#if NET40
-    public interface IReadOnlyDictionary<TKey, TValue> : IReadOnlyCollection<KeyValuePair<TKey, TValue>>, IEnumerable<KeyValuePair<TKey, TValue>>, IEnumerable
-    {
-        //
-        // Summary:
-        //     Gets the element that has the specified key in the read-only dictionary.
-        //
-        // Parameters:
-        //   key:
-        //     The key to locate.
-        //
-        // Returns:
-        //     The element that has the specified key in the read-only dictionary.
-        //
-        // Exceptions:
-        //   T:System.ArgumentNullException:
-        //     key is null.
-        //
-        //   T:System.Collections.Generic.KeyNotFoundException:
-        //     The property is retrieved and key is not found.
-        TValue this[TKey key] { get; }
-
-        //
-        // Summary:
-        //     Gets an enumerable collection that contains the keys in the read-only dictionary.
-        //
-        // Returns:
-        //     An enumerable collection that contains the keys in the read-only dictionary.
-        IEnumerable<TKey> Keys { get; }
-        //
-        // Summary:
-        //     Gets an enumerable collection that contains the values in the read-only dictionary.
-        //
-        // Returns:
-        //     An enumerable collection that contains the values in the read-only dictionary.
-        IEnumerable<TValue> Values { get; }
-
-        //
-        // Summary:
-        //     Determines whether the read-only dictionary contains an element that has the
-        //     specified key.
-        //
-        // Parameters:
-        //   key:
-        //     The key to locate.
-        //
-        // Returns:
-        //     true if the read-only dictionary contains an element that has the specified key;
-        //     otherwise, false.
-        //
-        // Exceptions:
-        //   T:System.ArgumentNullException:
-        //     key is null.
-        bool ContainsKey(TKey key);
-        //
-        // Summary:
-        //     Gets the value that is associated with the specified key.
-        //
-        // Parameters:
-        //   key:
-        //     The key to locate.
-        //
-        //   value:
-        //     When this method returns, the value associated with the specified key, if the
-        //     key is found; otherwise, the default value for the type of the value parameter.
-        //     This parameter is passed uninitialized.
-        //
-        // Returns:
-        //     true if the object that implements the System.Collections.Generic.IReadOnlyDictionary`2
-        //     interface contains an element that has the specified key; otherwise, false.
-        //
-        // Exceptions:
-        //   T:System.ArgumentNullException:
-        //     key is null.
-        bool TryGetValue(TKey key, out TValue value);
-    }
-
-    //
-    // Summary:
-    //     Represents a read-only collection of elements that can be accessed by index.
-    //
-    // Type parameters:
-    //   T:
-    //     The type of elements in the read-only list. This type parameter is covariant.
-    //     That is, you can use either the type you specified or any type that is more derived.
-    //     For more information about covariance and contravariance, see Covariance and
-    //     Contravariance in Generics.
-    public interface IReadOnlyList<out T> : IReadOnlyCollection<T>, IEnumerable<T>, IEnumerable
-    {
-        //
-        // Summary:
-        //     Gets the element at the specified index in the read-only list.
-        //
-        // Parameters:
-        //   index:
-        //     The zero-based index of the element to get.
-        //
-        // Returns:
-        //     The element at the specified index in the read-only list.
-        T this[int index] { get; }
-    }
-#endif
 }

--- a/src/Hl7.Fhir.Specification/Specification/Source/Summary/ArtifactSummaryPropertyBag.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/Summary/ArtifactSummaryPropertyBag.cs
@@ -38,11 +38,6 @@ namespace Hl7.Fhir.Specification.Summary
         /// <summary>Returns an empty <see cref="ArtifactSummaryPropertyBag"/> instance.</summary>
         public static ArtifactSummaryPropertyBag Empty => new ArtifactSummaryPropertyBag();
 
-#if NET40
-        IEnumerable<string> IReadOnlyDictionary<string, object>.Keys => this.Keys;
-
-        IEnumerable<object> IReadOnlyDictionary<string, object>.Values => this.Values;
-#endif
 
         /// <summary>Default initial capacity.</summary>
         public const int DefaultCapacity = 8;

--- a/src/Hl7.Fhir.Specification/Specification/Source/ZipCacher.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Source/ZipCacher.cs
@@ -9,12 +9,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-#if NET40
-using ICSharpCode.SharpZipLib.Zip;
-#else
 using System.IO.Compression;
-#endif
+using System.Linq;
 
 namespace Hl7.Fhir.Specification.Source
 {
@@ -32,9 +28,9 @@ namespace Hl7.Fhir.Specification.Source
         private string _cachePath;
         private string _zipPath;
 
-        public ZipCacher(string zipPath, string cacheKey=null)
+        public ZipCacher(string zipPath, string cacheKey = null)
         {
-            if(cacheKey == null) cacheKey = Guid.NewGuid().ToString();
+            if (cacheKey == null) cacheKey = Guid.NewGuid().ToString();
             _cachePath = Path.Combine(Path.GetTempPath(), cacheKey);
             _zipPath = zipPath;
         }
@@ -82,18 +78,12 @@ namespace Hl7.Fhir.Specification.Source
 
             dir.Create();
 
-#if NET40
-            ExtractToDirectory(_zipPath, dir.FullName);
 
-            if (File.Exists(Path.Combine(dir.FullName, "fhir-all-xsd.zip")))
-                ExtractToDirectory(Path.Combine(dir.FullName, "fhir-all-xsd.zip"), dir.FullName);
-#else
             ZipFile.ExtractToDirectory(_zipPath, dir.FullName);
 
             // and also extract the contained zip in there too with all the xsds in there
             if (File.Exists(Path.Combine(dir.FullName, "fhir-all-xsd.zip")))
                 ZipFile.ExtractToDirectory(Path.Combine(dir.FullName, "fhir-all-xsd.zip"), dir.FullName);
-#endif
 
             // Set the last write time to be equal to the write time of the zip file,
             // this way, we can compare this time to the write times of newer zips and
@@ -128,43 +118,8 @@ namespace Hl7.Fhir.Specification.Source
             var zipCachePath = Path.Combine(cache.FullName, cacheName);
 
             var zipCacheDir = new DirectoryInfo(zipCachePath);
-                        
+
             return zipCacheDir;
         }
-
-#if NET40
-        private void ExtractToDirectory(string zipFilePath, string directory)
-        {
-            byte[] buffer = new byte[4096];
-
-            using (ZipFile zipFile = new ZipFile(zipFilePath))
-            {
-                foreach (ZipEntry entry in zipFile)
-                {
-                    using (Stream entryStream = zipFile.GetInputStream(entry))
-                    {
-                        string fullPath = Path.Combine(directory, entry.Name.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar));
-                        FileInfo entryFileInfo = new FileInfo(fullPath);
-
-                        if (!Directory.Exists(entryFileInfo.DirectoryName))
-                        {
-                            Directory.CreateDirectory(entryFileInfo.DirectoryName);
-                        }
-
-                        using (FileStream entryOutputStream = File.Create(fullPath))
-                        {
-                            int bytesRead = entryStream.Read(buffer, 0, 4096);
-
-                            while (bytesRead > 0)
-                            {
-                                entryOutputStream.Write(buffer, 0, bytesRead);
-                                bytesRead = entryStream.Read(buffer, 0, 4096);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-#endif
     }
 }

--- a/src/Hl7.Fhir.Specification/Specification/StructureDefinitionSummaryProvider.cs
+++ b/src/Hl7.Fhir.Specification/Specification/StructureDefinitionSummaryProvider.cs
@@ -79,11 +79,7 @@ namespace Hl7.Fhir.Specification
         public bool IsResource => false;
 
         public IReadOnlyCollection<IElementDefinitionSummary> GetElements() =>
-#if NET40
-            StructureDefinitionComplexTypeSerializationInfo.getElements(_nav).ToReadOnlyCollection();
-#else
             StructureDefinitionComplexTypeSerializationInfo.getElements(_nav).ToList();
-#endif
     }
 
     internal struct StructureDefinitionComplexTypeSerializationInfo : IStructureDefinitionSummary
@@ -101,15 +97,6 @@ namespace Hl7.Fhir.Specification
 
         public bool IsResource => _nav.StructureDefinition.Kind == StructureDefinition.StructureDefinitionKind.Resource;
 
-#if NET40
-        public IReadOnlyCollection<IElementDefinitionSummary> GetElements()
-        {
-            if (_nav.Current == null && !_nav.MoveToFirstChild())
-                return new ReadOnlyList<IElementDefinitionSummary>();
-
-            return getElements(_nav).ToReadOnlyCollection();
-        }
-#else
         public IReadOnlyCollection<IElementDefinitionSummary> GetElements()
         {
             if (_nav.Current == null && !_nav.MoveToFirstChild())
@@ -117,7 +104,6 @@ namespace Hl7.Fhir.Specification
 
             return getElements(_nav).ToList();
         }
-#endif
 
         private static bool isPrimitiveValueConstraint(ElementDefinition ed) => ed.Path.EndsWith(".value") && ed.Type.All(t => t.Code == null);
 


### PR DESCRIPTION
## Description
There were a lot of unused `#if NET40` still in the code. Those compiler directives were for .NET Framework 4.0, but we don't target that framework anymore. 
By doing this we also removed the reference to `SharpZipLib`

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes