### PR TITLE
Pass the exceptionhandler in from the settings into the pocobuilder

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/Serialization/ResourceParsingTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/Serialization/ResourceParsingTests.cs
@@ -15,6 +15,7 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using Tasks = System.Threading.Tasks;
 using Hl7.Fhir.ElementModel;
+using Hl7.FhirPath.Functions;
 
 namespace Hl7.Fhir.Tests.Serialization
 {
@@ -31,8 +32,8 @@ namespace Hl7.Fhir.Tests.Serialization
                 Debug.WriteLine(args.Message);
                 if (args.Exception is StructuralTypeException && args.Severity == Utility.ExceptionSeverity.Error)
                 {
+                    Assert.IsTrue(args.Exception.Message.Contains("Type checking the data: "), "Error message detected");
                     throw new StructuralTypeException(args.Exception.Message.Replace("Type checking the data: ", ""), args.Exception.InnerException);
-                    // throw args.Exception;
                 }
             };
 
@@ -44,6 +45,7 @@ namespace Hl7.Fhir.Tests.Serialization
             catch (StructuralTypeException ste)
             {
                 Debug.WriteLine(ste.Message);
+                Assert.IsFalse(ste.Message.Contains("Type checking the data: "), "Custom error message should have removed the prefix");
             }
 
             parser.Settings.AcceptUnknownMembers = true;

--- a/src/Hl7.Fhir.Core/Serialization/BaseFhirParser.cs
+++ b/src/Hl7.Fhir.Core/Serialization/BaseFhirParser.cs
@@ -1,7 +1,7 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2018, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
- * 
+ *
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
@@ -26,6 +26,7 @@ namespace Hl7.Fhir.Serialization
             {
                 AllowUnrecognizedEnums = ps.AllowUnrecognizedEnums,
                 IgnoreUnknownMembers = ps.AcceptUnknownMembers,
+                ExceptionHandler = ps.ExceptionHandler,
 #pragma warning disable CS0618 // Type or member is obsolete
                 TruncateDateTimeToDate = ps.TruncateDateTimeToDate
 #pragma warning restore CS0618 // Type or member is obsolete


### PR DESCRIPTION
## Description
In order to be able to inject custom error/exception handling to the parser need to be able to provide the handler through the settings object on the parser.

## Related issues
Resolves #2222

## Testing
The unit test `ConfigureFailOnUnknownMember` was updated to verify this new functionality