### PR TITLE
Small corrections

### DIFF
--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.3" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.13.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Hl7.Fhir.Base/Introspection/DeclaredTypeAttribute.cs
+++ b/src/Hl7.Fhir.Base/Introspection/DeclaredTypeAttribute.cs
@@ -16,7 +16,7 @@ namespace Hl7.Fhir.Introspection
     /// in the constructor to this attribute.
     /// </summary>
     [CLSCompliant(false)]
-    [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
     public class DeclaredTypeAttribute : VersionedAttribute
     {
         public DeclaredTypeAttribute()

--- a/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
@@ -22,7 +22,7 @@ namespace Hl7.Fhir.Introspection
     /// <summary>
     /// A cache of FHIR type mappings found on .NET classes.
     /// </summary>
-    /// <remarks>POCO's in the "common" assemblies
+    /// <remarks>POCO's in the "base" assembly
     /// can reflect the definition of multiple releases of FHIR using <see cref="IFhirVersionDependent"/>
     /// attributes. A <see cref="ModelInspector"/> will always capture the metadata for one such
     /// <see cref="Specification.FhirRelease" /> which is passed to it in the constructor.
@@ -41,8 +41,8 @@ namespace Hl7.Fhir.Introspection
         /// Calling this function repeatedly for the same type will return the same ClassMapping.
         /// </summary>
         /// <remarks>If the type given is FHIR Release specific, the returned mapping will contain
-        /// metadata for that release only. If the type is from the common assembly, it will contain
-        /// metadata for that type from the most recent release of the common assembly.</remarks>
+        /// metadata for that release only. If the type is from the base assembly, it will contain
+        /// metadata for that type from the most recent release of the base assembly.</remarks>
         public static ClassMapping? GetClassMappingForType(Type t) =>
             ForAssembly(t.GetTypeInfo().Assembly).FindOrImportClassMapping(t);
 
@@ -52,8 +52,8 @@ namespace Hl7.Fhir.Introspection
         /// the same assembly will return the same inspector.
         /// </summary>
         /// <remarks>If the assembly given is FHIR Release specific, the returned inspector will contain
-        /// metadata for that release only. If the assembly is the common assembly, it will contain
-        /// metadata for the most recent release for those common classes.</remarks>
+        /// metadata for that release only. If the assembly is the base assembly, it will contain
+        /// metadata for the most recent release for those base classes.</remarks>
         public static ModelInspector ForAssembly(Assembly a)
         {
             return _inspectedAssemblies.GetOrAdd(a.FullName ?? throw Error.ArgumentNull(nameof(a.FullName)), _ => configureInspector(a));
@@ -67,10 +67,10 @@ namespace Hl7.Fhir.Introspection
                 var newInspector = new ModelInspector(modelAssemblyAttr.Since);
                 newInspector.Import(a);
 
-                // Make sure we always include the common types too. 
-                var commonAssembly = typeof(Resource).GetTypeInfo().Assembly;
-                if (a.FullName != commonAssembly.FullName)
-                    newInspector.Import(commonAssembly);
+                // Make sure we always include the types from the base assembly too. 
+                var baseAssembly = typeof(Resource).GetTypeInfo().Assembly;
+                if (a.FullName != baseAssembly.FullName)
+                    newInspector.Import(baseAssembly);
 
                 // And finally, the System/CQL primitive types
                 foreach (var cqlType in getCqlTypes())
@@ -104,9 +104,9 @@ namespace Hl7.Fhir.Introspection
 
         /// <summary>
         /// Returns a fully configured <see cref="ModelInspector"/> with the
-        /// FHIR metadata contents of the common assembly
+        /// FHIR metadata contents of the base assembly
         /// </summary>
-        public static ModelInspector Common => ForType(typeof(ModelInspector));
+        public static ModelInspector Base => ForType(typeof(ModelInspector));
 
         /// <summary>
         /// Constructs a ModelInspector that will reflect the FHIR metadata for the given FHIR release

--- a/src/Hl7.Fhir.Base/Model/Generated/Attachment.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/Attachment.cs
@@ -183,8 +183,8 @@ namespace Hl7.Fhir.Model
     /// Number of bytes of content (if url provided)
     /// </summary>
     [FhirElement("size", InSummary=true, Order=70)]
-    [DeclaredType(Since=FhirRelease.STU3, Type=typeof(UnsignedInt))]
-    [DeclaredType(Since=FhirRelease.R5, Type=typeof(Integer64))]
+    [DeclaredType(Type = typeof(UnsignedInt), Since = FhirRelease.STU3)]
+    [DeclaredType(Type = typeof(Integer64), Since = FhirRelease.R5)]
     [DataMember]
     public Hl7.Fhir.Model.Integer64 SizeElement
     {

--- a/src/Hl7.Fhir.Base/Model/Generated/Attachment.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/Attachment.cs
@@ -183,8 +183,8 @@ namespace Hl7.Fhir.Model
     /// Number of bytes of content (if url provided)
     /// </summary>
     [FhirElement("size", InSummary=true, Order=70)]
-    [DeclaredType(Since = FhirRelease.STU3, Type=typeof(UnsignedInt))]
-    [DeclaredType(Since = FhirRelease.R5, Type = typeof(Integer64))]
+    [DeclaredType(Since=FhirRelease.STU3, Type=typeof(UnsignedInt))]
+    [DeclaredType(Since=FhirRelease.R5, Type=typeof(Integer64))]
     [DataMember]
     public Hl7.Fhir.Model.Integer64 SizeElement
     {

--- a/src/Hl7.Fhir.Base/Model/Generated/Attachment.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/Attachment.cs
@@ -183,6 +183,8 @@ namespace Hl7.Fhir.Model
     /// Number of bytes of content (if url provided)
     /// </summary>
     [FhirElement("size", InSummary=true, Order=70)]
+    [DeclaredType(Since = FhirRelease.STU3, Type=typeof(UnsignedInt))]
+    [DeclaredType(Since = FhirRelease.R5, Type = typeof(Integer64))]
     [DataMember]
     public Hl7.Fhir.Model.Integer64 SizeElement
     {

--- a/src/Hl7.Fhir.Base/Model/Markdown.cs
+++ b/src/Hl7.Fhir.Base/Model/Markdown.cs
@@ -40,8 +40,8 @@ namespace Hl7.Fhir.Model
         /// </summary>
         public static bool IsValidValue(string value) => FhirString.IsValidValue(value);
 
-        public static implicit operator string(Markdown md) => md.Value;
-        public static implicit operator Markdown(string s) => new(s);
+        public static implicit operator string?(Markdown? md) => md?.Value;
+        public static implicit operator Markdown?(string? s) => s is not null ? new(s) : null;
 
     }
 

--- a/src/Hl7.Fhir.Base/Properties/AssemblyInfo.cs
+++ b/src/Hl7.Fhir.Base/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Runtime.CompilerServices;
 
-[assembly: FhirModelAssembly]
+[assembly: FhirModelAssembly(Since = Hl7.Fhir.Specification.FhirRelease.STU3)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 

--- a/src/Hl7.Fhir.Base/Rest/TransactionBuilder.cs
+++ b/src/Hl7.Fhir.Base/Rest/TransactionBuilder.cs
@@ -269,7 +269,7 @@ namespace Hl7.Fhir.Rest
                     case CodeableConcept codeableConcept:
                         return codeableConcept.ToToken();
                     default:
-                        if (ModelInspector.Common.IsPrimitive(parameter.Value.GetType()))
+                        if (ModelInspector.Base.IsPrimitive(parameter.Value.GetType()))
                         {
                             return parameter.Value.ToString();
                         }

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonBuilder.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonBuilder.cs
@@ -204,7 +204,7 @@ namespace Hl7.Fhir.Serialization
         {
             bool or decimal or Int32 or Int16 or ulong or double or BigInteger or float => new JValue(value),
             string s => new JValue(s.Trim()),
-            long l when requiredType is "integer" or "unsignedInt" or "positiveInt" => new JValue((int)l),
+            long l when requiredType is "integer" or "unsignedInt" or "positiveInt" => new JValue(l),
             _ => new JValue(PrimitiveTypeConverter.ConvertTo<string>(value)),
         };
     }

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
@@ -11,7 +11,6 @@
 using Hl7.Fhir.Utility;
 using System;
 using System.Globalization;
-using System.Linq;
 using System.Text.Json;
 
 #nullable enable
@@ -46,6 +45,7 @@ namespace Hl7.Fhir.Serialization
         public const string RESOURCETYPE_UNEXPECTED_CODE = "JSON119";
         public const string OBJECTS_CANNOT_BE_EMPTY_CODE = "JSON120";
         public const string ARRAYS_CANNOT_BE_EMPTY_CODE = "JSON121";
+        public const string LONG_CANNOT_BE_PARSED_CODE = "JSON122";
 
         [Obsolete("According to the latest updates of the Json format, primitive arrays of different sizes are no longer considered an error.")]
         public const string PRIMITIVE_ARRAYS_INCOMPAT_SIZE_CODE = "JSON122";
@@ -80,6 +80,9 @@ namespace Hl7.Fhir.Serialization
         internal static readonly FhirJsonException STRING_ISNOTAN_INSTANT = new(STRING_ISNOTAN_INSTANT_CODE, "Literal string '{0}' cannot be parsed as an instant.");
         internal static readonly FhirJsonException NUMBER_CANNOT_BE_PARSED = new(NUMBER_CANNOT_BE_PARSED_CODE, "Json number '{0}' cannot be parsed as a {1}.");
         internal static readonly FhirJsonException UNEXPECTED_JSON_TOKEN = new(UNEXPECTED_JSON_TOKEN_CODE, "Expecting a {0}, but found a json {1} with value '{2}'.");
+
+        // In R5 Integer64 (long) are serialized as string. So we would expect a string during parsing.
+        internal static readonly FhirJsonException LONG_CANNOT_BE_PARSED = new(LONG_CANNOT_BE_PARSED_CODE, "Json number '{0}' cannot be parsed as a {1}. Json token should be string.");
 
         // The parser will turn a non-array value into an array with a single element, so no data is lost.
         internal static readonly FhirJsonException EXPECTED_START_OF_ARRAY = new(EXPECTED_START_OF_ARRAY_CODE, "Expected start of array.");

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
@@ -46,6 +46,7 @@ namespace Hl7.Fhir.Serialization
         public const string OBJECTS_CANNOT_BE_EMPTY_CODE = "JSON120";
         public const string ARRAYS_CANNOT_BE_EMPTY_CODE = "JSON121";
         public const string LONG_CANNOT_BE_PARSED_CODE = "JSON122";
+        public const string LONG_INCORRECT_FORMAT_CODE = "JSON123";
 
         [Obsolete("According to the latest updates of the Json format, primitive arrays of different sizes are no longer considered an error.")]
         public const string PRIMITIVE_ARRAYS_INCOMPAT_SIZE_CODE = "JSON122";
@@ -82,7 +83,8 @@ namespace Hl7.Fhir.Serialization
         internal static readonly FhirJsonException UNEXPECTED_JSON_TOKEN = new(UNEXPECTED_JSON_TOKEN_CODE, "Expecting a {0}, but found a json {1} with value '{2}'.");
 
         // In R5 Integer64 (long) are serialized as string. So we would expect a string during parsing.
-        internal static readonly FhirJsonException LONG_CANNOT_BE_PARSED = new(LONG_CANNOT_BE_PARSED_CODE, "Json number '{0}' cannot be parsed as a {1}. Json token should be string.");
+        internal static readonly FhirJsonException LONG_CANNOT_BE_PARSED = new(LONG_CANNOT_BE_PARSED_CODE, "Json string '{0}' cannot be parsed as a {1}.");
+        internal static readonly FhirJsonException LONG_INCORRECT_FORMAT = new(LONG_INCORRECT_FORMAT_CODE, "{0} '{1}' cannot be parsed as a {2}, because it should be a {3}.");
 
         // The parser will turn a non-array value into an array with a single element, so no data is lost.
         internal static readonly FhirJsonException EXPECTED_START_OF_ARRAY = new(EXPECTED_START_OF_ARRAY_CODE, "Expected start of array.");

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonPocoDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonPocoDeserializer.cs
@@ -678,6 +678,7 @@ namespace Hl7.Fhir.Serialization
                 JsonTokenType.String when requiredType == typeof(long) => readLong(ref reader),
                 //JsonTokenType.String when requiredType.IsEnum => readEnum(ref reader, requiredType),
                 JsonTokenType.String => unexpectedToken(ref reader, reader.GetString(), requiredType.Name, "string"),
+                JsonTokenType.Number when requiredType == typeof(long) => new(null, ERR.LONG_CANNOT_BE_PARSED.With(ref reader, reader.GetRawText(), requiredType.Name)),
                 JsonTokenType.Number => tryGetMatchingNumber(ref reader, requiredType),
                 JsonTokenType.True or JsonTokenType.False when requiredType == typeof(bool) => new(reader.GetBoolean(), null),
                 JsonTokenType.True or JsonTokenType.False => unexpectedToken(ref reader, reader.GetRawText(), requiredType.Name, "boolean"),
@@ -721,7 +722,7 @@ namespace Hl7.Fhir.Serialization
 
                 return long.TryParse(contents, out var parsed) ?
                     new(parsed, null) :
-                    new(contents, ERR.STRING_ISNOTAN_INSTANT.With(ref reader, contents));
+                    new(contents, ERR.NUMBER_CANNOT_BE_PARSED.With(ref reader, contents));
             }
 
             // Validation is now done using POCO validation, so have removed it here.

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonPocoDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonPocoDeserializer.cs
@@ -728,9 +728,9 @@ namespace Hl7.Fhir.Serialization
                 return long.TryParse(contents, out var parsed) switch
                 {
                     true when isInteger64() => new(parsed, null),
-                    true => new(parsed, ERR.LONG_CANNOT_BE_PARSED.With(ref reader, contents, typeName())),
-                    false when isInteger64() => new(contents, ERR.NUMBER_CANNOT_BE_PARSED.With(ref reader, contents, nameof(Integer64))),
-                    false => new(contents, ERR.LONG_CANNOT_BE_PARSED.With(ref reader, contents, typeName()))
+                    true => new(parsed, ERR.LONG_INCORRECT_FORMAT.With(ref reader, "Json string", contents, typeName(), "Json number")),
+                    false when isInteger64() => new(contents, ERR.LONG_CANNOT_BE_PARSED.With(ref reader, contents, nameof(Integer64))),
+                    false => new(contents, ERR.LONG_INCORRECT_FORMAT.With(ref reader, "Json string", contents, typeName(), "Json number"))
                 };
 
                 string typeName()
@@ -793,7 +793,7 @@ namespace Hl7.Fhir.Serialization
             if (success)
             {
                 return implementingType == typeof(long) && fhirType == typeof(Integer64)
-                    ? new(value, ERR.LONG_CANNOT_BE_PARSED.With(ref reader, reader.GetRawText(), nameof(Integer64)))
+                    ? new(value, ERR.LONG_INCORRECT_FORMAT.With(ref reader, "Json number", reader.GetRawText(), nameof(Integer64), "Json string"))
                     : new(value, null);
             }
             else

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonPocoDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonPocoDeserializer.cs
@@ -13,6 +13,7 @@ using Hl7.Fhir.Model;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using ERR = Hl7.Fhir.Serialization.FhirJsonException;
@@ -344,11 +345,13 @@ namespace Hl7.Fhir.Serialization
                 // (one with, and one without the '_')
                 var existingValue = propertyMapping.GetValue(target);
 
+                var fhirType = propertyMapping.FhirType.FirstOrDefault();
+
                 // Note that the POCO model will always allocate a new list if the property had not been set before,
                 // so there is always an existingValue for IList
                 result = propertyMapping.IsCollection ?
-                    deserializeFhirPrimitiveList((IList)existingValue!, propertyName, propertyValueMapping, ref reader, delayedValidations, state) :
-                    DeserializeFhirPrimitive(existingValue as PrimitiveType, propertyName, propertyValueMapping, ref reader, delayedValidations, state);
+                    deserializeFhirPrimitiveList((IList)existingValue!, propertyName, propertyValueMapping, fhirType, ref reader, delayedValidations, state) :
+                    DeserializeFhirPrimitive(existingValue as PrimitiveType, propertyName, propertyValueMapping, fhirType, ref reader, delayedValidations, state);
             }
             else
             {
@@ -358,8 +361,8 @@ namespace Hl7.Fhir.Serialization
 
                 // Note that repeating simple elements (like Extension.url) do not currently exist in the FHIR serialization
                 result = propertyMapping.IsCollection
-                    ? deserializeNormalList(propertyValueMapping, ref reader, state)
-                    : deserializeSingleValue(ref reader, propertyValueMapping, state);
+                    ? deserializeNormalList(propertyValueMapping, ref reader, propertyMapping, state)
+                    : deserializeSingleValue(ref reader, propertyValueMapping, propertyMapping, state);
             }
 
             // Only do validation when no parse errors were encountered, otherwise we'll just
@@ -397,6 +400,7 @@ namespace Hl7.Fhir.Serialization
         private IList? deserializeNormalList(
             ClassMapping propertyValueMapping,
             ref Utf8JsonReader reader,
+            PropertyMapping propertyMapping,
             FhirJsonPocoDeserializerState state)
         {
             // Create a list of the type of this property's value.
@@ -424,7 +428,7 @@ namespace Hl7.Fhir.Serialization
             // to simply create a list by Adding(). Not the fastest approach :-(
             while (reader.TokenType != JsonTokenType.EndArray)
             {
-                var result = deserializeSingleValue(ref reader, propertyValueMapping, state);
+                var result = deserializeSingleValue(ref reader, propertyValueMapping, propertyMapping, state);
                 listInstance.Add(result);
 
                 if (oneshot) break;
@@ -462,6 +466,7 @@ namespace Hl7.Fhir.Serialization
             IList existingList,
             string propertyName,
             ClassMapping propertyValueMapping,
+            Type? fhirType,
             ref Utf8JsonReader reader,
             DelayedValidations delayedValidations,
             FhirJsonPocoDeserializerState state
@@ -508,7 +513,7 @@ namespace Hl7.Fhir.Serialization
                 {
                     existingList[elementIndex] ??= propertyValueMapping.Factory();
                     onlyNulls = false;
-                    _ = DeserializeFhirPrimitive((PrimitiveType)existingList[elementIndex]!, propertyName, propertyValueMapping, ref reader, delayedValidations, state);
+                    _ = DeserializeFhirPrimitive((PrimitiveType)existingList[elementIndex]!, propertyName, propertyValueMapping, fhirType, ref reader, delayedValidations, state);
                 }
 
                 elementIndex += 1;
@@ -538,6 +543,7 @@ namespace Hl7.Fhir.Serialization
             PrimitiveType? existingPrimitive,
             string propertyName,
             ClassMapping propertyValueMapping,
+            Type? fhirType,
             ref Utf8JsonReader reader,
             DelayedValidations? delayedValidations,
             FhirJsonPocoDeserializerState state
@@ -558,7 +564,7 @@ namespace Hl7.Fhir.Serialization
                 try
                 {
 
-                    var (result, error) = DeserializePrimitiveValue(ref reader, primitiveValueProperty.ImplementingType);
+                    var (result, error) = DeserializePrimitiveValue(ref reader, primitiveValueProperty.ImplementingType, fhirType);
 
                     // Only do validation when no parse errors were encountered, otherwise we'll just
                     // produce spurious messages.
@@ -609,7 +615,7 @@ namespace Hl7.Fhir.Serialization
         /// Deserializes a single object, either a resource, a FHIR primitive or a primitive value.
         /// </summary>
         /// <remarks>Upon completion, reader will be located at the next token afther the value.</remarks>
-        private object? deserializeSingleValue(ref Utf8JsonReader reader, ClassMapping propertyValueMapping, FhirJsonPocoDeserializerState state)
+        private object? deserializeSingleValue(ref Utf8JsonReader reader, ClassMapping propertyValueMapping, PropertyMapping propertyMapping, FhirJsonPocoDeserializerState state)
         {
             // Resources
             if (propertyValueMapping.IsResource)
@@ -622,7 +628,7 @@ namespace Hl7.Fhir.Serialization
             // needs to handle PrimitiveType.ObjectValue & dual properties.
             else if (propertyValueMapping.IsPrimitive)
             {
-                var (result, error) = DeserializePrimitiveValue(ref reader, propertyValueMapping.NativeType);
+                var (result, error) = DeserializePrimitiveValue(ref reader, propertyValueMapping.NativeType, propertyMapping.FhirType.FirstOrDefault());
 
                 if (error is not null && result is not null)
                 {
@@ -654,7 +660,7 @@ namespace Hl7.Fhir.Serialization
         /// <returns>A value without an error if the data could be parsed to the required type, and a value with an error if the
         /// value could not be parsed - in which case the value returned is the raw value coming in from the reader.</returns>
         /// <remarks>Upon completion, the reader will be positioned on the token after the primitive.</remarks>
-        internal (object?, FhirJsonException?) DeserializePrimitiveValue(ref Utf8JsonReader reader, Type requiredType)
+        internal (object?, FhirJsonException?) DeserializePrimitiveValue(ref Utf8JsonReader reader, Type implementingType, Type? fhirType)
         {
             // Check for unexpected non-value types.
             if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
@@ -670,18 +676,17 @@ namespace Hl7.Fhir.Serialization
             (object? partial, FhirJsonException? error) result = reader.TokenType switch
             {
                 JsonTokenType.Null => new(null, ERR.EXPECTED_PRIMITIVE_NOT_NULL.With(ref reader)),
-                JsonTokenType.String when requiredType == typeof(string) => new(reader.GetString(), null),
-                JsonTokenType.String when requiredType == typeof(byte[]) =>
+                JsonTokenType.String when implementingType == typeof(string) => new(reader.GetString(), null),
+                JsonTokenType.String when implementingType == typeof(byte[]) =>
                                 !Settings.DisableBase64Decoding ? readBase64(ref reader) : new(reader.GetString(), null),
-                JsonTokenType.String when requiredType == typeof(DateTimeOffset) => readDateTimeOffset(ref reader),
-                JsonTokenType.String when requiredType.IsEnum => new(reader.GetString(), null),
-                JsonTokenType.String when requiredType == typeof(long) => readLong(ref reader),
+                JsonTokenType.String when implementingType == typeof(DateTimeOffset) => readDateTimeOffset(ref reader),
+                JsonTokenType.String when implementingType.IsEnum => new(reader.GetString(), null),
+                JsonTokenType.String when implementingType == typeof(long) => readLong(ref reader, fhirType),
                 //JsonTokenType.String when requiredType.IsEnum => readEnum(ref reader, requiredType),
-                JsonTokenType.String => unexpectedToken(ref reader, reader.GetString(), requiredType.Name, "string"),
-                JsonTokenType.Number when requiredType == typeof(long) => new(null, ERR.LONG_CANNOT_BE_PARSED.With(ref reader, reader.GetRawText(), requiredType.Name)),
-                JsonTokenType.Number => tryGetMatchingNumber(ref reader, requiredType),
-                JsonTokenType.True or JsonTokenType.False when requiredType == typeof(bool) => new(reader.GetBoolean(), null),
-                JsonTokenType.True or JsonTokenType.False => unexpectedToken(ref reader, reader.GetRawText(), requiredType.Name, "boolean"),
+                JsonTokenType.String => unexpectedToken(ref reader, reader.GetString(), implementingType.Name, "string"),
+                JsonTokenType.Number => tryGetMatchingNumber(ref reader, implementingType, fhirType),
+                JsonTokenType.True or JsonTokenType.False when implementingType == typeof(bool) => new(reader.GetBoolean(), null),
+                JsonTokenType.True or JsonTokenType.False => unexpectedToken(ref reader, reader.GetRawText(), implementingType.Name, "boolean"),
 
                 _ =>
                     // This would be an internal logic error, since our callers should have made sure we're
@@ -694,7 +699,7 @@ namespace Hl7.Fhir.Serialization
 
             // If there is a failure, and we have a handler installed, call it
             if (Settings.OnPrimitiveParseFailed is not null && result.error is not null)
-                result = Settings.OnPrimitiveParseFailed(ref reader, requiredType, result.partial, result.error);
+                result = Settings.OnPrimitiveParseFailed(ref reader, implementingType, result.partial, result.error);
 
             // Read past the value
             reader.Read();
@@ -715,14 +720,24 @@ namespace Hl7.Fhir.Serialization
                     new(contents, ERR.STRING_ISNOTAN_INSTANT.With(ref reader, contents));
             }
 
-            static (object?, FhirJsonException?) readLong(ref Utf8JsonReader reader)
+            static (object?, FhirJsonException?) readLong(ref Utf8JsonReader reader, Type? fhirType)
             {
                 // convert string in json to a long.
                 var contents = reader.GetString()!;
 
-                return long.TryParse(contents, out var parsed) ?
-                    new(parsed, null) :
-                    new(contents, ERR.NUMBER_CANNOT_BE_PARSED.With(ref reader, contents));
+                return long.TryParse(contents, out var parsed) switch
+                {
+                    true when isInteger64() => new(parsed, null),
+                    true => new(parsed, ERR.LONG_CANNOT_BE_PARSED.With(ref reader, contents, typeName())),
+                    false when isInteger64() => new(contents, ERR.NUMBER_CANNOT_BE_PARSED.With(ref reader, contents, nameof(Integer64))),
+                    false => new(contents, ERR.LONG_CANNOT_BE_PARSED.With(ref reader, contents, typeName()))
+                };
+
+                string typeName()
+                    => fhirType?.Name ?? string.Empty;
+
+                bool isInteger64()
+                    => fhirType == typeof(Integer64);
             }
 
             // Validation is now done using POCO validation, so have removed it here.
@@ -745,7 +760,7 @@ namespace Hl7.Fhir.Serialization
         /// This function tries to map from the json-format "generic" number to the kind of numeric type defined in the POCO.
         /// </summary>
         /// <remarks>Reader must be positioned on a number token. This function will not move the reader to the next token.</remarks>
-        private static (object?, FhirJsonException?) tryGetMatchingNumber(ref Utf8JsonReader reader, Type requiredType)
+        private static (object?, FhirJsonException?) tryGetMatchingNumber(ref Utf8JsonReader reader, Type implementingType, Type? fhirType)
         {
             if (reader.TokenType != JsonTokenType.Number)
                 throw new InvalidOperationException($"Cannot read a numeric when reader is on a {reader.TokenType}. " +
@@ -754,35 +769,37 @@ namespace Hl7.Fhir.Serialization
             object? value = null;
             bool success;
 
-            if (requiredType == typeof(decimal))
+            if (implementingType == typeof(decimal))
                 success = reader.TryGetDecimal(out decimal dec) && (value = dec) is { };
-            else if (requiredType == typeof(int))
+            else if (implementingType == typeof(int))
                 success = reader.TryGetInt32(out int i32) && (value = i32) is { };
-            else if (requiredType == typeof(uint))
+            else if (implementingType == typeof(uint))
                 success = reader.TryGetUInt32(out uint ui32) && (value = ui32) is { };
-            else if (requiredType == typeof(long))
+            else if (implementingType == typeof(long))
                 success = reader.TryGetInt64(out long i64) && (value = i64) is { };
-            else if (requiredType == typeof(ulong))
+            else if (implementingType == typeof(ulong))
                 success = reader.TryGetUInt64(out ulong ui64) && (value = ui64) is { };
-            else if (requiredType == typeof(float))
+            else if (implementingType == typeof(float))
                 success = reader.TryGetSingle(out float si) && si.IsNormal() && (value = si) is { };
-            else if (requiredType == typeof(double))
+            else if (implementingType == typeof(double))
                 success = reader.TryGetDouble(out double dbl) && dbl.IsNormal() && (value = dbl) is { };
             else
             {
                 var rawValue = reader.GetRawText();
-                return unexpectedToken(ref reader, rawValue, requiredType.Name, "number");
+                return unexpectedToken(ref reader, rawValue, implementingType.Name, "number");
             }
 
             // We expected a number, we found a json number, but they don't match (e.g. precision etc)
             if (success)
             {
-                return new(value, null);
+                return implementingType == typeof(long) && fhirType == typeof(Integer64)
+                    ? new(value, ERR.LONG_CANNOT_BE_PARSED.With(ref reader, reader.GetRawText(), nameof(Integer64)))
+                    : new(value, null);
             }
             else
             {
                 var rawValue = reader.GetRawText();
-                return new(rawValue, ERR.NUMBER_CANNOT_BE_PARSED.With(ref reader, rawValue, requiredType.Name));
+                return new(rawValue, ERR.NUMBER_CANNOT_BE_PARSED.With(ref reader, rawValue, implementingType.Name));
             }
         }
 

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonPocoDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonPocoDeserializer.cs
@@ -675,6 +675,7 @@ namespace Hl7.Fhir.Serialization
                                 !Settings.DisableBase64Decoding ? readBase64(ref reader) : new(reader.GetString(), null),
                 JsonTokenType.String when requiredType == typeof(DateTimeOffset) => readDateTimeOffset(ref reader),
                 JsonTokenType.String when requiredType.IsEnum => new(reader.GetString(), null),
+                JsonTokenType.String when requiredType == typeof(long) => readLong(ref reader),
                 //JsonTokenType.String when requiredType.IsEnum => readEnum(ref reader, requiredType),
                 JsonTokenType.String => unexpectedToken(ref reader, reader.GetString(), requiredType.Name, "string"),
                 JsonTokenType.Number => tryGetMatchingNumber(ref reader, requiredType),
@@ -710,6 +711,16 @@ namespace Hl7.Fhir.Serialization
 
                 return ElementModel.Types.DateTime.TryParse(contents, out var parsed) ?
                     new(parsed.ToDateTimeOffset(TimeSpan.Zero), null) :
+                    new(contents, ERR.STRING_ISNOTAN_INSTANT.With(ref reader, contents));
+            }
+
+            static (object?, FhirJsonException?) readLong(ref Utf8JsonReader reader)
+            {
+                // convert string in json to a long.
+                var contents = reader.GetString()!;
+
+                return long.TryParse(contents, out var parsed) ?
+                    new(parsed, null) :
                     new(contents, ERR.STRING_ISNOTAN_INSTANT.With(ref reader, contents));
             }
 

--- a/src/Hl7.Fhir.Conformance/Properties/AssemblyInfo.cs
+++ b/src/Hl7.Fhir.Conformance/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 // This assembly is not fully CLSCompliant, but this triggers compiler warnings to avoid the issue as described here, when mixing C# and VB 
 // https://msdn.microsoft.com/en-us/library/ms235408(v=vs.90).aspx 
 [assembly: CLSCompliant(true)]
-[assembly: FhirModelAssembly]
+[assembly: FhirModelAssembly(Since = Hl7.Fhir.Specification.FhirRelease.R4)]
 
 #if DEBUG
 [assembly: InternalsVisibleTo("Hl7.Fhir.R4")]

--- a/src/Hl7.Fhir.Conformance/Specification/Navigation/ElementDefinitionNavigationFunctions.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Navigation/ElementDefinitionNavigationFunctions.cs
@@ -118,7 +118,7 @@ namespace Hl7.Fhir.Specification.Navigation
 
                 // Primitive types start with a lower-case character
                 var altTypeName = Utility.StringExtensions.Uncapitalize(typeName);
-                if (ModelInspector.Common.IsPrimitive(altTypeName)) { return altTypeName; }
+                if (ModelInspector.Base.IsPrimitive(altTypeName)) { return altTypeName; }
                 return typeName;
 
             }

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/ElementDefnMerger.cs
@@ -173,7 +173,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 snap.Binding = mergeBinding(snap.Binding, diff.Binding);
 
                 // [MV 20220803] Remove Binding when the element has no bindable type
-                if (snap.Binding is not null && !snap.Type.Any(t => ModelInspector.Common.IsBindable(t.Code)))
+                if (snap.Binding is not null && !snap.Type.Any(t => ModelInspector.Base.IsBindable(t.Code)))
                 {
                     snap.Binding = null;
                 }

--- a/src/Hl7.Fhir.ElementModel.STU3.Tests/TypedElementToSourceNodeAdapterTests.cs
+++ b/src/Hl7.Fhir.ElementModel.STU3.Tests/TypedElementToSourceNodeAdapterTests.cs
@@ -28,7 +28,7 @@ namespace Hl7.Fhir.ElementModel.Tests
             var result2 = sourceNode.Annotation<IResourceTypeSupplier>();
             Assert.IsNotNull(result2);
             Assert.AreEqual("TypedElementToSourceNodeAdapter", result2.GetType().Name); // I use the classname here, because PocoElementNode is internal in Hl7.Fhir.Core
-            Assert.AreSame<object>(sourceNode, result2);
+            Assert.AreSame(sourceNode, result2);
         }
 
         [TestMethod]
@@ -72,7 +72,7 @@ namespace Hl7.Fhir.ElementModel.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual(typeof(TypedElementToSourceNodeAdapter), result.GetType());
             Assert.AreEqual("Patient", adapter.GetResourceTypeIndicator());
-            Assert.AreSame<object>(adapter, result);
+            Assert.AreSame(adapter, result);
         }
     }
 }

--- a/src/Hl7.Fhir.ElementModel.Shared.Tests/TypedElementToSourceNodeAdapterTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Shared.Tests/TypedElementToSourceNodeAdapterTests.cs
@@ -28,7 +28,7 @@ namespace Hl7.Fhir.ElementModel.Tests
             var result2 = sourceNode.Annotation<IResourceTypeSupplier>();
             Assert.IsNotNull(result2);
             Assert.AreEqual("TypedElementToSourceNodeAdapter", result2.GetType().Name); // I use the classname here, because PocoElementNode is internal in Hl7.Fhir.Core
-            Assert.AreSame<object>(sourceNode, result2);
+            Assert.AreSame(sourceNode, result2);
         }
 
         [TestMethod]
@@ -72,7 +72,7 @@ namespace Hl7.Fhir.ElementModel.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual(typeof(TypedElementToSourceNodeAdapter), result.GetType());
             Assert.AreEqual("Patient", adapter.GetResourceTypeIndicator());
-            Assert.AreSame<object>(adapter, result);
+            Assert.AreSame(adapter, result);
         }
     }
 }

--- a/src/Hl7.Fhir.Serialization.R4.Tests/RoundtripNewSerializers.cs
+++ b/src/Hl7.Fhir.Serialization.R4.Tests/RoundtripNewSerializers.cs
@@ -6,6 +6,8 @@ namespace Hl7.Fhir.Serialization.Tests
     [TestClass]
     public partial class RoundTripNewSerializers
     {
+        private readonly string _attachmentJson = "{\"size\":12}";
+
         [DynamicData(nameof(prepareExampleZipFilesXml), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(GetTestDisplayNames))]
         [DataTestMethod]
         [TestCategory("LongRunner")]

--- a/src/Hl7.Fhir.Serialization.R4.Tests/RoundtripNewSerializers.cs
+++ b/src/Hl7.Fhir.Serialization.R4.Tests/RoundtripNewSerializers.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿#nullable enable
+using FluentAssertions;
+using Hl7.Fhir.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Text.Json;
 
 namespace Hl7.Fhir.Serialization.Tests
@@ -23,5 +27,30 @@ namespace Hl7.Fhir.Serialization.Tests
         {
             doRoundTrip(baseTestPath, file, xmlSerializer, xmlDeserializer, jsonOptions);
         }
+
+        [DataTestMethod]
+        [DataRow("{\"size\":12, \"title\": \"Correct Attachment\"}", 12L, null)]
+        [DataRow("{\"size\":12.345, \"title\": \"An incorrect Attachment\"}", null, "*Json number '12.345' cannot be parsed as a Int64*")]
+        [DataRow("{\"size\":\"12\", \"title\": \"An incorrect Attachment\"}", null, "*Json number '12' cannot be parsed as a UnsignedInt. Json token should be string*")]
+        [DataRow("{\"size\":\"12.345\", \"title\": \"An incorrect Attachment\"}", null, "*Json number '12.345' cannot be parsed as a UnsignedInt*")]
+
+        public void ParseAttachment(string input, long? expectedAttachmentSize, string? errorMessage)
+        {
+            var options = new JsonSerializerOptions().ForFhir(ModelInfo.ModelInspector);
+            if (errorMessage is not null)
+            {
+                Action action = () => JsonSerializer.Deserialize<Attachment>(input, options);
+
+                action.Should().Throw<DeserializationFailedException>()
+                    .WithMessage(errorMessage);
+            }
+            else
+            {
+                var attachment = JsonSerializer.Deserialize<Attachment>(input, options);
+                attachment.Should().NotBeNull();
+                attachment!.Size.Should().Be(expectedAttachmentSize!.Value);
+            }
+        }
     }
 }
+#nullable restore

--- a/src/Hl7.Fhir.Serialization.R4.Tests/RoundtripNewSerializers.cs
+++ b/src/Hl7.Fhir.Serialization.R4.Tests/RoundtripNewSerializers.cs
@@ -1,9 +1,8 @@
 ﻿#nullable enable
-using FluentAssertions;
-using Hl7.Fhir.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+using System.Collections.Generic;
 using System.Text.Json;
+using ERR = Hl7.Fhir.Serialization.FhirJsonException;
 
 namespace Hl7.Fhir.Serialization.Tests
 {
@@ -28,28 +27,12 @@ namespace Hl7.Fhir.Serialization.Tests
             doRoundTrip(baseTestPath, file, xmlSerializer, xmlDeserializer, jsonOptions);
         }
 
-        [DataTestMethod]
-        [DataRow("{\"size\":12, \"title\": \"Correct Attachment\"}", 12L, null)]
-        [DataRow("{\"size\":12.345, \"title\": \"An incorrect Attachment\"}", null, "*Json number '12.345' cannot be parsed as a Int64*")]
-        [DataRow("{\"size\":\"12\", \"title\": \"An incorrect Attachment\"}", null, "*Json number '12' cannot be parsed as a UnsignedInt. Json token should be string*")]
-        [DataRow("{\"size\":\"12.345\", \"title\": \"An incorrect Attachment\"}", null, "*Json number '12.345' cannot be parsed as a UnsignedInt*")]
-
-        public void ParseAttachment(string input, long? expectedAttachmentSize, string? errorMessage)
+        private static IEnumerable<object[]> attachmentSource()
         {
-            var options = new JsonSerializerOptions().ForFhir(ModelInfo.ModelInspector);
-            if (errorMessage is not null)
-            {
-                Action action = () => JsonSerializer.Deserialize<Attachment>(input, options);
-
-                action.Should().Throw<DeserializationFailedException>()
-                    .WithMessage(errorMessage);
-            }
-            else
-            {
-                var attachment = JsonSerializer.Deserialize<Attachment>(input, options);
-                attachment.Should().NotBeNull();
-                attachment!.Size.Should().Be(expectedAttachmentSize!.Value);
-            }
+            yield return new object[] { "{\"size\":12, \"title\": \"Correct Attachment\"}", 12L, null! };
+            yield return new object[] { "{\"size\":12.345, \"title\": \"An incorrect Attachment\"}", null!, ERR.NUMBER_CANNOT_BE_PARSED_CODE };
+            yield return new object[] { "{\"size\":\"12\", \"title\": \"An incorrect Attachment\"}", null!, ERR.LONG_INCORRECT_FORMAT_CODE };
+            yield return new object[] { "{\"size\":\"12.345\", \"title\": \"An incorrect Attachment\"}", null!, ERR.LONG_INCORRECT_FORMAT_CODE };
         }
     }
 }

