### PR TITLE
[SnapshotGenerator] Fix invalid constraint sources [STU3]

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -7890,6 +7890,21 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsNull(valueQuantityEld);
         }
 
+        [TestMethod]
+        public async T.Task TestConstraintSource()
+        {
+            var observation = await _testResolver.FindStructureDefinitionAsync("http://hl7.org/fhir/StructureDefinition/Observation");
+            _generator = new SnapshotGenerator(_testResolver, _settings);
+
+            var snapshot = await _generator.GenerateAsync(observation);
+
+            var element = snapshot.Should().Contain(e => e.Path == "Observation.subject").Subject;
+            var constraint = element.Constraint.Where(c => c.Key == "ref-1").FirstOrDefault();
+            constraint.Source.Should().Be("http://hl7.org/fhir/StructureDefinition/Reference");
+
+        }
+
+
         [DataTestMethod]
         [DataRow("http://validationtest.org/fhir/StructureDefinition/DeceasedPatient", "Patient.deceased[x].extension:range")]
         [DataRow("http://validationtest.org/fhir/StructureDefinition/DeceasedPatientRequiredBoolean", "Patient.deceased[x].extension:range")]

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -430,7 +430,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                             onConstraint(mergedItem);
                         }
                     }
-                    if (!string.IsNullOrEmpty(source)
+                    if (!string.IsNullOrEmpty(source))
                     {
                         InitializeConstraintSource(result, source);
                     }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementDefnMerger.cs
@@ -430,8 +430,11 @@ namespace Hl7.Fhir.Specification.Snapshot
                             onConstraint(mergedItem);
                         }
                     }
+                    if (!string.IsNullOrEmpty(source)
+                    {
+                        InitializeConstraintSource(result, source);
+                    }
 
-                    InitializeConstraintSource(result, source);
                 }
                 return result;
             }

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -723,7 +723,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 OnPrepareElement(newElement, typeStructure, baseElement);
 
                 // [WMR 20170421] Merge custom element Id from diff
-                mergeElementDefinition(newElement, diff.Current, true);
+                mergeElementDefinition(newElement, diff.Current, true, diff?.StructureDefinition?.Url ?? _stack.CurrentProfileUri);
 
                 snap.AppendChild(newElement);
             }
@@ -834,7 +834,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                 // Then merge diff constraints from profile
                 // [WMR 20170424] Merge custom element Id from diff, if specified
-                mergeElementDefinition(snap.Current, diffElem, true);
+                mergeElementDefinition(snap.Current, diffElem, true, diff?.StructureDefinition?.Url ?? _stack.CurrentProfileUri);
 
                 // [WMR 20170710] NEW: Generate element IDs while processing
                 // Generate id if not explicitly specified in diff (don't inherit from base)
@@ -951,11 +951,12 @@ namespace Hl7.Fhir.Specification.Snapshot
         /// <param name="snap"></param>
         /// <param name="diff"></param>
         /// <param name="mergeElementId">Determines if the snapshot should inherit Element.id values from the differential.</param>
-        private void mergeElementDefinition(ElementDefinition snap, ElementDefinition diff, bool mergeElementId)
+        /// <param name="diffBaseUrl">The base url of the differential, this might be needed to set Constraint.Source</param>
+        private void mergeElementDefinition(ElementDefinition snap, ElementDefinition diff, bool mergeElementId, string diffBaseUrl)
         {
 
             // [WMR 20170421] Add parameter to control when (not) to inherit Element.id
-            ElementDefnMerger.Merge(this, snap, diff, mergeElementId);
+            ElementDefnMerger.Merge(this, snap, diff, mergeElementId, diffBaseUrl);
         }
 
         // [WMR 20160720] Merge custom element type profiles, e.g. Patient.name with type.profile = "MyHumanName"
@@ -1198,7 +1199,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                             rebasedRootElem.Path = diff.Path;
 
                             // Merge the type profile root element; no need to expand children
-                            mergeElementDefinition(snap.Current, rebasedRootElem, false);
+                            mergeElementDefinition(snap.Current, rebasedRootElem, false, typeStructure.Url);
                         }
                     }
                 }
@@ -1571,7 +1572,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 {
                     // Merge newly created slicing entry onto snap
                     // [WMR 20170421] Don't merge element Id from slice entry
-                    mergeElementDefinition(snap.Current, slicingEntry, false);
+                    mergeElementDefinition(snap.Current, slicingEntry, false, diff?.StructureDefinition?.Url ?? _stack.CurrentProfileUri);
 
                     // [WMR 20170711] Explicitly re-generate the extension element id
                     if (_settings.GenerateElementIds)
@@ -2102,7 +2103,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                 // Merge differential constraints onto base root element definition
                 // [WMR 20170421] Merge element Id from differential
-                mergeElementDefinition(rebasedRoot, diffRoot, true);
+                mergeElementDefinition(rebasedRoot, diffRoot, true, profileUri);
             }
 
 


### PR DESCRIPTION
fixes: 2118

Needed to backport some logic from R4 and add an nullable argument to a public function to fix this in STU3