### PR TITLE
DeclaredType attributes on ElementDefintion properties 

### DIFF
--- a/src/Hl7.Fhir.Conformance/Model/Generated/ElementDefinition.cs
+++ b/src/Hl7.Fhir.Conformance/Model/Generated/ElementDefinition.cs
@@ -1401,6 +1401,8 @@ namespace Hl7.Fhir.Model
       /// Why this constraint is necessary or appropriate
       /// </summary>
       [FhirElement("requirements", InSummary=true, Order=40)]
+      [DeclaredType(Type = typeof(FhirString))]
+      [DeclaredType(Type = typeof(Markdown), Since = FhirRelease.R5)]
       [DataMember]
       public Hl7.Fhir.Model.Markdown Requirements
       {
@@ -2113,6 +2115,8 @@ namespace Hl7.Fhir.Model
       /// Intended use of codes in the bound value set
       /// </summary>
       [FhirElement("description", InSummary=true, Order=40)]
+      [DeclaredType(Type = typeof(FhirString))]
+      [DeclaredType(Type = typeof(Markdown), Since = FhirRelease.R5)]
       [DataMember]
       public Hl7.Fhir.Model.Markdown Description
       {
@@ -2684,6 +2688,8 @@ namespace Hl7.Fhir.Model
       /// Comments about the mapping or its use
       /// </summary>
       [FhirElement("comment", InSummary=true, Order=60)]
+      [DeclaredType(Type = typeof(FhirString))]
+      [DeclaredType(Type = typeof(Markdown), Since = FhirRelease.R5)]
       [DataMember]
       public Hl7.Fhir.Model.Markdown Comment
       {

--- a/src/Hl7.Fhir.R5.Tests/Hl7.Fhir.R5.Tests.csproj
+++ b/src/Hl7.Fhir.R5.Tests/Hl7.Fhir.R5.Tests.csproj
@@ -5,6 +5,10 @@
 	<Import Project="..\firely-net-sdk-tests.props" />
 
 	<PropertyGroup>
+		<DefineConstants>R5</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup>
 		<AssemblyName>Hl7.Fhir.R5.Tests</AssemblyName>
 	</PropertyGroup>
 

--- a/src/Hl7.Fhir.STU3/Model/Generated/ElementDefinition.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/ElementDefinition.cs
@@ -1346,6 +1346,8 @@ namespace Hl7.Fhir.Model
       /// Why this constraint is necessary or appropriate
       /// </summary>
       [FhirElement("requirements", InSummary=true, Order=40)]
+      [DeclaredType(Type = typeof(FhirString))]
+      [DeclaredType(Type = typeof(Markdown), Since = FhirRelease.R5)]
       [DataMember]
       public Hl7.Fhir.Model.FhirString RequirementsElement
       {
@@ -1720,6 +1722,8 @@ namespace Hl7.Fhir.Model
       /// Human explanation of the value set
       /// </summary>
       [FhirElement("description", InSummary=true, Order=40)]
+      [DeclaredType(Type = typeof(FhirString))]
+      [DeclaredType(Type = typeof(Markdown), Since = FhirRelease.R5)]
       [DataMember]
       public Hl7.Fhir.Model.FhirString DescriptionElement
       {
@@ -1976,6 +1980,8 @@ namespace Hl7.Fhir.Model
       /// Comments about the mapping or its use
       /// </summary>
       [FhirElement("comment", InSummary=true, Order=60)]
+      [DeclaredType(Type = typeof(FhirString))]
+      [DeclaredType(Type = typeof(Markdown), Since = FhirRelease.R5)]
       [DataMember]
       public Hl7.Fhir.Model.FhirString CommentElement
       {

--- a/src/Hl7.Fhir.Shared.Tests/ElementModel/PocoTypedElementTests.cs
+++ b/src/Hl7.Fhir.Shared.Tests/ElementModel/PocoTypedElementTests.cs
@@ -1,4 +1,5 @@
-﻿using Hl7.Fhir.ElementModel;
+﻿using FluentAssertions;
+using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.FhirPath;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
@@ -191,5 +192,41 @@ namespace Hl7.Fhir.Core.Tests.ElementModel
 
             Assert.AreEqual(poco.Subject, subjectProp);
         }
+
+
+        [TestMethod]
+        public void CheckTypeOfElementDefinitionMembers()
+        {
+#if !R5
+            var resultType = "string";
+#else
+            var resultType = "markdown";
+#endif
+            var ed = new ElementDefinition()
+            {
+                Mapping = new System.Collections.Generic.List<ElementDefinition.MappingComponent>() {
+                            new ElementDefinition.MappingComponent() {
+                                Comment = "comment"
+                                }
+                            },
+                Binding = new ElementDefinition.ElementDefinitionBindingComponent()
+                {
+                    Description = "description",
+
+                },
+                Constraint = new System.Collections.Generic.List<ElementDefinition.ConstraintComponent>()
+                {
+                    new ElementDefinition.ConstraintComponent()
+                    {
+                        Requirements = "requirements"
+                    }
+                }
+            };
+            var element = ed.ToTypedElement();
+            element.Select("mapping.comment").First().InstanceType.Should().Be(resultType);
+            element.Select("binding.description").First().InstanceType.Should().Be(resultType);
+            element.Select("constraint.requirements").First().InstanceType.Should().Be(resultType);
+        }
+
     }
 }


### PR DESCRIPTION
## Description
For the following properties of `ElementDefinition` we've added the `DeclaredType` attribute, because the type has changed in 5.0.0-snapshot3 from `FhirString` to `Markdown`:
- `ElementDefinition.mapping.comment`
- `ElementDefinition.binding.description`
- `ElementDefinition.constraint.requirements`

See also PR: https://github.com/FirelyTeam/fhir-codegen/pull/23