### PR TITLE
R4: Remove binding after Type slicing and the slice does not contain a bindable type

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -9755,11 +9755,6 @@ namespace Hl7.Fhir.Specification.Tests
             var element = elements.Should().ContainSingle(e => e.Path == "MedicationStatement.dosage.asNeeded[x]").Subject;
             element.Type.Should().OnlyContain(t => t.Code == "boolean");
             element.Binding.Should().BeNull();
-
-            //element = elements.Should().ContainSingle(e => e.ElementId == "MedicationStatement.dosage.asNeeded[x]:asNeededCodeableConcept").Subject;
-            //element.Type.Should().OnlyContain(t => t.Code == "CodeableConcept");
-            //element.Binding.Should().NotBeNull();
-
         }
 
         private void logExtensions(string title, IEnumerable<Extension> extensions, int level = 1)

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -9735,6 +9735,33 @@ namespace Hl7.Fhir.Specification.Tests
 
         }
 
+        [TestMethod]
+        public async T.Task BindingRemovedAfterTypeConstraint()
+        {
+            // Arrange
+            var resolver = new CachedResolver(
+                    new MultiResolver(
+                        new TestProfileArtifactSource(),
+                        ZipSource.CreateValidationSource()));
+
+            string url = $"http://validationtest.org/fhir/StructureDefinition/MedicationStatement-issue-2132-2";
+
+            var sd = await resolver.FindStructureDefinitionAsync(url);
+
+            var snapshotGenerator = new SnapshotGenerator(resolver, _settings);
+
+            var elements = await snapshotGenerator.GenerateAsync(sd);
+
+            var element = elements.Should().ContainSingle(e => e.Path == "MedicationStatement.dosage.asNeeded[x]").Subject;
+            element.Type.Should().OnlyContain(t => t.Code == "boolean");
+            element.Binding.Should().BeNull();
+
+            //element = elements.Should().ContainSingle(e => e.ElementId == "MedicationStatement.dosage.asNeeded[x]:asNeededCodeableConcept").Subject;
+            //element.Type.Should().OnlyContain(t => t.Code == "CodeableConcept");
+            //element.Binding.Should().NotBeNull();
+
+        }
+
         private void logExtensions(string title, IEnumerable<Extension> extensions, int level = 1)
         {
             Debug.WriteLine(title);

--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -9708,6 +9708,33 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsNull(valueQuantityEld);
         }
 
+        [TestMethod]
+        public async T.Task BindingRemovedAfterTypeSlicing()
+        {
+            // Arrange
+            var resolver = new CachedResolver(
+                    new MultiResolver(
+                        new TestProfileArtifactSource(),
+                        ZipSource.CreateValidationSource()));
+
+            string url = $"http://validationtest.org/fhir/StructureDefinition/MedicationStatement-issue-2132";
+
+            var sd = await resolver.FindStructureDefinitionAsync(url);
+
+            var snapshotGenerator = new SnapshotGenerator(resolver, _settings);
+
+            var elements = await snapshotGenerator.GenerateAsync(sd);
+
+            var element = elements.Should().ContainSingle(e => e.ElementId == "MedicationStatement.dosage.asNeeded[x]:asNeededBoolean").Subject;
+            element.Type.Should().OnlyContain(t => t.Code == "boolean");
+            element.Binding.Should().BeNull();
+
+            element = elements.Should().ContainSingle(e => e.ElementId == "MedicationStatement.dosage.asNeeded[x]:asNeededCodeableConcept").Subject;
+            element.Type.Should().OnlyContain(t => t.Code == "CodeableConcept");
+            element.Binding.Should().NotBeNull();
+
+        }
+
         private void logExtensions(string title, IEnumerable<Extension> extensions, int level = 1)
         {
             Debug.WriteLine(title);

--- a/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
@@ -53,7 +53,8 @@ namespace Hl7.Fhir.Specification.Tests
             buildPatientWithDeceasedConstraints("RequiredBoolean"),
             buildPatientWithDeceasedConstraints(),
             buildBoolean(),
-            buildMyExtension()
+            buildMyExtension(),
+            buildSliceOnChoice()
         }.AddM(buildPatientWithProfiledReferences());
 
         private static StructureDefinition buildObservationWithTargetProfilesAndChildDefs()
@@ -656,5 +657,33 @@ namespace Hl7.Fhir.Specification.Tests
             cons.Add(new ElementDefinition("Patient.managingOrganization").OfReference(PROFILED_ORG_URL));
             yield return result;
         }
+
+        private static StructureDefinition buildSliceOnChoice()
+        {
+            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/MedicationStatement-issue-2132", "MedicationStatement-issue-2132",
+                "MedicationStatement sliced on asNeeded[x]", FHIRAllTypes.MedicationStatement);
+
+            var cons = result.Differential.Element;
+
+            var slicingIntro = new ElementDefinition("MedicationStatement.dosage.asNeeded[x]")
+               .WithSlicingIntro(ElementDefinition.SlicingRules.Closed, (ElementDefinition.DiscriminatorType.Type, "$this"));
+
+            cons.Add(slicingIntro);
+
+            cons.Add(new ElementDefinition("MedicationStatement.dosage.asNeeded[x]")
+            {
+                ElementId = "MedicationStatement.dosage.asNeeded[x]:asNeededBoolean",
+                SliceName = "asNeededBoolean",
+            }.OfType(FHIRAllTypes.Boolean));
+
+            cons.Add(new ElementDefinition("MedicationStatement.dosage.asNeeded[x]")
+            {
+                ElementId = "MedicationStatement.dosage.asNeeded[x]:asNeededCodeableConcept",
+                SliceName = "asNeededCodeableConcept",
+            }.OfType(FHIRAllTypes.CodeableConcept));
+
+            return result;
+        }
+
     }
 }

