### PR TITLE
Move some more classes to common

### DIFF
--- a/src/Hl7.Fhir.Core/Model/Generated/ValueSet.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/ValueSet.cs
@@ -447,7 +447,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// A copyright statement for the specific code system included in the value set
       /// </summary>
-      [FhirElement("copyright", Order=90, Since =FhirRelease.R5)]
+      [FhirElement("copyright", Order=90, Since=FhirRelease.R5)]
       [DataMember]
       public Hl7.Fhir.Model.FhirString CopyrightElement
       {
@@ -1350,7 +1350,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Additional information supplied about each concept
       /// </summary>
-      [FhirElement("property", Order = 90, Since = FhirRelease.R5)]
+      [FhirElement("property", Order=90, Since=FhirRelease.R5)]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.ValueSet.PropertyComponent> Property
@@ -2048,7 +2048,7 @@ namespace Hl7.Fhir.Model
       /// <summary>
       /// Property value for the concept
       /// </summary>
-      [FhirElement("property", Order = 110, Since = FhirRelease.R5)]
+      [FhirElement("property", Order=110, Since=FhirRelease.R5)]
       [Cardinality(Min=0,Max=-1)]
       [DataMember]
       public List<Hl7.Fhir.Model.ValueSet.ConceptPropertyComponent> Property
@@ -2993,7 +2993,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// Description of the semantic space the Value Set Expansion is intended to cover
     /// </summary>
-    [FhirElement("scope", Order=270, Since = FhirRelease.R5)]
+    [FhirElement("scope", Order=270, Since=FhirRelease.R5)]
     [DataMember]
     public Hl7.Fhir.Model.ValueSet.ScopeComponent Scope
     {

--- a/src/Hl7.Fhir.Core/Model/Generated/_GeneratorLog.cs
+++ b/src/Hl7.Fhir.Core/Model/Generated/_GeneratorLog.cs
@@ -321,9 +321,6 @@
 
 // Generated items
 // ElementDefinition.cs
-// Signature.cs
-// Binary.cs
-// Bundle.cs
 // CapabilityStatement.cs
 // CodeSystem.cs
 // StructureDefinition.cs

--- a/src/Hl7.Fhir.STU3.Core/Model/Generated/_GeneratorLog.cs
+++ b/src/Hl7.Fhir.STU3.Core/Model/Generated/_GeneratorLog.cs
@@ -242,7 +242,6 @@
 // Ratio.cs
 // RelatedArtifact.cs
 // SampledData.cs
-// Signature.cs
 // Timing.cs
 // TriggerDefinition.cs
 // Account.cs
@@ -253,9 +252,7 @@
 // AppointmentResponse.cs
 // AuditEvent.cs
 // Basic.cs
-// Binary.cs
 // BodySite.cs
-// Bundle.cs
 // CapabilityStatement.cs
 // CarePlan.cs
 // CareTeam.cs

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Binary.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Binary.cs
@@ -105,39 +105,6 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// The actual content
     /// </summary>
-    [FhirElement("content", Order = 70)]
-    [NotMapped(Since=FhirRelease.R4)]
-    [Cardinality(Min = 1, Max = 1)]
-    [DataMember]
-    public Hl7.Fhir.Model.Base64Binary ContentElement
-    {
-        get { return _ContentElement; }
-        set { _ContentElement = value; OnPropertyChanged("ContentElement"); }
-    }
-
-    private Hl7.Fhir.Model.Base64Binary _ContentElement;
-
-    /// <summary>
-    /// The actual content
-    /// </summary>
-    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
-    [IgnoreDataMember]
-    public byte[] Content
-    {
-        get { return ContentElement != null ? ContentElement.Value : null; }
-        set
-        {
-            if (value == null)
-                ContentElement = null;
-            else
-                ContentElement = new Hl7.Fhir.Model.Base64Binary(value);
-            OnPropertyChanged("Content");
-        }
-    }
-
-    /// <summary>
-    /// The actual content
-    /// </summary>
     [FhirElement("data", Order=70, Since=FhirRelease.R4)]
     [DataMember]
     public Hl7.Fhir.Model.Base64Binary DataElement
@@ -166,6 +133,39 @@ namespace Hl7.Fhir.Model
       }
     }
 
+    /// <summary>
+    /// The actual content
+    /// </summary>
+    [FhirElement("content", Order=70)]
+    [NotMapped(Since=FhirRelease.R4)]
+    [Cardinality(Min=1,Max=1)]
+    [DataMember]
+    public Hl7.Fhir.Model.Base64Binary ContentElement
+    {
+      get { return _ContentElement; }
+      set { _ContentElement = value; OnPropertyChanged("ContentElement"); }
+    }
+
+    private Hl7.Fhir.Model.Base64Binary _ContentElement;
+
+    /// <summary>
+    /// The actual content
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public byte[] Content
+    {
+      get { return ContentElement != null ? ContentElement.Value : null; }
+      set
+      {
+        if (value == null)
+          ContentElement = null;
+        else
+          ContentElement = new Hl7.Fhir.Model.Base64Binary(value);
+        OnPropertyChanged("Content");
+      }
+    }
+
     public override IDeepCopyable CopyTo(IDeepCopyable other)
     {
       var dest = other as Binary;
@@ -178,8 +178,8 @@ namespace Hl7.Fhir.Model
       base.CopyTo(dest);
       if(ContentTypeElement != null) dest.ContentTypeElement = (Hl7.Fhir.Model.Code)ContentTypeElement.DeepCopy();
       if(SecurityContext != null) dest.SecurityContext = (Hl7.Fhir.Model.ResourceReference)SecurityContext.DeepCopy();
-      if(ContentElement != null) dest.ContentElement = (Hl7.Fhir.Model.Base64Binary)ContentElement.DeepCopy();
       if(DataElement != null) dest.DataElement = (Hl7.Fhir.Model.Base64Binary)DataElement.DeepCopy();
+      if(ContentElement != null) dest.ContentElement = (Hl7.Fhir.Model.Base64Binary)ContentElement.DeepCopy();
       return dest;
     }
 
@@ -197,8 +197,8 @@ namespace Hl7.Fhir.Model
       if(!base.Matches(otherT)) return false;
       if( !DeepComparable.Matches(ContentTypeElement, otherT.ContentTypeElement)) return false;
       if( !DeepComparable.Matches(SecurityContext, otherT.SecurityContext)) return false;
-      if( !DeepComparable.Matches(ContentElement, otherT.ContentElement)) return false;
       if( !DeepComparable.Matches(DataElement, otherT.DataElement)) return false;
+      if( !DeepComparable.Matches(ContentElement, otherT.ContentElement)) return false;
 
       return true;
     }
@@ -211,8 +211,8 @@ namespace Hl7.Fhir.Model
       if(!base.IsExactly(otherT)) return false;
       if( !DeepComparable.IsExactly(ContentTypeElement, otherT.ContentTypeElement)) return false;
       if( !DeepComparable.IsExactly(SecurityContext, otherT.SecurityContext)) return false;
-      if( !DeepComparable.IsExactly(ContentElement, otherT.ContentElement)) return false;
       if( !DeepComparable.IsExactly(DataElement, otherT.DataElement)) return false;
+      if( !DeepComparable.IsExactly(ContentElement, otherT.ContentElement)) return false;
 
       return true;
     }
@@ -225,8 +225,8 @@ namespace Hl7.Fhir.Model
         foreach (var item in base.Children) yield return item;
         if (ContentTypeElement != null) yield return ContentTypeElement;
         if (SecurityContext != null) yield return SecurityContext;
-        if (ContentElement != null) yield return ContentElement;
         if (DataElement != null) yield return DataElement;
+        if (ContentElement != null) yield return ContentElement;
       }
     }
 
@@ -238,8 +238,8 @@ namespace Hl7.Fhir.Model
         foreach (var item in base.NamedChildren) yield return item;
         if (ContentTypeElement != null) yield return new ElementValue("contentType", ContentTypeElement);
         if (SecurityContext != null) yield return new ElementValue("securityContext", SecurityContext);
-        if (ContentElement != null) yield return new ElementValue("content", ContentElement);
         if (DataElement != null) yield return new ElementValue("data", DataElement);
+        if (ContentElement != null) yield return new ElementValue("content", ContentElement);
       }
     }
 
@@ -253,12 +253,12 @@ namespace Hl7.Fhir.Model
         case "securityContext":
           value = SecurityContext;
           return SecurityContext is not null;
-        case "content":
-          value = ContentElement;
-          return ContentElement is not null;
         case "data":
           value = DataElement;
           return DataElement is not null;
+        case "content":
+          value = ContentElement;
+          return ContentElement is not null;
         default:
           return base.TryGetValue(key, out value);
       };
@@ -270,8 +270,8 @@ namespace Hl7.Fhir.Model
       foreach (var kvp in base.GetElementPairs()) yield return kvp;
       if (ContentTypeElement is not null) yield return new KeyValuePair<string,object>("contentType",ContentTypeElement);
       if (SecurityContext is not null) yield return new KeyValuePair<string,object>("securityContext",SecurityContext);
-      if (ContentElement is not null) yield return new KeyValuePair<string,object>("content",ContentElement);
       if (DataElement is not null) yield return new KeyValuePair<string,object>("data",DataElement);
+      if (ContentElement is not null) yield return new KeyValuePair<string,object>("content",ContentElement);
     }
 
   }

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Bundle.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Bundle.cs
@@ -1427,7 +1427,7 @@ namespace Hl7.Fhir.Model
     /// <summary>
     /// When the bundle was assembled
     /// </summary>
-    [FhirElement("timestamp", InSummary=true, Order=70, Since = FhirRelease.R4, FiveWs="FiveWs.init")]
+    [FhirElement("timestamp", InSummary=true, Order=70, FiveWs="FiveWs.init", Since=FhirRelease.R4)]
     [DataMember]
     public Hl7.Fhir.Model.Instant TimestampElement
     {

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/_GeneratorLog.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/_GeneratorLog.cs
@@ -354,7 +354,10 @@
 // Quantity.cs
 // Range.cs
 // ResourceReference.cs
+// Signature.cs
 // UsageContext.cs
+// Binary.cs
+// Bundle.cs
 // DomainResource.cs
 // OperationOutcome.cs
 // Parameters.cs


### PR DESCRIPTION
These changes had been applied manually by MV when designing the new satellite/common projects in 5.0.

This PR includes the (comparable) code generated by our code generator. Again, this should be the same code as the stuff Marco wrote manually, but spacing/ordering might differ.