### PR TITLE
Remove unnecessary dependency on SymbolTable from ExpressionVisitor

### DIFF
--- a/src/Hl7.Fhir.STU3.Specification/Specification/Navigation/DiscriminatorInterpreter.cs
+++ b/src/Hl7.Fhir.STU3.Specification/Specification/Navigation/DiscriminatorInterpreter.cs
@@ -28,16 +28,16 @@ namespace Hl7.Fhir.Specification.Navigation
             Root = root;
         }
 
-        public override IEnumerable<StructureDefinitionWalker> VisitConstant(ConstantExpression expression, SymbolTable _) =>
+        public override IEnumerable<StructureDefinitionWalker> VisitConstant(ConstantExpression expression) =>
             throw new DiscriminatorFormatException("Discriminator paths cannot contain constants.");
 
         /// <summary>
         /// Visit a function call appearing in a discriminator expression
         /// </summary>
         /// <remarks>May only be 'builtin.children', 'resolve' and 'extension'</remarks>
-        public override IEnumerable<StructureDefinitionWalker> VisitFunctionCall(FunctionCallExpression call, SymbolTable scope)
+        public override IEnumerable<StructureDefinitionWalker> VisitFunctionCall(FunctionCallExpression call)
         {
-            var parentSet = call.Focus.Accept(this, scope);
+            var parentSet = call.Focus.Accept(this);
 
             if (call is ChildExpression childExpr)
                 return parentSet.Child(childExpr.ChildName);
@@ -83,12 +83,12 @@ namespace Hl7.Fhir.Specification.Navigation
             throw new DiscriminatorFormatException($"Function '{call.FunctionName}' should be invoked with a single parameter or type string");
         }
 
-        public override IEnumerable<StructureDefinitionWalker> VisitNewNodeListInit(NewNodeListInitExpression expression, SymbolTable scope) =>
+        public override IEnumerable<StructureDefinitionWalker> VisitNewNodeListInit(NewNodeListInitExpression expression) =>
             throw new DiscriminatorFormatException("The empty set constructor '{}', is not supported in discriminators.");
 
         public StructureDefinitionWalker Root { get; private set; }
 
-        public override IEnumerable<StructureDefinitionWalker> VisitVariableRef(VariableRefExpression expression, SymbolTable scope)
+        public override IEnumerable<StructureDefinitionWalker> VisitVariableRef(VariableRefExpression expression)
         {
             if (expression.Name == "builtin.this")
                 return new[] { Root };

--- a/src/Hl7.Fhir.STU3.Specification/Specification/Navigation/DiscriminatorInterpreterExtensions.cs
+++ b/src/Hl7.Fhir.STU3.Specification/Specification/Navigation/DiscriminatorInterpreterExtensions.cs
@@ -20,7 +20,7 @@ namespace Hl7.Fhir.Specification.Navigation
         {
             var interpeter = new DiscriminatorInterpreter(walker);
             //interpeter.AssertSupportedRootExpression(expr);
-            return expr.Accept(interpeter, new SymbolTable());
+            return expr.Accept(interpeter);
         }
 
         /// <summary>

--- a/src/Hl7.Fhir.Specification/Specification/Navigation/DiscriminatorInterpreter.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Navigation/DiscriminatorInterpreter.cs
@@ -27,16 +27,16 @@ namespace Hl7.Fhir.Specification.Navigation
             Root = root;
         }
 
-        public override IEnumerable<StructureDefinitionWalker> VisitConstant(ConstantExpression expression, SymbolTable _) =>
+        public override IEnumerable<StructureDefinitionWalker> VisitConstant(ConstantExpression expression) =>
             throw new DiscriminatorFormatException("Discriminator paths cannot contain constants.");
 
         /// <summary>
         /// Visit a function call appearing in a discriminator expression
         /// </summary>
         /// <remarks>May only be 'builtin.children', 'resolve' and 'extension'</remarks>
-        public override IEnumerable<StructureDefinitionWalker> VisitFunctionCall(FunctionCallExpression call, SymbolTable scope)
+        public override IEnumerable<StructureDefinitionWalker> VisitFunctionCall(FunctionCallExpression call)
         {
-            var parentSet = call.Focus.Accept(this, scope);
+            var parentSet = call.Focus.Accept(this);
 
             if (call is ChildExpression childExpr)
                 return parentSet.Child(childExpr.ChildName);
@@ -83,12 +83,12 @@ namespace Hl7.Fhir.Specification.Navigation
             throw new DiscriminatorFormatException($"Function '{call.FunctionName}' should be invoked with a single parameter or type string");
         }
 
-        public override IEnumerable<StructureDefinitionWalker> VisitNewNodeListInit(NewNodeListInitExpression expression, SymbolTable scope) =>
+        public override IEnumerable<StructureDefinitionWalker> VisitNewNodeListInit(NewNodeListInitExpression expression) =>
             throw new DiscriminatorFormatException("The empty set constructor '{}', is not supported in discriminators.");
 
         public StructureDefinitionWalker Root { get; private set; }
 
-        public override IEnumerable<StructureDefinitionWalker> VisitVariableRef(VariableRefExpression expression, SymbolTable scope)
+        public override IEnumerable<StructureDefinitionWalker> VisitVariableRef(VariableRefExpression expression)
         {
             if (expression.Name == "builtin.this")
                 return new[] { Root };

--- a/src/Hl7.Fhir.Specification/Specification/Navigation/DiscriminatorInterpreterExtensions.cs
+++ b/src/Hl7.Fhir.Specification/Specification/Navigation/DiscriminatorInterpreterExtensions.cs
@@ -20,7 +20,7 @@ namespace Hl7.Fhir.Specification.Navigation
         {
             var interpeter = new DiscriminatorInterpreter(walker);
             //interpeter.AssertSupportedRootExpression(expr);
-            return expr.Accept(interpeter, new SymbolTable());
+            return expr.Accept(interpeter);
         }
 
         /// <summary>


### PR DESCRIPTION
Adapted the SDK to the breaking changes in the common repo for the ExpressionVisitor.