--- a/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/TestProfileArtifactSource.cs
@@ -54,7 +54,8 @@ namespace Hl7.Fhir.Specification.Tests
             buildPatientWithDeceasedConstraints(),
             buildBoolean(),
             buildMyExtension(),
-            buildSliceOnChoice()
+            buildSliceOnChoice(),
+            buildConstrainBindableType()
         }.AddM(buildPatientWithProfiledReferences());
 
         private static StructureDefinition buildObservationWithTargetProfilesAndChildDefs()
@@ -681,6 +682,20 @@ namespace Hl7.Fhir.Specification.Tests
                 ElementId = "MedicationStatement.dosage.asNeeded[x]:asNeededCodeableConcept",
                 SliceName = "asNeededCodeableConcept",
             }.OfType(FHIRAllTypes.CodeableConcept));
+
+            return result;
+        }
+
+        private static StructureDefinition buildConstrainBindableType()
+        {
+            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/MedicationStatement-issue-2132-2", "MedicationStatement-issue-2132",
+                "MedicationStatement sliced on asNeeded[x]", FHIRAllTypes.MedicationStatement);
+
+            var cons = result.Differential.Element;
+
+            var typeConstraint = new ElementDefinition("MedicationStatement.dosage.asNeeded[x]").OfType(FHIRAllTypes.Boolean);
+
+            cons.Add(typeConstraint);
 
             return result;
         }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -11,7 +11,6 @@
 #define NORMALIZE_RENAMED_TYPESLICE
 
 using Hl7.Fhir.Model;
-using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Utility;
 using System;
 using System.Collections.Generic;
@@ -171,6 +170,12 @@ namespace Hl7.Fhir.Specification.Snapshot
                 snap.IsSummaryElement = mergePrimitiveElement(snap.IsSummaryElement, diff.IsSummaryElement);
 
                 snap.Binding = mergeBinding(snap.Binding, diff.Binding);
+
+                // [MV 20220803] Remove Binding when the element has no bindable type
+                if (snap.Binding is not null && !snap.Type.Any(t => ModelInfo.IsBindable(t.Code)))
+                {
+                    snap.Binding = null;
+                }
 
                 // Mappings are cumulative, but keep unique on full contents
                 snap.Mapping = mergeCollection(snap.Mapping, diff.Mapping, matchExactly);

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -1925,7 +1925,17 @@ namespace Hl7.Fhir.Specification.Snapshot
 
             result = snap.ReturnToBookmark(lastSlice);
             // Copy the original (unmerged) slice base element to snapshot
-            if (result) { result = snap.InsertAfter((ElementDefinition)sliceBase.Current.DeepCopy()); }
+            if (result)
+            {
+                result = snap.InsertAfter((ElementDefinition)sliceBase.Current.DeepCopy());
+
+                // snapshot has a binding, but not a bindable type
+                if (result && snap.Current.Binding is not null && !diff.Current.Type.Any(t => ModelInfo.IsBindable(t.Code)))
+                {
+                    // remove the binding then
+                    snap.Current.Binding = null;
+                }
+            }
             // Recursively copy the original (unmerged) child elements, if necessary
             if (result && sliceBase.HasChildren)
             {

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -1925,17 +1925,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
             result = snap.ReturnToBookmark(lastSlice);
             // Copy the original (unmerged) slice base element to snapshot
-            if (result)
-            {
-                result = snap.InsertAfter((ElementDefinition)sliceBase.Current.DeepCopy());
-
-                // snapshot has a binding, but not a bindable type
-                if (result && snap.Current.Binding is not null && !diff.Current.Type.Any(t => ModelInfo.IsBindable(t.Code)))
-                {
-                    // remove the binding then
-                    snap.Current.Binding = null;
-                }
-            }
+            result = snap.InsertAfter((ElementDefinition)sliceBase.Current.DeepCopy());
             // Recursively copy the original (unmerged) child elements, if necessary
             if (result && sliceBase.HasChildren)
             {

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -1925,7 +1925,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
             result = snap.ReturnToBookmark(lastSlice);
             // Copy the original (unmerged) slice base element to snapshot
-            result = snap.InsertAfter((ElementDefinition)sliceBase.Current.DeepCopy());
+            if (result) { result = snap.InsertAfter((ElementDefinition)sliceBase.Current.DeepCopy()); }
             // Recursively copy the original (unmerged) child elements, if necessary
             if (result && sliceBase.HasChildren)
             {

--- a/src/firely-net-sdk-tests.props
+++ b/src/firely-net-sdk-tests.props
@@ -27,7 +27,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="FluentAssertions" Version="6.7.0" />
-		<PackageReference Include="Moq" Version="4.18.1" />
+		<PackageReference Include="Moq" Version="4.18.2" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net40'">

--- a/src/firely-net-sdk-tests.props
+++ b/src/firely-net-sdk-tests.props
@@ -21,7 +21,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Description
Remove binding from the snapshot after Type slicing and the slice does not contain a bindable type.

## Related issues
Resolves #2132 .

## Testing
See unit test BindingRemovedAfterTypeSlicing()

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes