### PR TITLE
2219 - Correct names for enums

### DIFF
--- a/src/Hl7.Fhir.R4.Core/Model/Generated/Claim.cs
+++ b/src/Hl7.Fhir.R4.Core/Model/Generated/Claim.cs
@@ -3310,20 +3310,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.Use> UseElement
+    public Code<Hl7.Fhir.Model.ClaimUseCode> UseElement
     {
       get { return _UseElement; }
       set { _UseElement = value; OnPropertyChanged("UseElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.Use> _UseElement;
+    private Code<Hl7.Fhir.Model.ClaimUseCode> _UseElement;
 
     /// <summary>
     /// claim | preauthorization | predetermination
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.Use? Use
+    public Hl7.Fhir.Model.ClaimUseCode? Use
     {
       get { return UseElement != null ? UseElement.Value : null; }
       set
@@ -3331,7 +3331,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           UseElement = null;
         else
-          UseElement = new Code<Hl7.Fhir.Model.Use>(value);
+          UseElement = new Code<Hl7.Fhir.Model.ClaimUseCode>(value);
         OnPropertyChanged("Use");
       }
     }
@@ -3681,7 +3681,7 @@ namespace Hl7.Fhir.Model
       if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.FinancialResourceStatusCodes>)StatusElement.DeepCopy();
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
       if(SubType != null) dest.SubType = (Hl7.Fhir.Model.CodeableConcept)SubType.DeepCopy();
-      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.Use>)UseElement.DeepCopy();
+      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.ClaimUseCode>)UseElement.DeepCopy();
       if(Patient != null) dest.Patient = (Hl7.Fhir.Model.ResourceReference)Patient.DeepCopy();
       if(BillablePeriod != null) dest.BillablePeriod = (Hl7.Fhir.Model.Period)BillablePeriod.DeepCopy();
       if(CreatedElement != null) dest.CreatedElement = (Hl7.Fhir.Model.FhirDateTime)CreatedElement.DeepCopy();

--- a/src/Hl7.Fhir.R4.Core/Model/Generated/ClaimResponse.cs
+++ b/src/Hl7.Fhir.R4.Core/Model/Generated/ClaimResponse.cs
@@ -3263,20 +3263,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.Use> UseElement
+    public Code<Hl7.Fhir.Model.ClaimUseCode> UseElement
     {
       get { return _UseElement; }
       set { _UseElement = value; OnPropertyChanged("UseElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.Use> _UseElement;
+    private Code<Hl7.Fhir.Model.ClaimUseCode> _UseElement;
 
     /// <summary>
     /// claim | preauthorization | predetermination
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.Use? Use
+    public Hl7.Fhir.Model.ClaimUseCode? Use
     {
       get { return UseElement != null ? UseElement.Value : null; }
       set
@@ -3284,7 +3284,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           UseElement = null;
         else
-          UseElement = new Code<Hl7.Fhir.Model.Use>(value);
+          UseElement = new Code<Hl7.Fhir.Model.ClaimUseCode>(value);
         OnPropertyChanged("Use");
       }
     }
@@ -3684,7 +3684,7 @@ namespace Hl7.Fhir.Model
       if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.FinancialResourceStatusCodes>)StatusElement.DeepCopy();
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
       if(SubType != null) dest.SubType = (Hl7.Fhir.Model.CodeableConcept)SubType.DeepCopy();
-      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.Use>)UseElement.DeepCopy();
+      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.ClaimUseCode>)UseElement.DeepCopy();
       if(Patient != null) dest.Patient = (Hl7.Fhir.Model.ResourceReference)Patient.DeepCopy();
       if(CreatedElement != null) dest.CreatedElement = (Hl7.Fhir.Model.FhirDateTime)CreatedElement.DeepCopy();
       if(Insurer != null) dest.Insurer = (Hl7.Fhir.Model.ResourceReference)Insurer.DeepCopy();

--- a/src/Hl7.Fhir.R4.Core/Model/Generated/Composition.cs
+++ b/src/Hl7.Fhir.R4.Core/Model/Generated/Composition.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://terminology.hl7.org/CodeSystem/v3-Confidentiality)
     /// </summary>
     [FhirEnumeration("v3.ConfidentialityClassification")]
-    public enum v3_ConfidentialityClassification
+    public enum V3ConfidentialityClassification
     {
       /// <summary>
       /// Definition: Privacy metadata indicating that the information is not classified as sensitive.
@@ -1234,20 +1234,20 @@ namespace Hl7.Fhir.Model
     [FhirElement("confidentiality", InSummary=true, Order=180)]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
-    public Code<Hl7.Fhir.Model.Composition.v3_ConfidentialityClassification> ConfidentialityElement
+    public Code<Hl7.Fhir.Model.Composition.V3ConfidentialityClassification> ConfidentialityElement
     {
       get { return _ConfidentialityElement; }
       set { _ConfidentialityElement = value; OnPropertyChanged("ConfidentialityElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.Composition.v3_ConfidentialityClassification> _ConfidentialityElement;
+    private Code<Hl7.Fhir.Model.Composition.V3ConfidentialityClassification> _ConfidentialityElement;
 
     /// <summary>
     /// As defined by affinity domain
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.Composition.v3_ConfidentialityClassification? Confidentiality
+    public Hl7.Fhir.Model.Composition.V3ConfidentialityClassification? Confidentiality
     {
       get { return ConfidentialityElement != null ? ConfidentialityElement.Value : null; }
       set
@@ -1255,7 +1255,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           ConfidentialityElement = null;
         else
-          ConfidentialityElement = new Code<Hl7.Fhir.Model.Composition.v3_ConfidentialityClassification>(value);
+          ConfidentialityElement = new Code<Hl7.Fhir.Model.Composition.V3ConfidentialityClassification>(value);
         OnPropertyChanged("Confidentiality");
       }
     }
@@ -1350,7 +1350,7 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(Author != null) dest.Author = new List<Hl7.Fhir.Model.ResourceReference>(Author.DeepCopy());
       if(TitleElement != null) dest.TitleElement = (Hl7.Fhir.Model.FhirString)TitleElement.DeepCopy();
-      if(ConfidentialityElement != null) dest.ConfidentialityElement = (Code<Hl7.Fhir.Model.Composition.v3_ConfidentialityClassification>)ConfidentialityElement.DeepCopy();
+      if(ConfidentialityElement != null) dest.ConfidentialityElement = (Code<Hl7.Fhir.Model.Composition.V3ConfidentialityClassification>)ConfidentialityElement.DeepCopy();
       if(Attester != null) dest.Attester = new List<Hl7.Fhir.Model.Composition.AttesterComponent>(Attester.DeepCopy());
       if(Custodian != null) dest.Custodian = (Hl7.Fhir.Model.ResourceReference)Custodian.DeepCopy();
       if(RelatesTo != null) dest.RelatesTo = new List<Hl7.Fhir.Model.Composition.RelatesToComponent>(RelatesTo.DeepCopy());

--- a/src/Hl7.Fhir.R4.Core/Model/Generated/EffectEvidenceSynthesis.cs
+++ b/src/Hl7.Fhir.R4.Core/Model/Generated/EffectEvidenceSynthesis.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/exposure-state)
     /// </summary>
     [FhirEnumeration("ExposureState")]
-    public enum ExposureState
+    public enum ExposureStateCode
     {
       /// <summary>
       /// used when the results by exposure is describing the results for the primary exposure of interest.
@@ -334,29 +334,29 @@ namespace Hl7.Fhir.Model
       [FhirElement("exposureState", Order=50)]
       [DeclaredType(Type = typeof(Code))]
       [DataMember]
-      public Code<Hl7.Fhir.Model.EffectEvidenceSynthesis.ExposureState> ExposureState_Element
+      public Code<Hl7.Fhir.Model.EffectEvidenceSynthesis.ExposureStateCode> ExposureStateElement
       {
-        get { return _ExposureState_Element; }
-        set { _ExposureState_Element = value; OnPropertyChanged("ExposureState_Element"); }
+        get { return _ExposureStateElement; }
+        set { _ExposureStateElement = value; OnPropertyChanged("ExposureStateElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.EffectEvidenceSynthesis.ExposureState> _ExposureState_Element;
+      private Code<Hl7.Fhir.Model.EffectEvidenceSynthesis.ExposureStateCode> _ExposureStateElement;
 
       /// <summary>
       /// exposure | exposure-alternative
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.EffectEvidenceSynthesis.ExposureState? ExposureState_
+      public Hl7.Fhir.Model.EffectEvidenceSynthesis.ExposureStateCode? ExposureState
       {
-        get { return ExposureState_Element != null ? ExposureState_Element.Value : null; }
+        get { return ExposureStateElement != null ? ExposureStateElement.Value : null; }
         set
         {
           if (value == null)
-            ExposureState_Element = null;
+            ExposureStateElement = null;
           else
-            ExposureState_Element = new Code<Hl7.Fhir.Model.EffectEvidenceSynthesis.ExposureState>(value);
-          OnPropertyChanged("ExposureState_");
+            ExposureStateElement = new Code<Hl7.Fhir.Model.EffectEvidenceSynthesis.ExposureStateCode>(value);
+          OnPropertyChanged("ExposureState");
         }
       }
 
@@ -400,7 +400,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.FhirString)DescriptionElement.DeepCopy();
-        if(ExposureState_Element != null) dest.ExposureState_Element = (Code<Hl7.Fhir.Model.EffectEvidenceSynthesis.ExposureState>)ExposureState_Element.DeepCopy();
+        if(ExposureStateElement != null) dest.ExposureStateElement = (Code<Hl7.Fhir.Model.EffectEvidenceSynthesis.ExposureStateCode>)ExposureStateElement.DeepCopy();
         if(VariantState != null) dest.VariantState = (Hl7.Fhir.Model.CodeableConcept)VariantState.DeepCopy();
         if(RiskEvidenceSynthesis != null) dest.RiskEvidenceSynthesis = (Hl7.Fhir.Model.ResourceReference)RiskEvidenceSynthesis.DeepCopy();
         return dest;
@@ -419,7 +419,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
-        if( !DeepComparable.Matches(ExposureState_Element, otherT.ExposureState_Element)) return false;
+        if( !DeepComparable.Matches(ExposureStateElement, otherT.ExposureStateElement)) return false;
         if( !DeepComparable.Matches(VariantState, otherT.VariantState)) return false;
         if( !DeepComparable.Matches(RiskEvidenceSynthesis, otherT.RiskEvidenceSynthesis)) return false;
 
@@ -433,7 +433,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
-        if( !DeepComparable.IsExactly(ExposureState_Element, otherT.ExposureState_Element)) return false;
+        if( !DeepComparable.IsExactly(ExposureStateElement, otherT.ExposureStateElement)) return false;
         if( !DeepComparable.IsExactly(VariantState, otherT.VariantState)) return false;
         if( !DeepComparable.IsExactly(RiskEvidenceSynthesis, otherT.RiskEvidenceSynthesis)) return false;
 
@@ -447,7 +447,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (DescriptionElement != null) yield return DescriptionElement;
-          if (ExposureState_Element != null) yield return ExposureState_Element;
+          if (ExposureStateElement != null) yield return ExposureStateElement;
           if (VariantState != null) yield return VariantState;
           if (RiskEvidenceSynthesis != null) yield return RiskEvidenceSynthesis;
         }
@@ -460,7 +460,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
-          if (ExposureState_Element != null) yield return new ElementValue("exposureState", ExposureState_Element);
+          if (ExposureStateElement != null) yield return new ElementValue("exposureState", ExposureStateElement);
           if (VariantState != null) yield return new ElementValue("variantState", VariantState);
           if (RiskEvidenceSynthesis != null) yield return new ElementValue("riskEvidenceSynthesis", RiskEvidenceSynthesis);
         }
@@ -474,8 +474,8 @@ namespace Hl7.Fhir.Model
             value = DescriptionElement;
             return DescriptionElement is not null;
           case "exposureState":
-            value = ExposureState_Element;
-            return ExposureState_Element is not null;
+            value = ExposureStateElement;
+            return ExposureStateElement is not null;
           case "variantState":
             value = VariantState;
             return VariantState is not null;
@@ -492,7 +492,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
-        if (ExposureState_Element is not null) yield return new KeyValuePair<string,object>("exposureState",ExposureState_Element);
+        if (ExposureStateElement is not null) yield return new KeyValuePair<string,object>("exposureState",ExposureStateElement);
         if (VariantState is not null) yield return new KeyValuePair<string,object>("variantState",VariantState);
         if (RiskEvidenceSynthesis is not null) yield return new KeyValuePair<string,object>("riskEvidenceSynthesis",RiskEvidenceSynthesis);
       }

--- a/src/Hl7.Fhir.R4.Core/Model/Generated/EvidenceVariable.cs
+++ b/src/Hl7.Fhir.R4.Core/Model/Generated/EvidenceVariable.cs
@@ -900,20 +900,20 @@ namespace Hl7.Fhir.Model
     [FhirElement("type", InSummary=true, Order=340)]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
-    public Code<Hl7.Fhir.Model.EvidenceVariableType> TypeElement
+    public Code<Hl7.Fhir.Model.VariableTypeCode> TypeElement
     {
       get { return _TypeElement; }
       set { _TypeElement = value; OnPropertyChanged("TypeElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.EvidenceVariableType> _TypeElement;
+    private Code<Hl7.Fhir.Model.VariableTypeCode> _TypeElement;
 
     /// <summary>
     /// dichotomous | continuous | descriptive
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.EvidenceVariableType? Type
+    public Hl7.Fhir.Model.VariableTypeCode? Type
     {
       get { return TypeElement != null ? TypeElement.Value : null; }
       set
@@ -921,7 +921,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           TypeElement = null;
         else
-          TypeElement = new Code<Hl7.Fhir.Model.EvidenceVariableType>(value);
+          TypeElement = new Code<Hl7.Fhir.Model.VariableTypeCode>(value);
         OnPropertyChanged("Type");
       }
     }
@@ -975,7 +975,7 @@ namespace Hl7.Fhir.Model
       if(Reviewer != null) dest.Reviewer = new List<Hl7.Fhir.Model.ContactDetail>(Reviewer.DeepCopy());
       if(Endorser != null) dest.Endorser = new List<Hl7.Fhir.Model.ContactDetail>(Endorser.DeepCopy());
       if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
-      if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.EvidenceVariableType>)TypeElement.DeepCopy();
+      if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.VariableTypeCode>)TypeElement.DeepCopy();
       if(Characteristic != null) dest.Characteristic = new List<Hl7.Fhir.Model.EvidenceVariable.CharacteristicComponent>(Characteristic.DeepCopy());
       return dest;
     }

--- a/src/Hl7.Fhir.R4.Core/Model/Generated/ExplanationOfBenefit.cs
+++ b/src/Hl7.Fhir.R4.Core/Model/Generated/ExplanationOfBenefit.cs
@@ -5898,20 +5898,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.Use> UseElement
+    public Code<Hl7.Fhir.Model.ClaimUseCode> UseElement
     {
       get { return _UseElement; }
       set { _UseElement = value; OnPropertyChanged("UseElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.Use> _UseElement;
+    private Code<Hl7.Fhir.Model.ClaimUseCode> _UseElement;
 
     /// <summary>
     /// claim | preauthorization | predetermination
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.Use? Use
+    public Hl7.Fhir.Model.ClaimUseCode? Use
     {
       get { return UseElement != null ? UseElement.Value : null; }
       set
@@ -5919,7 +5919,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           UseElement = null;
         else
-          UseElement = new Code<Hl7.Fhir.Model.Use>(value);
+          UseElement = new Code<Hl7.Fhir.Model.ClaimUseCode>(value);
         OnPropertyChanged("Use");
       }
     }
@@ -6562,7 +6562,7 @@ namespace Hl7.Fhir.Model
       if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.ExplanationOfBenefit.ExplanationOfBenefitStatus>)StatusElement.DeepCopy();
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
       if(SubType != null) dest.SubType = (Hl7.Fhir.Model.CodeableConcept)SubType.DeepCopy();
-      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.Use>)UseElement.DeepCopy();
+      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.ClaimUseCode>)UseElement.DeepCopy();
       if(Patient != null) dest.Patient = (Hl7.Fhir.Model.ResourceReference)Patient.DeepCopy();
       if(BillablePeriod != null) dest.BillablePeriod = (Hl7.Fhir.Model.Period)BillablePeriod.DeepCopy();
       if(CreatedElement != null) dest.CreatedElement = (Hl7.Fhir.Model.FhirDateTime)CreatedElement.DeepCopy();

--- a/src/Hl7.Fhir.R4.Core/Model/Generated/MedicationRequest.cs
+++ b/src/Hl7.Fhir.R4.Core/Model/Generated/MedicationRequest.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/CodeSystem/medicationrequest-status)
     /// </summary>
     [FhirEnumeration("medicationrequestStatus")]
-    public enum medicationrequestStatus
+    public enum MedicationrequestStatus
     {
       /// <summary>
       /// The prescription is 'actionable', but not all actions that are implied by it have occurred yet.
@@ -119,7 +119,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/CodeSystem/medicationrequest-intent)
     /// </summary>
     [FhirEnumeration("medicationRequestIntent")]
-    public enum medicationRequestIntent
+    public enum MedicationRequestIntent
     {
       /// <summary>
       /// The request is a suggestion made by someone/something that doesn't have an intention to ensure it occurs and without providing an authorization to act
@@ -718,20 +718,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.MedicationRequest.medicationrequestStatus> StatusElement
+    public Code<Hl7.Fhir.Model.MedicationRequest.MedicationrequestStatus> StatusElement
     {
       get { return _StatusElement; }
       set { _StatusElement = value; OnPropertyChanged("StatusElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.MedicationRequest.medicationrequestStatus> _StatusElement;
+    private Code<Hl7.Fhir.Model.MedicationRequest.MedicationrequestStatus> _StatusElement;
 
     /// <summary>
     /// active | on-hold | cancelled | completed | entered-in-error | stopped | draft | unknown
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.MedicationRequest.medicationrequestStatus? Status
+    public Hl7.Fhir.Model.MedicationRequest.MedicationrequestStatus? Status
     {
       get { return StatusElement != null ? StatusElement.Value : null; }
       set
@@ -739,7 +739,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           StatusElement = null;
         else
-          StatusElement = new Code<Hl7.Fhir.Model.MedicationRequest.medicationrequestStatus>(value);
+          StatusElement = new Code<Hl7.Fhir.Model.MedicationRequest.MedicationrequestStatus>(value);
         OnPropertyChanged("Status");
       }
     }
@@ -764,20 +764,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.MedicationRequest.medicationRequestIntent> IntentElement
+    public Code<Hl7.Fhir.Model.MedicationRequest.MedicationRequestIntent> IntentElement
     {
       get { return _IntentElement; }
       set { _IntentElement = value; OnPropertyChanged("IntentElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.MedicationRequest.medicationRequestIntent> _IntentElement;
+    private Code<Hl7.Fhir.Model.MedicationRequest.MedicationRequestIntent> _IntentElement;
 
     /// <summary>
     /// proposal | plan | order | original-order | reflex-order | filler-order | instance-order | option
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.MedicationRequest.medicationRequestIntent? Intent
+    public Hl7.Fhir.Model.MedicationRequest.MedicationRequestIntent? Intent
     {
       get { return IntentElement != null ? IntentElement.Value : null; }
       set
@@ -785,7 +785,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           IntentElement = null;
         else
-          IntentElement = new Code<Hl7.Fhir.Model.MedicationRequest.medicationRequestIntent>(value);
+          IntentElement = new Code<Hl7.Fhir.Model.MedicationRequest.MedicationRequestIntent>(value);
         OnPropertyChanged("Intent");
       }
     }
@@ -1300,9 +1300,9 @@ namespace Hl7.Fhir.Model
 
       base.CopyTo(dest);
       if(Identifier != null) dest.Identifier = new List<Hl7.Fhir.Model.Identifier>(Identifier.DeepCopy());
-      if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.MedicationRequest.medicationrequestStatus>)StatusElement.DeepCopy();
+      if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.MedicationRequest.MedicationrequestStatus>)StatusElement.DeepCopy();
       if(StatusReason != null) dest.StatusReason = (Hl7.Fhir.Model.CodeableConcept)StatusReason.DeepCopy();
-      if(IntentElement != null) dest.IntentElement = (Code<Hl7.Fhir.Model.MedicationRequest.medicationRequestIntent>)IntentElement.DeepCopy();
+      if(IntentElement != null) dest.IntentElement = (Code<Hl7.Fhir.Model.MedicationRequest.MedicationRequestIntent>)IntentElement.DeepCopy();
       if(Category != null) dest.Category = new List<Hl7.Fhir.Model.CodeableConcept>(Category.DeepCopy());
       if(PriorityElement != null) dest.PriorityElement = (Code<Hl7.Fhir.Model.RequestPriority>)PriorityElement.DeepCopy();
       if(DoNotPerformElement != null) dest.DoNotPerformElement = (Hl7.Fhir.Model.FhirBoolean)DoNotPerformElement.DeepCopy();

--- a/src/Hl7.Fhir.R4.Core/Model/Generated/MessageDefinition.cs
+++ b/src/Hl7.Fhir.R4.Core/Model/Generated/MessageDefinition.cs
@@ -992,20 +992,20 @@ namespace Hl7.Fhir.Model
     [FhirElement("responseRequired", Order=300)]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
-    public Code<Hl7.Fhir.Model.messageheader_response_request> ResponseRequiredElement
+    public Code<Hl7.Fhir.Model.MessageheaderResponseRequest> ResponseRequiredElement
     {
       get { return _ResponseRequiredElement; }
       set { _ResponseRequiredElement = value; OnPropertyChanged("ResponseRequiredElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.messageheader_response_request> _ResponseRequiredElement;
+    private Code<Hl7.Fhir.Model.MessageheaderResponseRequest> _ResponseRequiredElement;
 
     /// <summary>
     /// always | on-error | never | on-success
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.messageheader_response_request? ResponseRequired
+    public Hl7.Fhir.Model.MessageheaderResponseRequest? ResponseRequired
     {
       get { return ResponseRequiredElement != null ? ResponseRequiredElement.Value : null; }
       set
@@ -1013,7 +1013,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           ResponseRequiredElement = null;
         else
-          ResponseRequiredElement = new Code<Hl7.Fhir.Model.messageheader_response_request>(value);
+          ResponseRequiredElement = new Code<Hl7.Fhir.Model.MessageheaderResponseRequest>(value);
         OnPropertyChanged("ResponseRequired");
       }
     }
@@ -1095,7 +1095,7 @@ namespace Hl7.Fhir.Model
       if(Event != null) dest.Event = (Hl7.Fhir.Model.DataType)Event.DeepCopy();
       if(CategoryElement != null) dest.CategoryElement = (Code<Hl7.Fhir.Model.MessageDefinition.MessageSignificanceCategory>)CategoryElement.DeepCopy();
       if(Focus != null) dest.Focus = new List<Hl7.Fhir.Model.MessageDefinition.FocusComponent>(Focus.DeepCopy());
-      if(ResponseRequiredElement != null) dest.ResponseRequiredElement = (Code<Hl7.Fhir.Model.messageheader_response_request>)ResponseRequiredElement.DeepCopy();
+      if(ResponseRequiredElement != null) dest.ResponseRequiredElement = (Code<Hl7.Fhir.Model.MessageheaderResponseRequest>)ResponseRequiredElement.DeepCopy();
       if(AllowedResponse != null) dest.AllowedResponse = new List<Hl7.Fhir.Model.MessageDefinition.AllowedResponseComponent>(AllowedResponse.DeepCopy());
       if(GraphElement != null) dest.GraphElement = new List<Hl7.Fhir.Model.Canonical>(GraphElement.DeepCopy());
       return dest;

--- a/src/Hl7.Fhir.R4.Core/Model/Generated/MolecularSequence.cs
+++ b/src/Hl7.Fhir.R4.Core/Model/Generated/MolecularSequence.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/sequence-type)
     /// </summary>
     [FhirEnumeration("sequenceType")]
-    public enum sequenceType
+    public enum SequenceType
     {
       /// <summary>
       /// Amino acid sequence.
@@ -89,7 +89,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/orientation-type)
     /// </summary>
     [FhirEnumeration("orientationType")]
-    public enum orientationType
+    public enum OrientationType
     {
       /// <summary>
       /// Sense orientation of reference sequence.
@@ -111,7 +111,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/strand-type)
     /// </summary>
     [FhirEnumeration("strandType")]
-    public enum strandType
+    public enum StrandType
     {
       /// <summary>
       /// Watson strand of reference sequence.
@@ -133,7 +133,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/quality-type)
     /// </summary>
     [FhirEnumeration("qualityType")]
-    public enum qualityType
+    public enum QualityType
     {
       /// <summary>
       /// INDEL Comparison.
@@ -161,7 +161,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/repository-type)
     /// </summary>
     [FhirEnumeration("repositoryType")]
-    public enum repositoryType
+    public enum RepositoryType
     {
       /// <summary>
       /// When URL is clicked, the resource can be seen directly (by webpage or by download link format).
@@ -258,20 +258,20 @@ namespace Hl7.Fhir.Model
       [FhirElement("orientation", InSummary=true, Order=60)]
       [DeclaredType(Type = typeof(Code))]
       [DataMember]
-      public Code<Hl7.Fhir.Model.MolecularSequence.orientationType> OrientationElement
+      public Code<Hl7.Fhir.Model.MolecularSequence.OrientationType> OrientationElement
       {
         get { return _OrientationElement; }
         set { _OrientationElement = value; OnPropertyChanged("OrientationElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.MolecularSequence.orientationType> _OrientationElement;
+      private Code<Hl7.Fhir.Model.MolecularSequence.OrientationType> _OrientationElement;
 
       /// <summary>
       /// sense | antisense
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.MolecularSequence.orientationType? Orientation
+      public Hl7.Fhir.Model.MolecularSequence.OrientationType? Orientation
       {
         get { return OrientationElement != null ? OrientationElement.Value : null; }
         set
@@ -279,7 +279,7 @@ namespace Hl7.Fhir.Model
           if (value == null)
             OrientationElement = null;
           else
-            OrientationElement = new Code<Hl7.Fhir.Model.MolecularSequence.orientationType>(value);
+            OrientationElement = new Code<Hl7.Fhir.Model.MolecularSequence.OrientationType>(value);
           OnPropertyChanged("Orientation");
         }
       }
@@ -349,20 +349,20 @@ namespace Hl7.Fhir.Model
       [FhirElement("strand", InSummary=true, Order=100)]
       [DeclaredType(Type = typeof(Code))]
       [DataMember]
-      public Code<Hl7.Fhir.Model.MolecularSequence.strandType> StrandElement
+      public Code<Hl7.Fhir.Model.MolecularSequence.StrandType> StrandElement
       {
         get { return _StrandElement; }
         set { _StrandElement = value; OnPropertyChanged("StrandElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.MolecularSequence.strandType> _StrandElement;
+      private Code<Hl7.Fhir.Model.MolecularSequence.StrandType> _StrandElement;
 
       /// <summary>
       /// watson | crick
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.MolecularSequence.strandType? Strand
+      public Hl7.Fhir.Model.MolecularSequence.StrandType? Strand
       {
         get { return StrandElement != null ? StrandElement.Value : null; }
         set
@@ -370,7 +370,7 @@ namespace Hl7.Fhir.Model
           if (value == null)
             StrandElement = null;
           else
-            StrandElement = new Code<Hl7.Fhir.Model.MolecularSequence.strandType>(value);
+            StrandElement = new Code<Hl7.Fhir.Model.MolecularSequence.StrandType>(value);
           OnPropertyChanged("Strand");
         }
       }
@@ -449,11 +449,11 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(Chromosome != null) dest.Chromosome = (Hl7.Fhir.Model.CodeableConcept)Chromosome.DeepCopy();
         if(GenomeBuildElement != null) dest.GenomeBuildElement = (Hl7.Fhir.Model.FhirString)GenomeBuildElement.DeepCopy();
-        if(OrientationElement != null) dest.OrientationElement = (Code<Hl7.Fhir.Model.MolecularSequence.orientationType>)OrientationElement.DeepCopy();
+        if(OrientationElement != null) dest.OrientationElement = (Code<Hl7.Fhir.Model.MolecularSequence.OrientationType>)OrientationElement.DeepCopy();
         if(ReferenceSeqId != null) dest.ReferenceSeqId = (Hl7.Fhir.Model.CodeableConcept)ReferenceSeqId.DeepCopy();
         if(ReferenceSeqPointer != null) dest.ReferenceSeqPointer = (Hl7.Fhir.Model.ResourceReference)ReferenceSeqPointer.DeepCopy();
         if(ReferenceSeqStringElement != null) dest.ReferenceSeqStringElement = (Hl7.Fhir.Model.FhirString)ReferenceSeqStringElement.DeepCopy();
-        if(StrandElement != null) dest.StrandElement = (Code<Hl7.Fhir.Model.MolecularSequence.strandType>)StrandElement.DeepCopy();
+        if(StrandElement != null) dest.StrandElement = (Code<Hl7.Fhir.Model.MolecularSequence.StrandType>)StrandElement.DeepCopy();
         if(WindowStartElement != null) dest.WindowStartElement = (Hl7.Fhir.Model.Integer)WindowStartElement.DeepCopy();
         if(WindowEndElement != null) dest.WindowEndElement = (Hl7.Fhir.Model.Integer)WindowEndElement.DeepCopy();
         return dest;
@@ -923,20 +923,20 @@ namespace Hl7.Fhir.Model
       [DeclaredType(Type = typeof(Code))]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Code<Hl7.Fhir.Model.MolecularSequence.qualityType> TypeElement
+      public Code<Hl7.Fhir.Model.MolecularSequence.QualityType> TypeElement
       {
         get { return _TypeElement; }
         set { _TypeElement = value; OnPropertyChanged("TypeElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.MolecularSequence.qualityType> _TypeElement;
+      private Code<Hl7.Fhir.Model.MolecularSequence.QualityType> _TypeElement;
 
       /// <summary>
       /// indel | snp | unknown
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.MolecularSequence.qualityType? Type
+      public Hl7.Fhir.Model.MolecularSequence.QualityType? Type
       {
         get { return TypeElement != null ? TypeElement.Value : null; }
         set
@@ -944,7 +944,7 @@ namespace Hl7.Fhir.Model
           if (value == null)
             TypeElement = null;
           else
-            TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.qualityType>(value);
+            TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.QualityType>(value);
           OnPropertyChanged("Type");
         }
       }
@@ -1321,7 +1321,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.qualityType>)TypeElement.DeepCopy();
+        if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.QualityType>)TypeElement.DeepCopy();
         if(StandardSequence != null) dest.StandardSequence = (Hl7.Fhir.Model.CodeableConcept)StandardSequence.DeepCopy();
         if(StartElement != null) dest.StartElement = (Hl7.Fhir.Model.Integer)StartElement.DeepCopy();
         if(EndElement != null) dest.EndElement = (Hl7.Fhir.Model.Integer)EndElement.DeepCopy();
@@ -1914,20 +1914,20 @@ namespace Hl7.Fhir.Model
       [DeclaredType(Type = typeof(Code))]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Code<Hl7.Fhir.Model.MolecularSequence.repositoryType> TypeElement
+      public Code<Hl7.Fhir.Model.MolecularSequence.RepositoryType> TypeElement
       {
         get { return _TypeElement; }
         set { _TypeElement = value; OnPropertyChanged("TypeElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.MolecularSequence.repositoryType> _TypeElement;
+      private Code<Hl7.Fhir.Model.MolecularSequence.RepositoryType> _TypeElement;
 
       /// <summary>
       /// directlink | openapi | login | oauth | other
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.MolecularSequence.repositoryType? Type
+      public Hl7.Fhir.Model.MolecularSequence.RepositoryType? Type
       {
         get { return TypeElement != null ? TypeElement.Value : null; }
         set
@@ -1935,7 +1935,7 @@ namespace Hl7.Fhir.Model
           if (value == null)
             TypeElement = null;
           else
-            TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.repositoryType>(value);
+            TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.RepositoryType>(value);
           OnPropertyChanged("Type");
         }
       }
@@ -2105,7 +2105,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.repositoryType>)TypeElement.DeepCopy();
+        if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.RepositoryType>)TypeElement.DeepCopy();
         if(UrlElement != null) dest.UrlElement = (Hl7.Fhir.Model.FhirUri)UrlElement.DeepCopy();
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
         if(DatasetIdElement != null) dest.DatasetIdElement = (Hl7.Fhir.Model.FhirString)DatasetIdElement.DeepCopy();
@@ -2810,20 +2810,20 @@ namespace Hl7.Fhir.Model
     [FhirElement("type", InSummary=true, Order=100)]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
-    public Code<Hl7.Fhir.Model.MolecularSequence.sequenceType> TypeElement
+    public Code<Hl7.Fhir.Model.MolecularSequence.SequenceType> TypeElement
     {
       get { return _TypeElement; }
       set { _TypeElement = value; OnPropertyChanged("TypeElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.MolecularSequence.sequenceType> _TypeElement;
+    private Code<Hl7.Fhir.Model.MolecularSequence.SequenceType> _TypeElement;
 
     /// <summary>
     /// aa | dna | rna
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.MolecularSequence.sequenceType? Type
+    public Hl7.Fhir.Model.MolecularSequence.SequenceType? Type
     {
       get { return TypeElement != null ? TypeElement.Value : null; }
       set
@@ -2831,7 +2831,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           TypeElement = null;
         else
-          TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.sequenceType>(value);
+          TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.SequenceType>(value);
         OnPropertyChanged("Type");
       }
     }
@@ -3099,7 +3099,7 @@ namespace Hl7.Fhir.Model
 
       base.CopyTo(dest);
       if(Identifier != null) dest.Identifier = new List<Hl7.Fhir.Model.Identifier>(Identifier.DeepCopy());
-      if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.sequenceType>)TypeElement.DeepCopy();
+      if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.SequenceType>)TypeElement.DeepCopy();
       if(CoordinateSystemElement != null) dest.CoordinateSystemElement = (Hl7.Fhir.Model.Integer)CoordinateSystemElement.DeepCopy();
       if(Patient != null) dest.Patient = (Hl7.Fhir.Model.ResourceReference)Patient.DeepCopy();
       if(Specimen != null) dest.Specimen = (Hl7.Fhir.Model.ResourceReference)Specimen.DeepCopy();

--- a/src/Hl7.Fhir.R4.Core/Model/Generated/ResearchElementDefinition.cs
+++ b/src/Hl7.Fhir.R4.Core/Model/Generated/ResearchElementDefinition.cs
@@ -1250,20 +1250,20 @@ namespace Hl7.Fhir.Model
     [FhirElement("variableType", Order=400)]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
-    public Code<Hl7.Fhir.Model.EvidenceVariableType> VariableTypeElement
+    public Code<Hl7.Fhir.Model.VariableTypeCode> VariableTypeElement
     {
       get { return _VariableTypeElement; }
       set { _VariableTypeElement = value; OnPropertyChanged("VariableTypeElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.EvidenceVariableType> _VariableTypeElement;
+    private Code<Hl7.Fhir.Model.VariableTypeCode> _VariableTypeElement;
 
     /// <summary>
     /// dichotomous | continuous | descriptive
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.EvidenceVariableType? VariableType
+    public Hl7.Fhir.Model.VariableTypeCode? VariableType
     {
       get { return VariableTypeElement != null ? VariableTypeElement.Value : null; }
       set
@@ -1271,7 +1271,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           VariableTypeElement = null;
         else
-          VariableTypeElement = new Code<Hl7.Fhir.Model.EvidenceVariableType>(value);
+          VariableTypeElement = new Code<Hl7.Fhir.Model.VariableTypeCode>(value);
         OnPropertyChanged("VariableType");
       }
     }
@@ -1331,7 +1331,7 @@ namespace Hl7.Fhir.Model
       if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
       if(LibraryElement != null) dest.LibraryElement = new List<Hl7.Fhir.Model.Canonical>(LibraryElement.DeepCopy());
       if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.ResearchElementDefinition.ResearchElementType>)TypeElement.DeepCopy();
-      if(VariableTypeElement != null) dest.VariableTypeElement = (Code<Hl7.Fhir.Model.EvidenceVariableType>)VariableTypeElement.DeepCopy();
+      if(VariableTypeElement != null) dest.VariableTypeElement = (Code<Hl7.Fhir.Model.VariableTypeCode>)VariableTypeElement.DeepCopy();
       if(Characteristic != null) dest.Characteristic = new List<Hl7.Fhir.Model.ResearchElementDefinition.CharacteristicComponent>(Characteristic.DeepCopy());
       return dest;
     }

--- a/src/Hl7.Fhir.R4.Core/Model/Generated/Template-Bindings.cs
+++ b/src/Hl7.Fhir.R4.Core/Model/Generated/Template-Bindings.cs
@@ -1636,7 +1636,7 @@ namespace Hl7.Fhir.Model
   /// (system: http://hl7.org/fhir/claim-use)
   /// </summary>
   [FhirEnumeration("Use")]
-  public enum Use
+  public enum ClaimUseCode
   {
     /// <summary>
     /// The treatment is complete and this represents a Claim for the services.
@@ -4840,7 +4840,7 @@ namespace Hl7.Fhir.Model
   /// (system: http://hl7.org/fhir/variable-type)
   /// </summary>
   [FhirEnumeration("EvidenceVariableType")]
-  public enum EvidenceVariableType
+  public enum VariableTypeCode
   {
     /// <summary>
     /// The variable is dichotomous, such as present or absent.

--- a/src/Hl7.Fhir.R4.Core/Model/Generated/Template-Bindings.cs
+++ b/src/Hl7.Fhir.R4.Core/Model/Generated/Template-Bindings.cs
@@ -3580,7 +3580,7 @@ namespace Hl7.Fhir.Model
   /// (system: http://hl7.org/fhir/messageheader-response-request)
   /// </summary>
   [FhirEnumeration("messageheader-response-request")]
-  public enum messageheader_response_request
+  public enum MessageheaderResponseRequest
   {
     /// <summary>
     /// initiator expects a response for this message.

--- a/src/Hl7.Fhir.R4.Core/Model/Generated/VerificationResult.cs
+++ b/src/Hl7.Fhir.R4.Core/Model/Generated/VerificationResult.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/CodeSystem/status)
     /// </summary>
     [FhirEnumeration("status")]
-    public enum status
+    public enum Status
     {
       /// <summary>
       /// ***TODO***
@@ -928,20 +928,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.VerificationResult.status> Status_Element
+    public Code<Hl7.Fhir.Model.VerificationResult.Status> Status_Element
     {
       get { return _Status_Element; }
       set { _Status_Element = value; OnPropertyChanged("Status_Element"); }
     }
 
-    private Code<Hl7.Fhir.Model.VerificationResult.status> _Status_Element;
+    private Code<Hl7.Fhir.Model.VerificationResult.Status> _Status_Element;
 
     /// <summary>
     /// attested | validated | in-process | req-revalid | val-fail | reval-fail
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.VerificationResult.status? Status_
+    public Hl7.Fhir.Model.VerificationResult.Status? Status_
     {
       get { return Status_Element != null ? Status_Element.Value : null; }
       set
@@ -949,7 +949,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           Status_Element = null;
         else
-          Status_Element = new Code<Hl7.Fhir.Model.VerificationResult.status>(value);
+          Status_Element = new Code<Hl7.Fhir.Model.VerificationResult.Status>(value);
         OnPropertyChanged("Status_");
       }
     }
@@ -1154,7 +1154,7 @@ namespace Hl7.Fhir.Model
       if(Target != null) dest.Target = new List<Hl7.Fhir.Model.ResourceReference>(Target.DeepCopy());
       if(TargetLocationElement != null) dest.TargetLocationElement = new List<Hl7.Fhir.Model.FhirString>(TargetLocationElement.DeepCopy());
       if(Need != null) dest.Need = (Hl7.Fhir.Model.CodeableConcept)Need.DeepCopy();
-      if(Status_Element != null) dest.Status_Element = (Code<Hl7.Fhir.Model.VerificationResult.status>)Status_Element.DeepCopy();
+      if(Status_Element != null) dest.Status_Element = (Code<Hl7.Fhir.Model.VerificationResult.Status>)Status_Element.DeepCopy();
       if(StatusDateElement != null) dest.StatusDateElement = (Hl7.Fhir.Model.FhirDateTime)StatusDateElement.DeepCopy();
       if(ValidationType != null) dest.ValidationType = (Hl7.Fhir.Model.CodeableConcept)ValidationType.DeepCopy();
       if(ValidationProcess != null) dest.ValidationProcess = new List<Hl7.Fhir.Model.CodeableConcept>(ValidationProcess.DeepCopy());

--- a/src/Hl7.Fhir.R4.Core/Model/Generated/VerificationResult.cs
+++ b/src/Hl7.Fhir.R4.Core/Model/Generated/VerificationResult.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/CodeSystem/status)
     /// </summary>
     [FhirEnumeration("status")]
-    public enum Status
+    public enum StatusCode
     {
       /// <summary>
       /// ***TODO***
@@ -928,29 +928,29 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.VerificationResult.Status> Status_Element
+    public Code<Hl7.Fhir.Model.VerificationResult.StatusCode> StatusElement
     {
-      get { return _Status_Element; }
-      set { _Status_Element = value; OnPropertyChanged("Status_Element"); }
+      get { return _StatusElement; }
+      set { _StatusElement = value; OnPropertyChanged("StatusElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.VerificationResult.Status> _Status_Element;
+    private Code<Hl7.Fhir.Model.VerificationResult.StatusCode> _StatusElement;
 
     /// <summary>
     /// attested | validated | in-process | req-revalid | val-fail | reval-fail
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.VerificationResult.Status? Status_
+    public Hl7.Fhir.Model.VerificationResult.StatusCode? Status
     {
-      get { return Status_Element != null ? Status_Element.Value : null; }
+      get { return StatusElement != null ? StatusElement.Value : null; }
       set
       {
         if (value == null)
-          Status_Element = null;
+          StatusElement = null;
         else
-          Status_Element = new Code<Hl7.Fhir.Model.VerificationResult.Status>(value);
-        OnPropertyChanged("Status_");
+          StatusElement = new Code<Hl7.Fhir.Model.VerificationResult.StatusCode>(value);
+        OnPropertyChanged("Status");
       }
     }
 
@@ -1154,7 +1154,7 @@ namespace Hl7.Fhir.Model
       if(Target != null) dest.Target = new List<Hl7.Fhir.Model.ResourceReference>(Target.DeepCopy());
       if(TargetLocationElement != null) dest.TargetLocationElement = new List<Hl7.Fhir.Model.FhirString>(TargetLocationElement.DeepCopy());
       if(Need != null) dest.Need = (Hl7.Fhir.Model.CodeableConcept)Need.DeepCopy();
-      if(Status_Element != null) dest.Status_Element = (Code<Hl7.Fhir.Model.VerificationResult.Status>)Status_Element.DeepCopy();
+      if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.VerificationResult.StatusCode>)StatusElement.DeepCopy();
       if(StatusDateElement != null) dest.StatusDateElement = (Hl7.Fhir.Model.FhirDateTime)StatusDateElement.DeepCopy();
       if(ValidationType != null) dest.ValidationType = (Hl7.Fhir.Model.CodeableConcept)ValidationType.DeepCopy();
       if(ValidationProcess != null) dest.ValidationProcess = new List<Hl7.Fhir.Model.CodeableConcept>(ValidationProcess.DeepCopy());
@@ -1183,7 +1183,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Target, otherT.Target)) return false;
       if( !DeepComparable.Matches(TargetLocationElement, otherT.TargetLocationElement)) return false;
       if( !DeepComparable.Matches(Need, otherT.Need)) return false;
-      if( !DeepComparable.Matches(Status_Element, otherT.Status_Element)) return false;
+      if( !DeepComparable.Matches(StatusElement, otherT.StatusElement)) return false;
       if( !DeepComparable.Matches(StatusDateElement, otherT.StatusDateElement)) return false;
       if( !DeepComparable.Matches(ValidationType, otherT.ValidationType)) return false;
       if( !DeepComparable.Matches(ValidationProcess, otherT.ValidationProcess)) return false;
@@ -1207,7 +1207,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Target, otherT.Target)) return false;
       if( !DeepComparable.IsExactly(TargetLocationElement, otherT.TargetLocationElement)) return false;
       if( !DeepComparable.IsExactly(Need, otherT.Need)) return false;
-      if( !DeepComparable.IsExactly(Status_Element, otherT.Status_Element)) return false;
+      if( !DeepComparable.IsExactly(StatusElement, otherT.StatusElement)) return false;
       if( !DeepComparable.IsExactly(StatusDateElement, otherT.StatusDateElement)) return false;
       if( !DeepComparable.IsExactly(ValidationType, otherT.ValidationType)) return false;
       if( !DeepComparable.IsExactly(ValidationProcess, otherT.ValidationProcess)) return false;
@@ -1231,7 +1231,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Target) { if (elem != null) yield return elem; }
         foreach (var elem in TargetLocationElement) { if (elem != null) yield return elem; }
         if (Need != null) yield return Need;
-        if (Status_Element != null) yield return Status_Element;
+        if (StatusElement != null) yield return StatusElement;
         if (StatusDateElement != null) yield return StatusDateElement;
         if (ValidationType != null) yield return ValidationType;
         foreach (var elem in ValidationProcess) { if (elem != null) yield return elem; }
@@ -1254,7 +1254,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Target) { if (elem != null) yield return new ElementValue("target", elem); }
         foreach (var elem in TargetLocationElement) { if (elem != null) yield return new ElementValue("targetLocation", elem); }
         if (Need != null) yield return new ElementValue("need", Need);
-        if (Status_Element != null) yield return new ElementValue("status", Status_Element);
+        if (StatusElement != null) yield return new ElementValue("status", StatusElement);
         if (StatusDateElement != null) yield return new ElementValue("statusDate", StatusDateElement);
         if (ValidationType != null) yield return new ElementValue("validationType", ValidationType);
         foreach (var elem in ValidationProcess) { if (elem != null) yield return new ElementValue("validationProcess", elem); }
@@ -1282,8 +1282,8 @@ namespace Hl7.Fhir.Model
           value = Need;
           return Need is not null;
         case "status":
-          value = Status_Element;
-          return Status_Element is not null;
+          value = StatusElement;
+          return StatusElement is not null;
         case "statusDate":
           value = StatusDateElement;
           return StatusDateElement is not null;
@@ -1326,7 +1326,7 @@ namespace Hl7.Fhir.Model
       if (Target?.Any() == true) yield return new KeyValuePair<string,object>("target",Target);
       if (TargetLocationElement?.Any() == true) yield return new KeyValuePair<string,object>("targetLocation",TargetLocationElement);
       if (Need is not null) yield return new KeyValuePair<string,object>("need",Need);
-      if (Status_Element is not null) yield return new KeyValuePair<string,object>("status",Status_Element);
+      if (StatusElement is not null) yield return new KeyValuePair<string,object>("status",StatusElement);
       if (StatusDateElement is not null) yield return new KeyValuePair<string,object>("statusDate",StatusDateElement);
       if (ValidationType is not null) yield return new KeyValuePair<string,object>("validationType",ValidationType);
       if (ValidationProcess?.Any() == true) yield return new KeyValuePair<string,object>("validationProcess",ValidationProcess);

--- a/src/Hl7.Fhir.R4.Core/Model/Generated/_GeneratorLog.cs
+++ b/src/Hl7.Fhir.R4.Core/Model/Generated/_GeneratorLog.cs
@@ -152,7 +152,7 @@
   // Used in model class (resource): Measure.improvementNotation
   // Used in model class (resource): MeasureReport.improvementNotation
 
-// Generated Shared Enumeration: messageheader_response_request (http://hl7.org/fhir/ValueSet/messageheader-response-request)
+// Generated Shared Enumeration: MessageheaderResponseRequest (http://hl7.org/fhir/ValueSet/messageheader-response-request)
   // Used in model class (resource): MessageDefinition.responseRequired
   // Used in model class (type): Extension.value[x]
 

--- a/src/Hl7.Fhir.R4.Core/Model/Generated/_GeneratorLog.cs
+++ b/src/Hl7.Fhir.R4.Core/Model/Generated/_GeneratorLog.cs
@@ -56,7 +56,7 @@
   // Used in model class (resource): CapabilityStatement.kind
   // Used in model class (resource): TerminologyCapabilities.kind
 
-// Generated Shared Enumeration: Use (http://hl7.org/fhir/ValueSet/claim-use)
+// Generated Shared Enumeration: ClaimUseCode (http://hl7.org/fhir/ValueSet/claim-use)
   // Used in model class (resource): Claim.use
   // Used in model class (resource): ClaimResponse.use
   // Used in model class (resource): ExplanationOfBenefit.use
@@ -267,7 +267,7 @@
   // Used in model class (resource): OperationDefinition.parameter.searchType
   // Used in model class (resource): SearchParameter.type
 
-// Generated Shared Enumeration: EvidenceVariableType (http://hl7.org/fhir/ValueSet/variable-type)
+// Generated Shared Enumeration: VariableTypeCode (http://hl7.org/fhir/ValueSet/variable-type)
   // Used in model class (resource): EvidenceVariable.type
   // Used in model class (resource): ResearchElementDefinition.variableType
 

--- a/src/Hl7.Fhir.R4B.Core/Model/Generated/Claim.cs
+++ b/src/Hl7.Fhir.R4B.Core/Model/Generated/Claim.cs
@@ -3310,20 +3310,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.Use> UseElement
+    public Code<Hl7.Fhir.Model.ClaimUseCode> UseElement
     {
       get { return _UseElement; }
       set { _UseElement = value; OnPropertyChanged("UseElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.Use> _UseElement;
+    private Code<Hl7.Fhir.Model.ClaimUseCode> _UseElement;
 
     /// <summary>
     /// claim | preauthorization | predetermination
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.Use? Use
+    public Hl7.Fhir.Model.ClaimUseCode? Use
     {
       get { return UseElement != null ? UseElement.Value : null; }
       set
@@ -3331,7 +3331,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           UseElement = null;
         else
-          UseElement = new Code<Hl7.Fhir.Model.Use>(value);
+          UseElement = new Code<Hl7.Fhir.Model.ClaimUseCode>(value);
         OnPropertyChanged("Use");
       }
     }
@@ -3681,7 +3681,7 @@ namespace Hl7.Fhir.Model
       if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.FinancialResourceStatusCodes>)StatusElement.DeepCopy();
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
       if(SubType != null) dest.SubType = (Hl7.Fhir.Model.CodeableConcept)SubType.DeepCopy();
-      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.Use>)UseElement.DeepCopy();
+      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.ClaimUseCode>)UseElement.DeepCopy();
       if(Patient != null) dest.Patient = (Hl7.Fhir.Model.ResourceReference)Patient.DeepCopy();
       if(BillablePeriod != null) dest.BillablePeriod = (Hl7.Fhir.Model.Period)BillablePeriod.DeepCopy();
       if(CreatedElement != null) dest.CreatedElement = (Hl7.Fhir.Model.FhirDateTime)CreatedElement.DeepCopy();

--- a/src/Hl7.Fhir.R4B.Core/Model/Generated/ClaimResponse.cs
+++ b/src/Hl7.Fhir.R4B.Core/Model/Generated/ClaimResponse.cs
@@ -3263,20 +3263,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.Use> UseElement
+    public Code<Hl7.Fhir.Model.ClaimUseCode> UseElement
     {
       get { return _UseElement; }
       set { _UseElement = value; OnPropertyChanged("UseElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.Use> _UseElement;
+    private Code<Hl7.Fhir.Model.ClaimUseCode> _UseElement;
 
     /// <summary>
     /// claim | preauthorization | predetermination
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.Use? Use
+    public Hl7.Fhir.Model.ClaimUseCode? Use
     {
       get { return UseElement != null ? UseElement.Value : null; }
       set
@@ -3284,7 +3284,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           UseElement = null;
         else
-          UseElement = new Code<Hl7.Fhir.Model.Use>(value);
+          UseElement = new Code<Hl7.Fhir.Model.ClaimUseCode>(value);
         OnPropertyChanged("Use");
       }
     }
@@ -3684,7 +3684,7 @@ namespace Hl7.Fhir.Model
       if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.FinancialResourceStatusCodes>)StatusElement.DeepCopy();
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
       if(SubType != null) dest.SubType = (Hl7.Fhir.Model.CodeableConcept)SubType.DeepCopy();
-      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.Use>)UseElement.DeepCopy();
+      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.ClaimUseCode>)UseElement.DeepCopy();
       if(Patient != null) dest.Patient = (Hl7.Fhir.Model.ResourceReference)Patient.DeepCopy();
       if(CreatedElement != null) dest.CreatedElement = (Hl7.Fhir.Model.FhirDateTime)CreatedElement.DeepCopy();
       if(Insurer != null) dest.Insurer = (Hl7.Fhir.Model.ResourceReference)Insurer.DeepCopy();

--- a/src/Hl7.Fhir.R4B.Core/Model/Generated/Composition.cs
+++ b/src/Hl7.Fhir.R4B.Core/Model/Generated/Composition.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (systems: 0)
     /// </summary>
     [FhirEnumeration("Confidentiality")]
-    public enum Confidentiality
+    public enum ConfidentialityCode
     {
       /// <summary>
       /// MISSING DESCRIPTION
@@ -1183,29 +1183,29 @@ namespace Hl7.Fhir.Model
     [FhirElement("confidentiality", InSummary=true, Order=180)]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
-    public Code<Hl7.Fhir.Model.Composition.Confidentiality> Confidentiality_Element
+    public Code<Hl7.Fhir.Model.Composition.ConfidentialityCode> ConfidentialityElement
     {
-      get { return _Confidentiality_Element; }
-      set { _Confidentiality_Element = value; OnPropertyChanged("Confidentiality_Element"); }
+      get { return _ConfidentialityElement; }
+      set { _ConfidentialityElement = value; OnPropertyChanged("ConfidentialityElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.Composition.Confidentiality> _Confidentiality_Element;
+    private Code<Hl7.Fhir.Model.Composition.ConfidentialityCode> _ConfidentialityElement;
 
     /// <summary>
     /// As defined by affinity domain
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.Composition.Confidentiality? Confidentiality_
+    public Hl7.Fhir.Model.Composition.ConfidentialityCode? Confidentiality
     {
-      get { return Confidentiality_Element != null ? Confidentiality_Element.Value : null; }
+      get { return ConfidentialityElement != null ? ConfidentialityElement.Value : null; }
       set
       {
         if (value == null)
-          Confidentiality_Element = null;
+          ConfidentialityElement = null;
         else
-          Confidentiality_Element = new Code<Hl7.Fhir.Model.Composition.Confidentiality>(value);
-        OnPropertyChanged("Confidentiality_");
+          ConfidentialityElement = new Code<Hl7.Fhir.Model.Composition.ConfidentialityCode>(value);
+        OnPropertyChanged("Confidentiality");
       }
     }
 
@@ -1299,7 +1299,7 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(Author != null) dest.Author = new List<Hl7.Fhir.Model.ResourceReference>(Author.DeepCopy());
       if(TitleElement != null) dest.TitleElement = (Hl7.Fhir.Model.FhirString)TitleElement.DeepCopy();
-      if(Confidentiality_Element != null) dest.Confidentiality_Element = (Code<Hl7.Fhir.Model.Composition.Confidentiality>)Confidentiality_Element.DeepCopy();
+      if(ConfidentialityElement != null) dest.ConfidentialityElement = (Code<Hl7.Fhir.Model.Composition.ConfidentialityCode>)ConfidentialityElement.DeepCopy();
       if(Attester != null) dest.Attester = new List<Hl7.Fhir.Model.Composition.AttesterComponent>(Attester.DeepCopy());
       if(Custodian != null) dest.Custodian = (Hl7.Fhir.Model.ResourceReference)Custodian.DeepCopy();
       if(RelatesTo != null) dest.RelatesTo = new List<Hl7.Fhir.Model.Composition.RelatesToComponent>(RelatesTo.DeepCopy());
@@ -1329,7 +1329,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(Author, otherT.Author)) return false;
       if( !DeepComparable.Matches(TitleElement, otherT.TitleElement)) return false;
-      if( !DeepComparable.Matches(Confidentiality_Element, otherT.Confidentiality_Element)) return false;
+      if( !DeepComparable.Matches(ConfidentialityElement, otherT.ConfidentialityElement)) return false;
       if( !DeepComparable.Matches(Attester, otherT.Attester)) return false;
       if( !DeepComparable.Matches(Custodian, otherT.Custodian)) return false;
       if( !DeepComparable.Matches(RelatesTo, otherT.RelatesTo)) return false;
@@ -1354,7 +1354,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(Author, otherT.Author)) return false;
       if( !DeepComparable.IsExactly(TitleElement, otherT.TitleElement)) return false;
-      if( !DeepComparable.IsExactly(Confidentiality_Element, otherT.Confidentiality_Element)) return false;
+      if( !DeepComparable.IsExactly(ConfidentialityElement, otherT.ConfidentialityElement)) return false;
       if( !DeepComparable.IsExactly(Attester, otherT.Attester)) return false;
       if( !DeepComparable.IsExactly(Custodian, otherT.Custodian)) return false;
       if( !DeepComparable.IsExactly(RelatesTo, otherT.RelatesTo)) return false;
@@ -1379,7 +1379,7 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         foreach (var elem in Author) { if (elem != null) yield return elem; }
         if (TitleElement != null) yield return TitleElement;
-        if (Confidentiality_Element != null) yield return Confidentiality_Element;
+        if (ConfidentialityElement != null) yield return ConfidentialityElement;
         foreach (var elem in Attester) { if (elem != null) yield return elem; }
         if (Custodian != null) yield return Custodian;
         foreach (var elem in RelatesTo) { if (elem != null) yield return elem; }
@@ -1403,7 +1403,7 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         foreach (var elem in Author) { if (elem != null) yield return new ElementValue("author", elem); }
         if (TitleElement != null) yield return new ElementValue("title", TitleElement);
-        if (Confidentiality_Element != null) yield return new ElementValue("confidentiality", Confidentiality_Element);
+        if (ConfidentialityElement != null) yield return new ElementValue("confidentiality", ConfidentialityElement);
         foreach (var elem in Attester) { if (elem != null) yield return new ElementValue("attester", elem); }
         if (Custodian != null) yield return new ElementValue("custodian", Custodian);
         foreach (var elem in RelatesTo) { if (elem != null) yield return new ElementValue("relatesTo", elem); }
@@ -1444,8 +1444,8 @@ namespace Hl7.Fhir.Model
           value = TitleElement;
           return TitleElement is not null;
         case "confidentiality":
-          value = Confidentiality_Element;
-          return Confidentiality_Element is not null;
+          value = ConfidentialityElement;
+          return ConfidentialityElement is not null;
         case "attester":
           value = Attester;
           return Attester?.Any() == true;
@@ -1479,7 +1479,7 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (Author?.Any() == true) yield return new KeyValuePair<string,object>("author",Author);
       if (TitleElement is not null) yield return new KeyValuePair<string,object>("title",TitleElement);
-      if (Confidentiality_Element is not null) yield return new KeyValuePair<string,object>("confidentiality",Confidentiality_Element);
+      if (ConfidentialityElement is not null) yield return new KeyValuePair<string,object>("confidentiality",ConfidentialityElement);
       if (Attester?.Any() == true) yield return new KeyValuePair<string,object>("attester",Attester);
       if (Custodian is not null) yield return new KeyValuePair<string,object>("custodian",Custodian);
       if (RelatesTo?.Any() == true) yield return new KeyValuePair<string,object>("relatesTo",RelatesTo);

--- a/src/Hl7.Fhir.R4B.Core/Model/Generated/ExplanationOfBenefit.cs
+++ b/src/Hl7.Fhir.R4B.Core/Model/Generated/ExplanationOfBenefit.cs
@@ -5898,20 +5898,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.Use> UseElement
+    public Code<Hl7.Fhir.Model.ClaimUseCode> UseElement
     {
       get { return _UseElement; }
       set { _UseElement = value; OnPropertyChanged("UseElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.Use> _UseElement;
+    private Code<Hl7.Fhir.Model.ClaimUseCode> _UseElement;
 
     /// <summary>
     /// claim | preauthorization | predetermination
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.Use? Use
+    public Hl7.Fhir.Model.ClaimUseCode? Use
     {
       get { return UseElement != null ? UseElement.Value : null; }
       set
@@ -5919,7 +5919,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           UseElement = null;
         else
-          UseElement = new Code<Hl7.Fhir.Model.Use>(value);
+          UseElement = new Code<Hl7.Fhir.Model.ClaimUseCode>(value);
         OnPropertyChanged("Use");
       }
     }
@@ -6562,7 +6562,7 @@ namespace Hl7.Fhir.Model
       if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.ExplanationOfBenefit.ExplanationOfBenefitStatus>)StatusElement.DeepCopy();
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
       if(SubType != null) dest.SubType = (Hl7.Fhir.Model.CodeableConcept)SubType.DeepCopy();
-      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.Use>)UseElement.DeepCopy();
+      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.ClaimUseCode>)UseElement.DeepCopy();
       if(Patient != null) dest.Patient = (Hl7.Fhir.Model.ResourceReference)Patient.DeepCopy();
       if(BillablePeriod != null) dest.BillablePeriod = (Hl7.Fhir.Model.Period)BillablePeriod.DeepCopy();
       if(CreatedElement != null) dest.CreatedElement = (Hl7.Fhir.Model.FhirDateTime)CreatedElement.DeepCopy();

--- a/src/Hl7.Fhir.R4B.Core/Model/Generated/MedicationRequest.cs
+++ b/src/Hl7.Fhir.R4B.Core/Model/Generated/MedicationRequest.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/CodeSystem/medicationrequest-status)
     /// </summary>
     [FhirEnumeration("medicationrequestStatus")]
-    public enum medicationrequestStatus
+    public enum MedicationrequestStatus
     {
       /// <summary>
       /// The prescription is 'actionable', but not all actions that are implied by it have occurred yet.
@@ -119,7 +119,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/CodeSystem/medicationrequest-intent)
     /// </summary>
     [FhirEnumeration("medicationRequestIntent")]
-    public enum medicationRequestIntent
+    public enum MedicationRequestIntent
     {
       /// <summary>
       /// The request is a suggestion made by someone/something that doesn't have an intention to ensure it occurs and without providing an authorization to act
@@ -718,20 +718,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.MedicationRequest.medicationrequestStatus> StatusElement
+    public Code<Hl7.Fhir.Model.MedicationRequest.MedicationrequestStatus> StatusElement
     {
       get { return _StatusElement; }
       set { _StatusElement = value; OnPropertyChanged("StatusElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.MedicationRequest.medicationrequestStatus> _StatusElement;
+    private Code<Hl7.Fhir.Model.MedicationRequest.MedicationrequestStatus> _StatusElement;
 
     /// <summary>
     /// active | on-hold | cancelled | completed | entered-in-error | stopped | draft | unknown
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.MedicationRequest.medicationrequestStatus? Status
+    public Hl7.Fhir.Model.MedicationRequest.MedicationrequestStatus? Status
     {
       get { return StatusElement != null ? StatusElement.Value : null; }
       set
@@ -739,7 +739,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           StatusElement = null;
         else
-          StatusElement = new Code<Hl7.Fhir.Model.MedicationRequest.medicationrequestStatus>(value);
+          StatusElement = new Code<Hl7.Fhir.Model.MedicationRequest.MedicationrequestStatus>(value);
         OnPropertyChanged("Status");
       }
     }
@@ -764,20 +764,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.MedicationRequest.medicationRequestIntent> IntentElement
+    public Code<Hl7.Fhir.Model.MedicationRequest.MedicationRequestIntent> IntentElement
     {
       get { return _IntentElement; }
       set { _IntentElement = value; OnPropertyChanged("IntentElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.MedicationRequest.medicationRequestIntent> _IntentElement;
+    private Code<Hl7.Fhir.Model.MedicationRequest.MedicationRequestIntent> _IntentElement;
 
     /// <summary>
     /// proposal | plan | order | original-order | reflex-order | filler-order | instance-order | option
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.MedicationRequest.medicationRequestIntent? Intent
+    public Hl7.Fhir.Model.MedicationRequest.MedicationRequestIntent? Intent
     {
       get { return IntentElement != null ? IntentElement.Value : null; }
       set
@@ -785,7 +785,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           IntentElement = null;
         else
-          IntentElement = new Code<Hl7.Fhir.Model.MedicationRequest.medicationRequestIntent>(value);
+          IntentElement = new Code<Hl7.Fhir.Model.MedicationRequest.MedicationRequestIntent>(value);
         OnPropertyChanged("Intent");
       }
     }
@@ -1300,9 +1300,9 @@ namespace Hl7.Fhir.Model
 
       base.CopyTo(dest);
       if(Identifier != null) dest.Identifier = new List<Hl7.Fhir.Model.Identifier>(Identifier.DeepCopy());
-      if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.MedicationRequest.medicationrequestStatus>)StatusElement.DeepCopy();
+      if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.MedicationRequest.MedicationrequestStatus>)StatusElement.DeepCopy();
       if(StatusReason != null) dest.StatusReason = (Hl7.Fhir.Model.CodeableConcept)StatusReason.DeepCopy();
-      if(IntentElement != null) dest.IntentElement = (Code<Hl7.Fhir.Model.MedicationRequest.medicationRequestIntent>)IntentElement.DeepCopy();
+      if(IntentElement != null) dest.IntentElement = (Code<Hl7.Fhir.Model.MedicationRequest.MedicationRequestIntent>)IntentElement.DeepCopy();
       if(Category != null) dest.Category = new List<Hl7.Fhir.Model.CodeableConcept>(Category.DeepCopy());
       if(PriorityElement != null) dest.PriorityElement = (Code<Hl7.Fhir.Model.RequestPriority>)PriorityElement.DeepCopy();
       if(DoNotPerformElement != null) dest.DoNotPerformElement = (Hl7.Fhir.Model.FhirBoolean)DoNotPerformElement.DeepCopy();

--- a/src/Hl7.Fhir.R4B.Core/Model/Generated/MessageDefinition.cs
+++ b/src/Hl7.Fhir.R4B.Core/Model/Generated/MessageDefinition.cs
@@ -992,20 +992,20 @@ namespace Hl7.Fhir.Model
     [FhirElement("responseRequired", Order=300)]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
-    public Code<Hl7.Fhir.Model.messageheader_response_request> ResponseRequiredElement
+    public Code<Hl7.Fhir.Model.MessageheaderResponseRequest> ResponseRequiredElement
     {
       get { return _ResponseRequiredElement; }
       set { _ResponseRequiredElement = value; OnPropertyChanged("ResponseRequiredElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.messageheader_response_request> _ResponseRequiredElement;
+    private Code<Hl7.Fhir.Model.MessageheaderResponseRequest> _ResponseRequiredElement;
 
     /// <summary>
     /// always | on-error | never | on-success
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.messageheader_response_request? ResponseRequired
+    public Hl7.Fhir.Model.MessageheaderResponseRequest? ResponseRequired
     {
       get { return ResponseRequiredElement != null ? ResponseRequiredElement.Value : null; }
       set
@@ -1013,7 +1013,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           ResponseRequiredElement = null;
         else
-          ResponseRequiredElement = new Code<Hl7.Fhir.Model.messageheader_response_request>(value);
+          ResponseRequiredElement = new Code<Hl7.Fhir.Model.MessageheaderResponseRequest>(value);
         OnPropertyChanged("ResponseRequired");
       }
     }
@@ -1095,7 +1095,7 @@ namespace Hl7.Fhir.Model
       if(Event != null) dest.Event = (Hl7.Fhir.Model.DataType)Event.DeepCopy();
       if(CategoryElement != null) dest.CategoryElement = (Code<Hl7.Fhir.Model.MessageDefinition.MessageSignificanceCategory>)CategoryElement.DeepCopy();
       if(Focus != null) dest.Focus = new List<Hl7.Fhir.Model.MessageDefinition.FocusComponent>(Focus.DeepCopy());
-      if(ResponseRequiredElement != null) dest.ResponseRequiredElement = (Code<Hl7.Fhir.Model.messageheader_response_request>)ResponseRequiredElement.DeepCopy();
+      if(ResponseRequiredElement != null) dest.ResponseRequiredElement = (Code<Hl7.Fhir.Model.MessageheaderResponseRequest>)ResponseRequiredElement.DeepCopy();
       if(AllowedResponse != null) dest.AllowedResponse = new List<Hl7.Fhir.Model.MessageDefinition.AllowedResponseComponent>(AllowedResponse.DeepCopy());
       if(GraphElement != null) dest.GraphElement = new List<Hl7.Fhir.Model.Canonical>(GraphElement.DeepCopy());
       return dest;

--- a/src/Hl7.Fhir.R4B.Core/Model/Generated/MolecularSequence.cs
+++ b/src/Hl7.Fhir.R4B.Core/Model/Generated/MolecularSequence.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/sequence-type)
     /// </summary>
     [FhirEnumeration("sequenceType")]
-    public enum sequenceType
+    public enum SequenceType
     {
       /// <summary>
       /// Amino acid sequence.
@@ -89,7 +89,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/orientation-type)
     /// </summary>
     [FhirEnumeration("orientationType")]
-    public enum orientationType
+    public enum OrientationType
     {
       /// <summary>
       /// Sense orientation of reference sequence.
@@ -111,7 +111,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/strand-type)
     /// </summary>
     [FhirEnumeration("strandType")]
-    public enum strandType
+    public enum StrandType
     {
       /// <summary>
       /// Watson strand of reference sequence.
@@ -133,7 +133,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/quality-type)
     /// </summary>
     [FhirEnumeration("qualityType")]
-    public enum qualityType
+    public enum QualityType
     {
       /// <summary>
       /// INDEL Comparison.
@@ -161,7 +161,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/repository-type)
     /// </summary>
     [FhirEnumeration("repositoryType")]
-    public enum repositoryType
+    public enum RepositoryType
     {
       /// <summary>
       /// When URL is clicked, the resource can be seen directly (by webpage or by download link format).
@@ -258,20 +258,20 @@ namespace Hl7.Fhir.Model
       [FhirElement("orientation", InSummary=true, Order=60)]
       [DeclaredType(Type = typeof(Code))]
       [DataMember]
-      public Code<Hl7.Fhir.Model.MolecularSequence.orientationType> OrientationElement
+      public Code<Hl7.Fhir.Model.MolecularSequence.OrientationType> OrientationElement
       {
         get { return _OrientationElement; }
         set { _OrientationElement = value; OnPropertyChanged("OrientationElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.MolecularSequence.orientationType> _OrientationElement;
+      private Code<Hl7.Fhir.Model.MolecularSequence.OrientationType> _OrientationElement;
 
       /// <summary>
       /// sense | antisense
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.MolecularSequence.orientationType? Orientation
+      public Hl7.Fhir.Model.MolecularSequence.OrientationType? Orientation
       {
         get { return OrientationElement != null ? OrientationElement.Value : null; }
         set
@@ -279,7 +279,7 @@ namespace Hl7.Fhir.Model
           if (value == null)
             OrientationElement = null;
           else
-            OrientationElement = new Code<Hl7.Fhir.Model.MolecularSequence.orientationType>(value);
+            OrientationElement = new Code<Hl7.Fhir.Model.MolecularSequence.OrientationType>(value);
           OnPropertyChanged("Orientation");
         }
       }
@@ -349,20 +349,20 @@ namespace Hl7.Fhir.Model
       [FhirElement("strand", InSummary=true, Order=100)]
       [DeclaredType(Type = typeof(Code))]
       [DataMember]
-      public Code<Hl7.Fhir.Model.MolecularSequence.strandType> StrandElement
+      public Code<Hl7.Fhir.Model.MolecularSequence.StrandType> StrandElement
       {
         get { return _StrandElement; }
         set { _StrandElement = value; OnPropertyChanged("StrandElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.MolecularSequence.strandType> _StrandElement;
+      private Code<Hl7.Fhir.Model.MolecularSequence.StrandType> _StrandElement;
 
       /// <summary>
       /// watson | crick
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.MolecularSequence.strandType? Strand
+      public Hl7.Fhir.Model.MolecularSequence.StrandType? Strand
       {
         get { return StrandElement != null ? StrandElement.Value : null; }
         set
@@ -370,7 +370,7 @@ namespace Hl7.Fhir.Model
           if (value == null)
             StrandElement = null;
           else
-            StrandElement = new Code<Hl7.Fhir.Model.MolecularSequence.strandType>(value);
+            StrandElement = new Code<Hl7.Fhir.Model.MolecularSequence.StrandType>(value);
           OnPropertyChanged("Strand");
         }
       }
@@ -449,11 +449,11 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(Chromosome != null) dest.Chromosome = (Hl7.Fhir.Model.CodeableConcept)Chromosome.DeepCopy();
         if(GenomeBuildElement != null) dest.GenomeBuildElement = (Hl7.Fhir.Model.FhirString)GenomeBuildElement.DeepCopy();
-        if(OrientationElement != null) dest.OrientationElement = (Code<Hl7.Fhir.Model.MolecularSequence.orientationType>)OrientationElement.DeepCopy();
+        if(OrientationElement != null) dest.OrientationElement = (Code<Hl7.Fhir.Model.MolecularSequence.OrientationType>)OrientationElement.DeepCopy();
         if(ReferenceSeqId != null) dest.ReferenceSeqId = (Hl7.Fhir.Model.CodeableConcept)ReferenceSeqId.DeepCopy();
         if(ReferenceSeqPointer != null) dest.ReferenceSeqPointer = (Hl7.Fhir.Model.ResourceReference)ReferenceSeqPointer.DeepCopy();
         if(ReferenceSeqStringElement != null) dest.ReferenceSeqStringElement = (Hl7.Fhir.Model.FhirString)ReferenceSeqStringElement.DeepCopy();
-        if(StrandElement != null) dest.StrandElement = (Code<Hl7.Fhir.Model.MolecularSequence.strandType>)StrandElement.DeepCopy();
+        if(StrandElement != null) dest.StrandElement = (Code<Hl7.Fhir.Model.MolecularSequence.StrandType>)StrandElement.DeepCopy();
         if(WindowStartElement != null) dest.WindowStartElement = (Hl7.Fhir.Model.Integer)WindowStartElement.DeepCopy();
         if(WindowEndElement != null) dest.WindowEndElement = (Hl7.Fhir.Model.Integer)WindowEndElement.DeepCopy();
         return dest;
@@ -923,20 +923,20 @@ namespace Hl7.Fhir.Model
       [DeclaredType(Type = typeof(Code))]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Code<Hl7.Fhir.Model.MolecularSequence.qualityType> TypeElement
+      public Code<Hl7.Fhir.Model.MolecularSequence.QualityType> TypeElement
       {
         get { return _TypeElement; }
         set { _TypeElement = value; OnPropertyChanged("TypeElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.MolecularSequence.qualityType> _TypeElement;
+      private Code<Hl7.Fhir.Model.MolecularSequence.QualityType> _TypeElement;
 
       /// <summary>
       /// indel | snp | unknown
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.MolecularSequence.qualityType? Type
+      public Hl7.Fhir.Model.MolecularSequence.QualityType? Type
       {
         get { return TypeElement != null ? TypeElement.Value : null; }
         set
@@ -944,7 +944,7 @@ namespace Hl7.Fhir.Model
           if (value == null)
             TypeElement = null;
           else
-            TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.qualityType>(value);
+            TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.QualityType>(value);
           OnPropertyChanged("Type");
         }
       }
@@ -1321,7 +1321,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.qualityType>)TypeElement.DeepCopy();
+        if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.QualityType>)TypeElement.DeepCopy();
         if(StandardSequence != null) dest.StandardSequence = (Hl7.Fhir.Model.CodeableConcept)StandardSequence.DeepCopy();
         if(StartElement != null) dest.StartElement = (Hl7.Fhir.Model.Integer)StartElement.DeepCopy();
         if(EndElement != null) dest.EndElement = (Hl7.Fhir.Model.Integer)EndElement.DeepCopy();
@@ -1914,20 +1914,20 @@ namespace Hl7.Fhir.Model
       [DeclaredType(Type = typeof(Code))]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Code<Hl7.Fhir.Model.MolecularSequence.repositoryType> TypeElement
+      public Code<Hl7.Fhir.Model.MolecularSequence.RepositoryType> TypeElement
       {
         get { return _TypeElement; }
         set { _TypeElement = value; OnPropertyChanged("TypeElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.MolecularSequence.repositoryType> _TypeElement;
+      private Code<Hl7.Fhir.Model.MolecularSequence.RepositoryType> _TypeElement;
 
       /// <summary>
       /// directlink | openapi | login | oauth | other
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.MolecularSequence.repositoryType? Type
+      public Hl7.Fhir.Model.MolecularSequence.RepositoryType? Type
       {
         get { return TypeElement != null ? TypeElement.Value : null; }
         set
@@ -1935,7 +1935,7 @@ namespace Hl7.Fhir.Model
           if (value == null)
             TypeElement = null;
           else
-            TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.repositoryType>(value);
+            TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.RepositoryType>(value);
           OnPropertyChanged("Type");
         }
       }
@@ -2105,7 +2105,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.repositoryType>)TypeElement.DeepCopy();
+        if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.RepositoryType>)TypeElement.DeepCopy();
         if(UrlElement != null) dest.UrlElement = (Hl7.Fhir.Model.FhirUri)UrlElement.DeepCopy();
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
         if(DatasetIdElement != null) dest.DatasetIdElement = (Hl7.Fhir.Model.FhirString)DatasetIdElement.DeepCopy();
@@ -2810,20 +2810,20 @@ namespace Hl7.Fhir.Model
     [FhirElement("type", InSummary=true, Order=100)]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
-    public Code<Hl7.Fhir.Model.MolecularSequence.sequenceType> TypeElement
+    public Code<Hl7.Fhir.Model.MolecularSequence.SequenceType> TypeElement
     {
       get { return _TypeElement; }
       set { _TypeElement = value; OnPropertyChanged("TypeElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.MolecularSequence.sequenceType> _TypeElement;
+    private Code<Hl7.Fhir.Model.MolecularSequence.SequenceType> _TypeElement;
 
     /// <summary>
     /// aa | dna | rna
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.MolecularSequence.sequenceType? Type
+    public Hl7.Fhir.Model.MolecularSequence.SequenceType? Type
     {
       get { return TypeElement != null ? TypeElement.Value : null; }
       set
@@ -2831,7 +2831,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           TypeElement = null;
         else
-          TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.sequenceType>(value);
+          TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.SequenceType>(value);
         OnPropertyChanged("Type");
       }
     }
@@ -3099,7 +3099,7 @@ namespace Hl7.Fhir.Model
 
       base.CopyTo(dest);
       if(Identifier != null) dest.Identifier = new List<Hl7.Fhir.Model.Identifier>(Identifier.DeepCopy());
-      if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.sequenceType>)TypeElement.DeepCopy();
+      if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.SequenceType>)TypeElement.DeepCopy();
       if(CoordinateSystemElement != null) dest.CoordinateSystemElement = (Hl7.Fhir.Model.Integer)CoordinateSystemElement.DeepCopy();
       if(Patient != null) dest.Patient = (Hl7.Fhir.Model.ResourceReference)Patient.DeepCopy();
       if(Specimen != null) dest.Specimen = (Hl7.Fhir.Model.ResourceReference)Specimen.DeepCopy();

--- a/src/Hl7.Fhir.R4B.Core/Model/Generated/ResearchElementDefinition.cs
+++ b/src/Hl7.Fhir.R4B.Core/Model/Generated/ResearchElementDefinition.cs
@@ -89,7 +89,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/variable-type)
     /// </summary>
     [FhirEnumeration("VariableType")]
-    public enum VariableType
+    public enum VariableTypeCode
     {
       /// <summary>
       /// The variable is dichotomous, such as present or absent.
@@ -1278,29 +1278,29 @@ namespace Hl7.Fhir.Model
     [FhirElement("variableType", Order=400)]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
-    public Code<Hl7.Fhir.Model.ResearchElementDefinition.VariableType> VariableType_Element
+    public Code<Hl7.Fhir.Model.ResearchElementDefinition.VariableTypeCode> VariableTypeElement
     {
-      get { return _VariableType_Element; }
-      set { _VariableType_Element = value; OnPropertyChanged("VariableType_Element"); }
+      get { return _VariableTypeElement; }
+      set { _VariableTypeElement = value; OnPropertyChanged("VariableTypeElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.ResearchElementDefinition.VariableType> _VariableType_Element;
+    private Code<Hl7.Fhir.Model.ResearchElementDefinition.VariableTypeCode> _VariableTypeElement;
 
     /// <summary>
     /// dichotomous | continuous | descriptive
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.ResearchElementDefinition.VariableType? VariableType_
+    public Hl7.Fhir.Model.ResearchElementDefinition.VariableTypeCode? VariableType
     {
-      get { return VariableType_Element != null ? VariableType_Element.Value : null; }
+      get { return VariableTypeElement != null ? VariableTypeElement.Value : null; }
       set
       {
         if (value == null)
-          VariableType_Element = null;
+          VariableTypeElement = null;
         else
-          VariableType_Element = new Code<Hl7.Fhir.Model.ResearchElementDefinition.VariableType>(value);
-        OnPropertyChanged("VariableType_");
+          VariableTypeElement = new Code<Hl7.Fhir.Model.ResearchElementDefinition.VariableTypeCode>(value);
+        OnPropertyChanged("VariableType");
       }
     }
 
@@ -1359,7 +1359,7 @@ namespace Hl7.Fhir.Model
       if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
       if(LibraryElement != null) dest.LibraryElement = new List<Hl7.Fhir.Model.Canonical>(LibraryElement.DeepCopy());
       if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.ResearchElementDefinition.ResearchElementType>)TypeElement.DeepCopy();
-      if(VariableType_Element != null) dest.VariableType_Element = (Code<Hl7.Fhir.Model.ResearchElementDefinition.VariableType>)VariableType_Element.DeepCopy();
+      if(VariableTypeElement != null) dest.VariableTypeElement = (Code<Hl7.Fhir.Model.ResearchElementDefinition.VariableTypeCode>)VariableTypeElement.DeepCopy();
       if(Characteristic != null) dest.Characteristic = new List<Hl7.Fhir.Model.ResearchElementDefinition.CharacteristicComponent>(Characteristic.DeepCopy());
       return dest;
     }
@@ -1407,7 +1407,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.Matches(LibraryElement, otherT.LibraryElement)) return false;
       if( !DeepComparable.Matches(TypeElement, otherT.TypeElement)) return false;
-      if( !DeepComparable.Matches(VariableType_Element, otherT.VariableType_Element)) return false;
+      if( !DeepComparable.Matches(VariableTypeElement, otherT.VariableTypeElement)) return false;
       if( !DeepComparable.Matches(Characteristic, otherT.Characteristic)) return false;
 
       return true;
@@ -1450,7 +1450,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.IsExactly(LibraryElement, otherT.LibraryElement)) return false;
       if( !DeepComparable.IsExactly(TypeElement, otherT.TypeElement)) return false;
-      if( !DeepComparable.IsExactly(VariableType_Element, otherT.VariableType_Element)) return false;
+      if( !DeepComparable.IsExactly(VariableTypeElement, otherT.VariableTypeElement)) return false;
       if( !DeepComparable.IsExactly(Characteristic, otherT.Characteristic)) return false;
 
       return true;
@@ -1493,7 +1493,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return elem; }
         foreach (var elem in LibraryElement) { if (elem != null) yield return elem; }
         if (TypeElement != null) yield return TypeElement;
-        if (VariableType_Element != null) yield return VariableType_Element;
+        if (VariableTypeElement != null) yield return VariableTypeElement;
         foreach (var elem in Characteristic) { if (elem != null) yield return elem; }
       }
     }
@@ -1535,7 +1535,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return new ElementValue("relatedArtifact", elem); }
         foreach (var elem in LibraryElement) { if (elem != null) yield return new ElementValue("library", elem); }
         if (TypeElement != null) yield return new ElementValue("type", TypeElement);
-        if (VariableType_Element != null) yield return new ElementValue("variableType", VariableType_Element);
+        if (VariableTypeElement != null) yield return new ElementValue("variableType", VariableTypeElement);
         foreach (var elem in Characteristic) { if (elem != null) yield return new ElementValue("characteristic", elem); }
       }
     }
@@ -1638,8 +1638,8 @@ namespace Hl7.Fhir.Model
           value = TypeElement;
           return TypeElement is not null;
         case "variableType":
-          value = VariableType_Element;
-          return VariableType_Element is not null;
+          value = VariableTypeElement;
+          return VariableTypeElement is not null;
         case "characteristic":
           value = Characteristic;
           return Characteristic?.Any() == true;
@@ -1683,7 +1683,7 @@ namespace Hl7.Fhir.Model
       if (RelatedArtifact?.Any() == true) yield return new KeyValuePair<string,object>("relatedArtifact",RelatedArtifact);
       if (LibraryElement?.Any() == true) yield return new KeyValuePair<string,object>("library",LibraryElement);
       if (TypeElement is not null) yield return new KeyValuePair<string,object>("type",TypeElement);
-      if (VariableType_Element is not null) yield return new KeyValuePair<string,object>("variableType",VariableType_Element);
+      if (VariableTypeElement is not null) yield return new KeyValuePair<string,object>("variableType",VariableTypeElement);
       if (Characteristic?.Any() == true) yield return new KeyValuePair<string,object>("characteristic",Characteristic);
     }
 

--- a/src/Hl7.Fhir.R4B.Core/Model/Generated/Template-Bindings.cs
+++ b/src/Hl7.Fhir.R4B.Core/Model/Generated/Template-Bindings.cs
@@ -1612,7 +1612,7 @@ namespace Hl7.Fhir.Model
   /// (system: http://hl7.org/fhir/claim-use)
   /// </summary>
   [FhirEnumeration("Use")]
-  public enum Use
+  public enum ClaimUseCode
   {
     /// <summary>
     /// The treatment is complete and this represents a Claim for the services.

--- a/src/Hl7.Fhir.R4B.Core/Model/Generated/Template-Bindings.cs
+++ b/src/Hl7.Fhir.R4B.Core/Model/Generated/Template-Bindings.cs
@@ -8026,7 +8026,7 @@ namespace Hl7.Fhir.Model
   /// (system: http://hl7.org/fhir/messageheader-response-request)
   /// </summary>
   [FhirEnumeration("messageheader-response-request")]
-  public enum messageheader_response_request
+  public enum MessageheaderResponseRequest
   {
     /// <summary>
     /// initiator expects a response for this message.

--- a/src/Hl7.Fhir.R4B.Core/Model/Generated/VerificationResult.cs
+++ b/src/Hl7.Fhir.R4B.Core/Model/Generated/VerificationResult.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/verificationresult-status)
     /// </summary>
     [FhirEnumeration("status")]
-    public enum Status
+    public enum StatusCode
     {
       /// <summary>
       /// ***TODO***
@@ -928,29 +928,29 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.VerificationResult.Status> Status_Element
+    public Code<Hl7.Fhir.Model.VerificationResult.StatusCode> StatusElement
     {
-      get { return _Status_Element; }
-      set { _Status_Element = value; OnPropertyChanged("Status_Element"); }
+      get { return _StatusElement; }
+      set { _StatusElement = value; OnPropertyChanged("StatusElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.VerificationResult.Status> _Status_Element;
+    private Code<Hl7.Fhir.Model.VerificationResult.StatusCode> _StatusElement;
 
     /// <summary>
     /// attested | validated | in-process | req-revalid | val-fail | reval-fail
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.VerificationResult.Status? Status_
+    public Hl7.Fhir.Model.VerificationResult.StatusCode? Status
     {
-      get { return Status_Element != null ? Status_Element.Value : null; }
+      get { return StatusElement != null ? StatusElement.Value : null; }
       set
       {
         if (value == null)
-          Status_Element = null;
+          StatusElement = null;
         else
-          Status_Element = new Code<Hl7.Fhir.Model.VerificationResult.Status>(value);
-        OnPropertyChanged("Status_");
+          StatusElement = new Code<Hl7.Fhir.Model.VerificationResult.StatusCode>(value);
+        OnPropertyChanged("Status");
       }
     }
 
@@ -1154,7 +1154,7 @@ namespace Hl7.Fhir.Model
       if(Target != null) dest.Target = new List<Hl7.Fhir.Model.ResourceReference>(Target.DeepCopy());
       if(TargetLocationElement != null) dest.TargetLocationElement = new List<Hl7.Fhir.Model.FhirString>(TargetLocationElement.DeepCopy());
       if(Need != null) dest.Need = (Hl7.Fhir.Model.CodeableConcept)Need.DeepCopy();
-      if(Status_Element != null) dest.Status_Element = (Code<Hl7.Fhir.Model.VerificationResult.Status>)Status_Element.DeepCopy();
+      if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.VerificationResult.StatusCode>)StatusElement.DeepCopy();
       if(StatusDateElement != null) dest.StatusDateElement = (Hl7.Fhir.Model.FhirDateTime)StatusDateElement.DeepCopy();
       if(ValidationType != null) dest.ValidationType = (Hl7.Fhir.Model.CodeableConcept)ValidationType.DeepCopy();
       if(ValidationProcess != null) dest.ValidationProcess = new List<Hl7.Fhir.Model.CodeableConcept>(ValidationProcess.DeepCopy());
@@ -1183,7 +1183,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Target, otherT.Target)) return false;
       if( !DeepComparable.Matches(TargetLocationElement, otherT.TargetLocationElement)) return false;
       if( !DeepComparable.Matches(Need, otherT.Need)) return false;
-      if( !DeepComparable.Matches(Status_Element, otherT.Status_Element)) return false;
+      if( !DeepComparable.Matches(StatusElement, otherT.StatusElement)) return false;
       if( !DeepComparable.Matches(StatusDateElement, otherT.StatusDateElement)) return false;
       if( !DeepComparable.Matches(ValidationType, otherT.ValidationType)) return false;
       if( !DeepComparable.Matches(ValidationProcess, otherT.ValidationProcess)) return false;
@@ -1207,7 +1207,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Target, otherT.Target)) return false;
       if( !DeepComparable.IsExactly(TargetLocationElement, otherT.TargetLocationElement)) return false;
       if( !DeepComparable.IsExactly(Need, otherT.Need)) return false;
-      if( !DeepComparable.IsExactly(Status_Element, otherT.Status_Element)) return false;
+      if( !DeepComparable.IsExactly(StatusElement, otherT.StatusElement)) return false;
       if( !DeepComparable.IsExactly(StatusDateElement, otherT.StatusDateElement)) return false;
       if( !DeepComparable.IsExactly(ValidationType, otherT.ValidationType)) return false;
       if( !DeepComparable.IsExactly(ValidationProcess, otherT.ValidationProcess)) return false;
@@ -1231,7 +1231,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Target) { if (elem != null) yield return elem; }
         foreach (var elem in TargetLocationElement) { if (elem != null) yield return elem; }
         if (Need != null) yield return Need;
-        if (Status_Element != null) yield return Status_Element;
+        if (StatusElement != null) yield return StatusElement;
         if (StatusDateElement != null) yield return StatusDateElement;
         if (ValidationType != null) yield return ValidationType;
         foreach (var elem in ValidationProcess) { if (elem != null) yield return elem; }
@@ -1254,7 +1254,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Target) { if (elem != null) yield return new ElementValue("target", elem); }
         foreach (var elem in TargetLocationElement) { if (elem != null) yield return new ElementValue("targetLocation", elem); }
         if (Need != null) yield return new ElementValue("need", Need);
-        if (Status_Element != null) yield return new ElementValue("status", Status_Element);
+        if (StatusElement != null) yield return new ElementValue("status", StatusElement);
         if (StatusDateElement != null) yield return new ElementValue("statusDate", StatusDateElement);
         if (ValidationType != null) yield return new ElementValue("validationType", ValidationType);
         foreach (var elem in ValidationProcess) { if (elem != null) yield return new ElementValue("validationProcess", elem); }
@@ -1282,8 +1282,8 @@ namespace Hl7.Fhir.Model
           value = Need;
           return Need is not null;
         case "status":
-          value = Status_Element;
-          return Status_Element is not null;
+          value = StatusElement;
+          return StatusElement is not null;
         case "statusDate":
           value = StatusDateElement;
           return StatusDateElement is not null;
@@ -1326,7 +1326,7 @@ namespace Hl7.Fhir.Model
       if (Target?.Any() == true) yield return new KeyValuePair<string,object>("target",Target);
       if (TargetLocationElement?.Any() == true) yield return new KeyValuePair<string,object>("targetLocation",TargetLocationElement);
       if (Need is not null) yield return new KeyValuePair<string,object>("need",Need);
-      if (Status_Element is not null) yield return new KeyValuePair<string,object>("status",Status_Element);
+      if (StatusElement is not null) yield return new KeyValuePair<string,object>("status",StatusElement);
       if (StatusDateElement is not null) yield return new KeyValuePair<string,object>("statusDate",StatusDateElement);
       if (ValidationType is not null) yield return new KeyValuePair<string,object>("validationType",ValidationType);
       if (ValidationProcess?.Any() == true) yield return new KeyValuePair<string,object>("validationProcess",ValidationProcess);

--- a/src/Hl7.Fhir.R4B.Core/Model/Generated/VerificationResult.cs
+++ b/src/Hl7.Fhir.R4B.Core/Model/Generated/VerificationResult.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/verificationresult-status)
     /// </summary>
     [FhirEnumeration("status")]
-    public enum status
+    public enum Status
     {
       /// <summary>
       /// ***TODO***
@@ -928,20 +928,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.VerificationResult.status> Status_Element
+    public Code<Hl7.Fhir.Model.VerificationResult.Status> Status_Element
     {
       get { return _Status_Element; }
       set { _Status_Element = value; OnPropertyChanged("Status_Element"); }
     }
 
-    private Code<Hl7.Fhir.Model.VerificationResult.status> _Status_Element;
+    private Code<Hl7.Fhir.Model.VerificationResult.Status> _Status_Element;
 
     /// <summary>
     /// attested | validated | in-process | req-revalid | val-fail | reval-fail
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.VerificationResult.status? Status_
+    public Hl7.Fhir.Model.VerificationResult.Status? Status_
     {
       get { return Status_Element != null ? Status_Element.Value : null; }
       set
@@ -949,7 +949,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           Status_Element = null;
         else
-          Status_Element = new Code<Hl7.Fhir.Model.VerificationResult.status>(value);
+          Status_Element = new Code<Hl7.Fhir.Model.VerificationResult.Status>(value);
         OnPropertyChanged("Status_");
       }
     }
@@ -1154,7 +1154,7 @@ namespace Hl7.Fhir.Model
       if(Target != null) dest.Target = new List<Hl7.Fhir.Model.ResourceReference>(Target.DeepCopy());
       if(TargetLocationElement != null) dest.TargetLocationElement = new List<Hl7.Fhir.Model.FhirString>(TargetLocationElement.DeepCopy());
       if(Need != null) dest.Need = (Hl7.Fhir.Model.CodeableConcept)Need.DeepCopy();
-      if(Status_Element != null) dest.Status_Element = (Code<Hl7.Fhir.Model.VerificationResult.status>)Status_Element.DeepCopy();
+      if(Status_Element != null) dest.Status_Element = (Code<Hl7.Fhir.Model.VerificationResult.Status>)Status_Element.DeepCopy();
       if(StatusDateElement != null) dest.StatusDateElement = (Hl7.Fhir.Model.FhirDateTime)StatusDateElement.DeepCopy();
       if(ValidationType != null) dest.ValidationType = (Hl7.Fhir.Model.CodeableConcept)ValidationType.DeepCopy();
       if(ValidationProcess != null) dest.ValidationProcess = new List<Hl7.Fhir.Model.CodeableConcept>(ValidationProcess.DeepCopy());

--- a/src/Hl7.Fhir.R4B.Core/Model/Generated/_GeneratorLog.cs
+++ b/src/Hl7.Fhir.R4B.Core/Model/Generated/_GeneratorLog.cs
@@ -56,7 +56,7 @@
   // Used in model class (resource): CapabilityStatement.kind
   // Used in model class (resource): TerminologyCapabilities.kind
 
-// Generated Shared Enumeration: Use (http://hl7.org/fhir/ValueSet/claim-use)
+// Generated Shared Enumeration: ClaimUseCode (http://hl7.org/fhir/ValueSet/claim-use)
   // Used in model class (resource): Claim.use
   // Used in model class (resource): ClaimResponse.use
   // Used in model class (resource): ExplanationOfBenefit.use

--- a/src/Hl7.Fhir.R4B.Core/Model/Generated/_GeneratorLog.cs
+++ b/src/Hl7.Fhir.R4B.Core/Model/Generated/_GeneratorLog.cs
@@ -162,7 +162,7 @@
   // Used in model class (resource): Measure.improvementNotation
   // Used in model class (resource): MeasureReport.improvementNotation
 
-// Generated Shared Enumeration: messageheader_response_request (http://hl7.org/fhir/ValueSet/messageheader-response-request)
+// Generated Shared Enumeration: MessageheaderResponseRequest (http://hl7.org/fhir/ValueSet/messageheader-response-request)
   // Used in model class (resource): MessageDefinition.responseRequired
   // Used in model class (type): Extension.value[x]
 

--- a/src/Hl7.Fhir.R5.Core/Model/Generated/Claim.cs
+++ b/src/Hl7.Fhir.R5.Core/Model/Generated/Claim.cs
@@ -3310,20 +3310,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.Use> UseElement
+    public Code<Hl7.Fhir.Model.ClaimUseCode> UseElement
     {
       get { return _UseElement; }
       set { _UseElement = value; OnPropertyChanged("UseElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.Use> _UseElement;
+    private Code<Hl7.Fhir.Model.ClaimUseCode> _UseElement;
 
     /// <summary>
     /// claim | preauthorization | predetermination
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.Use? Use
+    public Hl7.Fhir.Model.ClaimUseCode? Use
     {
       get { return UseElement != null ? UseElement.Value : null; }
       set
@@ -3331,7 +3331,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           UseElement = null;
         else
-          UseElement = new Code<Hl7.Fhir.Model.Use>(value);
+          UseElement = new Code<Hl7.Fhir.Model.ClaimUseCode>(value);
         OnPropertyChanged("Use");
       }
     }
@@ -3681,7 +3681,7 @@ namespace Hl7.Fhir.Model
       if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.FinancialResourceStatusCodes>)StatusElement.DeepCopy();
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
       if(SubType != null) dest.SubType = (Hl7.Fhir.Model.CodeableConcept)SubType.DeepCopy();
-      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.Use>)UseElement.DeepCopy();
+      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.ClaimUseCode>)UseElement.DeepCopy();
       if(Patient != null) dest.Patient = (Hl7.Fhir.Model.ResourceReference)Patient.DeepCopy();
       if(BillablePeriod != null) dest.BillablePeriod = (Hl7.Fhir.Model.Period)BillablePeriod.DeepCopy();
       if(CreatedElement != null) dest.CreatedElement = (Hl7.Fhir.Model.FhirDateTime)CreatedElement.DeepCopy();

--- a/src/Hl7.Fhir.R5.Core/Model/Generated/ClaimResponse.cs
+++ b/src/Hl7.Fhir.R5.Core/Model/Generated/ClaimResponse.cs
@@ -3263,20 +3263,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.Use> UseElement
+    public Code<Hl7.Fhir.Model.ClaimUseCode> UseElement
     {
       get { return _UseElement; }
       set { _UseElement = value; OnPropertyChanged("UseElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.Use> _UseElement;
+    private Code<Hl7.Fhir.Model.ClaimUseCode> _UseElement;
 
     /// <summary>
     /// claim | preauthorization | predetermination
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.Use? Use
+    public Hl7.Fhir.Model.ClaimUseCode? Use
     {
       get { return UseElement != null ? UseElement.Value : null; }
       set
@@ -3284,7 +3284,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           UseElement = null;
         else
-          UseElement = new Code<Hl7.Fhir.Model.Use>(value);
+          UseElement = new Code<Hl7.Fhir.Model.ClaimUseCode>(value);
         OnPropertyChanged("Use");
       }
     }
@@ -3684,7 +3684,7 @@ namespace Hl7.Fhir.Model
       if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.FinancialResourceStatusCodes>)StatusElement.DeepCopy();
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
       if(SubType != null) dest.SubType = (Hl7.Fhir.Model.CodeableConcept)SubType.DeepCopy();
-      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.Use>)UseElement.DeepCopy();
+      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.ClaimUseCode>)UseElement.DeepCopy();
       if(Patient != null) dest.Patient = (Hl7.Fhir.Model.ResourceReference)Patient.DeepCopy();
       if(CreatedElement != null) dest.CreatedElement = (Hl7.Fhir.Model.FhirDateTime)CreatedElement.DeepCopy();
       if(Insurer != null) dest.Insurer = (Hl7.Fhir.Model.ResourceReference)Insurer.DeepCopy();

--- a/src/Hl7.Fhir.R5.Core/Model/Generated/Composition.cs
+++ b/src/Hl7.Fhir.R5.Core/Model/Generated/Composition.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (systems: 0)
     /// </summary>
     [FhirEnumeration("Confidentiality")]
-    public enum Confidentiality
+    public enum ConfidentialityCode
     {
       /// <summary>
       /// MISSING DESCRIPTION
@@ -975,29 +975,29 @@ namespace Hl7.Fhir.Model
     [FhirElement("confidentiality", InSummary=true, Order=180)]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
-    public Code<Hl7.Fhir.Model.Composition.Confidentiality> Confidentiality_Element
+    public Code<Hl7.Fhir.Model.Composition.ConfidentialityCode> ConfidentialityElement
     {
-      get { return _Confidentiality_Element; }
-      set { _Confidentiality_Element = value; OnPropertyChanged("Confidentiality_Element"); }
+      get { return _ConfidentialityElement; }
+      set { _ConfidentialityElement = value; OnPropertyChanged("ConfidentialityElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.Composition.Confidentiality> _Confidentiality_Element;
+    private Code<Hl7.Fhir.Model.Composition.ConfidentialityCode> _ConfidentialityElement;
 
     /// <summary>
     /// As defined by affinity domain
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.Composition.Confidentiality? Confidentiality_
+    public Hl7.Fhir.Model.Composition.ConfidentialityCode? Confidentiality
     {
-      get { return Confidentiality_Element != null ? Confidentiality_Element.Value : null; }
+      get { return ConfidentialityElement != null ? ConfidentialityElement.Value : null; }
       set
       {
         if (value == null)
-          Confidentiality_Element = null;
+          ConfidentialityElement = null;
         else
-          Confidentiality_Element = new Code<Hl7.Fhir.Model.Composition.Confidentiality>(value);
-        OnPropertyChanged("Confidentiality_");
+          ConfidentialityElement = new Code<Hl7.Fhir.Model.Composition.ConfidentialityCode>(value);
+        OnPropertyChanged("Confidentiality");
       }
     }
 
@@ -1091,7 +1091,7 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(Author != null) dest.Author = new List<Hl7.Fhir.Model.ResourceReference>(Author.DeepCopy());
       if(TitleElement != null) dest.TitleElement = (Hl7.Fhir.Model.FhirString)TitleElement.DeepCopy();
-      if(Confidentiality_Element != null) dest.Confidentiality_Element = (Code<Hl7.Fhir.Model.Composition.Confidentiality>)Confidentiality_Element.DeepCopy();
+      if(ConfidentialityElement != null) dest.ConfidentialityElement = (Code<Hl7.Fhir.Model.Composition.ConfidentialityCode>)ConfidentialityElement.DeepCopy();
       if(Attester != null) dest.Attester = new List<Hl7.Fhir.Model.Composition.AttesterComponent>(Attester.DeepCopy());
       if(Custodian != null) dest.Custodian = (Hl7.Fhir.Model.ResourceReference)Custodian.DeepCopy();
       if(RelatesTo != null) dest.RelatesTo = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatesTo.DeepCopy());
@@ -1121,7 +1121,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(Author, otherT.Author)) return false;
       if( !DeepComparable.Matches(TitleElement, otherT.TitleElement)) return false;
-      if( !DeepComparable.Matches(Confidentiality_Element, otherT.Confidentiality_Element)) return false;
+      if( !DeepComparable.Matches(ConfidentialityElement, otherT.ConfidentialityElement)) return false;
       if( !DeepComparable.Matches(Attester, otherT.Attester)) return false;
       if( !DeepComparable.Matches(Custodian, otherT.Custodian)) return false;
       if( !DeepComparable.Matches(RelatesTo, otherT.RelatesTo)) return false;
@@ -1146,7 +1146,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(Author, otherT.Author)) return false;
       if( !DeepComparable.IsExactly(TitleElement, otherT.TitleElement)) return false;
-      if( !DeepComparable.IsExactly(Confidentiality_Element, otherT.Confidentiality_Element)) return false;
+      if( !DeepComparable.IsExactly(ConfidentialityElement, otherT.ConfidentialityElement)) return false;
       if( !DeepComparable.IsExactly(Attester, otherT.Attester)) return false;
       if( !DeepComparable.IsExactly(Custodian, otherT.Custodian)) return false;
       if( !DeepComparable.IsExactly(RelatesTo, otherT.RelatesTo)) return false;
@@ -1171,7 +1171,7 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         foreach (var elem in Author) { if (elem != null) yield return elem; }
         if (TitleElement != null) yield return TitleElement;
-        if (Confidentiality_Element != null) yield return Confidentiality_Element;
+        if (ConfidentialityElement != null) yield return ConfidentialityElement;
         foreach (var elem in Attester) { if (elem != null) yield return elem; }
         if (Custodian != null) yield return Custodian;
         foreach (var elem in RelatesTo) { if (elem != null) yield return elem; }
@@ -1195,7 +1195,7 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         foreach (var elem in Author) { if (elem != null) yield return new ElementValue("author", elem); }
         if (TitleElement != null) yield return new ElementValue("title", TitleElement);
-        if (Confidentiality_Element != null) yield return new ElementValue("confidentiality", Confidentiality_Element);
+        if (ConfidentialityElement != null) yield return new ElementValue("confidentiality", ConfidentialityElement);
         foreach (var elem in Attester) { if (elem != null) yield return new ElementValue("attester", elem); }
         if (Custodian != null) yield return new ElementValue("custodian", Custodian);
         foreach (var elem in RelatesTo) { if (elem != null) yield return new ElementValue("relatesTo", elem); }
@@ -1236,8 +1236,8 @@ namespace Hl7.Fhir.Model
           value = TitleElement;
           return TitleElement is not null;
         case "confidentiality":
-          value = Confidentiality_Element;
-          return Confidentiality_Element is not null;
+          value = ConfidentialityElement;
+          return ConfidentialityElement is not null;
         case "attester":
           value = Attester;
           return Attester?.Any() == true;
@@ -1271,7 +1271,7 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (Author?.Any() == true) yield return new KeyValuePair<string,object>("author",Author);
       if (TitleElement is not null) yield return new KeyValuePair<string,object>("title",TitleElement);
-      if (Confidentiality_Element is not null) yield return new KeyValuePair<string,object>("confidentiality",Confidentiality_Element);
+      if (ConfidentialityElement is not null) yield return new KeyValuePair<string,object>("confidentiality",ConfidentialityElement);
       if (Attester?.Any() == true) yield return new KeyValuePair<string,object>("attester",Attester);
       if (Custodian is not null) yield return new KeyValuePair<string,object>("custodian",Custodian);
       if (RelatesTo?.Any() == true) yield return new KeyValuePair<string,object>("relatesTo",RelatesTo);

--- a/src/Hl7.Fhir.R5.Core/Model/Generated/EvidenceVariable.cs
+++ b/src/Hl7.Fhir.R5.Core/Model/Generated/EvidenceVariable.cs
@@ -101,7 +101,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/group-measure)
     /// </summary>
     [FhirEnumeration("GroupMeasure")]
-    public enum GroupMeasure
+    public enum GroupMeasureCode
     {
       /// <summary>
       /// Aggregated using Mean of participant values.
@@ -463,29 +463,29 @@ namespace Hl7.Fhir.Model
       [FhirElement("groupMeasure", Order=110)]
       [DeclaredType(Type = typeof(Code))]
       [DataMember]
-      public Code<Hl7.Fhir.Model.EvidenceVariable.GroupMeasure> GroupMeasure_Element
+      public Code<Hl7.Fhir.Model.EvidenceVariable.GroupMeasureCode> GroupMeasureElement
       {
-        get { return _GroupMeasure_Element; }
-        set { _GroupMeasure_Element = value; OnPropertyChanged("GroupMeasure_Element"); }
+        get { return _GroupMeasureElement; }
+        set { _GroupMeasureElement = value; OnPropertyChanged("GroupMeasureElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.EvidenceVariable.GroupMeasure> _GroupMeasure_Element;
+      private Code<Hl7.Fhir.Model.EvidenceVariable.GroupMeasureCode> _GroupMeasureElement;
 
       /// <summary>
       /// mean | median | mean-of-mean | mean-of-median | median-of-mean | median-of-median
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.EvidenceVariable.GroupMeasure? GroupMeasure_
+      public Hl7.Fhir.Model.EvidenceVariable.GroupMeasureCode? GroupMeasure
       {
-        get { return GroupMeasure_Element != null ? GroupMeasure_Element.Value : null; }
+        get { return GroupMeasureElement != null ? GroupMeasureElement.Value : null; }
         set
         {
           if (value == null)
-            GroupMeasure_Element = null;
+            GroupMeasureElement = null;
           else
-            GroupMeasure_Element = new Code<Hl7.Fhir.Model.EvidenceVariable.GroupMeasure>(value);
-          OnPropertyChanged("GroupMeasure_");
+            GroupMeasureElement = new Code<Hl7.Fhir.Model.EvidenceVariable.GroupMeasureCode>(value);
+          OnPropertyChanged("GroupMeasure");
         }
       }
 
@@ -506,7 +506,7 @@ namespace Hl7.Fhir.Model
         if(Device != null) dest.Device = (Hl7.Fhir.Model.ResourceReference)Device.DeepCopy();
         if(ExcludeElement != null) dest.ExcludeElement = (Hl7.Fhir.Model.FhirBoolean)ExcludeElement.DeepCopy();
         if(TimeFromEvent != null) dest.TimeFromEvent = new List<Hl7.Fhir.Model.EvidenceVariable.TimeFromEventComponent>(TimeFromEvent.DeepCopy());
-        if(GroupMeasure_Element != null) dest.GroupMeasure_Element = (Code<Hl7.Fhir.Model.EvidenceVariable.GroupMeasure>)GroupMeasure_Element.DeepCopy();
+        if(GroupMeasureElement != null) dest.GroupMeasureElement = (Code<Hl7.Fhir.Model.EvidenceVariable.GroupMeasureCode>)GroupMeasureElement.DeepCopy();
         return dest;
       }
 
@@ -529,7 +529,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(Device, otherT.Device)) return false;
         if( !DeepComparable.Matches(ExcludeElement, otherT.ExcludeElement)) return false;
         if( !DeepComparable.Matches(TimeFromEvent, otherT.TimeFromEvent)) return false;
-        if( !DeepComparable.Matches(GroupMeasure_Element, otherT.GroupMeasure_Element)) return false;
+        if( !DeepComparable.Matches(GroupMeasureElement, otherT.GroupMeasureElement)) return false;
 
         return true;
       }
@@ -547,7 +547,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(Device, otherT.Device)) return false;
         if( !DeepComparable.IsExactly(ExcludeElement, otherT.ExcludeElement)) return false;
         if( !DeepComparable.IsExactly(TimeFromEvent, otherT.TimeFromEvent)) return false;
-        if( !DeepComparable.IsExactly(GroupMeasure_Element, otherT.GroupMeasure_Element)) return false;
+        if( !DeepComparable.IsExactly(GroupMeasureElement, otherT.GroupMeasureElement)) return false;
 
         return true;
       }
@@ -565,7 +565,7 @@ namespace Hl7.Fhir.Model
           if (Device != null) yield return Device;
           if (ExcludeElement != null) yield return ExcludeElement;
           foreach (var elem in TimeFromEvent) { if (elem != null) yield return elem; }
-          if (GroupMeasure_Element != null) yield return GroupMeasure_Element;
+          if (GroupMeasureElement != null) yield return GroupMeasureElement;
         }
       }
 
@@ -582,7 +582,7 @@ namespace Hl7.Fhir.Model
           if (Device != null) yield return new ElementValue("device", Device);
           if (ExcludeElement != null) yield return new ElementValue("exclude", ExcludeElement);
           foreach (var elem in TimeFromEvent) { if (elem != null) yield return new ElementValue("timeFromEvent", elem); }
-          if (GroupMeasure_Element != null) yield return new ElementValue("groupMeasure", GroupMeasure_Element);
+          if (GroupMeasureElement != null) yield return new ElementValue("groupMeasure", GroupMeasureElement);
         }
       }
 
@@ -612,8 +612,8 @@ namespace Hl7.Fhir.Model
             value = TimeFromEvent;
             return TimeFromEvent?.Any() == true;
           case "groupMeasure":
-            value = GroupMeasure_Element;
-            return GroupMeasure_Element is not null;
+            value = GroupMeasureElement;
+            return GroupMeasureElement is not null;
           default:
             return base.TryGetValue(key, out value);
         };
@@ -630,7 +630,7 @@ namespace Hl7.Fhir.Model
         if (Device is not null) yield return new KeyValuePair<string,object>("device",Device);
         if (ExcludeElement is not null) yield return new KeyValuePair<string,object>("exclude",ExcludeElement);
         if (TimeFromEvent?.Any() == true) yield return new KeyValuePair<string,object>("timeFromEvent",TimeFromEvent);
-        if (GroupMeasure_Element is not null) yield return new KeyValuePair<string,object>("groupMeasure",GroupMeasure_Element);
+        if (GroupMeasureElement is not null) yield return new KeyValuePair<string,object>("groupMeasure",GroupMeasureElement);
       }
 
     }

--- a/src/Hl7.Fhir.R5.Core/Model/Generated/ExplanationOfBenefit.cs
+++ b/src/Hl7.Fhir.R5.Core/Model/Generated/ExplanationOfBenefit.cs
@@ -5898,20 +5898,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.Use> UseElement
+    public Code<Hl7.Fhir.Model.ClaimUseCode> UseElement
     {
       get { return _UseElement; }
       set { _UseElement = value; OnPropertyChanged("UseElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.Use> _UseElement;
+    private Code<Hl7.Fhir.Model.ClaimUseCode> _UseElement;
 
     /// <summary>
     /// claim | preauthorization | predetermination
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.Use? Use
+    public Hl7.Fhir.Model.ClaimUseCode? Use
     {
       get { return UseElement != null ? UseElement.Value : null; }
       set
@@ -5919,7 +5919,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           UseElement = null;
         else
-          UseElement = new Code<Hl7.Fhir.Model.Use>(value);
+          UseElement = new Code<Hl7.Fhir.Model.ClaimUseCode>(value);
         OnPropertyChanged("Use");
       }
     }
@@ -6562,7 +6562,7 @@ namespace Hl7.Fhir.Model
       if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.ExplanationOfBenefit.ExplanationOfBenefitStatus>)StatusElement.DeepCopy();
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
       if(SubType != null) dest.SubType = (Hl7.Fhir.Model.CodeableConcept)SubType.DeepCopy();
-      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.Use>)UseElement.DeepCopy();
+      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.ClaimUseCode>)UseElement.DeepCopy();
       if(Patient != null) dest.Patient = (Hl7.Fhir.Model.ResourceReference)Patient.DeepCopy();
       if(BillablePeriod != null) dest.BillablePeriod = (Hl7.Fhir.Model.Period)BillablePeriod.DeepCopy();
       if(CreatedElement != null) dest.CreatedElement = (Hl7.Fhir.Model.FhirDateTime)CreatedElement.DeepCopy();

--- a/src/Hl7.Fhir.R5.Core/Model/Generated/MedicationRequest.cs
+++ b/src/Hl7.Fhir.R5.Core/Model/Generated/MedicationRequest.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/CodeSystem/medicationrequest-status)
     /// </summary>
     [FhirEnumeration("medicationrequestStatus")]
-    public enum medicationrequestStatus
+    public enum MedicationrequestStatus
     {
       /// <summary>
       /// The request is 'actionable', but not all actions that are implied by it have occurred yet.
@@ -125,7 +125,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/CodeSystem/medicationrequest-intent)
     /// </summary>
     [FhirEnumeration("medicationRequestIntent")]
-    public enum medicationRequestIntent
+    public enum MedicationRequestIntent
     {
       /// <summary>
       /// The request is a suggestion made by someone/something that doesn't have an intention to ensure it occurs and without providing an authorization to act
@@ -1067,20 +1067,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.MedicationRequest.medicationrequestStatus> StatusElement
+    public Code<Hl7.Fhir.Model.MedicationRequest.MedicationrequestStatus> StatusElement
     {
       get { return _StatusElement; }
       set { _StatusElement = value; OnPropertyChanged("StatusElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.MedicationRequest.medicationrequestStatus> _StatusElement;
+    private Code<Hl7.Fhir.Model.MedicationRequest.MedicationrequestStatus> _StatusElement;
 
     /// <summary>
     /// active | on-hold | ended | stopped | completed | cancelled | entered-in-error | draft | unknown
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.MedicationRequest.medicationrequestStatus? Status
+    public Hl7.Fhir.Model.MedicationRequest.MedicationrequestStatus? Status
     {
       get { return StatusElement != null ? StatusElement.Value : null; }
       set
@@ -1088,7 +1088,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           StatusElement = null;
         else
-          StatusElement = new Code<Hl7.Fhir.Model.MedicationRequest.medicationrequestStatus>(value);
+          StatusElement = new Code<Hl7.Fhir.Model.MedicationRequest.MedicationrequestStatus>(value);
         OnPropertyChanged("Status");
       }
     }
@@ -1144,20 +1144,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.MedicationRequest.medicationRequestIntent> IntentElement
+    public Code<Hl7.Fhir.Model.MedicationRequest.MedicationRequestIntent> IntentElement
     {
       get { return _IntentElement; }
       set { _IntentElement = value; OnPropertyChanged("IntentElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.MedicationRequest.medicationRequestIntent> _IntentElement;
+    private Code<Hl7.Fhir.Model.MedicationRequest.MedicationRequestIntent> _IntentElement;
 
     /// <summary>
     /// proposal | plan | order | original-order | reflex-order | filler-order | instance-order | option
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.MedicationRequest.medicationRequestIntent? Intent
+    public Hl7.Fhir.Model.MedicationRequest.MedicationRequestIntent? Intent
     {
       get { return IntentElement != null ? IntentElement.Value : null; }
       set
@@ -1165,7 +1165,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           IntentElement = null;
         else
-          IntentElement = new Code<Hl7.Fhir.Model.MedicationRequest.medicationRequestIntent>(value);
+          IntentElement = new Code<Hl7.Fhir.Model.MedicationRequest.MedicationRequestIntent>(value);
         OnPropertyChanged("Intent");
       }
     }
@@ -1587,10 +1587,10 @@ namespace Hl7.Fhir.Model
       if(BasedOn != null) dest.BasedOn = new List<Hl7.Fhir.Model.ResourceReference>(BasedOn.DeepCopy());
       if(PriorPrescription != null) dest.PriorPrescription = (Hl7.Fhir.Model.ResourceReference)PriorPrescription.DeepCopy();
       if(GroupIdentifier != null) dest.GroupIdentifier = (Hl7.Fhir.Model.Identifier)GroupIdentifier.DeepCopy();
-      if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.MedicationRequest.medicationrequestStatus>)StatusElement.DeepCopy();
+      if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.MedicationRequest.MedicationrequestStatus>)StatusElement.DeepCopy();
       if(StatusReason != null) dest.StatusReason = (Hl7.Fhir.Model.CodeableConcept)StatusReason.DeepCopy();
       if(StatusChangedElement != null) dest.StatusChangedElement = (Hl7.Fhir.Model.FhirDateTime)StatusChangedElement.DeepCopy();
-      if(IntentElement != null) dest.IntentElement = (Code<Hl7.Fhir.Model.MedicationRequest.medicationRequestIntent>)IntentElement.DeepCopy();
+      if(IntentElement != null) dest.IntentElement = (Code<Hl7.Fhir.Model.MedicationRequest.MedicationRequestIntent>)IntentElement.DeepCopy();
       if(Category != null) dest.Category = new List<Hl7.Fhir.Model.CodeableConcept>(Category.DeepCopy());
       if(PriorityElement != null) dest.PriorityElement = (Code<Hl7.Fhir.Model.RequestPriority>)PriorityElement.DeepCopy();
       if(DoNotPerformElement != null) dest.DoNotPerformElement = (Hl7.Fhir.Model.FhirBoolean)DoNotPerformElement.DeepCopy();

--- a/src/Hl7.Fhir.R5.Core/Model/Generated/MessageDefinition.cs
+++ b/src/Hl7.Fhir.R5.Core/Model/Generated/MessageDefinition.cs
@@ -992,20 +992,20 @@ namespace Hl7.Fhir.Model
     [FhirElement("responseRequired", Order=300)]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
-    public Code<Hl7.Fhir.Model.messageheader_response_request> ResponseRequiredElement
+    public Code<Hl7.Fhir.Model.MessageheaderResponseRequest> ResponseRequiredElement
     {
       get { return _ResponseRequiredElement; }
       set { _ResponseRequiredElement = value; OnPropertyChanged("ResponseRequiredElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.messageheader_response_request> _ResponseRequiredElement;
+    private Code<Hl7.Fhir.Model.MessageheaderResponseRequest> _ResponseRequiredElement;
 
     /// <summary>
     /// always | on-error | never | on-success
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.messageheader_response_request? ResponseRequired
+    public Hl7.Fhir.Model.MessageheaderResponseRequest? ResponseRequired
     {
       get { return ResponseRequiredElement != null ? ResponseRequiredElement.Value : null; }
       set
@@ -1013,7 +1013,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           ResponseRequiredElement = null;
         else
-          ResponseRequiredElement = new Code<Hl7.Fhir.Model.messageheader_response_request>(value);
+          ResponseRequiredElement = new Code<Hl7.Fhir.Model.MessageheaderResponseRequest>(value);
         OnPropertyChanged("ResponseRequired");
       }
     }
@@ -1095,7 +1095,7 @@ namespace Hl7.Fhir.Model
       if(Event != null) dest.Event = (Hl7.Fhir.Model.DataType)Event.DeepCopy();
       if(CategoryElement != null) dest.CategoryElement = (Code<Hl7.Fhir.Model.MessageDefinition.MessageSignificanceCategory>)CategoryElement.DeepCopy();
       if(Focus != null) dest.Focus = new List<Hl7.Fhir.Model.MessageDefinition.FocusComponent>(Focus.DeepCopy());
-      if(ResponseRequiredElement != null) dest.ResponseRequiredElement = (Code<Hl7.Fhir.Model.messageheader_response_request>)ResponseRequiredElement.DeepCopy();
+      if(ResponseRequiredElement != null) dest.ResponseRequiredElement = (Code<Hl7.Fhir.Model.MessageheaderResponseRequest>)ResponseRequiredElement.DeepCopy();
       if(AllowedResponse != null) dest.AllowedResponse = new List<Hl7.Fhir.Model.MessageDefinition.AllowedResponseComponent>(AllowedResponse.DeepCopy());
       if(GraphElement != null) dest.GraphElement = new List<Hl7.Fhir.Model.Canonical>(GraphElement.DeepCopy());
       return dest;

--- a/src/Hl7.Fhir.R5.Core/Model/Generated/MolecularSequence.cs
+++ b/src/Hl7.Fhir.R5.Core/Model/Generated/MolecularSequence.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/sequence-type)
     /// </summary>
     [FhirEnumeration("sequenceType")]
-    public enum sequenceType
+    public enum SequenceType
     {
       /// <summary>
       /// Amino acid sequence.
@@ -89,7 +89,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/orientation-type)
     /// </summary>
     [FhirEnumeration("orientationType")]
-    public enum orientationType
+    public enum OrientationType
     {
       /// <summary>
       /// Sense orientation of reference sequence.
@@ -111,7 +111,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/strand-type)
     /// </summary>
     [FhirEnumeration("strandType")]
-    public enum strandType
+    public enum StrandType
     {
       /// <summary>
       /// Watson strand of reference sequence.
@@ -133,7 +133,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/quality-type)
     /// </summary>
     [FhirEnumeration("qualityType")]
-    public enum qualityType
+    public enum QualityType
     {
       /// <summary>
       /// INDEL Comparison.
@@ -161,7 +161,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/repository-type)
     /// </summary>
     [FhirEnumeration("repositoryType")]
-    public enum repositoryType
+    public enum RepositoryType
     {
       /// <summary>
       /// When URL is clicked, the resource can be seen directly (by webpage or by download link format).
@@ -258,20 +258,20 @@ namespace Hl7.Fhir.Model
       [FhirElement("orientation", InSummary=true, Order=60)]
       [DeclaredType(Type = typeof(Code))]
       [DataMember]
-      public Code<Hl7.Fhir.Model.MolecularSequence.orientationType> OrientationElement
+      public Code<Hl7.Fhir.Model.MolecularSequence.OrientationType> OrientationElement
       {
         get { return _OrientationElement; }
         set { _OrientationElement = value; OnPropertyChanged("OrientationElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.MolecularSequence.orientationType> _OrientationElement;
+      private Code<Hl7.Fhir.Model.MolecularSequence.OrientationType> _OrientationElement;
 
       /// <summary>
       /// sense | antisense
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.MolecularSequence.orientationType? Orientation
+      public Hl7.Fhir.Model.MolecularSequence.OrientationType? Orientation
       {
         get { return OrientationElement != null ? OrientationElement.Value : null; }
         set
@@ -279,7 +279,7 @@ namespace Hl7.Fhir.Model
           if (value == null)
             OrientationElement = null;
           else
-            OrientationElement = new Code<Hl7.Fhir.Model.MolecularSequence.orientationType>(value);
+            OrientationElement = new Code<Hl7.Fhir.Model.MolecularSequence.OrientationType>(value);
           OnPropertyChanged("Orientation");
         }
       }
@@ -349,20 +349,20 @@ namespace Hl7.Fhir.Model
       [FhirElement("strand", InSummary=true, Order=100)]
       [DeclaredType(Type = typeof(Code))]
       [DataMember]
-      public Code<Hl7.Fhir.Model.MolecularSequence.strandType> StrandElement
+      public Code<Hl7.Fhir.Model.MolecularSequence.StrandType> StrandElement
       {
         get { return _StrandElement; }
         set { _StrandElement = value; OnPropertyChanged("StrandElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.MolecularSequence.strandType> _StrandElement;
+      private Code<Hl7.Fhir.Model.MolecularSequence.StrandType> _StrandElement;
 
       /// <summary>
       /// watson | crick
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.MolecularSequence.strandType? Strand
+      public Hl7.Fhir.Model.MolecularSequence.StrandType? Strand
       {
         get { return StrandElement != null ? StrandElement.Value : null; }
         set
@@ -370,7 +370,7 @@ namespace Hl7.Fhir.Model
           if (value == null)
             StrandElement = null;
           else
-            StrandElement = new Code<Hl7.Fhir.Model.MolecularSequence.strandType>(value);
+            StrandElement = new Code<Hl7.Fhir.Model.MolecularSequence.StrandType>(value);
           OnPropertyChanged("Strand");
         }
       }
@@ -449,11 +449,11 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(Chromosome != null) dest.Chromosome = (Hl7.Fhir.Model.CodeableConcept)Chromosome.DeepCopy();
         if(GenomeBuildElement != null) dest.GenomeBuildElement = (Hl7.Fhir.Model.FhirString)GenomeBuildElement.DeepCopy();
-        if(OrientationElement != null) dest.OrientationElement = (Code<Hl7.Fhir.Model.MolecularSequence.orientationType>)OrientationElement.DeepCopy();
+        if(OrientationElement != null) dest.OrientationElement = (Code<Hl7.Fhir.Model.MolecularSequence.OrientationType>)OrientationElement.DeepCopy();
         if(ReferenceSeqId != null) dest.ReferenceSeqId = (Hl7.Fhir.Model.CodeableConcept)ReferenceSeqId.DeepCopy();
         if(ReferenceSeqPointer != null) dest.ReferenceSeqPointer = (Hl7.Fhir.Model.ResourceReference)ReferenceSeqPointer.DeepCopy();
         if(ReferenceSeqStringElement != null) dest.ReferenceSeqStringElement = (Hl7.Fhir.Model.FhirString)ReferenceSeqStringElement.DeepCopy();
-        if(StrandElement != null) dest.StrandElement = (Code<Hl7.Fhir.Model.MolecularSequence.strandType>)StrandElement.DeepCopy();
+        if(StrandElement != null) dest.StrandElement = (Code<Hl7.Fhir.Model.MolecularSequence.StrandType>)StrandElement.DeepCopy();
         if(WindowStartElement != null) dest.WindowStartElement = (Hl7.Fhir.Model.Integer)WindowStartElement.DeepCopy();
         if(WindowEndElement != null) dest.WindowEndElement = (Hl7.Fhir.Model.Integer)WindowEndElement.DeepCopy();
         return dest;
@@ -923,20 +923,20 @@ namespace Hl7.Fhir.Model
       [DeclaredType(Type = typeof(Code))]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Code<Hl7.Fhir.Model.MolecularSequence.qualityType> TypeElement
+      public Code<Hl7.Fhir.Model.MolecularSequence.QualityType> TypeElement
       {
         get { return _TypeElement; }
         set { _TypeElement = value; OnPropertyChanged("TypeElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.MolecularSequence.qualityType> _TypeElement;
+      private Code<Hl7.Fhir.Model.MolecularSequence.QualityType> _TypeElement;
 
       /// <summary>
       /// indel | snp | unknown
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.MolecularSequence.qualityType? Type
+      public Hl7.Fhir.Model.MolecularSequence.QualityType? Type
       {
         get { return TypeElement != null ? TypeElement.Value : null; }
         set
@@ -944,7 +944,7 @@ namespace Hl7.Fhir.Model
           if (value == null)
             TypeElement = null;
           else
-            TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.qualityType>(value);
+            TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.QualityType>(value);
           OnPropertyChanged("Type");
         }
       }
@@ -1321,7 +1321,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.qualityType>)TypeElement.DeepCopy();
+        if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.QualityType>)TypeElement.DeepCopy();
         if(StandardSequence != null) dest.StandardSequence = (Hl7.Fhir.Model.CodeableConcept)StandardSequence.DeepCopy();
         if(StartElement != null) dest.StartElement = (Hl7.Fhir.Model.Integer)StartElement.DeepCopy();
         if(EndElement != null) dest.EndElement = (Hl7.Fhir.Model.Integer)EndElement.DeepCopy();
@@ -1914,20 +1914,20 @@ namespace Hl7.Fhir.Model
       [DeclaredType(Type = typeof(Code))]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Code<Hl7.Fhir.Model.MolecularSequence.repositoryType> TypeElement
+      public Code<Hl7.Fhir.Model.MolecularSequence.RepositoryType> TypeElement
       {
         get { return _TypeElement; }
         set { _TypeElement = value; OnPropertyChanged("TypeElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.MolecularSequence.repositoryType> _TypeElement;
+      private Code<Hl7.Fhir.Model.MolecularSequence.RepositoryType> _TypeElement;
 
       /// <summary>
       /// directlink | openapi | login | oauth | other
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.MolecularSequence.repositoryType? Type
+      public Hl7.Fhir.Model.MolecularSequence.RepositoryType? Type
       {
         get { return TypeElement != null ? TypeElement.Value : null; }
         set
@@ -1935,7 +1935,7 @@ namespace Hl7.Fhir.Model
           if (value == null)
             TypeElement = null;
           else
-            TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.repositoryType>(value);
+            TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.RepositoryType>(value);
           OnPropertyChanged("Type");
         }
       }
@@ -2105,7 +2105,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.repositoryType>)TypeElement.DeepCopy();
+        if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.RepositoryType>)TypeElement.DeepCopy();
         if(UrlElement != null) dest.UrlElement = (Hl7.Fhir.Model.FhirUri)UrlElement.DeepCopy();
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
         if(DatasetIdElement != null) dest.DatasetIdElement = (Hl7.Fhir.Model.FhirString)DatasetIdElement.DeepCopy();
@@ -2810,20 +2810,20 @@ namespace Hl7.Fhir.Model
     [FhirElement("type", InSummary=true, Order=100)]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
-    public Code<Hl7.Fhir.Model.MolecularSequence.sequenceType> TypeElement
+    public Code<Hl7.Fhir.Model.MolecularSequence.SequenceType> TypeElement
     {
       get { return _TypeElement; }
       set { _TypeElement = value; OnPropertyChanged("TypeElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.MolecularSequence.sequenceType> _TypeElement;
+    private Code<Hl7.Fhir.Model.MolecularSequence.SequenceType> _TypeElement;
 
     /// <summary>
     /// aa | dna | rna
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.MolecularSequence.sequenceType? Type
+    public Hl7.Fhir.Model.MolecularSequence.SequenceType? Type
     {
       get { return TypeElement != null ? TypeElement.Value : null; }
       set
@@ -2831,7 +2831,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           TypeElement = null;
         else
-          TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.sequenceType>(value);
+          TypeElement = new Code<Hl7.Fhir.Model.MolecularSequence.SequenceType>(value);
         OnPropertyChanged("Type");
       }
     }
@@ -3099,7 +3099,7 @@ namespace Hl7.Fhir.Model
 
       base.CopyTo(dest);
       if(Identifier != null) dest.Identifier = new List<Hl7.Fhir.Model.Identifier>(Identifier.DeepCopy());
-      if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.sequenceType>)TypeElement.DeepCopy();
+      if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.MolecularSequence.SequenceType>)TypeElement.DeepCopy();
       if(CoordinateSystemElement != null) dest.CoordinateSystemElement = (Hl7.Fhir.Model.Integer)CoordinateSystemElement.DeepCopy();
       if(Patient != null) dest.Patient = (Hl7.Fhir.Model.ResourceReference)Patient.DeepCopy();
       if(Specimen != null) dest.Specimen = (Hl7.Fhir.Model.ResourceReference)Specimen.DeepCopy();

--- a/src/Hl7.Fhir.R5.Core/Model/Generated/Template-Bindings.cs
+++ b/src/Hl7.Fhir.R5.Core/Model/Generated/Template-Bindings.cs
@@ -3796,7 +3796,7 @@ namespace Hl7.Fhir.Model
   /// (system: http://hl7.org/fhir/messageheader-response-request)
   /// </summary>
   [FhirEnumeration("messageheader-response-request")]
-  public enum messageheader_response_request
+  public enum MessageheaderResponseRequest
   {
     /// <summary>
     /// initiator expects a response for this message.

--- a/src/Hl7.Fhir.R5.Core/Model/Generated/Template-Bindings.cs
+++ b/src/Hl7.Fhir.R5.Core/Model/Generated/Template-Bindings.cs
@@ -1789,7 +1789,7 @@ namespace Hl7.Fhir.Model
   /// (system: http://hl7.org/fhir/claim-use)
   /// </summary>
   [FhirEnumeration("Use")]
-  public enum Use
+  public enum ClaimUseCode
   {
     /// <summary>
     /// The treatment is complete and this represents a Claim for the services.

--- a/src/Hl7.Fhir.R5.Core/Model/Generated/VerificationResult.cs
+++ b/src/Hl7.Fhir.R5.Core/Model/Generated/VerificationResult.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/CodeSystem/verificationresult-status)
     /// </summary>
     [FhirEnumeration("status")]
-    public enum Status
+    public enum StatusCode
     {
       /// <summary>
       /// ***TODO***
@@ -928,29 +928,29 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.VerificationResult.Status> Status_Element
+    public Code<Hl7.Fhir.Model.VerificationResult.StatusCode> StatusElement
     {
-      get { return _Status_Element; }
-      set { _Status_Element = value; OnPropertyChanged("Status_Element"); }
+      get { return _StatusElement; }
+      set { _StatusElement = value; OnPropertyChanged("StatusElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.VerificationResult.Status> _Status_Element;
+    private Code<Hl7.Fhir.Model.VerificationResult.StatusCode> _StatusElement;
 
     /// <summary>
     /// attested | validated | in-process | req-revalid | val-fail | reval-fail
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.VerificationResult.Status? Status_
+    public Hl7.Fhir.Model.VerificationResult.StatusCode? Status
     {
-      get { return Status_Element != null ? Status_Element.Value : null; }
+      get { return StatusElement != null ? StatusElement.Value : null; }
       set
       {
         if (value == null)
-          Status_Element = null;
+          StatusElement = null;
         else
-          Status_Element = new Code<Hl7.Fhir.Model.VerificationResult.Status>(value);
-        OnPropertyChanged("Status_");
+          StatusElement = new Code<Hl7.Fhir.Model.VerificationResult.StatusCode>(value);
+        OnPropertyChanged("Status");
       }
     }
 
@@ -1154,7 +1154,7 @@ namespace Hl7.Fhir.Model
       if(Target != null) dest.Target = new List<Hl7.Fhir.Model.ResourceReference>(Target.DeepCopy());
       if(TargetLocationElement != null) dest.TargetLocationElement = new List<Hl7.Fhir.Model.FhirString>(TargetLocationElement.DeepCopy());
       if(Need != null) dest.Need = (Hl7.Fhir.Model.CodeableConcept)Need.DeepCopy();
-      if(Status_Element != null) dest.Status_Element = (Code<Hl7.Fhir.Model.VerificationResult.Status>)Status_Element.DeepCopy();
+      if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.VerificationResult.StatusCode>)StatusElement.DeepCopy();
       if(StatusDateElement != null) dest.StatusDateElement = (Hl7.Fhir.Model.FhirDateTime)StatusDateElement.DeepCopy();
       if(ValidationType != null) dest.ValidationType = (Hl7.Fhir.Model.CodeableConcept)ValidationType.DeepCopy();
       if(ValidationProcess != null) dest.ValidationProcess = new List<Hl7.Fhir.Model.CodeableConcept>(ValidationProcess.DeepCopy());
@@ -1183,7 +1183,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Target, otherT.Target)) return false;
       if( !DeepComparable.Matches(TargetLocationElement, otherT.TargetLocationElement)) return false;
       if( !DeepComparable.Matches(Need, otherT.Need)) return false;
-      if( !DeepComparable.Matches(Status_Element, otherT.Status_Element)) return false;
+      if( !DeepComparable.Matches(StatusElement, otherT.StatusElement)) return false;
       if( !DeepComparable.Matches(StatusDateElement, otherT.StatusDateElement)) return false;
       if( !DeepComparable.Matches(ValidationType, otherT.ValidationType)) return false;
       if( !DeepComparable.Matches(ValidationProcess, otherT.ValidationProcess)) return false;
@@ -1207,7 +1207,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Target, otherT.Target)) return false;
       if( !DeepComparable.IsExactly(TargetLocationElement, otherT.TargetLocationElement)) return false;
       if( !DeepComparable.IsExactly(Need, otherT.Need)) return false;
-      if( !DeepComparable.IsExactly(Status_Element, otherT.Status_Element)) return false;
+      if( !DeepComparable.IsExactly(StatusElement, otherT.StatusElement)) return false;
       if( !DeepComparable.IsExactly(StatusDateElement, otherT.StatusDateElement)) return false;
       if( !DeepComparable.IsExactly(ValidationType, otherT.ValidationType)) return false;
       if( !DeepComparable.IsExactly(ValidationProcess, otherT.ValidationProcess)) return false;
@@ -1231,7 +1231,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Target) { if (elem != null) yield return elem; }
         foreach (var elem in TargetLocationElement) { if (elem != null) yield return elem; }
         if (Need != null) yield return Need;
-        if (Status_Element != null) yield return Status_Element;
+        if (StatusElement != null) yield return StatusElement;
         if (StatusDateElement != null) yield return StatusDateElement;
         if (ValidationType != null) yield return ValidationType;
         foreach (var elem in ValidationProcess) { if (elem != null) yield return elem; }
@@ -1254,7 +1254,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Target) { if (elem != null) yield return new ElementValue("target", elem); }
         foreach (var elem in TargetLocationElement) { if (elem != null) yield return new ElementValue("targetLocation", elem); }
         if (Need != null) yield return new ElementValue("need", Need);
-        if (Status_Element != null) yield return new ElementValue("status", Status_Element);
+        if (StatusElement != null) yield return new ElementValue("status", StatusElement);
         if (StatusDateElement != null) yield return new ElementValue("statusDate", StatusDateElement);
         if (ValidationType != null) yield return new ElementValue("validationType", ValidationType);
         foreach (var elem in ValidationProcess) { if (elem != null) yield return new ElementValue("validationProcess", elem); }
@@ -1282,8 +1282,8 @@ namespace Hl7.Fhir.Model
           value = Need;
           return Need is not null;
         case "status":
-          value = Status_Element;
-          return Status_Element is not null;
+          value = StatusElement;
+          return StatusElement is not null;
         case "statusDate":
           value = StatusDateElement;
           return StatusDateElement is not null;
@@ -1326,7 +1326,7 @@ namespace Hl7.Fhir.Model
       if (Target?.Any() == true) yield return new KeyValuePair<string,object>("target",Target);
       if (TargetLocationElement?.Any() == true) yield return new KeyValuePair<string,object>("targetLocation",TargetLocationElement);
       if (Need is not null) yield return new KeyValuePair<string,object>("need",Need);
-      if (Status_Element is not null) yield return new KeyValuePair<string,object>("status",Status_Element);
+      if (StatusElement is not null) yield return new KeyValuePair<string,object>("status",StatusElement);
       if (StatusDateElement is not null) yield return new KeyValuePair<string,object>("statusDate",StatusDateElement);
       if (ValidationType is not null) yield return new KeyValuePair<string,object>("validationType",ValidationType);
       if (ValidationProcess?.Any() == true) yield return new KeyValuePair<string,object>("validationProcess",ValidationProcess);

--- a/src/Hl7.Fhir.R5.Core/Model/Generated/VerificationResult.cs
+++ b/src/Hl7.Fhir.R5.Core/Model/Generated/VerificationResult.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/CodeSystem/verificationresult-status)
     /// </summary>
     [FhirEnumeration("status")]
-    public enum status
+    public enum Status
     {
       /// <summary>
       /// ***TODO***
@@ -928,20 +928,20 @@ namespace Hl7.Fhir.Model
     [DeclaredType(Type = typeof(Code))]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Code<Hl7.Fhir.Model.VerificationResult.status> Status_Element
+    public Code<Hl7.Fhir.Model.VerificationResult.Status> Status_Element
     {
       get { return _Status_Element; }
       set { _Status_Element = value; OnPropertyChanged("Status_Element"); }
     }
 
-    private Code<Hl7.Fhir.Model.VerificationResult.status> _Status_Element;
+    private Code<Hl7.Fhir.Model.VerificationResult.Status> _Status_Element;
 
     /// <summary>
     /// attested | validated | in-process | req-revalid | val-fail | reval-fail
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.VerificationResult.status? Status_
+    public Hl7.Fhir.Model.VerificationResult.Status? Status_
     {
       get { return Status_Element != null ? Status_Element.Value : null; }
       set
@@ -949,7 +949,7 @@ namespace Hl7.Fhir.Model
         if (value == null)
           Status_Element = null;
         else
-          Status_Element = new Code<Hl7.Fhir.Model.VerificationResult.status>(value);
+          Status_Element = new Code<Hl7.Fhir.Model.VerificationResult.Status>(value);
         OnPropertyChanged("Status_");
       }
     }
@@ -1154,7 +1154,7 @@ namespace Hl7.Fhir.Model
       if(Target != null) dest.Target = new List<Hl7.Fhir.Model.ResourceReference>(Target.DeepCopy());
       if(TargetLocationElement != null) dest.TargetLocationElement = new List<Hl7.Fhir.Model.FhirString>(TargetLocationElement.DeepCopy());
       if(Need != null) dest.Need = (Hl7.Fhir.Model.CodeableConcept)Need.DeepCopy();
-      if(Status_Element != null) dest.Status_Element = (Code<Hl7.Fhir.Model.VerificationResult.status>)Status_Element.DeepCopy();
+      if(Status_Element != null) dest.Status_Element = (Code<Hl7.Fhir.Model.VerificationResult.Status>)Status_Element.DeepCopy();
       if(StatusDateElement != null) dest.StatusDateElement = (Hl7.Fhir.Model.FhirDateTime)StatusDateElement.DeepCopy();
       if(ValidationType != null) dest.ValidationType = (Hl7.Fhir.Model.CodeableConcept)ValidationType.DeepCopy();
       if(ValidationProcess != null) dest.ValidationProcess = new List<Hl7.Fhir.Model.CodeableConcept>(ValidationProcess.DeepCopy());

--- a/src/Hl7.Fhir.R5.Core/Model/Generated/_GeneratorLog.cs
+++ b/src/Hl7.Fhir.R5.Core/Model/Generated/_GeneratorLog.cs
@@ -66,7 +66,7 @@
   // Used in model class (resource): ClaimResponse.outcome
   // Used in model class (resource): ExplanationOfBenefit.outcome
 
-// Generated Shared Enumeration: Use (http://hl7.org/fhir/ValueSet/claim-use)
+// Generated Shared Enumeration: ClaimUseCode (http://hl7.org/fhir/ValueSet/claim-use)
   // Used in model class (resource): Claim.use
   // Used in model class (resource): ClaimResponse.use
   // Used in model class (resource): ExplanationOfBenefit.use

--- a/src/Hl7.Fhir.R5.Core/Model/Generated/_GeneratorLog.cs
+++ b/src/Hl7.Fhir.R5.Core/Model/Generated/_GeneratorLog.cs
@@ -174,7 +174,7 @@
   // Used in model class (resource): Measure.group.improvementNotation
   // Used in model class (resource): MeasureReport.improvementNotation
 
-// Generated Shared Enumeration: messageheader_response_request (http://hl7.org/fhir/ValueSet/messageheader-response-request)
+// Generated Shared Enumeration: MessageheaderResponseRequest (http://hl7.org/fhir/ValueSet/messageheader-response-request)
   // Used in model class (resource): MessageDefinition.responseRequired
   // Used in model class (type): Extension.value[x]
 

--- a/src/Hl7.Fhir.STU3.Core/Model/Generated/Claim.cs
+++ b/src/Hl7.Fhir.STU3.Core/Model/Generated/Claim.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/claim-use)
     /// </summary>
     [FhirEnumeration("Use")]
-    public enum Use
+    public enum ClaimUseCode
     {
       /// <summary>
       /// The treatment is complete and this represents a Claim for the services.
@@ -3273,29 +3273,29 @@ namespace Hl7.Fhir.Model
     [FhirElement("use", Order=130)]
     [DeclaredType(Type = typeof(Code))]
     [DataMember]
-    public Code<Hl7.Fhir.Model.Claim.Use> Use_Element
+    public Code<Hl7.Fhir.Model.Claim.ClaimUseCode> UseElement
     {
-      get { return _Use_Element; }
-      set { _Use_Element = value; OnPropertyChanged("Use_Element"); }
+      get { return _UseElement; }
+      set { _UseElement = value; OnPropertyChanged("UseElement"); }
     }
 
-    private Code<Hl7.Fhir.Model.Claim.Use> _Use_Element;
+    private Code<Hl7.Fhir.Model.Claim.ClaimUseCode> _UseElement;
 
     /// <summary>
     /// complete | proposed | exploratory | other
     /// </summary>
     /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
     [IgnoreDataMember]
-    public Hl7.Fhir.Model.Claim.Use? Use_
+    public Hl7.Fhir.Model.Claim.ClaimUseCode? Use
     {
-      get { return Use_Element != null ? Use_Element.Value : null; }
+      get { return UseElement != null ? UseElement.Value : null; }
       set
       {
         if (value == null)
-          Use_Element = null;
+          UseElement = null;
         else
-          Use_Element = new Code<Hl7.Fhir.Model.Claim.Use>(value);
-        OnPropertyChanged("Use_");
+          UseElement = new Code<Hl7.Fhir.Model.Claim.ClaimUseCode>(value);
+        OnPropertyChanged("Use");
       }
     }
 
@@ -3681,7 +3681,7 @@ namespace Hl7.Fhir.Model
       if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.FinancialResourceStatusCodes>)StatusElement.DeepCopy();
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
       if(SubType != null) dest.SubType = new List<Hl7.Fhir.Model.CodeableConcept>(SubType.DeepCopy());
-      if(Use_Element != null) dest.Use_Element = (Code<Hl7.Fhir.Model.Claim.Use>)Use_Element.DeepCopy();
+      if(UseElement != null) dest.UseElement = (Code<Hl7.Fhir.Model.Claim.ClaimUseCode>)UseElement.DeepCopy();
       if(Patient != null) dest.Patient = (Hl7.Fhir.Model.ResourceReference)Patient.DeepCopy();
       if(BillablePeriod != null) dest.BillablePeriod = (Hl7.Fhir.Model.Period)BillablePeriod.DeepCopy();
       if(CreatedElement != null) dest.CreatedElement = (Hl7.Fhir.Model.FhirDateTime)CreatedElement.DeepCopy();
@@ -3726,7 +3726,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(StatusElement, otherT.StatusElement)) return false;
       if( !DeepComparable.Matches(Type, otherT.Type)) return false;
       if( !DeepComparable.Matches(SubType, otherT.SubType)) return false;
-      if( !DeepComparable.Matches(Use_Element, otherT.Use_Element)) return false;
+      if( !DeepComparable.Matches(UseElement, otherT.UseElement)) return false;
       if( !DeepComparable.Matches(Patient, otherT.Patient)) return false;
       if( !DeepComparable.Matches(BillablePeriod, otherT.BillablePeriod)) return false;
       if( !DeepComparable.Matches(CreatedElement, otherT.CreatedElement)) return false;
@@ -3766,7 +3766,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(StatusElement, otherT.StatusElement)) return false;
       if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
       if( !DeepComparable.IsExactly(SubType, otherT.SubType)) return false;
-      if( !DeepComparable.IsExactly(Use_Element, otherT.Use_Element)) return false;
+      if( !DeepComparable.IsExactly(UseElement, otherT.UseElement)) return false;
       if( !DeepComparable.IsExactly(Patient, otherT.Patient)) return false;
       if( !DeepComparable.IsExactly(BillablePeriod, otherT.BillablePeriod)) return false;
       if( !DeepComparable.IsExactly(CreatedElement, otherT.CreatedElement)) return false;
@@ -3806,7 +3806,7 @@ namespace Hl7.Fhir.Model
         if (StatusElement != null) yield return StatusElement;
         if (Type != null) yield return Type;
         foreach (var elem in SubType) { if (elem != null) yield return elem; }
-        if (Use_Element != null) yield return Use_Element;
+        if (UseElement != null) yield return UseElement;
         if (Patient != null) yield return Patient;
         if (BillablePeriod != null) yield return BillablePeriod;
         if (CreatedElement != null) yield return CreatedElement;
@@ -3845,7 +3845,7 @@ namespace Hl7.Fhir.Model
         if (StatusElement != null) yield return new ElementValue("status", StatusElement);
         if (Type != null) yield return new ElementValue("type", Type);
         foreach (var elem in SubType) { if (elem != null) yield return new ElementValue("subType", elem); }
-        if (Use_Element != null) yield return new ElementValue("use", Use_Element);
+        if (UseElement != null) yield return new ElementValue("use", UseElement);
         if (Patient != null) yield return new ElementValue("patient", Patient);
         if (BillablePeriod != null) yield return new ElementValue("billablePeriod", BillablePeriod);
         if (CreatedElement != null) yield return new ElementValue("created", CreatedElement);
@@ -3891,8 +3891,8 @@ namespace Hl7.Fhir.Model
           value = SubType;
           return SubType?.Any() == true;
         case "use":
-          value = Use_Element;
-          return Use_Element is not null;
+          value = UseElement;
+          return UseElement is not null;
         case "patient":
           value = Patient;
           return Patient is not null;
@@ -3981,7 +3981,7 @@ namespace Hl7.Fhir.Model
       if (StatusElement is not null) yield return new KeyValuePair<string,object>("status",StatusElement);
       if (Type is not null) yield return new KeyValuePair<string,object>("type",Type);
       if (SubType?.Any() == true) yield return new KeyValuePair<string,object>("subType",SubType);
-      if (Use_Element is not null) yield return new KeyValuePair<string,object>("use",Use_Element);
+      if (UseElement is not null) yield return new KeyValuePair<string,object>("use",UseElement);
       if (Patient is not null) yield return new KeyValuePair<string,object>("patient",Patient);
       if (BillablePeriod is not null) yield return new KeyValuePair<string,object>("billablePeriod",BillablePeriod);
       if (CreatedElement is not null) yield return new KeyValuePair<string,object>("created",CreatedElement);

--- a/src/Hl7.Fhir.STU3.Core/Model/Generated/Sequence.cs
+++ b/src/Hl7.Fhir.STU3.Core/Model/Generated/Sequence.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/quality-type)
     /// </summary>
     [FhirEnumeration("qualityType")]
-    public enum qualityType
+    public enum QualityType
     {
       /// <summary>
       /// INDEL Comparison
@@ -89,7 +89,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/repository-type)
     /// </summary>
     [FhirEnumeration("repositoryType")]
-    public enum repositoryType
+    public enum RepositoryType
     {
       /// <summary>
       /// When URL is clicked, the resource can be seen directly (by webpage or by download link format)
@@ -811,20 +811,20 @@ namespace Hl7.Fhir.Model
       [DeclaredType(Type = typeof(Code))]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Code<Hl7.Fhir.Model.Sequence.qualityType> TypeElement
+      public Code<Hl7.Fhir.Model.Sequence.QualityType> TypeElement
       {
         get { return _TypeElement; }
         set { _TypeElement = value; OnPropertyChanged("TypeElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.Sequence.qualityType> _TypeElement;
+      private Code<Hl7.Fhir.Model.Sequence.QualityType> _TypeElement;
 
       /// <summary>
       /// indel | snp | unknown
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.Sequence.qualityType? Type
+      public Hl7.Fhir.Model.Sequence.QualityType? Type
       {
         get { return TypeElement != null ? TypeElement.Value : null; }
         set
@@ -832,7 +832,7 @@ namespace Hl7.Fhir.Model
           if (value == null)
             TypeElement = null;
           else
-            TypeElement = new Code<Hl7.Fhir.Model.Sequence.qualityType>(value);
+            TypeElement = new Code<Hl7.Fhir.Model.Sequence.QualityType>(value);
           OnPropertyChanged("Type");
         }
       }
@@ -1196,7 +1196,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.Sequence.qualityType>)TypeElement.DeepCopy();
+        if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.Sequence.QualityType>)TypeElement.DeepCopy();
         if(StandardSequence != null) dest.StandardSequence = (Hl7.Fhir.Model.CodeableConcept)StandardSequence.DeepCopy();
         if(StartElement != null) dest.StartElement = (Hl7.Fhir.Model.Integer)StartElement.DeepCopy();
         if(EndElement != null) dest.EndElement = (Hl7.Fhir.Model.Integer)EndElement.DeepCopy();
@@ -1406,20 +1406,20 @@ namespace Hl7.Fhir.Model
       [DeclaredType(Type = typeof(Code))]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Code<Hl7.Fhir.Model.Sequence.repositoryType> TypeElement
+      public Code<Hl7.Fhir.Model.Sequence.RepositoryType> TypeElement
       {
         get { return _TypeElement; }
         set { _TypeElement = value; OnPropertyChanged("TypeElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.Sequence.repositoryType> _TypeElement;
+      private Code<Hl7.Fhir.Model.Sequence.RepositoryType> _TypeElement;
 
       /// <summary>
       /// directlink | openapi | login | oauth | other
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.Sequence.repositoryType? Type
+      public Hl7.Fhir.Model.Sequence.RepositoryType? Type
       {
         get { return TypeElement != null ? TypeElement.Value : null; }
         set
@@ -1427,7 +1427,7 @@ namespace Hl7.Fhir.Model
           if (value == null)
             TypeElement = null;
           else
-            TypeElement = new Code<Hl7.Fhir.Model.Sequence.repositoryType>(value);
+            TypeElement = new Code<Hl7.Fhir.Model.Sequence.RepositoryType>(value);
           OnPropertyChanged("Type");
         }
       }
@@ -1597,7 +1597,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.Sequence.repositoryType>)TypeElement.DeepCopy();
+        if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.Sequence.RepositoryType>)TypeElement.DeepCopy();
         if(UrlElement != null) dest.UrlElement = (Hl7.Fhir.Model.FhirUri)UrlElement.DeepCopy();
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
         if(DatasetIdElement != null) dest.DatasetIdElement = (Hl7.Fhir.Model.FhirString)DatasetIdElement.DeepCopy();

--- a/src/Hl7.Fhir.STU3.Core/Model/Generated/TestScript.cs
+++ b/src/Hl7.Fhir.STU3.Core/Model/Generated/TestScript.cs
@@ -61,7 +61,7 @@ namespace Hl7.Fhir.Model
     /// (system: http://hl7.org/fhir/content-type)
     /// </summary>
     [FhirEnumeration("ContentType")]
-    public enum ContentType
+    public enum ContentTypeCode
     {
       /// <summary>
       /// XML content-type corresponding to the application/fhir+xml mime-type.
@@ -2995,20 +2995,20 @@ namespace Hl7.Fhir.Model
       [FhirElement("accept", Order=80)]
       [DeclaredType(Type = typeof(Code))]
       [DataMember]
-      public Code<Hl7.Fhir.Model.TestScript.ContentType> AcceptElement
+      public Code<Hl7.Fhir.Model.TestScript.ContentTypeCode> AcceptElement
       {
         get { return _AcceptElement; }
         set { _AcceptElement = value; OnPropertyChanged("AcceptElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.TestScript.ContentType> _AcceptElement;
+      private Code<Hl7.Fhir.Model.TestScript.ContentTypeCode> _AcceptElement;
 
       /// <summary>
       /// xml | json | ttl | none
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.TestScript.ContentType? Accept
+      public Hl7.Fhir.Model.TestScript.ContentTypeCode? Accept
       {
         get { return AcceptElement != null ? AcceptElement.Value : null; }
         set
@@ -3016,7 +3016,7 @@ namespace Hl7.Fhir.Model
           if (value == null)
             AcceptElement = null;
           else
-            AcceptElement = new Code<Hl7.Fhir.Model.TestScript.ContentType>(value);
+            AcceptElement = new Code<Hl7.Fhir.Model.TestScript.ContentTypeCode>(value);
           OnPropertyChanged("Accept");
         }
       }
@@ -3027,29 +3027,29 @@ namespace Hl7.Fhir.Model
       [FhirElement("contentType", Order=90)]
       [DeclaredType(Type = typeof(Code))]
       [DataMember]
-      public Code<Hl7.Fhir.Model.TestScript.ContentType> ContentType_Element
+      public Code<Hl7.Fhir.Model.TestScript.ContentTypeCode> ContentTypeElement
       {
-        get { return _ContentType_Element; }
-        set { _ContentType_Element = value; OnPropertyChanged("ContentType_Element"); }
+        get { return _ContentTypeElement; }
+        set { _ContentTypeElement = value; OnPropertyChanged("ContentTypeElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.TestScript.ContentType> _ContentType_Element;
+      private Code<Hl7.Fhir.Model.TestScript.ContentTypeCode> _ContentTypeElement;
 
       /// <summary>
       /// xml | json | ttl | none
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.TestScript.ContentType? ContentType_
+      public Hl7.Fhir.Model.TestScript.ContentTypeCode? ContentType
       {
-        get { return ContentType_Element != null ? ContentType_Element.Value : null; }
+        get { return ContentTypeElement != null ? ContentTypeElement.Value : null; }
         set
         {
           if (value == null)
-            ContentType_Element = null;
+            ContentTypeElement = null;
           else
-            ContentType_Element = new Code<Hl7.Fhir.Model.TestScript.ContentType>(value);
-          OnPropertyChanged("ContentType_");
+            ContentTypeElement = new Code<Hl7.Fhir.Model.TestScript.ContentTypeCode>(value);
+          OnPropertyChanged("ContentType");
         }
       }
 
@@ -3360,8 +3360,8 @@ namespace Hl7.Fhir.Model
         if(ResourceElement != null) dest.ResourceElement = (Code<Hl7.Fhir.Model.FHIRDefinedType>)ResourceElement.DeepCopy();
         if(LabelElement != null) dest.LabelElement = (Hl7.Fhir.Model.FhirString)LabelElement.DeepCopy();
         if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.FhirString)DescriptionElement.DeepCopy();
-        if(AcceptElement != null) dest.AcceptElement = (Code<Hl7.Fhir.Model.TestScript.ContentType>)AcceptElement.DeepCopy();
-        if(ContentType_Element != null) dest.ContentType_Element = (Code<Hl7.Fhir.Model.TestScript.ContentType>)ContentType_Element.DeepCopy();
+        if(AcceptElement != null) dest.AcceptElement = (Code<Hl7.Fhir.Model.TestScript.ContentTypeCode>)AcceptElement.DeepCopy();
+        if(ContentTypeElement != null) dest.ContentTypeElement = (Code<Hl7.Fhir.Model.TestScript.ContentTypeCode>)ContentTypeElement.DeepCopy();
         if(DestinationElement != null) dest.DestinationElement = (Hl7.Fhir.Model.Integer)DestinationElement.DeepCopy();
         if(EncodeRequestUrlElement != null) dest.EncodeRequestUrlElement = (Hl7.Fhir.Model.FhirBoolean)EncodeRequestUrlElement.DeepCopy();
         if(OriginElement != null) dest.OriginElement = (Hl7.Fhir.Model.Integer)OriginElement.DeepCopy();
@@ -3392,7 +3392,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(LabelElement, otherT.LabelElement)) return false;
         if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(AcceptElement, otherT.AcceptElement)) return false;
-        if( !DeepComparable.Matches(ContentType_Element, otherT.ContentType_Element)) return false;
+        if( !DeepComparable.Matches(ContentTypeElement, otherT.ContentTypeElement)) return false;
         if( !DeepComparable.Matches(DestinationElement, otherT.DestinationElement)) return false;
         if( !DeepComparable.Matches(EncodeRequestUrlElement, otherT.EncodeRequestUrlElement)) return false;
         if( !DeepComparable.Matches(OriginElement, otherT.OriginElement)) return false;
@@ -3418,7 +3418,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(LabelElement, otherT.LabelElement)) return false;
         if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(AcceptElement, otherT.AcceptElement)) return false;
-        if( !DeepComparable.IsExactly(ContentType_Element, otherT.ContentType_Element)) return false;
+        if( !DeepComparable.IsExactly(ContentTypeElement, otherT.ContentTypeElement)) return false;
         if( !DeepComparable.IsExactly(DestinationElement, otherT.DestinationElement)) return false;
         if( !DeepComparable.IsExactly(EncodeRequestUrlElement, otherT.EncodeRequestUrlElement)) return false;
         if( !DeepComparable.IsExactly(OriginElement, otherT.OriginElement)) return false;
@@ -3444,7 +3444,7 @@ namespace Hl7.Fhir.Model
           if (LabelElement != null) yield return LabelElement;
           if (DescriptionElement != null) yield return DescriptionElement;
           if (AcceptElement != null) yield return AcceptElement;
-          if (ContentType_Element != null) yield return ContentType_Element;
+          if (ContentTypeElement != null) yield return ContentTypeElement;
           if (DestinationElement != null) yield return DestinationElement;
           if (EncodeRequestUrlElement != null) yield return EncodeRequestUrlElement;
           if (OriginElement != null) yield return OriginElement;
@@ -3469,7 +3469,7 @@ namespace Hl7.Fhir.Model
           if (LabelElement != null) yield return new ElementValue("label", LabelElement);
           if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (AcceptElement != null) yield return new ElementValue("accept", AcceptElement);
-          if (ContentType_Element != null) yield return new ElementValue("contentType", ContentType_Element);
+          if (ContentTypeElement != null) yield return new ElementValue("contentType", ContentTypeElement);
           if (DestinationElement != null) yield return new ElementValue("destination", DestinationElement);
           if (EncodeRequestUrlElement != null) yield return new ElementValue("encodeRequestUrl", EncodeRequestUrlElement);
           if (OriginElement != null) yield return new ElementValue("origin", OriginElement);
@@ -3503,8 +3503,8 @@ namespace Hl7.Fhir.Model
             value = AcceptElement;
             return AcceptElement is not null;
           case "contentType":
-            value = ContentType_Element;
-            return ContentType_Element is not null;
+            value = ContentTypeElement;
+            return ContentTypeElement is not null;
           case "destination":
             value = DestinationElement;
             return DestinationElement is not null;
@@ -3549,7 +3549,7 @@ namespace Hl7.Fhir.Model
         if (LabelElement is not null) yield return new KeyValuePair<string,object>("label",LabelElement);
         if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (AcceptElement is not null) yield return new KeyValuePair<string,object>("accept",AcceptElement);
-        if (ContentType_Element is not null) yield return new KeyValuePair<string,object>("contentType",ContentType_Element);
+        if (ContentTypeElement is not null) yield return new KeyValuePair<string,object>("contentType",ContentTypeElement);
         if (DestinationElement is not null) yield return new KeyValuePair<string,object>("destination",DestinationElement);
         if (EncodeRequestUrlElement is not null) yield return new KeyValuePair<string,object>("encodeRequestUrl",EncodeRequestUrlElement);
         if (OriginElement is not null) yield return new KeyValuePair<string,object>("origin",OriginElement);
@@ -3939,29 +3939,29 @@ namespace Hl7.Fhir.Model
       [FhirElement("contentType", Order=100)]
       [DeclaredType(Type = typeof(Code))]
       [DataMember]
-      public Code<Hl7.Fhir.Model.TestScript.ContentType> ContentType_Element
+      public Code<Hl7.Fhir.Model.TestScript.ContentTypeCode> ContentTypeElement
       {
-        get { return _ContentType_Element; }
-        set { _ContentType_Element = value; OnPropertyChanged("ContentType_Element"); }
+        get { return _ContentTypeElement; }
+        set { _ContentTypeElement = value; OnPropertyChanged("ContentTypeElement"); }
       }
 
-      private Code<Hl7.Fhir.Model.TestScript.ContentType> _ContentType_Element;
+      private Code<Hl7.Fhir.Model.TestScript.ContentTypeCode> _ContentTypeElement;
 
       /// <summary>
       /// xml | json | ttl | none
       /// </summary>
       /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
       [IgnoreDataMember]
-      public Hl7.Fhir.Model.TestScript.ContentType? ContentType_
+      public Hl7.Fhir.Model.TestScript.ContentTypeCode? ContentType
       {
-        get { return ContentType_Element != null ? ContentType_Element.Value : null; }
+        get { return ContentTypeElement != null ? ContentTypeElement.Value : null; }
         set
         {
           if (value == null)
-            ContentType_Element = null;
+            ContentTypeElement = null;
           else
-            ContentType_Element = new Code<Hl7.Fhir.Model.TestScript.ContentType>(value);
-          OnPropertyChanged("ContentType_");
+            ContentTypeElement = new Code<Hl7.Fhir.Model.TestScript.ContentTypeCode>(value);
+          OnPropertyChanged("ContentType");
         }
       }
 
@@ -4476,7 +4476,7 @@ namespace Hl7.Fhir.Model
         if(CompareToSourceIdElement != null) dest.CompareToSourceIdElement = (Hl7.Fhir.Model.FhirString)CompareToSourceIdElement.DeepCopy();
         if(CompareToSourceExpressionElement != null) dest.CompareToSourceExpressionElement = (Hl7.Fhir.Model.FhirString)CompareToSourceExpressionElement.DeepCopy();
         if(CompareToSourcePathElement != null) dest.CompareToSourcePathElement = (Hl7.Fhir.Model.FhirString)CompareToSourcePathElement.DeepCopy();
-        if(ContentType_Element != null) dest.ContentType_Element = (Code<Hl7.Fhir.Model.TestScript.ContentType>)ContentType_Element.DeepCopy();
+        if(ContentTypeElement != null) dest.ContentTypeElement = (Code<Hl7.Fhir.Model.TestScript.ContentTypeCode>)ContentTypeElement.DeepCopy();
         if(ExpressionElement != null) dest.ExpressionElement = (Hl7.Fhir.Model.FhirString)ExpressionElement.DeepCopy();
         if(HeaderFieldElement != null) dest.HeaderFieldElement = (Hl7.Fhir.Model.FhirString)HeaderFieldElement.DeepCopy();
         if(MinimumIdElement != null) dest.MinimumIdElement = (Hl7.Fhir.Model.FhirString)MinimumIdElement.DeepCopy();
@@ -4515,7 +4515,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(CompareToSourceIdElement, otherT.CompareToSourceIdElement)) return false;
         if( !DeepComparable.Matches(CompareToSourceExpressionElement, otherT.CompareToSourceExpressionElement)) return false;
         if( !DeepComparable.Matches(CompareToSourcePathElement, otherT.CompareToSourcePathElement)) return false;
-        if( !DeepComparable.Matches(ContentType_Element, otherT.ContentType_Element)) return false;
+        if( !DeepComparable.Matches(ContentTypeElement, otherT.ContentTypeElement)) return false;
         if( !DeepComparable.Matches(ExpressionElement, otherT.ExpressionElement)) return false;
         if( !DeepComparable.Matches(HeaderFieldElement, otherT.HeaderFieldElement)) return false;
         if( !DeepComparable.Matches(MinimumIdElement, otherT.MinimumIdElement)) return false;
@@ -4549,7 +4549,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(CompareToSourceIdElement, otherT.CompareToSourceIdElement)) return false;
         if( !DeepComparable.IsExactly(CompareToSourceExpressionElement, otherT.CompareToSourceExpressionElement)) return false;
         if( !DeepComparable.IsExactly(CompareToSourcePathElement, otherT.CompareToSourcePathElement)) return false;
-        if( !DeepComparable.IsExactly(ContentType_Element, otherT.ContentType_Element)) return false;
+        if( !DeepComparable.IsExactly(ContentTypeElement, otherT.ContentTypeElement)) return false;
         if( !DeepComparable.IsExactly(ExpressionElement, otherT.ExpressionElement)) return false;
         if( !DeepComparable.IsExactly(HeaderFieldElement, otherT.HeaderFieldElement)) return false;
         if( !DeepComparable.IsExactly(MinimumIdElement, otherT.MinimumIdElement)) return false;
@@ -4583,7 +4583,7 @@ namespace Hl7.Fhir.Model
           if (CompareToSourceIdElement != null) yield return CompareToSourceIdElement;
           if (CompareToSourceExpressionElement != null) yield return CompareToSourceExpressionElement;
           if (CompareToSourcePathElement != null) yield return CompareToSourcePathElement;
-          if (ContentType_Element != null) yield return ContentType_Element;
+          if (ContentTypeElement != null) yield return ContentTypeElement;
           if (ExpressionElement != null) yield return ExpressionElement;
           if (HeaderFieldElement != null) yield return HeaderFieldElement;
           if (MinimumIdElement != null) yield return MinimumIdElement;
@@ -4616,7 +4616,7 @@ namespace Hl7.Fhir.Model
           if (CompareToSourceIdElement != null) yield return new ElementValue("compareToSourceId", CompareToSourceIdElement);
           if (CompareToSourceExpressionElement != null) yield return new ElementValue("compareToSourceExpression", CompareToSourceExpressionElement);
           if (CompareToSourcePathElement != null) yield return new ElementValue("compareToSourcePath", CompareToSourcePathElement);
-          if (ContentType_Element != null) yield return new ElementValue("contentType", ContentType_Element);
+          if (ContentTypeElement != null) yield return new ElementValue("contentType", ContentTypeElement);
           if (ExpressionElement != null) yield return new ElementValue("expression", ExpressionElement);
           if (HeaderFieldElement != null) yield return new ElementValue("headerField", HeaderFieldElement);
           if (MinimumIdElement != null) yield return new ElementValue("minimumId", MinimumIdElement);
@@ -4660,8 +4660,8 @@ namespace Hl7.Fhir.Model
             value = CompareToSourcePathElement;
             return CompareToSourcePathElement is not null;
           case "contentType":
-            value = ContentType_Element;
-            return ContentType_Element is not null;
+            value = ContentTypeElement;
+            return ContentTypeElement is not null;
           case "expression":
             value = ExpressionElement;
             return ExpressionElement is not null;
@@ -4728,7 +4728,7 @@ namespace Hl7.Fhir.Model
         if (CompareToSourceIdElement is not null) yield return new KeyValuePair<string,object>("compareToSourceId",CompareToSourceIdElement);
         if (CompareToSourceExpressionElement is not null) yield return new KeyValuePair<string,object>("compareToSourceExpression",CompareToSourceExpressionElement);
         if (CompareToSourcePathElement is not null) yield return new KeyValuePair<string,object>("compareToSourcePath",CompareToSourcePathElement);
-        if (ContentType_Element is not null) yield return new KeyValuePair<string,object>("contentType",ContentType_Element);
+        if (ContentTypeElement is not null) yield return new KeyValuePair<string,object>("contentType",ContentTypeElement);
         if (ExpressionElement is not null) yield return new KeyValuePair<string,object>("expression",ExpressionElement);
         if (HeaderFieldElement is not null) yield return new KeyValuePair<string,object>("headerField",HeaderFieldElement);
         if (MinimumIdElement is not null) yield return new KeyValuePair<string,object>("minimumId",MinimumIdElement);


### PR DESCRIPTION
* Renamed enums for which the enum name clashes with a property name in the same class.
* Made sure all enum names are capitalized.