### PR TITLE
2232 Support implicit type slicing

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -5955,6 +5955,44 @@ namespace Hl7.Fhir.Specification.Tests
             }
         };
 
+
+        [TestMethod]
+        public async T.Task TestNamedTypeSlice()
+        {
+            var derivedObs = MyNamedTypeSlice;
+            var resolver = new InMemoryProfileResolver(derivedObs);
+            var multiResolver = new MultiResolver(_testResolver, resolver);
+
+            _generator = new SnapshotGenerator(multiResolver, _settings);
+
+            var (_, expanded) = await generateSnapshotAndCompare(derivedObs);
+
+            Assert.IsTrue(expanded.HasSnapshot);
+        }
+
+
+        private static StructureDefinition MyNamedTypeSlice => new()
+        {
+            Type = FHIRAllTypes.Observation.GetLiteral(),
+            BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Observation),
+            Name = "MyNamedTypeSlice",
+            Url = @"http://example.org/fhir/StructureDefinition/MyNamedTypeSlice",
+            Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+            Kind = StructureDefinition.StructureDefinitionKind.Resource,
+            Differential = new StructureDefinition.DifferentialComponent()
+            {
+                Element = new List<ElementDefinition>()
+                {
+                    new ElementDefinition("Observation"),
+                    new ElementDefinition("Observation.value[x]")
+                    {
+                        ElementId = "Observation.value[x]:valueString",
+                        SliceName = "valueString"
+                    }.OfType(FHIRAllTypes.String)
+                }
+            }
+        };
+
         [TestMethod]
         public async T.Task TestMoreDerivedObservation()
         {

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementMatcher.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/ElementMatcher.cs
@@ -230,7 +230,6 @@ namespace Hl7.Fhir.Specification.Snapshot
                         {
                             var slicedToBeRemoved = findRedundantTypeSliceEntries(snapNav, removedTypes);
                             result.AddRange(slicedToBeRemoved);
-
                         }
                     }
                 }
@@ -935,7 +934,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
         private class SliceByTypeProfileEqualityComparer : IEqualityComparer<string>
         {
-            readonly string _sliceName;
+            private readonly string _sliceName;
 
             public SliceByTypeProfileEqualityComparer(string sliceName)
             {

--- a/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Snapshot/SnapshotGenerator.cs
@@ -1820,17 +1820,19 @@ namespace Hl7.Fhir.Specification.Snapshot
 
 
             bool isRenamed = !IsEqualPath(snap.PathName, diff.PathName);
+            bool isImplicitTypeSlice = snap.PathName == diff.PathName && snap.Current.IsChoice() && !string.IsNullOrEmpty(diff.Current.SliceName);
 
-            // [WMR 20190822] R4 TODO
             // Emit default Slicing component for type slices, if omitted
-            if (isRenamed && snap.Current.Slicing is null)
+            if ((isRenamed || isImplicitTypeSlice) && snap.Current.Slicing is null)
             {
                 snap.Current.Slicing = new ElementDefinition.SlicingComponent()
                 {
                     Discriminator = new List<ElementDefinition.DiscriminatorComponent>()
                     {
                         ElementDefinition.DiscriminatorComponent.ForTypeSlice()
-                    }
+                    },
+                    Rules = ElementDefinition.SlicingRules.Open,    // since in R4, we can just have a slice with constraints for one of the types
+                    Ordered = false
                 };
             };
 

--- a/src/firely-net-sdk-tests.props
+++ b/src/firely-net-sdk-tests.props
@@ -18,7 +18,7 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' != 'net40'">
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
 		<PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
Will now create a type slice for type slices introduced with just a sliceName.  Such slices will now also explicitly set type slices to open (R4 semantics).

Fixes #2232.