### PR TITLE
Repair some invariants during validation

### DIFF
--- a/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
@@ -38,12 +38,6 @@ namespace Hl7.Fhir.Validation
                 // of FP up, which could do comparisons between quantities.
                 if (v.Settings.ConstraintsToIgnore.Contains(constraintElement.Key)) continue;
 
-                // This constraint got repaired in R4B - pre-apply it for other R3+ here as well.
-                if (constraintElement.Key == "ref-1" && constraintElement.Expression == "reference.startsWith('#').not() or (reference.substring(1).trace('url') in %resource.contained.id.trace('ids'))")
-                {
-                    constraintElement.Expression = "reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))";
-                }
-
                 // The following constraints will be repaired in R4B - pre-apply it for other R3+ here as well.
                 constraintElement.Expression = constraintElement switch
                 {
@@ -57,6 +51,12 @@ namespace Hl7.Fhir.Validation
                                               => @"path.matches('^[A-Za-z][A-Za-z0-9]*(\\.[a-z][A-Za-z0-9]*(\\[x])?)*$')",
                     { Key: "sdf-0", Expression: @"name.matches('[A-Z]([A-Za-z0-9_]){0,254}')" }
                                              => @"name.matches('^[A-Z]([A-Za-z0-9_]){0,254}$')",
+
+                    // do not use $this (see https://jira.hl7.org/browse/FHIR-37761)
+                    { Key: "sdf-24", Expression: @"element.where(type.code='Reference' and id.endsWith('.reference') and type.targetProfile.exists() and id.substring(0,$this.length()-10) in %context.element.where(type.code='CodeableReference').id).exists().not()" }
+                                              => @"element.where(type.code='Reference' and id.endsWith('.reference') and type.targetProfile.exists() and id.substring(0,id.length()-10) in %context.element.where(type.code='CodeableReference').id).exists().not()')",
+                    { Key: "sdf-25", Expression: @"element.where(type.code='CodeableConcept' and id.endsWith('.concept') and binding.exists() and id.substring(0,$this.length()-8) in %context.element.where(type.code='CodeableReference').id).exists().not()" }
+                                              => @"element.where(type.code='CodeableConcept' and id.endsWith('.concept') and binding.exists() and id.substring(0,id.length()-8) in %context.element.where(type.code='CodeableReference').id).exists().not()",
                     var ce => ce.Expression
                 };
 

--- a/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
@@ -57,6 +57,10 @@ namespace Hl7.Fhir.Validation
                                               => @"element.where(type.code='Reference' and id.endsWith('.reference') and type.targetProfile.exists() and id.substring(0,id.length()-10) in %context.element.where(type.code='CodeableReference').id).exists().not()')",
                     { Key: "sdf-25", Expression: @"element.where(type.code='CodeableConcept' and id.endsWith('.concept') and binding.exists() and id.substring(0,$this.length()-8) in %context.element.where(type.code='CodeableReference').id).exists().not()" }
                                               => @"element.where(type.code='CodeableConcept' and id.endsWith('.concept') and binding.exists() and id.substring(0,id.length()-8) in %context.element.where(type.code='CodeableReference').id).exists().not()",
+
+                    // correct datatype in expression:
+                    { Key: "que-7", Expression: @"operator = 'exists' implies (answer is Boolean)" }
+                                             => @"operator = 'exists' implies (answer is boolean)",
                     var ce => ce.Expression
                 };
 

--- a/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
@@ -48,7 +48,7 @@ namespace Hl7.Fhir.Validation
                 constraintElement.Expression = constraintElement switch
                 {
                     { Key: "ref-1", Expression: @"reference.startsWith('#').not() or (reference.substring(1).trace('url') in %resource.contained.id.trace('ids'))" }
-                                             => @"reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))",
+                                             => @"reference.exists() implies (reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids')))",
 
                     // matches should be applied on the whole string:
                     { Key: "eld-19", Expression: @"path.matches('[^\\s\\.,:;\\\'""\\/|?!@#$%&*()\\[\\]{}]{1,64}(\\.[^\\s\\.,:;\\\'""\\/|?!@#$%&*()\\[\\]{}]{1,64}(\\[x\\])?(\\:[^\\s\\.]+)?)*')" }

--- a/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
@@ -44,6 +44,22 @@ namespace Hl7.Fhir.Validation
                     constraintElement.Expression = "reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))";
                 }
 
+                // The following constraints will be repaired in R4B - pre-apply it for other R3+ here as well.
+                constraintElement.Expression = constraintElement switch
+                {
+                    { Key: "ref-1", Expression: @"reference.startsWith('#').not() or (reference.substring(1).trace('url') in %resource.contained.id.trace('ids'))" }
+                                             => @"reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))",
+
+                    // matches should be applied on the whole string:
+                    { Key: "eld-19", Expression: @"path.matches('[^\\s\\.,:;\\\'""\\/|?!@#$%&*()\\[\\]{}]{1,64}(\\.[^\\s\\.,:;\\\'""\\/|?!@#$%&*()\\[\\]{}]{1,64}(\\[x\\])?(\\:[^\\s\\.]+)?)*')" }
+                                              => @"path.matches('^[^\\s\\.,:;\\\'""\\/|?!@#$%&*()\\[\\]{}]{1,64}(\\.[^\\s\\.,:;\\\'""\\/|?!@#$%&*()\\[\\]{}]{1,64}(\\[x\\])?(\\:[^\\s\\.]+)?)*$')",
+                    { Key: "eld-20", Expression: @"path.matches('[A-Za-z][A-Za-z0-9]*(\\.[a-z][A-Za-z0-9]*(\\[x])?)*')" }
+                                              => @"path.matches('^[A-Za-z][A-Za-z0-9]*(\\.[a-z][A-Za-z0-9]*(\\[x])?)*$')",
+                    { Key: "sdf-0", Expression: @"name.matches('[A-Z]([A-Za-z0-9_]){0,254}')" }
+                                             => @"name.matches('^[A-Z]([A-Za-z0-9_]){0,254}$')",
+                    var ce => ce.Expression
+                };
+
                 bool success = false;
 
                 try


### PR DESCRIPTION
## Description
The following invariants are corrected during validation:
- `eld-19`: changed the expression in `matches()` so that the *whole* string is matched 
- `eld-20`: changed the expression in `matches()` so that the *whole* string is matched
- `sdf-0`: changed the expression in `matches()` so that the *whole* string is matched
- `sdf-24`: do not use `$this` in the expression, see also https://jira.hl7.org/browse/FHIR-37761
- `sdf-25`: do not use `$this` in the expression, see also https://jira.hl7.org/browse/FHIR-37761
- `ref-1`: Reference with only a display should succeed. See https://jira.hl7.org/browse/FHIR-37793
- `que-7`: use the correct FHIR boolean, see also https://jira.hl7.org/browse/FHIR-25390

## Related issues
Resolves #2013 
Resolves #2153 
Resolves #2174 

## Testing
Unfortunately no unit tests, because I could not find an easy way to test this.

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes