### PR TITLE
Improvement of invariants ref-1, sdf-24 and sdf-25 [R4]

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -1,4 +1,5 @@
-﻿using Hl7.Fhir.ElementModel;
+using FluentAssertions;
+using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.FhirPath;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
@@ -1430,6 +1431,82 @@ namespace Hl7.Fhir.Specification.Tests
             var outcome = validator.Validate(questionnaire);
             Assert.True(outcome.Success);
         }
+
+        [Theory]
+        [MemberData(nameof(InvariantTestcases))]
+        public void InvariantValidation(FHIRAllTypes type, string key, Base poco, bool successExpected)
+        {
+            var outcome = _validator.Validate(poco);
+            var issues = outcome.Issue.Where(i => i.ToString().Contains(key));
+
+            issues.Should().HaveCount(successExpected ? 0 : 1);
+        }
+
+        public static IEnumerable<object[]> InvariantTestcases =>
+        new List<object[]>
+        {
+            new object[] { FHIRAllTypes.Reference, "ref-1", new ResourceReference{ Display = "Only a display element" }, true },
+            
+            /* Tests for R4+
+            new object[] { FHIRAllTypes.ElementDefinition, "eld-19", new ElementDefinition { Path = ":.ContainingSpecialCharacters" }, false},
+            new object[] { FHIRAllTypes.ElementDefinition, "eld-19", new ElementDefinition { Path = "NoSpecialCharacters" }, true },
+            new object[] { FHIRAllTypes.ElementDefinition, "eld-20", new ElementDefinition { Path = "   leadingSpaces" }, false},
+            new object[] { FHIRAllTypes.ElementDefinition, "eld-19", new ElementDefinition { Path = "NoSpaces.withADot" }, true },
+            new object[] { FHIRAllTypes.StructureDefinition, "sdf-0", new StructureDefinition { Name = " leadingSpaces" }, false },
+            new object[] { FHIRAllTypes.StructureDefinition, "sdf-0", new StructureDefinition { Name = "Name" }, true },
+            new object[] { FHIRAllTypes.StructureDefinition, "sdf-24",
+                    new StructureDefinition.SnapshotComponent
+                        {
+                            Element = new List<ElementDefinition> {
+                                new ElementDefinition
+                                {
+                                    ElementId = "coderef.reference",
+                                    Type = new List<ElementDefinition.TypeRefComponent>
+                                           {
+                                                new ElementDefinition.TypeRefComponent { Code = "Reference", TargetProfile = "http://example.com/profile" }
+                                           }
+                                },
+                                new ElementDefinition
+                                {
+                                    ElementId = "coderef",
+                                    Type = new List<ElementDefinition.TypeRefComponent>
+                                           {
+                                                new ElementDefinition.TypeRefComponent { Code = "CodeableReference"}
+                                           }
+                                },
+                             }
+                    }, false },
+            new object[] { FHIRAllTypes.StructureDefinition, "sdf-25",
+                    new StructureDefinition.SnapshotComponent
+                        {
+                            Element = new List<ElementDefinition> {
+                                new ElementDefinition
+                                {
+                                    ElementId = "coderef.concept",
+                                    Type = new List<ElementDefinition.TypeRefComponent>
+                                           {
+                                                new ElementDefinition.TypeRefComponent { Code = "CodeableConcept" }
+                                           },
+                                    Binding = new ElementDefinition.ElementDefinitionBindingComponent { Description = "Just a description" }
+                                },
+                                new ElementDefinition
+                                {
+                                    ElementId = "coderef",
+                                    Type = new List<ElementDefinition.TypeRefComponent>
+                                           {
+                                                new ElementDefinition.TypeRefComponent { Code = "CodeableReference"}
+                                           }
+                                },
+                             }
+                    }, false },
+            new object[] { FHIRAllTypes.Questionnaire, "que-7",
+                    new Questionnaire.EnableWhenComponent
+                        {
+                            Operator = Questionnaire.QuestionnaireItemOperator.Exists,
+                            Answer = new FhirBoolean(true)
+                    }, true },
+            */
+        };
 
 
         private class ClearSnapshotResolver : IResourceResolver

--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -1446,14 +1446,13 @@ namespace Hl7.Fhir.Specification.Tests
         new List<object[]>
         {
             new object[] { FHIRAllTypes.Reference, "ref-1", new ResourceReference{ Display = "Only a display element" }, true },
-            
-            /* Tests for R4+
             new object[] { FHIRAllTypes.ElementDefinition, "eld-19", new ElementDefinition { Path = ":.ContainingSpecialCharacters" }, false},
             new object[] { FHIRAllTypes.ElementDefinition, "eld-19", new ElementDefinition { Path = "NoSpecialCharacters" }, true },
             new object[] { FHIRAllTypes.ElementDefinition, "eld-20", new ElementDefinition { Path = "   leadingSpaces" }, false},
             new object[] { FHIRAllTypes.ElementDefinition, "eld-19", new ElementDefinition { Path = "NoSpaces.withADot" }, true },
             new object[] { FHIRAllTypes.StructureDefinition, "sdf-0", new StructureDefinition { Name = " leadingSpaces" }, false },
             new object[] { FHIRAllTypes.StructureDefinition, "sdf-0", new StructureDefinition { Name = "Name" }, true },
+            /* Tests for R4B+
             new object[] { FHIRAllTypes.StructureDefinition, "sdf-24",
                     new StructureDefinition.SnapshotComponent
                         {
@@ -1463,7 +1462,7 @@ namespace Hl7.Fhir.Specification.Tests
                                     ElementId = "coderef.reference",
                                     Type = new List<ElementDefinition.TypeRefComponent>
                                            {
-                                                new ElementDefinition.TypeRefComponent { Code = "Reference", TargetProfile = "http://example.com/profile" }
+                                                new ElementDefinition.TypeRefComponent { Code = "Reference", TargetProfile = new [] { "http://example.com/profile" } }
                                            }
                                 },
                                 new ElementDefinition
@@ -1499,13 +1498,13 @@ namespace Hl7.Fhir.Specification.Tests
                                 },
                              }
                     }, false },
+            */
             new object[] { FHIRAllTypes.Questionnaire, "que-7",
                     new Questionnaire.EnableWhenComponent
                         {
                             Operator = Questionnaire.QuestionnaireItemOperator.Exists,
                             Answer = new FhirBoolean(true)
                     }, true },
-            */
         };
 
 

--- a/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BasicValidationTests.cs
@@ -1434,7 +1434,7 @@ namespace Hl7.Fhir.Specification.Tests
 
         [Theory]
         [MemberData(nameof(InvariantTestcases))]
-        public void InvariantValidation(FHIRAllTypes type, string key, Base poco, bool successExpected)
+        public void InvariantValidation(string key, Base poco, bool successExpected)
         {
             var outcome = _validator.Validate(poco);
             var issues = outcome.Issue.Where(i => i.ToString().Contains(key));
@@ -1445,15 +1445,18 @@ namespace Hl7.Fhir.Specification.Tests
         public static IEnumerable<object[]> InvariantTestcases =>
         new List<object[]>
         {
-            new object[] { FHIRAllTypes.Reference, "ref-1", new ResourceReference{ Display = "Only a display element" }, true },
-            new object[] { FHIRAllTypes.ElementDefinition, "eld-19", new ElementDefinition { Path = ":.ContainingSpecialCharacters" }, false},
-            new object[] { FHIRAllTypes.ElementDefinition, "eld-19", new ElementDefinition { Path = "NoSpecialCharacters" }, true },
-            new object[] { FHIRAllTypes.ElementDefinition, "eld-20", new ElementDefinition { Path = "   leadingSpaces" }, false},
-            new object[] { FHIRAllTypes.ElementDefinition, "eld-19", new ElementDefinition { Path = "NoSpaces.withADot" }, true },
-            new object[] { FHIRAllTypes.StructureDefinition, "sdf-0", new StructureDefinition { Name = " leadingSpaces" }, false },
-            new object[] { FHIRAllTypes.StructureDefinition, "sdf-0", new StructureDefinition { Name = "Name" }, true },
+            new object[] { "ref-1", new ResourceReference{ Display = "Only a display element" }, true },
+            new object[] { "eld-19", new ElementDefinition { Path = ":.ContainingSpecialCharacters" }, false},
+            new object[] { "eld-19", new ElementDefinition { Path = "NoSpecialCharacters" }, true },
+            new object[] { "eld-20", new ElementDefinition { Path = "   leadingSpaces" }, false},
+            new object[] { "eld-19", new ElementDefinition { Path = "NoSpaces.withADot" }, true },
+            new object[] { "sdf-0", new StructureDefinition { Name = " leadingSpaces" }, false },
+            new object[] { "sdf-0", new StructureDefinition { Name = "Name" }, true },
             /* Tests for R4B+
-            new object[] { FHIRAllTypes.StructureDefinition, "sdf-24",
+            new object[] { "sdf-24",
+                new StructureDefinition
+                {
+                    Snapshot =
                     new StructureDefinition.SnapshotComponent
                         {
                             Element = new List<ElementDefinition> {
@@ -1462,7 +1465,7 @@ namespace Hl7.Fhir.Specification.Tests
                                     ElementId = "coderef.reference",
                                     Type = new List<ElementDefinition.TypeRefComponent>
                                            {
-                                                new ElementDefinition.TypeRefComponent { Code = "Reference", TargetProfile = new [] { "http://example.com/profile" } }
+                                                new ElementDefinition.TypeRefComponent { Code = "Reference", TargetProfile = new[] { "http://example.com/profile" }  }
                                            }
                                 },
                                 new ElementDefinition
@@ -1474,8 +1477,12 @@ namespace Hl7.Fhir.Specification.Tests
                                            }
                                 },
                              }
-                    }, false },
-            new object[] { FHIRAllTypes.StructureDefinition, "sdf-25",
+                    }
+                }, false },
+            new object[] { "sdf-25",
+                new StructureDefinition
+                {
+                    Snapshot =
                     new StructureDefinition.SnapshotComponent
                         {
                             Element = new List<ElementDefinition> {
@@ -1497,9 +1504,10 @@ namespace Hl7.Fhir.Specification.Tests
                                            }
                                 },
                              }
-                    }, false },
+                    }
+                }, false },
             */
-            new object[] { FHIRAllTypes.Questionnaire, "que-7",
+            new object[] { "que-7",
                     new Questionnaire.EnableWhenComponent
                         {
                             Operator = Questionnaire.QuestionnaireItemOperator.Exists,

--- a/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
@@ -49,22 +49,26 @@ namespace Hl7.Fhir.Validation
                 {
                     {
                         Key: "ref-1", Expression: @"reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))" or
-                                                  @"reference.startsWith('#').not() or (reference.substring(1).trace('url') in %resource.contained.id.trace('ids'))"
+                                                  @"reference.startsWith('#').not() or (reference.substring(1).trace('url') in %resource.contained.id.trace('ids'))" or
+                                                  @"reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids')) or (reference='#' and %rootResource!=%resource)"
                     }
-                                               => @"reference.exists() implies (reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids')))",
+                                               => @"reference.exists() implies (reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids')) or (reference='#' and %rootResource!=%resource))",
 
                     // matches should be applied on the whole string:
                     { Key: "eld-19", Expression: @"path.matches('[^\\s\\.,:;\\\'""\\/|?!@#$%&*()\\[\\]{}]{1,64}(\\.[^\\s\\.,:;\\\'""\\/|?!@#$%&*()\\[\\]{}]{1,64}(\\[x\\])?(\\:[^\\s\\.]+)?)*')" }
                                               => @"path.matches('^[^\\s\\.,:;\\\'""\\/|?!@#$%&*()\\[\\]{}]{1,64}(\\.[^\\s\\.,:;\\\'""\\/|?!@#$%&*()\\[\\]{}]{1,64}(\\[x\\])?(\\:[^\\s\\.]+)?)*$')",
                     { Key: "eld-20", Expression: @"path.matches('[A-Za-z][A-Za-z0-9]*(\\.[a-z][A-Za-z0-9]*(\\[x])?)*')" }
                                               => @"path.matches('^[A-Za-z][A-Za-z0-9]*(\\.[a-z][A-Za-z0-9]*(\\[x])?)*$')",
-                    { Key: "sdf-0", Expression: @"name.matches('[A-Z]([A-Za-z0-9_]){0,254}')" }
-                                             => @"name.matches('^[A-Z]([A-Za-z0-9_]){0,254}$')",
+                    {
+                        Key: "sdf-0", Expression: @"name.matches('[A-Z]([A-Za-z0-9_]){0,254}')" or
+                                                  @"name.exists() implies name.matches('[A-Z]([A-Za-z0-9_]){0,254}')"
+                    }
+                                               => @"name.exists() implies name.matches('^[A-Z]([A-Za-z0-9_]){0,254}$')",
 
                     // do not use $this (see https://jira.hl7.org/browse/FHIR-37761)
                     { Key: "sdf-24", Expression: @"element.where(type.code='Reference' and id.endsWith('.reference') and type.targetProfile.exists() and id.substring(0,$this.length()-10) in %context.element.where(type.code='CodeableReference').id).exists().not()" }
                                               => @"element.where(type.code='Reference' and id.endsWith('.reference') and type.targetProfile.exists() and id.substring(0,$this.id.length()-10) in %context.element.where(type.code='CodeableReference').id).exists().not()",
-                    { Key: "sdf -25", Expression: @"element.where(type.code='CodeableConcept' and id.endsWith('.concept') and binding.exists() and id.substring(0,$this.length()-8) in %context.element.where(type.code='CodeableReference').id).exists().not()" }
+                    { Key: "sdf-25", Expression: @"element.where(type.code='CodeableConcept' and id.endsWith('.concept') and binding.exists() and id.substring(0,$this.length()-8) in %context.element.where(type.code='CodeableReference').id).exists().not()" }
                                                => @"element.where(type.code='CodeableConcept' and id.endsWith('.concept') and binding.exists() and id.substring(0,$this.id.length()-8) in %context.element.where(type.code='CodeableReference').id).exists().not()",
 
                     // correct datatype in expression:

--- a/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Validation/FpConstraintValidationExtensions.cs
@@ -44,6 +44,35 @@ namespace Hl7.Fhir.Validation
                     else if (v.Settings.ConstraintBestPracticesSeverity == ConstraintBestPracticesSeverity.Warning)
                         constraintElement.Severity = ElementDefinition.ConstraintSeverity.Warning;
 
+                // The following constraints will be repaired in R4B - pre-apply it for other R3+ here as well.
+                constraintElement.Expression = constraintElement switch
+                {
+                    {
+                        Key: "ref-1", Expression: @"reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids'))" or
+                                                  @"reference.startsWith('#').not() or (reference.substring(1).trace('url') in %resource.contained.id.trace('ids'))"
+                    }
+                                               => @"reference.exists() implies (reference.startsWith('#').not() or (reference.substring(1).trace('url') in %rootResource.contained.id.trace('ids')))",
+
+                    // matches should be applied on the whole string:
+                    { Key: "eld-19", Expression: @"path.matches('[^\\s\\.,:;\\\'""\\/|?!@#$%&*()\\[\\]{}]{1,64}(\\.[^\\s\\.,:;\\\'""\\/|?!@#$%&*()\\[\\]{}]{1,64}(\\[x\\])?(\\:[^\\s\\.]+)?)*')" }
+                                              => @"path.matches('^[^\\s\\.,:;\\\'""\\/|?!@#$%&*()\\[\\]{}]{1,64}(\\.[^\\s\\.,:;\\\'""\\/|?!@#$%&*()\\[\\]{}]{1,64}(\\[x\\])?(\\:[^\\s\\.]+)?)*$')",
+                    { Key: "eld-20", Expression: @"path.matches('[A-Za-z][A-Za-z0-9]*(\\.[a-z][A-Za-z0-9]*(\\[x])?)*')" }
+                                              => @"path.matches('^[A-Za-z][A-Za-z0-9]*(\\.[a-z][A-Za-z0-9]*(\\[x])?)*$')",
+                    { Key: "sdf-0", Expression: @"name.matches('[A-Z]([A-Za-z0-9_]){0,254}')" }
+                                             => @"name.matches('^[A-Z]([A-Za-z0-9_]){0,254}$')",
+
+                    // do not use $this (see https://jira.hl7.org/browse/FHIR-37761)
+                    { Key: "sdf-24", Expression: @"element.where(type.code='Reference' and id.endsWith('.reference') and type.targetProfile.exists() and id.substring(0,$this.length()-10) in %context.element.where(type.code='CodeableReference').id).exists().not()" }
+                                              => @"element.where(type.code='Reference' and id.endsWith('.reference') and type.targetProfile.exists() and id.substring(0,$this.id.length()-10) in %context.element.where(type.code='CodeableReference').id).exists().not()",
+                    { Key: "sdf -25", Expression: @"element.where(type.code='CodeableConcept' and id.endsWith('.concept') and binding.exists() and id.substring(0,$this.length()-8) in %context.element.where(type.code='CodeableReference').id).exists().not()" }
+                                               => @"element.where(type.code='CodeableConcept' and id.endsWith('.concept') and binding.exists() and id.substring(0,$this.id.length()-8) in %context.element.where(type.code='CodeableReference').id).exists().not()",
+
+                    // correct datatype in expression:
+                    { Key: "que-7", Expression: @"operator = 'exists' implies (answer is Boolean)" }
+                                             => @"operator = 'exists' implies (answer is boolean)",
+                    var ce => ce.Expression
+                };
+
                 bool success = false;
 
                 try


### PR DESCRIPTION
## Description
Improvement of the following invariants:
- ref-1
- sdf-24 
- sdf-25

And add an unit test to prove it.

## Related issues
Resolves #2153 

## Testing
See `BasicValidationTests.InvariantValidation`

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes