### PR TITLE
Corrected fullUrl for valueset-compose-include-valueSetTitle

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Source/ZipSourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ZipSourceTests.cs
@@ -38,7 +38,7 @@ namespace Hl7.Fhir.Specification.Tests.Source
         }
 
 
-        //issue #36678
+        //issue #2031
         [TestMethod]
         public void TestIncorrectFullUrlForValuesetComposeIncludeValueSetTitle()
         {
@@ -51,7 +51,7 @@ namespace Hl7.Fhir.Specification.Tests.Source
             extensionEntry.Should().NotBeNull();
             var sd = extensionEntry.Resource as StructureDefinition;
             sd.Url.Should().Be("http://hl7.org/fhir/StructureDefinition/valueset-compose-include-valueSetTitle");
-
+            sd.Id.Should().Be("valueset-compose-include-valueSetTitle");
         }
 
     }

--- a/src/Hl7.Fhir.Specification.Tests/Source/ZipSourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/ZipSourceTests.cs
@@ -1,4 +1,7 @@
-﻿using Hl7.Fhir.Specification.Source;
+﻿using FluentAssertions;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Hl7.Fhir.Specification.Source;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 using System.Linq;
@@ -33,5 +36,23 @@ namespace Hl7.Fhir.Specification.Tests.Source
             Assert.IsNotNull(summaries, "Collection of summeries should not be null");
             Assert.AreEqual(1, summaries.Count(), "In the zipfile there is 1 resource in the root folder.");
         }
+
+
+        //issue #36678
+        [TestMethod]
+        public void TestIncorrectFullUrlForValuesetComposeIncludeValueSetTitle()
+        {
+            var _resolver = ZipSource.CreateValidationSource();
+            var stream = _resolver.LoadArtifactByName("extension-definitions.xml");
+            var text = new StreamReader(stream).ReadToEnd();
+            var bundle = new FhirXmlParser().Parse<Bundle>(text);
+
+            var extensionEntry = bundle.Entry.Where(e => e.FullUrl == "http://hl7.org/fhir/StructureDefinition/valueset-compose-include-valueSetTitle").FirstOrDefault();
+            extensionEntry.Should().NotBeNull();
+            var sd = extensionEntry.Resource as StructureDefinition;
+            sd.Url.Should().Be("http://hl7.org/fhir/StructureDefinition/valueset-compose-include-valueSetTitle");
+
+        }
+
     }
 }


### PR DESCRIPTION
fixes [#2031](https://github.com/FirelyTeam/firely-net-sdk/issues/2031)

I have doubts about the location of the unit test, any suggestions?