--- a/src/Hl7.Fhir.Serialization.R4.Tests/RoundtripTest.cs
+++ b/src/Hl7.Fhir.Serialization.R4.Tests/RoundtripTest.cs
@@ -16,6 +16,8 @@ namespace Hl7.Fhir.Serialization.Tests
     [TestClass]
     public partial class RoundtripTest
     {
+        private readonly string _attachmentJson = "{\"size\":12}";
+
         [TestMethod]
         [TestCategory("LongRunner")]
         public void FullRoundtripOfAllExamplesXmlPoco()

--- a/src/Hl7.Fhir.Serialization.R4B.Tests/RoundtripNewSerializers.cs
+++ b/src/Hl7.Fhir.Serialization.R4B.Tests/RoundtripNewSerializers.cs
@@ -6,6 +6,8 @@ namespace Hl7.Fhir.Serialization.Tests
     [TestClass]
     public partial class RoundTripNewSerializers
     {
+        private readonly string _attachmentJson = "{\"size\":12}";
+
         [DynamicData(nameof(prepareExampleZipFilesXml), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(GetTestDisplayNames))]
         [DataTestMethod]
         [TestCategory("LongRunner")]

--- a/src/Hl7.Fhir.Serialization.R4B.Tests/RoundtripNewSerializers.cs
+++ b/src/Hl7.Fhir.Serialization.R4B.Tests/RoundtripNewSerializers.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using System.Text.Json;
+using ERR = Hl7.Fhir.Serialization.FhirJsonException;
 
 namespace Hl7.Fhir.Serialization.Tests
 {
@@ -23,5 +25,14 @@ namespace Hl7.Fhir.Serialization.Tests
         {
             doRoundTrip(baseTestPath, file, xmlSerializer, xmlDeserializer, jsonOptions);
         }
+
+        private static IEnumerable<object[]> attachmentSource()
+        {
+            yield return new object[] { "{\"size\":12, \"title\": \"Correct Attachment\"}", 12L, null! };
+            yield return new object[] { "{\"size\":12.345, \"title\": \"An incorrect Attachment\"}", null!, ERR.NUMBER_CANNOT_BE_PARSED_CODE };
+            yield return new object[] { "{\"size\":\"12\", \"title\": \"An incorrect Attachment\"}", null!, ERR.LONG_INCORRECT_FORMAT_CODE };
+            yield return new object[] { "{\"size\":\"12.345\", \"title\": \"An incorrect Attachment\"}", null!, ERR.LONG_INCORRECT_FORMAT_CODE };
+        }
+
     }
 }

--- a/src/Hl7.Fhir.Serialization.R4B.Tests/RoundtripTest.cs
+++ b/src/Hl7.Fhir.Serialization.R4B.Tests/RoundtripTest.cs
@@ -16,6 +16,8 @@ namespace Hl7.Fhir.Serialization.Tests
     [TestClass]
     public partial class RoundtripTest
     {
+        private readonly string _attachmentJson = "{\"size\":12}";
+
         [TestMethod]
         [TestCategory("LongRunner")]
         public void FullRoundtripOfAllExamplesXmlPoco()

--- a/src/Hl7.Fhir.Serialization.R5.Tests/RoundtripNewSerializers.cs
+++ b/src/Hl7.Fhir.Serialization.R5.Tests/RoundtripNewSerializers.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿#nullable enable
+using FluentAssertions;
 using Hl7.Fhir.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
@@ -29,16 +30,29 @@ namespace Hl7.Fhir.Serialization.Tests
             doRoundTrip(baseTestPath, file, xmlSerializer, xmlDeserializer, jsonOptions);
         }
 
-        [TestMethod]
-        public void ParseIncorrectAttachment()
+        [DataTestMethod]
+        [DataRow("{\"size\":\"12\", \"title\": \"Correct Attachment\"}", 12L, null)]
+        [DataRow("{\"size\":12, \"title\": \"An incorrect Attachment\"}", null, "*Json number '12' cannot be parsed as a Integer64*")]
+        [DataRow("{\"size\":12.345, \"title\": \"An incorrect Attachment\"}", null, "*Json number '12.345' cannot be parsed as a Int64*")]
+        [DataRow("{\"size\":\"12.345\", \"title\": \"An incorrect Attachment\"}", null, "*Json number '12.345' cannot be parsed as a Integer64*")]
+
+        public void ParseAttachment(string input, long? expectedAttachmentSize, string? errorMessage)
         {
-            var attachmentWithIncorrectSizeFormat = "{\"size\":12, \"title\": \"An incorrect Attachment\"}";
             var options = new JsonSerializerOptions().ForFhir(ModelInfo.ModelInspector);
+            if (errorMessage is not null)
+            {
+                Action action = () => JsonSerializer.Deserialize<Attachment>(input, options);
 
-            Action action = () => JsonSerializer.Deserialize<Attachment>(attachmentWithIncorrectSizeFormat, options);
-
-            action.Should().Throw<DeserializationFailedException>()
-                .WithMessage("*Json number '12' cannot be parsed as a Int64. Json token should be string*");
+                action.Should().Throw<DeserializationFailedException>()
+                    .WithMessage(errorMessage);
+            }
+            else
+            {
+                var attachment = JsonSerializer.Deserialize<Attachment>(input, options);
+                attachment.Should().NotBeNull();
+                attachment!.Size.Should().Be(expectedAttachmentSize!.Value);
+            }
         }
     }
 }
+#nullable restore

--- a/src/Hl7.Fhir.Serialization.R5.Tests/RoundtripNewSerializers.cs
+++ b/src/Hl7.Fhir.Serialization.R5.Tests/RoundtripNewSerializers.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using FluentAssertions;
+using Hl7.Fhir.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Text.Json;
 
 namespace Hl7.Fhir.Serialization.Tests
@@ -24,6 +27,18 @@ namespace Hl7.Fhir.Serialization.Tests
         public void FullRoundtripOfAllExamplesJsonNewSerializer(string file, string baseTestPath, FhirXmlPocoSerializer xmlSerializer, FhirXmlPocoDeserializer xmlDeserializer, JsonSerializerOptions jsonOptions)
         {
             doRoundTrip(baseTestPath, file, xmlSerializer, xmlDeserializer, jsonOptions);
+        }
+
+        [TestMethod]
+        public void ParseIncorrectAttachment()
+        {
+            var attachmentWithIncorrectSizeFormat = "{\"size\":12, \"title\": \"An incorrect Attachment\"}";
+            var options = new JsonSerializerOptions().ForFhir(ModelInfo.ModelInspector);
+
+            Action action = () => JsonSerializer.Deserialize<Attachment>(attachmentWithIncorrectSizeFormat, options);
+
+            action.Should().Throw<DeserializationFailedException>()
+                .WithMessage("*Json number '12' cannot be parsed as a Int64. Json token should be string*");
         }
     }
 }

--- a/src/Hl7.Fhir.Serialization.R5.Tests/RoundtripNewSerializers.cs
+++ b/src/Hl7.Fhir.Serialization.R5.Tests/RoundtripNewSerializers.cs
@@ -4,12 +4,14 @@ using System.Text.Json;
 namespace Hl7.Fhir.Serialization.Tests
 {
     [TestClass]
-    [Ignore("Because of incorrect example files in R5 (5.0.0-snapshot3).")]
     public partial class RoundTripNewSerializers
     {
+        private readonly string _attachmentJson = "{\"size\":\"12\"}";
+
         [DynamicData(nameof(prepareExampleZipFilesXml), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(GetTestDisplayNames))]
         [DataTestMethod]
         [TestCategory("LongRunner")]
+        [Ignore("Because of incorrect example files in R5 (5.0.0-snapshot3).")]
         public void FullRoundtripOfAllExamplesXmlNewSerializer(string file, string baseTestPath, FhirXmlPocoSerializer xmlSerializer, FhirXmlPocoDeserializer xmlDeserializer, JsonSerializerOptions jsonOptions)
         {
             doRoundTrip(baseTestPath, file, xmlSerializer, xmlDeserializer, jsonOptions);
@@ -18,6 +20,7 @@ namespace Hl7.Fhir.Serialization.Tests
         [DynamicData(nameof(prepareExampleZipFilesJson), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(GetTestDisplayNames))]
         [DataTestMethod]
         [TestCategory("LongRunner")]
+        [Ignore("Because of incorrect example files in R5 (5.0.0-snapshot3).")]
         public void FullRoundtripOfAllExamplesJsonNewSerializer(string file, string baseTestPath, FhirXmlPocoSerializer xmlSerializer, FhirXmlPocoDeserializer xmlDeserializer, JsonSerializerOptions jsonOptions)
         {
             doRoundTrip(baseTestPath, file, xmlSerializer, xmlDeserializer, jsonOptions);

--- a/src/Hl7.Fhir.Serialization.R5.Tests/RoundtripTest.cs
+++ b/src/Hl7.Fhir.Serialization.R5.Tests/RoundtripTest.cs
@@ -14,11 +14,13 @@ using Tasks = System.Threading.Tasks;
 namespace Hl7.Fhir.Serialization.Tests
 {
     [TestClass]
-    [Ignore("Because of incorrect example files in R5 (5.0.0-snapshot3).")]
     public partial class RoundtripTest
     {
+        private readonly string _attachmentJson = "{\"size\":\"12\"}";
+
         [TestMethod]
         [TestCategory("LongRunner")]
+        [Ignore("Because of incorrect example files in R5 (5.0.0-snapshot3).")]
         public void FullRoundtripOfAllExamplesXmlPoco()
         {
             FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml",
@@ -27,6 +29,7 @@ namespace Hl7.Fhir.Serialization.Tests
 
         [TestMethod]
         [TestCategory("LongRunner")]
+        [Ignore("Because of incorrect example files in R5 (5.0.0-snapshot3).")]
         public async Tasks.Task FullRoundtripOfAllExamplesXmlPocoAsync()
         {
             await FullRoundtripOfAllExamplesAsync("examples.zip", "FHIRRoundTripTestXml",
@@ -35,6 +38,7 @@ namespace Hl7.Fhir.Serialization.Tests
 
         [TestMethod]
         [TestCategory("LongRunner")]
+        [Ignore("Because of incorrect example files in R5 (5.0.0-snapshot3).")]
         public void FullRoundtripOfAllExamplesJsonPoco()
         {
             FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
@@ -43,6 +47,7 @@ namespace Hl7.Fhir.Serialization.Tests
 
         [TestMethod]
         [TestCategory("LongRunner")]
+        [Ignore("Because of incorrect example files in R5 (5.0.0-snapshot3).")]
         public async Tasks.Task FullRoundtripOfAllExamplesJsonPocoAsync()
         {
             await FullRoundtripOfAllExamplesAsync("examples-json.zip", "FHIRRoundTripTestJson",
@@ -51,6 +56,7 @@ namespace Hl7.Fhir.Serialization.Tests
 
         [TestMethod]
         [TestCategory("LongRunner")]
+        [Ignore("Because of incorrect example files in R5 (5.0.0-snapshot3).")]
         public void FullRoundtripOfAllExamplesXmlNavPocoProvider()
         {
             FullRoundtripOfAllExamples("examples.zip", "FHIRRoundTripTestXml",
@@ -59,6 +65,7 @@ namespace Hl7.Fhir.Serialization.Tests
 
         [TestMethod]
         [TestCategory("LongRunner")]
+        [Ignore("Because of incorrect example files in R5 (5.0.0-snapshot3).")]
         public async Tasks.Task FullRoundtripOfAllExamplesXmlNavPocoProviderAsync()
         {
             await FullRoundtripOfAllExamplesAsync("examples.zip", "FHIRRoundTripTestXml",
@@ -67,6 +74,7 @@ namespace Hl7.Fhir.Serialization.Tests
 
         [TestMethod]
         [TestCategory("LongRunner")]
+        [Ignore("Because of incorrect example files in R5 (5.0.0-snapshot3).")]
         public void FullRoundtripOfAllExamplesJsonNavPocoProvider()
         {
             FullRoundtripOfAllExamples("examples-json.zip", "FHIRRoundTripTestJson",
@@ -75,6 +83,7 @@ namespace Hl7.Fhir.Serialization.Tests
 
         [TestMethod]
         [TestCategory("LongRunner")]
+        [Ignore("Because of incorrect example files in R5 (5.0.0-snapshot3).")]
         public async Tasks.Task FullRoundtripOfAllExamplesJsonNavPocoProviderAsync()
         {
             await FullRoundtripOfAllExamplesAsync("examples-json.zip", "FHIRRoundTripTestJson",
@@ -83,6 +92,7 @@ namespace Hl7.Fhir.Serialization.Tests
 
         [TestMethod]
         [TestCategory("LongRunner")]
+        [Ignore("Because of incorrect example files in R5 (5.0.0-snapshot3).")]
         public void FullRoundtripOfAllExamplesXmlNavSdProvider()
         {
             var source = new CachedResolver(ZipSource.CreateValidationSource());
@@ -92,6 +102,7 @@ namespace Hl7.Fhir.Serialization.Tests
 
         [TestMethod]
         [TestCategory("LongRunner")]
+        [Ignore("Because of incorrect example files in R5 (5.0.0-snapshot3).")]
         public async Tasks.Task FullRoundtripOfAllExamplesXmlNavSdProviderAsync()
         {
             var source = new CachedResolver(ZipSource.CreateValidationSource());
@@ -101,6 +112,7 @@ namespace Hl7.Fhir.Serialization.Tests
 
         [TestMethod]
         [TestCategory("LongRunner")]
+        [Ignore("Because of incorrect example files in R5 (5.0.0-snapshot3).")]
         public void FullRoundtripOfAllExamplesJsonNavSdProvider()
         {
             var source = new CachedResolver(ZipSource.CreateValidationSource());
@@ -110,6 +122,7 @@ namespace Hl7.Fhir.Serialization.Tests
 
         [TestMethod]
         [TestCategory("LongRunner")]
+        [Ignore("Because of incorrect example files in R5 (5.0.0-snapshot3).")]
         public async Tasks.Task FullRoundtripOfAllExamplesJsonNavSdProviderAsync()
         {
             var source = new CachedResolver(ZipSource.CreateValidationSource());

--- a/src/Hl7.Fhir.Serialization.Shared.Tests/RoundtripNewSerializers.cs
+++ b/src/Hl7.Fhir.Serialization.Shared.Tests/RoundtripNewSerializers.cs
@@ -1,4 +1,5 @@
-﻿using Hl7.Fhir.Model;
+﻿using FluentAssertions;
+using Hl7.Fhir.Model;
 using Hl7.Fhir.Tests;
 using Hl7.Fhir.Utility;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -63,8 +64,6 @@ namespace Hl7.Fhir.Serialization.Tests
         {
             if (file.Contains("notification-") || file.Contains("subscriptionstatus-"))
                 return true; // These are Subscription resources that have invalid data in R5.
-            if (file.Contains("integer64.profile.json") || file.Contains("documentreference-example.json") || file.Contains("documentmanifest-fm-attachment.json") || file.Contains("communication-example-fm-solicited-attachment.json") || file.Contains("communication-example-fm-attachment.json"))
-                return true; // Are examples that have quotes around integers in R5
             if (file.Contains("examplescenario-example"))
                 return true; // this resource has a property name resourceType (which is reserved in the .net json serializer)
             if (file.Contains("json-edge-cases"))
@@ -222,6 +221,16 @@ namespace Hl7.Fhir.Serialization.Tests
                 JsonAssert.AreSame(new FileInfo(expectedFile).Name, File.ReadAllText(expectedFile),
                                     File.ReadAllText(actualFile), errors);
             }
+        }
+
+        [TestMethod]
+        public void RoundTripAttachmentWithSize()
+        {
+            var options = new JsonSerializerOptions().ForFhir(ModelInfo.ModelInspector);
+            var attachment = JsonSerializer.Deserialize<Attachment>(_attachmentJson, options);
+            attachment.Size.Should().Be(12L);
+            var json = JsonSerializer.Serialize(attachment, options);
+            json.Should().Be(_attachmentJson);
         }
     }
 }

--- a/src/Hl7.Fhir.Serialization.Shared.Tests/RoundtripTest.cs
+++ b/src/Hl7.Fhir.Serialization.Shared.Tests/RoundtripTest.cs
@@ -62,6 +62,7 @@ namespace Hl7.Fhir.Serialization.Tests
         {
             var parser = new FhirJsonParser(new ParserSettings() { PermissiveParsing = false });
             var attachment = parser.Parse<Attachment>(_attachmentJson);
+            attachment.Size.Should().Be(12L);
             var serializer = new FhirJsonSerializer();
             var result = serializer.SerializeToString(attachment);
             result.Should().Be(_attachmentJson);

--- a/src/Hl7.Fhir.Serialization.Shared.Tests/RoundtripTest.cs
+++ b/src/Hl7.Fhir.Serialization.Shared.Tests/RoundtripTest.cs
@@ -6,6 +6,7 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+using FluentAssertions;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification;
 using Hl7.Fhir.Tests;
@@ -56,7 +57,15 @@ namespace Hl7.Fhir.Serialization.Tests
             await doRoundTripAsync(examples, baseTestPath, usingPoco, provider);
         }
 
-
+        [TestMethod]
+        public void RoundTripAttachmentWithSize()
+        {
+            var parser = new FhirJsonParser(new ParserSettings() { PermissiveParsing = false });
+            var attachment = parser.Parse<Attachment>(_attachmentJson);
+            var serializer = new FhirJsonSerializer();
+            var result = serializer.SerializeToString(attachment);
+            result.Should().Be(_attachmentJson);
+        }
 
         //[TestMethod]
         //public void CompareIntermediate2Xml()

--- a/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirJsonDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirJsonDeserializationTests.cs
@@ -23,41 +23,38 @@ namespace Hl7.Fhir.Support.Poco.Tests
     [TestClass]
     public class FhirJsonDeserializationTests
     {
-        //TODO: Now that we have constants for all of these errors, we could replace the string here.
-        private const string NUMBER_CANNOT_BE_PARSED = "JSON108";
-
         [DataTestMethod]
-        [DataRow(null, null, typeof(decimal), null, "JSON109")]
-        [DataRow(new[] { 1, 2 }, null, typeof(decimal), null, "JSON105")]
+        [DataRow(null, null, typeof(decimal), null, ERR.EXPECTED_PRIMITIVE_NOT_NULL_CODE)]
+        [DataRow(new[] { 1, 2 }, null, typeof(decimal), null, ERR.EXPECTED_PRIMITIVE_NOT_ARRAY_CODE)]
 
         [DataRow("hi!", "hi!", typeof(string), null, null)]
         [DataRow("SGkh", null, typeof(byte[]), null, null)]
-        [DataRow("hi!", null, typeof(byte[]), null, "JSON106")]
-        [DataRow("hi!", null, typeof(DateTimeOffset), null, "JSON107")]
+        [DataRow("hi!", null, typeof(byte[]), null, ERR.INCORRECT_BASE64_DATA_CODE)]
+        [DataRow("hi!", null, typeof(DateTimeOffset), null, ERR.STRING_ISNOTAN_INSTANT_CODE)]
         [DataRow("2007-02-03", null, typeof(DateTimeOffset), null, null)]
         [DataRow("enumvalue", null, typeof(UriFormat), null, COVE.INVALID_CODED_VALUE_CODE)]
-        [DataRow(true, "true", typeof(Enum), null, "JSON110")]
-        [DataRow("hi!", "hi!", typeof(int), null, "JSON110")]
+        [DataRow(true, "true", typeof(Enum), null, ERR.UNEXPECTED_JSON_TOKEN_CODE)]
+        [DataRow("hi!", "hi!", typeof(int), null, ERR.UNEXPECTED_JSON_TOKEN_CODE)]
 
         [DataRow(3, 3, typeof(decimal), null, null)]
         [DataRow(3, 3, typeof(uint), null, null)]
-        [DataRow(3L, 3L, typeof(long), typeof(Integer64), "JSON122")]
+        [DataRow(3L, 3L, typeof(long), typeof(Integer64), ERR.LONG_INCORRECT_FORMAT_CODE)]
         [DataRow(3L, 3L, typeof(long), typeof(UnsignedInt), null)]
         [DataRow(3, 3, typeof(ulong), null, null)]
         [DataRow(3.14, 3.14, typeof(decimal), null, null)]
-        [DataRow(3.14, "3.14", typeof(int), null, NUMBER_CANNOT_BE_PARSED)]
-        [DataRow(3.14, "3.14", typeof(uint), null, NUMBER_CANNOT_BE_PARSED)]
-        [DataRow(3.14, "3.14", typeof(long), null, NUMBER_CANNOT_BE_PARSED)]
-        [DataRow(-3, "-3", typeof(ulong), null, NUMBER_CANNOT_BE_PARSED)]
+        [DataRow(3.14, "3.14", typeof(int), null, ERR.NUMBER_CANNOT_BE_PARSED_CODE)]
+        [DataRow(3.14, "3.14", typeof(uint), null, ERR.NUMBER_CANNOT_BE_PARSED_CODE)]
+        [DataRow(3.14, "3.14", typeof(long), null, ERR.NUMBER_CANNOT_BE_PARSED_CODE)]
+        [DataRow(-3, "-3", typeof(ulong), null, ERR.NUMBER_CANNOT_BE_PARSED_CODE)]
         [DataRow(long.MaxValue, long.MaxValue, typeof(decimal), null, null)]
         [DataRow(5, 5, typeof(float), null, null)]
         [DataRow(6.14, 6.14, typeof(double), null, null)]
         [DataRow(314, 314, typeof(int), null, null)]
         [DataRow(314, 314, typeof(decimal), null, null)]
-        [DataRow(3.14, "3.14", typeof(bool), null, "JSON110")]
+        [DataRow(3.14, "3.14", typeof(bool), null, ERR.UNEXPECTED_JSON_TOKEN_CODE)]
 
         [DataRow(true, true, typeof(bool), null, null)]
-        [DataRow(true, "true", typeof(string), null, "JSON110")]
+        [DataRow(true, "true", typeof(string), null, ERR.UNEXPECTED_JSON_TOKEN_CODE)]
         public void TryDeserializePrimitiveValue(object input, object expectedResult, Type expectedImplementingType, Type? fhirType, string code)
         {
             var reader = constructReader(input);
@@ -113,11 +110,11 @@ namespace Hl7.Fhir.Support.Poco.Tests
 
             (result, error) = test(21);
             result.Should().Be("21");
-            error?.ErrorCode.Should().Be(FhirJsonException.ARRAYS_CANNOT_BE_EMPTY_CODE);
+            error?.ErrorCode.Should().Be(ERR.ARRAYS_CANNOT_BE_EMPTY_CODE);
 
             (result, error) = test(31);
             result.Should().BeNull();
-            error?.ErrorCode.Should().Be(FhirJsonException.UNEXPECTED_JSON_TOKEN_CODE);
+            error?.ErrorCode.Should().Be(ERR.UNEXPECTED_JSON_TOKEN_CODE);
 
             try
             {
@@ -155,18 +152,18 @@ namespace Hl7.Fhir.Support.Poco.Tests
         public void PrimitiveValueCannotBeComplex()
         {
             TryDeserializePrimitiveValue(new { bla = 4 }, null!, typeof(int), null, ERR.EXPECTED_PRIMITIVE_NOT_OBJECT.ErrorCode);
-            TryDeserializePrimitiveValue(double.MaxValue, double.MaxValue.ToString(CultureInfo.InvariantCulture), typeof(decimal), null, NUMBER_CANNOT_BE_PARSED);
-            TryDeserializePrimitiveValue(long.MaxValue, long.MaxValue.ToString(), typeof(uint), null, NUMBER_CANNOT_BE_PARSED);
-            TryDeserializePrimitiveValue(long.MaxValue, long.MaxValue.ToString(), typeof(int), null, NUMBER_CANNOT_BE_PARSED);
-            TryDeserializePrimitiveValue(double.MaxValue, double.MaxValue.ToString(CultureInfo.InvariantCulture), typeof(float), null, NUMBER_CANNOT_BE_PARSED);
+            TryDeserializePrimitiveValue(double.MaxValue, double.MaxValue.ToString(CultureInfo.InvariantCulture), typeof(decimal), null, FhirJsonException.NUMBER_CANNOT_BE_PARSED_CODE);
+            TryDeserializePrimitiveValue(long.MaxValue, long.MaxValue.ToString(), typeof(uint), null, ERR.NUMBER_CANNOT_BE_PARSED_CODE);
+            TryDeserializePrimitiveValue(long.MaxValue, long.MaxValue.ToString(), typeof(int), null, ERR.NUMBER_CANNOT_BE_PARSED_CODE);
+            TryDeserializePrimitiveValue(double.MaxValue, double.MaxValue.ToString(CultureInfo.InvariantCulture), typeof(float), null, FhirJsonException.NUMBER_CANNOT_BE_PARSED_CODE);
         }
 
         [DataTestMethod]
         [DataRow("OperationOutcome", null)]
-        [DataRow("OperationOutcomeX", "JSON116")]
+        [DataRow("OperationOutcomeX", ERR.UNKNOWN_RESOURCE_TYPE_CODE)]
         [DataRow("Meta", null)]
-        [DataRow(4, "JSON102")]
-        [DataRow(null, "JSON103")]
+        [DataRow(4, ERR.RESOURCETYPE_SHOULD_BE_STRING_CODE)]
+        [DataRow(null, ERR.NO_RESOURCETYPE_PROPERTY_CODE)]
         public void DeriveClassMapping(object typename, string errorcode)
         {
             var (result, error) = test(typename);
@@ -193,24 +190,24 @@ namespace Hl7.Fhir.Support.Poco.Tests
         }
 
         [DataTestMethod]
-        [DataRow(null, typeof(FhirString), "JSON109")]
-        [DataRow(new[] { 1, 2 }, typeof(FhirString), "JSON105")]
+        [DataRow(null, typeof(FhirString), ERR.EXPECTED_PRIMITIVE_NOT_NULL_CODE)]
+        [DataRow(new[] { 1, 2 }, typeof(FhirString), ERR.EXPECTED_PRIMITIVE_NOT_ARRAY_CODE)]
         [DataRow("SGkh", typeof(FhirString), null, "SGkh")]
 
         [DataRow("SGkh", typeof(Base64Binary), null, new byte[] { 72, 105, 33 })]
-        [DataRow("hi!", typeof(Base64Binary), "JSON106", "hi!")]
-        [DataRow(4, typeof(Base64Binary), "JSON110", "4")]
+        [DataRow("hi!", typeof(Base64Binary), ERR.INCORRECT_BASE64_DATA_CODE, "hi!")]
+        [DataRow(4, typeof(Base64Binary), ERR.UNEXPECTED_JSON_TOKEN_CODE, "4")]
 
         [DataRow("2007-04", typeof(FhirDateTime), null, "2007-04")]
         [DataRow("2007-", typeof(FhirDateTime), COVE.DATETIME_LITERAL_INVALID_CODE, "2007-")]
-        [DataRow(4.45, typeof(FhirDateTime), "JSON110", "4.45")]
+        [DataRow(4.45, typeof(FhirDateTime), ERR.UNEXPECTED_JSON_TOKEN_CODE, "4.45")]
 
         [DataRow("female", typeof(Code), null, "female")]
         [DataRow("is-a", typeof(Code<FilterOperator>), null, "is-a")]
         [DataRow("wrong", typeof(Code<FilterOperator>), COVE.INVALID_CODED_VALUE_CODE, "wrong")]   // just sets ObjectValue, POCO validation handles enum checks
         [DataRow(true, typeof(Code), ERR.UNEXPECTED_JSON_TOKEN_CODE, "true")]
 
-        [DataRow("hi!", typeof(Instant), "JSON107")]
+        [DataRow("hi!", typeof(Instant), ERR.STRING_ISNOTAN_INSTANT_CODE)]
         [DataRow("2007-02-03", typeof(Instant), null, 2007)]
 
         public void ParsePrimitiveValue(object value, Type targetType, string errorcode, object? expectedObjectValue = null)

--- a/src/Hl7.Fhir.Support.Tests/FhirPath/FhirPathTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/FhirPath/FhirPathTests.cs
@@ -77,8 +77,8 @@ namespace Hl7.Fhir.Support.Tests
 
             yield return new object[] { sourceNode.ToTypedElement(ModelInspector.ForAssembly(typeof(Resource).Assembly)), "sourceNode to TypedElement" };
 
-            var poco = sourceNode.ToPoco<Parameters>(ModelInspector.Common);
-            yield return new object[] { poco.ToTypedElement(ModelInspector.Common), "poco to TypedElement" };
+            var poco = sourceNode.ToPoco<Parameters>(ModelInspector.Base);
+            yield return new object[] { poco.ToTypedElement(ModelInspector.Base), "poco to TypedElement" };
 
         }
     }

--- a/src/Hl7.Fhir.Support.Tests/Serialization/CommonTypeParsingTest.cs
+++ b/src/Hl7.Fhir.Support.Tests/Serialization/CommonTypeParsingTest.cs
@@ -20,10 +20,10 @@ namespace Hl7.Fhir.Support.Tests.Serialization
         public void CanConvertPocoToTypedElement()
         {
             Coding c = new Coding("http://nu.nl", "bla");
-            var te = c.ToTypedElement(ModelInspector.Common);
+            var te = c.ToTypedElement(ModelInspector.Base);
             Assert.AreEqual("Coding", te.InstanceType);
 
-            Coding c2 = te.ToPoco<Coding>(ModelInspector.Common);
+            Coding c2 = te.ToPoco<Coding>(ModelInspector.Base);
 
             Assert.AreEqual(c.Code, c2.Code);
             Assert.AreEqual(c.System, c2.System);
@@ -33,10 +33,10 @@ namespace Hl7.Fhir.Support.Tests.Serialization
         public void CanConvertPocoToSourceNode()
         {
             Coding c = new Coding("http://nu.nl", "bla");
-            var sn = c.ToSourceNode(ModelInspector.Common, "kode");
+            var sn = c.ToSourceNode(ModelInspector.Base, "kode");
             Assert.AreEqual("kode", sn.Name);
 
-            Coding c2 = sn.ToPoco<Coding>(ModelInspector.Common);
+            Coding c2 = sn.ToPoco<Coding>(ModelInspector.Base);
 
             Assert.AreEqual(c.Code, c2.Code);
             Assert.AreEqual(c.System, c2.System);

--- a/src/Hl7.FhirPath.Tests/Functions/FunctionsTests.cs
+++ b/src/Hl7.FhirPath.Tests/Functions/FunctionsTests.cs
@@ -558,7 +558,7 @@ namespace HL7.FhirPath.Tests
         public void ContextNestingLevelTest()
         {
             Coding c = new("http://nu.nl", "nl");
-            var te = c.ToTypedElement(ModelInspector.Common);
+            var te = c.ToTypedElement(ModelInspector.Base);
             Assert.IsTrue(te.IsBoolean($"system.endsWith(code)", true));
             Assert.IsTrue(te.IsBoolean($"system.endsWith(%context.code)", true));
             Assert.IsTrue(te.IsBoolean($"system.endsWith('nl')", true));

--- a/src/firely-net-sdk-tests.props
+++ b/src/firely-net-sdk-tests.props
@@ -19,8 +19,8 @@
 
 	<ItemGroup Condition="'$(TargetFramework)' != 'net40'">
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/firely-net-sdk-tests.props
+++ b/src/firely-net-sdk-tests.props
@@ -26,7 +26,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="6.8.0" />
+		<PackageReference Include="FluentAssertions" Version="6.9.0" />
 		<PackageReference Include="Moq" Version="4.18.4" />
 	</ItemGroup>
 

--- a/src/firely-net-sdk.props
+++ b/src/firely-net-sdk.props
@@ -10,7 +10,7 @@
 		<VersionSuffix>beta2</VersionSuffix>
 		<Authors>Firely (info@fire.ly) and contributors</Authors>
 		<Company>Firely (https://fire.ly)</Company>
-		<Copyright>Copyright 2013-2022 Firely.  Contains materials (C) HL7 International</Copyright>
+		<Copyright>Copyright 2013-2023 Firely.  Contains materials (C) HL7 International</Copyright>
 		<PackageProjectUrl>https://github.com/FirelyTeam/firely-net-sdk</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/FirelyTeam/firely-net-sdk</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>


### PR DESCRIPTION
## Description
- ModelInspector.Common => ModelInspector.Base
- FhirModelAssembly for Base is since STU3
- FhirModelAssembly for Conformance is since R4
- Deserializing and Serializing Integer64 with multiple DeclaredTypes
- Update FluentAssertion dependency
- Changed Copyright year
- Bump BenchmarkDotNet from 0.13.3 to 0.13.4
- Implicit Markdown operators can handle null values

## Corresponding PRs:
- https://github.com/FirelyTeam/fhir-codegen/pull/22

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes