### PR TITLE
Bugfix/2106 terminologyserviceexpand

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Rest/OperationsTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Rest/OperationsTests.cs
@@ -1,7 +1,7 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2014, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
- * 
+ *
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
@@ -73,7 +73,12 @@ namespace Hl7.Fhir.Tests.Rest
 
         private static void expandExistingValueset(BaseFhirClient client)
         {
+            // expand via instance level operation
             var vs = client.ExpandValueSet(ResourceIdentity.Build("ValueSet", "administrative-gender"));
+            Assert.IsTrue(vs.Expansion.Contains.Any());
+
+            // expand via Canonical URI
+            vs = client.ExpandValueSet(new FhirUri("http://hl7.org/fhir/ValueSet/administrative-gender"));
             Assert.IsTrue(vs.Expansion.Contains.Any());
         }
 

--- a/src/Hl7.Fhir.Core/Rest/FhirClientTermSvcExtensions.cs
+++ b/src/Hl7.Fhir.Core/Rest/FhirClientTermSvcExtensions.cs
@@ -96,7 +96,7 @@ namespace Hl7.Fhir.Rest
 
             var par = new Parameters();
 
-            par.Add("identifier", identifier);
+            par.Add("url", identifier);
             if (filter != null) par.Add("filter", filter);
             if (date != null) par.Add("date", date);
 

--- a/src/Hl7.Fhir.Specification.Tests/Source/TerminologyTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Source/TerminologyTests.cs
@@ -15,7 +15,7 @@ namespace Hl7.Fhir.Specification.Tests
     public class TerminologyTests : IClassFixture<ValidationFixture>
     {
         private readonly IAsyncResourceResolver _resolver;
-        private static Uri _externalTerminologyServerEndpoint = new("https://ontoserver.csiro.au/stu3-latest");
+        private static Uri _externalTerminologyServerEndpoint = new("https://r4.ontoserver.csiro.au/fhir");
 
         public TerminologyTests(ValidationFixture fixture, Xunit.Abstractions.ITestOutputHelper _)
         {


### PR DESCRIPTION
## Description
Update the parameter to be conformant with the R4+ specification
Update the URL of the CSIRO test server to use the R4 server, not STU3 endpoint.

_(Not sure if you'd mark this as a breaking change, but it's now conformant with the R4 spec, would have been working with many terminology servers as they've been tolerant of the old parameter name)_

## Related issues
Resolves #2106

## Testing
Unit test InvokeExpandExistingValueSet updated to also cover this code path.
