### PR TITLE
Binding: Add Error message to the response message

### DIFF
--- a/src/Hl7.Fhir.Specification.Tests/Validation/BindingValidationTests.cs
+++ b/src/Hl7.Fhir.Specification.Tests/Validation/BindingValidationTests.cs
@@ -244,13 +244,13 @@ namespace Hl7.Fhir.Specification.Tests
             var result = val.Validate(code.ToTypedElement(), vc);
 
             result.Issue.Should()
-                .OnlyContain(i => i.Details.Text == "Terminology service failed while validating code 'aValue'");
+                .OnlyContain(i => i.Details.Text.StartsWith("Terminology service failed while validating code 'aValue': Error"));
 
             var coding = new Coding("aSystem", "aValue");
             result = val.Validate(coding.ToTypedElement(), vc);
 
             result.Issue.Should()
-                .OnlyContain(i => i.Details.Text == "Terminology service failed while validating code 'aValue' (system 'aSystem')");
+                .OnlyContain(i => i.Details.Text.StartsWith("Terminology service failed while validating code 'aValue' (system 'aSystem'): Error"));
 
         }
     }

--- a/src/Hl7.Fhir.Specification/Schema/Binding.cs
+++ b/src/Hl7.Fhir.Specification/Schema/Binding.cs
@@ -165,7 +165,7 @@ namespace Hl7.Fhir.Specification.Schema
                     var codeText = code ?? coding?.Code ?? cc?.Coding[0]?.Code;
                     var systemName = system ?? coding?.System ?? cc?.Coding[0]?.System;
                     var systemText = systemName is null ? string.Empty : $" (system '{systemName}')";
-                    message = $"Terminology service failed while validating code '{codeText}'{systemText}";
+                    message = $"Terminology service failed while validating code '{codeText}'{systemText}: {tse.Message}";
                 }
                 else
                 {


### PR DESCRIPTION
## Description
The exception message should be added to the response message.

## Related issues
Part of #2224

## Testing
Unit test `ErrorMessageAtExceptionInService`
