### PR TITLE
Make Markdown primitive

### DIFF
--- a/src/Hl7.Fhir.Base/Model/IConformanceResource.cs
+++ b/src/Hl7.Fhir.Base/Model/IConformanceResource.cs
@@ -34,28 +34,29 @@ namespace Hl7.Fhir.Model
     public interface IConformanceResource
     {
         string Url { get; set; }
-        Hl7.Fhir.Model.FhirUri UrlElement { get; set; }
+        FhirUri UrlElement { get; set; }
         string Name { get; set; }
         FhirString NameElement { get; set; }
-        PublicationStatus? Status { get; set; }
         string Publisher { get; set; }
         FhirString PublisherElement { get; set; }
         List<ContactDetail> Contact { get; set; }
-        Markdown Description { get; set; }
-        //FhirString DescriptionElement { get; set; }
+        string Description { get; set; }
+        Markdown DescriptionElement { get; set; }
         List<UsageContext> UseContext { get; set; }
-        Markdown Purpose { get; set; }
-        Code<Hl7.Fhir.Model.PublicationStatus> StatusElement { get; set; }
+        string Purpose { get; set; }
+        Markdown PurposeElement { get; set; }
+        PublicationStatus? Status { get; set; }
+        Code<PublicationStatus> StatusElement { get; set; }
         bool? Experimental { get; set; }
-        Hl7.Fhir.Model.FhirBoolean ExperimentalElement { get; set; }
+        FhirBoolean ExperimentalElement { get; set; }
         string Date { get; set; }
-        Hl7.Fhir.Model.FhirDateTime DateElement { get; set; }
+        FhirDateTime DateElement { get; set; }
     }
 
     public interface IVersionableConformanceResource : IConformanceResource
     {
         string Version { get; set; }
 
-        Hl7.Fhir.Model.FhirString VersionElement { get; set; }
+        FhirString VersionElement { get; set; }
     }
 }

--- a/src/Hl7.Fhir.Conformance/Model/Generated/CapabilityStatement.cs
+++ b/src/Hl7.Fhir.Conformance/Model/Generated/CapabilityStatement.cs
@@ -800,13 +800,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("documentation", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Documentation
+      public Hl7.Fhir.Model.Markdown DocumentationElement
       {
-        get { return _Documentation; }
-        set { _Documentation = value; OnPropertyChanged("Documentation"); }
+        get { return _DocumentationElement; }
+        set { _DocumentationElement = value; OnPropertyChanged("DocumentationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Documentation;
+      private Hl7.Fhir.Model.Markdown _DocumentationElement;
+
+      /// <summary>
+      /// General description of implementation
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Documentation
+      {
+        get { return DocumentationElement != null ? DocumentationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DocumentationElement = null;
+          else
+            DocumentationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Documentation");
+        }
+      }
 
       /// <summary>
       /// Information about security of implementation
@@ -920,7 +938,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(ModeElement != null) dest.ModeElement = (Code<Hl7.Fhir.Model.CapabilityStatement.RestfulCapabilityMode>)ModeElement.DeepCopy();
-        if(Documentation != null) dest.Documentation = (Hl7.Fhir.Model.Markdown)Documentation.DeepCopy();
+        if(DocumentationElement != null) dest.DocumentationElement = (Hl7.Fhir.Model.Markdown)DocumentationElement.DeepCopy();
         if(Security != null) dest.Security = (Hl7.Fhir.Model.CapabilityStatement.SecurityComponent)Security.DeepCopy();
         if(Resource != null) dest.Resource = new List<Hl7.Fhir.Model.CapabilityStatement.ResourceComponent>(Resource.DeepCopy());
         if(Interaction != null) dest.Interaction = new List<Hl7.Fhir.Model.CapabilityStatement.SystemInteractionComponent>(Interaction.DeepCopy());
@@ -943,7 +961,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(ModeElement, otherT.ModeElement)) return false;
-        if( !DeepComparable.Matches(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.Matches(DocumentationElement, otherT.DocumentationElement)) return false;
         if( !DeepComparable.Matches(Security, otherT.Security)) return false;
         if( !DeepComparable.Matches(Resource, otherT.Resource)) return false;
         if( !DeepComparable.Matches(Interaction, otherT.Interaction)) return false;
@@ -961,7 +979,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(ModeElement, otherT.ModeElement)) return false;
-        if( !DeepComparable.IsExactly(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.IsExactly(DocumentationElement, otherT.DocumentationElement)) return false;
         if( !DeepComparable.IsExactly(Security, otherT.Security)) return false;
         if( !DeepComparable.IsExactly(Resource, otherT.Resource)) return false;
         if( !DeepComparable.IsExactly(Interaction, otherT.Interaction)) return false;
@@ -979,7 +997,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (ModeElement != null) yield return ModeElement;
-          if (Documentation != null) yield return Documentation;
+          if (DocumentationElement != null) yield return DocumentationElement;
           if (Security != null) yield return Security;
           foreach (var elem in Resource) { if (elem != null) yield return elem; }
           foreach (var elem in Interaction) { if (elem != null) yield return elem; }
@@ -996,7 +1014,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (ModeElement != null) yield return new ElementValue("mode", ModeElement);
-          if (Documentation != null) yield return new ElementValue("documentation", Documentation);
+          if (DocumentationElement != null) yield return new ElementValue("documentation", DocumentationElement);
           if (Security != null) yield return new ElementValue("security", Security);
           foreach (var elem in Resource) { if (elem != null) yield return new ElementValue("resource", elem); }
           foreach (var elem in Interaction) { if (elem != null) yield return new ElementValue("interaction", elem); }
@@ -1014,8 +1032,8 @@ namespace Hl7.Fhir.Model
             value = ModeElement;
             return ModeElement is not null;
           case "documentation":
-            value = Documentation;
-            return Documentation is not null;
+            value = DocumentationElement;
+            return DocumentationElement is not null;
           case "security":
             value = Security;
             return Security is not null;
@@ -1044,7 +1062,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (ModeElement is not null) yield return new KeyValuePair<string,object>("mode",ModeElement);
-        if (Documentation is not null) yield return new KeyValuePair<string,object>("documentation",Documentation);
+        if (DocumentationElement is not null) yield return new KeyValuePair<string,object>("documentation",DocumentationElement);
         if (Security is not null) yield return new KeyValuePair<string,object>("security",Security);
         if (Resource?.Any() == true) yield return new KeyValuePair<string,object>("resource",Resource);
         if (Interaction?.Any() == true) yield return new KeyValuePair<string,object>("interaction",Interaction);
@@ -1118,13 +1136,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=60)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// General description of how security works
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -1138,7 +1174,7 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(CorsElement != null) dest.CorsElement = (Hl7.Fhir.Model.FhirBoolean)CorsElement.DeepCopy();
         if(Service != null) dest.Service = new List<Hl7.Fhir.Model.CodeableConcept>(Service.DeepCopy());
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         return dest;
       }
 
@@ -1156,7 +1192,7 @@ namespace Hl7.Fhir.Model
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(CorsElement, otherT.CorsElement)) return false;
         if( !DeepComparable.Matches(Service, otherT.Service)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
 
         return true;
       }
@@ -1169,7 +1205,7 @@ namespace Hl7.Fhir.Model
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(CorsElement, otherT.CorsElement)) return false;
         if( !DeepComparable.IsExactly(Service, otherT.Service)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
 
         return true;
       }
@@ -1182,7 +1218,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.Children) yield return item;
           if (CorsElement != null) yield return CorsElement;
           foreach (var elem in Service) { if (elem != null) yield return elem; }
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
         }
       }
 
@@ -1194,7 +1230,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.NamedChildren) yield return item;
           if (CorsElement != null) yield return new ElementValue("cors", CorsElement);
           foreach (var elem in Service) { if (elem != null) yield return new ElementValue("service", elem); }
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         }
       }
 
@@ -1209,8 +1245,8 @@ namespace Hl7.Fhir.Model
             value = Service;
             return Service?.Any() == true;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -1222,7 +1258,7 @@ namespace Hl7.Fhir.Model
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (CorsElement is not null) yield return new KeyValuePair<string,object>("cors",CorsElement);
         if (Service?.Any() == true) yield return new KeyValuePair<string,object>("service",Service);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       }
 
     }
@@ -1340,13 +1376,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("documentation", Order=70)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Documentation
+      public Hl7.Fhir.Model.Markdown DocumentationElement
       {
-        get { return _Documentation; }
-        set { _Documentation = value; OnPropertyChanged("Documentation"); }
+        get { return _DocumentationElement; }
+        set { _DocumentationElement = value; OnPropertyChanged("DocumentationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Documentation;
+      private Hl7.Fhir.Model.Markdown _DocumentationElement;
+
+      /// <summary>
+      /// Additional information about the use of the resource type
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Documentation
+      {
+        get { return DocumentationElement != null ? DocumentationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DocumentationElement = null;
+          else
+            DocumentationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Documentation");
+        }
+      }
 
       /// <summary>
       /// What operations are supported?
@@ -1751,7 +1805,7 @@ namespace Hl7.Fhir.Model
         if(TypeElement != null) dest.TypeElement = (Hl7.Fhir.Model.Code)TypeElement.DeepCopy();
         if(ProfileElement != null) dest.ProfileElement = (Hl7.Fhir.Model.Canonical)ProfileElement.DeepCopy();
         if(SupportedProfileElement != null) dest.SupportedProfileElement = new List<Hl7.Fhir.Model.Canonical>(SupportedProfileElement.DeepCopy());
-        if(Documentation != null) dest.Documentation = (Hl7.Fhir.Model.Markdown)Documentation.DeepCopy();
+        if(DocumentationElement != null) dest.DocumentationElement = (Hl7.Fhir.Model.Markdown)DocumentationElement.DeepCopy();
         if(Interaction != null) dest.Interaction = new List<Hl7.Fhir.Model.CapabilityStatement.ResourceInteractionComponent>(Interaction.DeepCopy());
         if(VersioningElement != null) dest.VersioningElement = (Code<Hl7.Fhir.Model.CapabilityStatement.ResourceVersionPolicy>)VersioningElement.DeepCopy();
         if(ReadHistoryElement != null) dest.ReadHistoryElement = (Hl7.Fhir.Model.FhirBoolean)ReadHistoryElement.DeepCopy();
@@ -1784,7 +1838,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(TypeElement, otherT.TypeElement)) return false;
         if( !DeepComparable.Matches(ProfileElement, otherT.ProfileElement)) return false;
         if( !DeepComparable.Matches(SupportedProfileElement, otherT.SupportedProfileElement)) return false;
-        if( !DeepComparable.Matches(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.Matches(DocumentationElement, otherT.DocumentationElement)) return false;
         if( !DeepComparable.Matches(Interaction, otherT.Interaction)) return false;
         if( !DeepComparable.Matches(VersioningElement, otherT.VersioningElement)) return false;
         if( !DeepComparable.Matches(ReadHistoryElement, otherT.ReadHistoryElement)) return false;
@@ -1812,7 +1866,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(TypeElement, otherT.TypeElement)) return false;
         if( !DeepComparable.IsExactly(ProfileElement, otherT.ProfileElement)) return false;
         if( !DeepComparable.IsExactly(SupportedProfileElement, otherT.SupportedProfileElement)) return false;
-        if( !DeepComparable.IsExactly(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.IsExactly(DocumentationElement, otherT.DocumentationElement)) return false;
         if( !DeepComparable.IsExactly(Interaction, otherT.Interaction)) return false;
         if( !DeepComparable.IsExactly(VersioningElement, otherT.VersioningElement)) return false;
         if( !DeepComparable.IsExactly(ReadHistoryElement, otherT.ReadHistoryElement)) return false;
@@ -1840,7 +1894,7 @@ namespace Hl7.Fhir.Model
           if (TypeElement != null) yield return TypeElement;
           if (ProfileElement != null) yield return ProfileElement;
           foreach (var elem in SupportedProfileElement) { if (elem != null) yield return elem; }
-          if (Documentation != null) yield return Documentation;
+          if (DocumentationElement != null) yield return DocumentationElement;
           foreach (var elem in Interaction) { if (elem != null) yield return elem; }
           if (VersioningElement != null) yield return VersioningElement;
           if (ReadHistoryElement != null) yield return ReadHistoryElement;
@@ -1867,7 +1921,7 @@ namespace Hl7.Fhir.Model
           if (TypeElement != null) yield return new ElementValue("type", TypeElement);
           if (ProfileElement != null) yield return new ElementValue("profile", ProfileElement);
           foreach (var elem in SupportedProfileElement) { if (elem != null) yield return new ElementValue("supportedProfile", elem); }
-          if (Documentation != null) yield return new ElementValue("documentation", Documentation);
+          if (DocumentationElement != null) yield return new ElementValue("documentation", DocumentationElement);
           foreach (var elem in Interaction) { if (elem != null) yield return new ElementValue("interaction", elem); }
           if (VersioningElement != null) yield return new ElementValue("versioning", VersioningElement);
           if (ReadHistoryElement != null) yield return new ElementValue("readHistory", ReadHistoryElement);
@@ -1899,8 +1953,8 @@ namespace Hl7.Fhir.Model
             value = SupportedProfileElement;
             return SupportedProfileElement?.Any() == true;
           case "documentation":
-            value = Documentation;
-            return Documentation is not null;
+            value = DocumentationElement;
+            return DocumentationElement is not null;
           case "interaction":
             value = Interaction;
             return Interaction?.Any() == true;
@@ -1955,7 +2009,7 @@ namespace Hl7.Fhir.Model
         if (TypeElement is not null) yield return new KeyValuePair<string,object>("type",TypeElement);
         if (ProfileElement is not null) yield return new KeyValuePair<string,object>("profile",ProfileElement);
         if (SupportedProfileElement?.Any() == true) yield return new KeyValuePair<string,object>("supportedProfile",SupportedProfileElement);
-        if (Documentation is not null) yield return new KeyValuePair<string,object>("documentation",Documentation);
+        if (DocumentationElement is not null) yield return new KeyValuePair<string,object>("documentation",DocumentationElement);
         if (Interaction?.Any() == true) yield return new KeyValuePair<string,object>("interaction",Interaction);
         if (VersioningElement is not null) yield return new KeyValuePair<string,object>("versioning",VersioningElement);
         if (ReadHistoryElement is not null) yield return new KeyValuePair<string,object>("readHistory",ReadHistoryElement);
@@ -2025,13 +2079,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("documentation", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Documentation
+      public Hl7.Fhir.Model.Markdown DocumentationElement
       {
-        get { return _Documentation; }
-        set { _Documentation = value; OnPropertyChanged("Documentation"); }
+        get { return _DocumentationElement; }
+        set { _DocumentationElement = value; OnPropertyChanged("DocumentationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Documentation;
+      private Hl7.Fhir.Model.Markdown _DocumentationElement;
+
+      /// <summary>
+      /// Anything special about operation behavior
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Documentation
+      {
+        get { return DocumentationElement != null ? DocumentationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DocumentationElement = null;
+          else
+            DocumentationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Documentation");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -2044,7 +2116,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(CodeElement != null) dest.CodeElement = (Code<Hl7.Fhir.Model.CapabilityStatement.TypeRestfulInteraction>)CodeElement.DeepCopy();
-        if(Documentation != null) dest.Documentation = (Hl7.Fhir.Model.Markdown)Documentation.DeepCopy();
+        if(DocumentationElement != null) dest.DocumentationElement = (Hl7.Fhir.Model.Markdown)DocumentationElement.DeepCopy();
         return dest;
       }
 
@@ -2061,7 +2133,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(CodeElement, otherT.CodeElement)) return false;
-        if( !DeepComparable.Matches(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.Matches(DocumentationElement, otherT.DocumentationElement)) return false;
 
         return true;
       }
@@ -2073,7 +2145,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(CodeElement, otherT.CodeElement)) return false;
-        if( !DeepComparable.IsExactly(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.IsExactly(DocumentationElement, otherT.DocumentationElement)) return false;
 
         return true;
       }
@@ -2085,7 +2157,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (CodeElement != null) yield return CodeElement;
-          if (Documentation != null) yield return Documentation;
+          if (DocumentationElement != null) yield return DocumentationElement;
         }
       }
 
@@ -2096,7 +2168,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (CodeElement != null) yield return new ElementValue("code", CodeElement);
-          if (Documentation != null) yield return new ElementValue("documentation", Documentation);
+          if (DocumentationElement != null) yield return new ElementValue("documentation", DocumentationElement);
         }
       }
 
@@ -2108,8 +2180,8 @@ namespace Hl7.Fhir.Model
             value = CodeElement;
             return CodeElement is not null;
           case "documentation":
-            value = Documentation;
-            return Documentation is not null;
+            value = DocumentationElement;
+            return DocumentationElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -2120,7 +2192,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (CodeElement is not null) yield return new KeyValuePair<string,object>("code",CodeElement);
-        if (Documentation is not null) yield return new KeyValuePair<string,object>("documentation",Documentation);
+        if (DocumentationElement is not null) yield return new KeyValuePair<string,object>("documentation",DocumentationElement);
       }
 
     }
@@ -2239,13 +2311,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("documentation", Order=70)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Documentation
+      public Hl7.Fhir.Model.Markdown DocumentationElement
       {
-        get { return _Documentation; }
-        set { _Documentation = value; OnPropertyChanged("Documentation"); }
+        get { return _DocumentationElement; }
+        set { _DocumentationElement = value; OnPropertyChanged("DocumentationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Documentation;
+      private Hl7.Fhir.Model.Markdown _DocumentationElement;
+
+      /// <summary>
+      /// Server-specific usage
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Documentation
+      {
+        get { return DocumentationElement != null ? DocumentationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DocumentationElement = null;
+          else
+            DocumentationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Documentation");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -2260,7 +2350,7 @@ namespace Hl7.Fhir.Model
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
         if(DefinitionElement != null) dest.DefinitionElement = (Hl7.Fhir.Model.Canonical)DefinitionElement.DeepCopy();
         if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.SearchParamType>)TypeElement.DeepCopy();
-        if(Documentation != null) dest.Documentation = (Hl7.Fhir.Model.Markdown)Documentation.DeepCopy();
+        if(DocumentationElement != null) dest.DocumentationElement = (Hl7.Fhir.Model.Markdown)DocumentationElement.DeepCopy();
         return dest;
       }
 
@@ -2279,7 +2369,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
         if( !DeepComparable.Matches(DefinitionElement, otherT.DefinitionElement)) return false;
         if( !DeepComparable.Matches(TypeElement, otherT.TypeElement)) return false;
-        if( !DeepComparable.Matches(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.Matches(DocumentationElement, otherT.DocumentationElement)) return false;
 
         return true;
       }
@@ -2293,7 +2383,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
         if( !DeepComparable.IsExactly(DefinitionElement, otherT.DefinitionElement)) return false;
         if( !DeepComparable.IsExactly(TypeElement, otherT.TypeElement)) return false;
-        if( !DeepComparable.IsExactly(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.IsExactly(DocumentationElement, otherT.DocumentationElement)) return false;
 
         return true;
       }
@@ -2307,7 +2397,7 @@ namespace Hl7.Fhir.Model
           if (NameElement != null) yield return NameElement;
           if (DefinitionElement != null) yield return DefinitionElement;
           if (TypeElement != null) yield return TypeElement;
-          if (Documentation != null) yield return Documentation;
+          if (DocumentationElement != null) yield return DocumentationElement;
         }
       }
 
@@ -2320,7 +2410,7 @@ namespace Hl7.Fhir.Model
           if (NameElement != null) yield return new ElementValue("name", NameElement);
           if (DefinitionElement != null) yield return new ElementValue("definition", DefinitionElement);
           if (TypeElement != null) yield return new ElementValue("type", TypeElement);
-          if (Documentation != null) yield return new ElementValue("documentation", Documentation);
+          if (DocumentationElement != null) yield return new ElementValue("documentation", DocumentationElement);
         }
       }
 
@@ -2338,8 +2428,8 @@ namespace Hl7.Fhir.Model
             value = TypeElement;
             return TypeElement is not null;
           case "documentation":
-            value = Documentation;
-            return Documentation is not null;
+            value = DocumentationElement;
+            return DocumentationElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -2352,7 +2442,7 @@ namespace Hl7.Fhir.Model
         if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
         if (DefinitionElement is not null) yield return new KeyValuePair<string,object>("definition",DefinitionElement);
         if (TypeElement is not null) yield return new KeyValuePair<string,object>("type",TypeElement);
-        if (Documentation is not null) yield return new KeyValuePair<string,object>("documentation",Documentation);
+        if (DocumentationElement is not null) yield return new KeyValuePair<string,object>("documentation",DocumentationElement);
       }
 
     }
@@ -2439,13 +2529,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("documentation", Order=60)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Documentation
+      public Hl7.Fhir.Model.Markdown DocumentationElement
       {
-        get { return _Documentation; }
-        set { _Documentation = value; OnPropertyChanged("Documentation"); }
+        get { return _DocumentationElement; }
+        set { _DocumentationElement = value; OnPropertyChanged("DocumentationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Documentation;
+      private Hl7.Fhir.Model.Markdown _DocumentationElement;
+
+      /// <summary>
+      /// Specific details about operation behavior
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Documentation
+      {
+        get { return DocumentationElement != null ? DocumentationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DocumentationElement = null;
+          else
+            DocumentationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Documentation");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -2459,7 +2567,7 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
         if(DefinitionElement != null) dest.DefinitionElement = (Hl7.Fhir.Model.Canonical)DefinitionElement.DeepCopy();
-        if(Documentation != null) dest.Documentation = (Hl7.Fhir.Model.Markdown)Documentation.DeepCopy();
+        if(DocumentationElement != null) dest.DocumentationElement = (Hl7.Fhir.Model.Markdown)DocumentationElement.DeepCopy();
         return dest;
       }
 
@@ -2477,7 +2585,7 @@ namespace Hl7.Fhir.Model
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
         if( !DeepComparable.Matches(DefinitionElement, otherT.DefinitionElement)) return false;
-        if( !DeepComparable.Matches(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.Matches(DocumentationElement, otherT.DocumentationElement)) return false;
 
         return true;
       }
@@ -2490,7 +2598,7 @@ namespace Hl7.Fhir.Model
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
         if( !DeepComparable.IsExactly(DefinitionElement, otherT.DefinitionElement)) return false;
-        if( !DeepComparable.IsExactly(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.IsExactly(DocumentationElement, otherT.DocumentationElement)) return false;
 
         return true;
       }
@@ -2503,7 +2611,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.Children) yield return item;
           if (NameElement != null) yield return NameElement;
           if (DefinitionElement != null) yield return DefinitionElement;
-          if (Documentation != null) yield return Documentation;
+          if (DocumentationElement != null) yield return DocumentationElement;
         }
       }
 
@@ -2515,7 +2623,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.NamedChildren) yield return item;
           if (NameElement != null) yield return new ElementValue("name", NameElement);
           if (DefinitionElement != null) yield return new ElementValue("definition", DefinitionElement);
-          if (Documentation != null) yield return new ElementValue("documentation", Documentation);
+          if (DocumentationElement != null) yield return new ElementValue("documentation", DocumentationElement);
         }
       }
 
@@ -2530,8 +2638,8 @@ namespace Hl7.Fhir.Model
             value = DefinitionElement;
             return DefinitionElement is not null;
           case "documentation":
-            value = Documentation;
-            return Documentation is not null;
+            value = DocumentationElement;
+            return DocumentationElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -2543,7 +2651,7 @@ namespace Hl7.Fhir.Model
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
         if (DefinitionElement is not null) yield return new KeyValuePair<string,object>("definition",DefinitionElement);
-        if (Documentation is not null) yield return new KeyValuePair<string,object>("documentation",Documentation);
+        if (DocumentationElement is not null) yield return new KeyValuePair<string,object>("documentation",DocumentationElement);
       }
 
     }
@@ -2599,13 +2707,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("documentation", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Documentation
+      public Hl7.Fhir.Model.Markdown DocumentationElement
       {
-        get { return _Documentation; }
-        set { _Documentation = value; OnPropertyChanged("Documentation"); }
+        get { return _DocumentationElement; }
+        set { _DocumentationElement = value; OnPropertyChanged("DocumentationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Documentation;
+      private Hl7.Fhir.Model.Markdown _DocumentationElement;
+
+      /// <summary>
+      /// Anything special about operation behavior
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Documentation
+      {
+        get { return DocumentationElement != null ? DocumentationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DocumentationElement = null;
+          else
+            DocumentationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Documentation");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -2618,7 +2744,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(CodeElement != null) dest.CodeElement = (Code<Hl7.Fhir.Model.CapabilityStatement.SystemRestfulInteraction>)CodeElement.DeepCopy();
-        if(Documentation != null) dest.Documentation = (Hl7.Fhir.Model.Markdown)Documentation.DeepCopy();
+        if(DocumentationElement != null) dest.DocumentationElement = (Hl7.Fhir.Model.Markdown)DocumentationElement.DeepCopy();
         return dest;
       }
 
@@ -2635,7 +2761,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(CodeElement, otherT.CodeElement)) return false;
-        if( !DeepComparable.Matches(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.Matches(DocumentationElement, otherT.DocumentationElement)) return false;
 
         return true;
       }
@@ -2647,7 +2773,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(CodeElement, otherT.CodeElement)) return false;
-        if( !DeepComparable.IsExactly(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.IsExactly(DocumentationElement, otherT.DocumentationElement)) return false;
 
         return true;
       }
@@ -2659,7 +2785,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (CodeElement != null) yield return CodeElement;
-          if (Documentation != null) yield return Documentation;
+          if (DocumentationElement != null) yield return DocumentationElement;
         }
       }
 
@@ -2670,7 +2796,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (CodeElement != null) yield return new ElementValue("code", CodeElement);
-          if (Documentation != null) yield return new ElementValue("documentation", Documentation);
+          if (DocumentationElement != null) yield return new ElementValue("documentation", DocumentationElement);
         }
       }
 
@@ -2682,8 +2808,8 @@ namespace Hl7.Fhir.Model
             value = CodeElement;
             return CodeElement is not null;
           case "documentation":
-            value = Documentation;
-            return Documentation is not null;
+            value = DocumentationElement;
+            return DocumentationElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -2694,7 +2820,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (CodeElement is not null) yield return new KeyValuePair<string,object>("code",CodeElement);
-        if (Documentation is not null) yield return new KeyValuePair<string,object>("documentation",Documentation);
+        if (DocumentationElement is not null) yield return new KeyValuePair<string,object>("documentation",DocumentationElement);
       }
 
     }
@@ -2762,13 +2888,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("documentation", Order=60)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Documentation
+      public Hl7.Fhir.Model.Markdown DocumentationElement
       {
-        get { return _Documentation; }
-        set { _Documentation = value; OnPropertyChanged("Documentation"); }
+        get { return _DocumentationElement; }
+        set { _DocumentationElement = value; OnPropertyChanged("DocumentationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Documentation;
+      private Hl7.Fhir.Model.Markdown _DocumentationElement;
+
+      /// <summary>
+      /// Messaging interface behavior details
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Documentation
+      {
+        get { return DocumentationElement != null ? DocumentationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DocumentationElement = null;
+          else
+            DocumentationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Documentation");
+        }
+      }
 
       /// <summary>
       /// Messages supported by this system
@@ -2796,7 +2940,7 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(Endpoint != null) dest.Endpoint = new List<Hl7.Fhir.Model.CapabilityStatement.EndpointComponent>(Endpoint.DeepCopy());
         if(ReliableCacheElement != null) dest.ReliableCacheElement = (Hl7.Fhir.Model.UnsignedInt)ReliableCacheElement.DeepCopy();
-        if(Documentation != null) dest.Documentation = (Hl7.Fhir.Model.Markdown)Documentation.DeepCopy();
+        if(DocumentationElement != null) dest.DocumentationElement = (Hl7.Fhir.Model.Markdown)DocumentationElement.DeepCopy();
         if(SupportedMessage != null) dest.SupportedMessage = new List<Hl7.Fhir.Model.CapabilityStatement.SupportedMessageComponent>(SupportedMessage.DeepCopy());
         return dest;
       }
@@ -2815,7 +2959,7 @@ namespace Hl7.Fhir.Model
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(Endpoint, otherT.Endpoint)) return false;
         if( !DeepComparable.Matches(ReliableCacheElement, otherT.ReliableCacheElement)) return false;
-        if( !DeepComparable.Matches(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.Matches(DocumentationElement, otherT.DocumentationElement)) return false;
         if( !DeepComparable.Matches(SupportedMessage, otherT.SupportedMessage)) return false;
 
         return true;
@@ -2829,7 +2973,7 @@ namespace Hl7.Fhir.Model
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(Endpoint, otherT.Endpoint)) return false;
         if( !DeepComparable.IsExactly(ReliableCacheElement, otherT.ReliableCacheElement)) return false;
-        if( !DeepComparable.IsExactly(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.IsExactly(DocumentationElement, otherT.DocumentationElement)) return false;
         if( !DeepComparable.IsExactly(SupportedMessage, otherT.SupportedMessage)) return false;
 
         return true;
@@ -2843,7 +2987,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.Children) yield return item;
           foreach (var elem in Endpoint) { if (elem != null) yield return elem; }
           if (ReliableCacheElement != null) yield return ReliableCacheElement;
-          if (Documentation != null) yield return Documentation;
+          if (DocumentationElement != null) yield return DocumentationElement;
           foreach (var elem in SupportedMessage) { if (elem != null) yield return elem; }
         }
       }
@@ -2856,7 +3000,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.NamedChildren) yield return item;
           foreach (var elem in Endpoint) { if (elem != null) yield return new ElementValue("endpoint", elem); }
           if (ReliableCacheElement != null) yield return new ElementValue("reliableCache", ReliableCacheElement);
-          if (Documentation != null) yield return new ElementValue("documentation", Documentation);
+          if (DocumentationElement != null) yield return new ElementValue("documentation", DocumentationElement);
           foreach (var elem in SupportedMessage) { if (elem != null) yield return new ElementValue("supportedMessage", elem); }
         }
       }
@@ -2872,8 +3016,8 @@ namespace Hl7.Fhir.Model
             value = ReliableCacheElement;
             return ReliableCacheElement is not null;
           case "documentation":
-            value = Documentation;
-            return Documentation is not null;
+            value = DocumentationElement;
+            return DocumentationElement is not null;
           case "supportedMessage":
             value = SupportedMessage;
             return SupportedMessage?.Any() == true;
@@ -2888,7 +3032,7 @@ namespace Hl7.Fhir.Model
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (Endpoint?.Any() == true) yield return new KeyValuePair<string,object>("endpoint",Endpoint);
         if (ReliableCacheElement is not null) yield return new KeyValuePair<string,object>("reliableCache",ReliableCacheElement);
-        if (Documentation is not null) yield return new KeyValuePair<string,object>("documentation",Documentation);
+        if (DocumentationElement is not null) yield return new KeyValuePair<string,object>("documentation",DocumentationElement);
         if (SupportedMessage?.Any() == true) yield return new KeyValuePair<string,object>("supportedMessage",SupportedMessage);
       }
 
@@ -3266,13 +3410,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("documentation", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Documentation
+      public Hl7.Fhir.Model.Markdown DocumentationElement
       {
-        get { return _Documentation; }
-        set { _Documentation = value; OnPropertyChanged("Documentation"); }
+        get { return _DocumentationElement; }
+        set { _DocumentationElement = value; OnPropertyChanged("DocumentationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Documentation;
+      private Hl7.Fhir.Model.Markdown _DocumentationElement;
+
+      /// <summary>
+      /// Description of document support
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Documentation
+      {
+        get { return DocumentationElement != null ? DocumentationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DocumentationElement = null;
+          else
+            DocumentationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Documentation");
+        }
+      }
 
       /// <summary>
       /// Constraint on the resources used in the document
@@ -3317,7 +3479,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(ModeElement != null) dest.ModeElement = (Code<Hl7.Fhir.Model.CapabilityStatement.DocumentMode>)ModeElement.DeepCopy();
-        if(Documentation != null) dest.Documentation = (Hl7.Fhir.Model.Markdown)Documentation.DeepCopy();
+        if(DocumentationElement != null) dest.DocumentationElement = (Hl7.Fhir.Model.Markdown)DocumentationElement.DeepCopy();
         if(ProfileElement != null) dest.ProfileElement = (Hl7.Fhir.Model.Canonical)ProfileElement.DeepCopy();
         return dest;
       }
@@ -3335,7 +3497,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(ModeElement, otherT.ModeElement)) return false;
-        if( !DeepComparable.Matches(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.Matches(DocumentationElement, otherT.DocumentationElement)) return false;
         if( !DeepComparable.Matches(ProfileElement, otherT.ProfileElement)) return false;
 
         return true;
@@ -3348,7 +3510,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(ModeElement, otherT.ModeElement)) return false;
-        if( !DeepComparable.IsExactly(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.IsExactly(DocumentationElement, otherT.DocumentationElement)) return false;
         if( !DeepComparable.IsExactly(ProfileElement, otherT.ProfileElement)) return false;
 
         return true;
@@ -3361,7 +3523,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (ModeElement != null) yield return ModeElement;
-          if (Documentation != null) yield return Documentation;
+          if (DocumentationElement != null) yield return DocumentationElement;
           if (ProfileElement != null) yield return ProfileElement;
         }
       }
@@ -3373,7 +3535,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (ModeElement != null) yield return new ElementValue("mode", ModeElement);
-          if (Documentation != null) yield return new ElementValue("documentation", Documentation);
+          if (DocumentationElement != null) yield return new ElementValue("documentation", DocumentationElement);
           if (ProfileElement != null) yield return new ElementValue("profile", ProfileElement);
         }
       }
@@ -3386,8 +3548,8 @@ namespace Hl7.Fhir.Model
             value = ModeElement;
             return ModeElement is not null;
           case "documentation":
-            value = Documentation;
-            return Documentation is not null;
+            value = DocumentationElement;
+            return DocumentationElement is not null;
           case "profile":
             value = ProfileElement;
             return ProfileElement is not null;
@@ -3401,7 +3563,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (ModeElement is not null) yield return new KeyValuePair<string,object>("mode",ModeElement);
-        if (Documentation is not null) yield return new KeyValuePair<string,object>("documentation",Documentation);
+        if (DocumentationElement is not null) yield return new KeyValuePair<string,object>("documentation",DocumentationElement);
         if (ProfileElement is not null) yield return new KeyValuePair<string,object>("profile",ProfileElement);
       }
 
@@ -3692,13 +3854,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the capability statement
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -3733,26 +3913,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this capability statement is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Copyright holder and year(s). Note: Element was introduced in R5, do not use when working with older releases.
@@ -4131,11 +4347,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(CopyrightLabelElement != null) dest.CopyrightLabelElement = (Hl7.Fhir.Model.FhirString)CopyrightLabelElement.DeepCopy();
       if(KindElement != null) dest.KindElement = (Code<Hl7.Fhir.Model.CapabilityStatementKind>)KindElement.DeepCopy();
       if(InstantiatesElement != null) dest.InstantiatesElement = new List<Hl7.Fhir.Model.Canonical>(InstantiatesElement.DeepCopy());
@@ -4175,11 +4391,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.Matches(KindElement, otherT.KindElement)) return false;
       if( !DeepComparable.Matches(InstantiatesElement, otherT.InstantiatesElement)) return false;
@@ -4214,11 +4430,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.IsExactly(KindElement, otherT.KindElement)) return false;
       if( !DeepComparable.IsExactly(InstantiatesElement, otherT.InstantiatesElement)) return false;
@@ -4253,11 +4469,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (CopyrightLabelElement != null) yield return CopyrightLabelElement;
         if (KindElement != null) yield return KindElement;
         foreach (var elem in InstantiatesElement) { if (elem != null) yield return elem; }
@@ -4291,11 +4507,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (CopyrightLabelElement != null) yield return new ElementValue("copyrightLabel", CopyrightLabelElement);
         if (KindElement != null) yield return new ElementValue("kind", KindElement);
         foreach (var elem in InstantiatesElement) { if (elem != null) yield return new ElementValue("instantiates", elem); }
@@ -4348,8 +4564,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -4357,11 +4573,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "copyrightLabel":
           value = CopyrightLabelElement;
           return CopyrightLabelElement is not null;
@@ -4423,11 +4639,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (CopyrightLabelElement is not null) yield return new KeyValuePair<string,object>("copyrightLabel",CopyrightLabelElement);
       if (KindElement is not null) yield return new KeyValuePair<string,object>("kind",KindElement);
       if (InstantiatesElement?.Any() == true) yield return new KeyValuePair<string,object>("instantiates",InstantiatesElement);

--- a/src/Hl7.Fhir.Conformance/Model/Generated/CodeSystem.cs
+++ b/src/Hl7.Fhir.Conformance/Model/Generated/CodeSystem.cs
@@ -1568,13 +1568,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the code system
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1609,26 +1627,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this code system is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the CodeSystem was approved by publisher. Note: Element was introduced in R5, do not use when working with older releases.
@@ -2102,11 +2156,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -2152,11 +2206,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -2197,11 +2251,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -2242,11 +2296,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -2286,11 +2340,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -2349,8 +2403,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2358,11 +2412,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -2442,11 +2496,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.Conformance/Model/Generated/ElementDefinition.cs
+++ b/src/Hl7.Fhir.Conformance/Model/Generated/ElementDefinition.cs
@@ -1404,13 +1404,31 @@ namespace Hl7.Fhir.Model
       [DeclaredType(Type = typeof(FhirString))]
       [DeclaredType(Type = typeof(Markdown), Since = FhirRelease.R5)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Requirements
+      public Hl7.Fhir.Model.Markdown RequirementsElement
       {
-        get { return _Requirements; }
-        set { _Requirements = value; OnPropertyChanged("Requirements"); }
+        get { return _RequirementsElement; }
+        set { _RequirementsElement = value; OnPropertyChanged("RequirementsElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Requirements;
+      private Hl7.Fhir.Model.Markdown _RequirementsElement;
+
+      /// <summary>
+      /// Why this constraint is necessary or appropriate
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Requirements
+      {
+        get { return RequirementsElement != null ? RequirementsElement.Value : null; }
+        set
+        {
+          if (value == null)
+            RequirementsElement = null;
+          else
+            RequirementsElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Requirements");
+        }
+      }
 
       /// <summary>
       /// error | warning
@@ -1613,7 +1631,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(KeyElement != null) dest.KeyElement = (Hl7.Fhir.Model.Id)KeyElement.DeepCopy();
-        if(Requirements != null) dest.Requirements = (Hl7.Fhir.Model.Markdown)Requirements.DeepCopy();
+        if(RequirementsElement != null) dest.RequirementsElement = (Hl7.Fhir.Model.Markdown)RequirementsElement.DeepCopy();
         if(SeverityElement != null) dest.SeverityElement = (Code<Hl7.Fhir.Model.ConstraintSeverity>)SeverityElement.DeepCopy();
         if(SuppressElement != null) dest.SuppressElement = (Hl7.Fhir.Model.FhirBoolean)SuppressElement.DeepCopy();
         if(HumanElement != null) dest.HumanElement = (Hl7.Fhir.Model.FhirString)HumanElement.DeepCopy();
@@ -1636,7 +1654,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(KeyElement, otherT.KeyElement)) return false;
-        if( !DeepComparable.Matches(Requirements, otherT.Requirements)) return false;
+        if( !DeepComparable.Matches(RequirementsElement, otherT.RequirementsElement)) return false;
         if( !DeepComparable.Matches(SeverityElement, otherT.SeverityElement)) return false;
         if( !DeepComparable.Matches(SuppressElement, otherT.SuppressElement)) return false;
         if( !DeepComparable.Matches(HumanElement, otherT.HumanElement)) return false;
@@ -1654,7 +1672,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(KeyElement, otherT.KeyElement)) return false;
-        if( !DeepComparable.IsExactly(Requirements, otherT.Requirements)) return false;
+        if( !DeepComparable.IsExactly(RequirementsElement, otherT.RequirementsElement)) return false;
         if( !DeepComparable.IsExactly(SeverityElement, otherT.SeverityElement)) return false;
         if( !DeepComparable.IsExactly(SuppressElement, otherT.SuppressElement)) return false;
         if( !DeepComparable.IsExactly(HumanElement, otherT.HumanElement)) return false;
@@ -1672,7 +1690,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (KeyElement != null) yield return KeyElement;
-          if (Requirements != null) yield return Requirements;
+          if (RequirementsElement != null) yield return RequirementsElement;
           if (SeverityElement != null) yield return SeverityElement;
           if (SuppressElement != null) yield return SuppressElement;
           if (HumanElement != null) yield return HumanElement;
@@ -1689,7 +1707,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (KeyElement != null) yield return new ElementValue("key", KeyElement);
-          if (Requirements != null) yield return new ElementValue("requirements", Requirements);
+          if (RequirementsElement != null) yield return new ElementValue("requirements", RequirementsElement);
           if (SeverityElement != null) yield return new ElementValue("severity", SeverityElement);
           if (SuppressElement != null) yield return new ElementValue("suppress", SuppressElement);
           if (HumanElement != null) yield return new ElementValue("human", HumanElement);
@@ -1707,8 +1725,8 @@ namespace Hl7.Fhir.Model
             value = KeyElement;
             return KeyElement is not null;
           case "requirements":
-            value = Requirements;
-            return Requirements is not null;
+            value = RequirementsElement;
+            return RequirementsElement is not null;
           case "severity":
             value = SeverityElement;
             return SeverityElement is not null;
@@ -1737,7 +1755,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (KeyElement is not null) yield return new KeyValuePair<string,object>("key",KeyElement);
-        if (Requirements is not null) yield return new KeyValuePair<string,object>("requirements",Requirements);
+        if (RequirementsElement is not null) yield return new KeyValuePair<string,object>("requirements",RequirementsElement);
         if (SeverityElement is not null) yield return new KeyValuePair<string,object>("severity",SeverityElement);
         if (SuppressElement is not null) yield return new KeyValuePair<string,object>("suppress",SuppressElement);
         if (HumanElement is not null) yield return new KeyValuePair<string,object>("human",HumanElement);
@@ -1812,13 +1830,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("documentation", InSummary=true, Order=50, Since=FhirRelease.R5)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Documentation
+      public Hl7.Fhir.Model.Markdown DocumentationElement
       {
-        get { return _Documentation; }
-        set { _Documentation = value; OnPropertyChanged("Documentation"); }
+        get { return _DocumentationElement; }
+        set { _DocumentationElement = value; OnPropertyChanged("DocumentationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Documentation;
+      private Hl7.Fhir.Model.Markdown _DocumentationElement;
+
+      /// <summary>
+      /// Documentation of the purpose or application of the obligation
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Documentation
+      {
+        get { return DocumentationElement != null ? DocumentationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DocumentationElement = null;
+          else
+            DocumentationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Documentation");
+        }
+      }
 
       /// <summary>
       /// Qualifies the usage - jurisdiction, gender, workflow status etc. Note: Element was introduced in R5, do not use when working with older releases.
@@ -1940,7 +1976,7 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(Code != null) dest.Code = (Hl7.Fhir.Model.Coding)Code.DeepCopy();
         if(ActorElement != null) dest.ActorElement = new List<Hl7.Fhir.Model.Canonical>(ActorElement.DeepCopy());
-        if(Documentation != null) dest.Documentation = (Hl7.Fhir.Model.Markdown)Documentation.DeepCopy();
+        if(DocumentationElement != null) dest.DocumentationElement = (Hl7.Fhir.Model.Markdown)DocumentationElement.DeepCopy();
         if(Usage != null) dest.Usage = new List<Hl7.Fhir.Model.UsageContext>(Usage.DeepCopy());
         if(FilterElement != null) dest.FilterElement = (Hl7.Fhir.Model.FhirString)FilterElement.DeepCopy();
         if(FilterDocumentationElement != null) dest.FilterDocumentationElement = (Hl7.Fhir.Model.FhirString)FilterDocumentationElement.DeepCopy();
@@ -1962,7 +1998,7 @@ namespace Hl7.Fhir.Model
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(Code, otherT.Code)) return false;
         if( !DeepComparable.Matches(ActorElement, otherT.ActorElement)) return false;
-        if( !DeepComparable.Matches(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.Matches(DocumentationElement, otherT.DocumentationElement)) return false;
         if( !DeepComparable.Matches(Usage, otherT.Usage)) return false;
         if( !DeepComparable.Matches(FilterElement, otherT.FilterElement)) return false;
         if( !DeepComparable.Matches(FilterDocumentationElement, otherT.FilterDocumentationElement)) return false;
@@ -1979,7 +2015,7 @@ namespace Hl7.Fhir.Model
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(Code, otherT.Code)) return false;
         if( !DeepComparable.IsExactly(ActorElement, otherT.ActorElement)) return false;
-        if( !DeepComparable.IsExactly(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.IsExactly(DocumentationElement, otherT.DocumentationElement)) return false;
         if( !DeepComparable.IsExactly(Usage, otherT.Usage)) return false;
         if( !DeepComparable.IsExactly(FilterElement, otherT.FilterElement)) return false;
         if( !DeepComparable.IsExactly(FilterDocumentationElement, otherT.FilterDocumentationElement)) return false;
@@ -1996,7 +2032,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.Children) yield return item;
           if (Code != null) yield return Code;
           foreach (var elem in ActorElement) { if (elem != null) yield return elem; }
-          if (Documentation != null) yield return Documentation;
+          if (DocumentationElement != null) yield return DocumentationElement;
           foreach (var elem in Usage) { if (elem != null) yield return elem; }
           if (FilterElement != null) yield return FilterElement;
           if (FilterDocumentationElement != null) yield return FilterDocumentationElement;
@@ -2012,7 +2048,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.NamedChildren) yield return item;
           if (Code != null) yield return new ElementValue("code", Code);
           foreach (var elem in ActorElement) { if (elem != null) yield return new ElementValue("actor", elem); }
-          if (Documentation != null) yield return new ElementValue("documentation", Documentation);
+          if (DocumentationElement != null) yield return new ElementValue("documentation", DocumentationElement);
           foreach (var elem in Usage) { if (elem != null) yield return new ElementValue("usage", elem); }
           if (FilterElement != null) yield return new ElementValue("filter", FilterElement);
           if (FilterDocumentationElement != null) yield return new ElementValue("filterDocumentation", FilterDocumentationElement);
@@ -2031,8 +2067,8 @@ namespace Hl7.Fhir.Model
             value = ActorElement;
             return ActorElement?.Any() == true;
           case "documentation":
-            value = Documentation;
-            return Documentation is not null;
+            value = DocumentationElement;
+            return DocumentationElement is not null;
           case "usage":
             value = Usage;
             return Usage?.Any() == true;
@@ -2056,7 +2092,7 @@ namespace Hl7.Fhir.Model
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (Code is not null) yield return new KeyValuePair<string,object>("code",Code);
         if (ActorElement?.Any() == true) yield return new KeyValuePair<string,object>("actor",ActorElement);
-        if (Documentation is not null) yield return new KeyValuePair<string,object>("documentation",Documentation);
+        if (DocumentationElement is not null) yield return new KeyValuePair<string,object>("documentation",DocumentationElement);
         if (Usage?.Any() == true) yield return new KeyValuePair<string,object>("usage",Usage);
         if (FilterElement is not null) yield return new KeyValuePair<string,object>("filter",FilterElement);
         if (FilterDocumentationElement is not null) yield return new KeyValuePair<string,object>("filterDocumentation",FilterDocumentationElement);
@@ -2118,13 +2154,31 @@ namespace Hl7.Fhir.Model
       [DeclaredType(Type = typeof(FhirString))]
       [DeclaredType(Type = typeof(Markdown), Since = FhirRelease.R5)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Intended use of codes in the bound value set
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Source of value set
@@ -2182,7 +2236,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(StrengthElement != null) dest.StrengthElement = (Code<Hl7.Fhir.Model.BindingStrength>)StrengthElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(ValueSetElement != null) dest.ValueSetElement = (Hl7.Fhir.Model.Canonical)ValueSetElement.DeepCopy();
         if(Additional != null) dest.Additional = new List<Hl7.Fhir.Model.ElementDefinition.AdditionalComponent>(Additional.DeepCopy());
         return dest;
@@ -2201,7 +2255,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(StrengthElement, otherT.StrengthElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(ValueSetElement, otherT.ValueSetElement)) return false;
         if( !DeepComparable.Matches(Additional, otherT.Additional)) return false;
 
@@ -2215,7 +2269,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(StrengthElement, otherT.StrengthElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(ValueSetElement, otherT.ValueSetElement)) return false;
         if( !DeepComparable.IsExactly(Additional, otherT.Additional)) return false;
 
@@ -2229,7 +2283,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (StrengthElement != null) yield return StrengthElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           if (ValueSetElement != null) yield return ValueSetElement;
           foreach (var elem in Additional) { if (elem != null) yield return elem; }
         }
@@ -2242,7 +2296,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (StrengthElement != null) yield return new ElementValue("strength", StrengthElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (ValueSetElement != null) yield return new ElementValue("valueSet", ValueSetElement);
           foreach (var elem in Additional) { if (elem != null) yield return new ElementValue("additional", elem); }
         }
@@ -2256,8 +2310,8 @@ namespace Hl7.Fhir.Model
             value = StrengthElement;
             return StrengthElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "valueSet":
             value = ValueSetElement;
             return ValueSetElement is not null;
@@ -2274,7 +2328,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (StrengthElement is not null) yield return new KeyValuePair<string,object>("strength",StrengthElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (ValueSetElement is not null) yield return new KeyValuePair<string,object>("valueSet",ValueSetElement);
         if (Additional?.Any() == true) yield return new KeyValuePair<string,object>("additional",Additional);
       }
@@ -2364,13 +2418,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("documentation", InSummary=true, Order=50, Since=FhirRelease.R5)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Documentation
+      public Hl7.Fhir.Model.Markdown DocumentationElement
       {
-        get { return _Documentation; }
-        set { _Documentation = value; OnPropertyChanged("Documentation"); }
+        get { return _DocumentationElement; }
+        set { _DocumentationElement = value; OnPropertyChanged("DocumentationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Documentation;
+      private Hl7.Fhir.Model.Markdown _DocumentationElement;
+
+      /// <summary>
+      /// Documentation of the purpose of use of the binding
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Documentation
+      {
+        get { return DocumentationElement != null ? DocumentationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DocumentationElement = null;
+          else
+            DocumentationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Documentation");
+        }
+      }
 
       /// <summary>
       /// Concise documentation - for summary tables. Note: Element was introduced in R5, do not use when working with older releases.
@@ -2460,7 +2532,7 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(PurposeElement != null) dest.PurposeElement = (Code<Hl7.Fhir.Model.ElementDefinition.AdditionalBindingPurposeVS>)PurposeElement.DeepCopy();
         if(ValueSetElement != null) dest.ValueSetElement = (Hl7.Fhir.Model.Canonical)ValueSetElement.DeepCopy();
-        if(Documentation != null) dest.Documentation = (Hl7.Fhir.Model.Markdown)Documentation.DeepCopy();
+        if(DocumentationElement != null) dest.DocumentationElement = (Hl7.Fhir.Model.Markdown)DocumentationElement.DeepCopy();
         if(ShortDocoElement != null) dest.ShortDocoElement = (Hl7.Fhir.Model.FhirString)ShortDocoElement.DeepCopy();
         if(Usage != null) dest.Usage = new List<Hl7.Fhir.Model.UsageContext>(Usage.DeepCopy());
         if(AnyElement != null) dest.AnyElement = (Hl7.Fhir.Model.FhirBoolean)AnyElement.DeepCopy();
@@ -2481,7 +2553,7 @@ namespace Hl7.Fhir.Model
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
         if( !DeepComparable.Matches(ValueSetElement, otherT.ValueSetElement)) return false;
-        if( !DeepComparable.Matches(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.Matches(DocumentationElement, otherT.DocumentationElement)) return false;
         if( !DeepComparable.Matches(ShortDocoElement, otherT.ShortDocoElement)) return false;
         if( !DeepComparable.Matches(Usage, otherT.Usage)) return false;
         if( !DeepComparable.Matches(AnyElement, otherT.AnyElement)) return false;
@@ -2497,7 +2569,7 @@ namespace Hl7.Fhir.Model
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
         if( !DeepComparable.IsExactly(ValueSetElement, otherT.ValueSetElement)) return false;
-        if( !DeepComparable.IsExactly(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.IsExactly(DocumentationElement, otherT.DocumentationElement)) return false;
         if( !DeepComparable.IsExactly(ShortDocoElement, otherT.ShortDocoElement)) return false;
         if( !DeepComparable.IsExactly(Usage, otherT.Usage)) return false;
         if( !DeepComparable.IsExactly(AnyElement, otherT.AnyElement)) return false;
@@ -2513,7 +2585,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.Children) yield return item;
           if (PurposeElement != null) yield return PurposeElement;
           if (ValueSetElement != null) yield return ValueSetElement;
-          if (Documentation != null) yield return Documentation;
+          if (DocumentationElement != null) yield return DocumentationElement;
           if (ShortDocoElement != null) yield return ShortDocoElement;
           foreach (var elem in Usage) { if (elem != null) yield return elem; }
           if (AnyElement != null) yield return AnyElement;
@@ -2528,7 +2600,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.NamedChildren) yield return item;
           if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
           if (ValueSetElement != null) yield return new ElementValue("valueSet", ValueSetElement);
-          if (Documentation != null) yield return new ElementValue("documentation", Documentation);
+          if (DocumentationElement != null) yield return new ElementValue("documentation", DocumentationElement);
           if (ShortDocoElement != null) yield return new ElementValue("shortDoco", ShortDocoElement);
           foreach (var elem in Usage) { if (elem != null) yield return new ElementValue("usage", elem); }
           if (AnyElement != null) yield return new ElementValue("any", AnyElement);
@@ -2546,8 +2618,8 @@ namespace Hl7.Fhir.Model
             value = ValueSetElement;
             return ValueSetElement is not null;
           case "documentation":
-            value = Documentation;
-            return Documentation is not null;
+            value = DocumentationElement;
+            return DocumentationElement is not null;
           case "shortDoco":
             value = ShortDocoElement;
             return ShortDocoElement is not null;
@@ -2568,7 +2640,7 @@ namespace Hl7.Fhir.Model
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
         if (ValueSetElement is not null) yield return new KeyValuePair<string,object>("valueSet",ValueSetElement);
-        if (Documentation is not null) yield return new KeyValuePair<string,object>("documentation",Documentation);
+        if (DocumentationElement is not null) yield return new KeyValuePair<string,object>("documentation",DocumentationElement);
         if (ShortDocoElement is not null) yield return new KeyValuePair<string,object>("shortDoco",ShortDocoElement);
         if (Usage?.Any() == true) yield return new KeyValuePair<string,object>("usage",Usage);
         if (AnyElement is not null) yield return new KeyValuePair<string,object>("any",AnyElement);
@@ -2691,13 +2763,31 @@ namespace Hl7.Fhir.Model
       [DeclaredType(Type = typeof(FhirString))]
       [DeclaredType(Type = typeof(Markdown), Since = FhirRelease.R5)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Comment
+      public Hl7.Fhir.Model.Markdown CommentElement
       {
-        get { return _Comment; }
-        set { _Comment = value; OnPropertyChanged("Comment"); }
+        get { return _CommentElement; }
+        set { _CommentElement = value; OnPropertyChanged("CommentElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Comment;
+      private Hl7.Fhir.Model.Markdown _CommentElement;
+
+      /// <summary>
+      /// Comments about the mapping or its use
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Comment
+      {
+        get { return CommentElement != null ? CommentElement.Value : null; }
+        set
+        {
+          if (value == null)
+            CommentElement = null;
+          else
+            CommentElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Comment");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -2712,7 +2802,7 @@ namespace Hl7.Fhir.Model
         if(IdentityElement != null) dest.IdentityElement = (Hl7.Fhir.Model.Id)IdentityElement.DeepCopy();
         if(LanguageElement != null) dest.LanguageElement = (Hl7.Fhir.Model.Code)LanguageElement.DeepCopy();
         if(MapElement != null) dest.MapElement = (Hl7.Fhir.Model.FhirString)MapElement.DeepCopy();
-        if(Comment != null) dest.Comment = (Hl7.Fhir.Model.Markdown)Comment.DeepCopy();
+        if(CommentElement != null) dest.CommentElement = (Hl7.Fhir.Model.Markdown)CommentElement.DeepCopy();
         return dest;
       }
 
@@ -2731,7 +2821,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(IdentityElement, otherT.IdentityElement)) return false;
         if( !DeepComparable.Matches(LanguageElement, otherT.LanguageElement)) return false;
         if( !DeepComparable.Matches(MapElement, otherT.MapElement)) return false;
-        if( !DeepComparable.Matches(Comment, otherT.Comment)) return false;
+        if( !DeepComparable.Matches(CommentElement, otherT.CommentElement)) return false;
 
         return true;
       }
@@ -2745,7 +2835,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(IdentityElement, otherT.IdentityElement)) return false;
         if( !DeepComparable.IsExactly(LanguageElement, otherT.LanguageElement)) return false;
         if( !DeepComparable.IsExactly(MapElement, otherT.MapElement)) return false;
-        if( !DeepComparable.IsExactly(Comment, otherT.Comment)) return false;
+        if( !DeepComparable.IsExactly(CommentElement, otherT.CommentElement)) return false;
 
         return true;
       }
@@ -2759,7 +2849,7 @@ namespace Hl7.Fhir.Model
           if (IdentityElement != null) yield return IdentityElement;
           if (LanguageElement != null) yield return LanguageElement;
           if (MapElement != null) yield return MapElement;
-          if (Comment != null) yield return Comment;
+          if (CommentElement != null) yield return CommentElement;
         }
       }
 
@@ -2772,7 +2862,7 @@ namespace Hl7.Fhir.Model
           if (IdentityElement != null) yield return new ElementValue("identity", IdentityElement);
           if (LanguageElement != null) yield return new ElementValue("language", LanguageElement);
           if (MapElement != null) yield return new ElementValue("map", MapElement);
-          if (Comment != null) yield return new ElementValue("comment", Comment);
+          if (CommentElement != null) yield return new ElementValue("comment", CommentElement);
         }
       }
 
@@ -2790,8 +2880,8 @@ namespace Hl7.Fhir.Model
             value = MapElement;
             return MapElement is not null;
           case "comment":
-            value = Comment;
-            return Comment is not null;
+            value = CommentElement;
+            return CommentElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -2804,7 +2894,7 @@ namespace Hl7.Fhir.Model
         if (IdentityElement is not null) yield return new KeyValuePair<string,object>("identity",IdentityElement);
         if (LanguageElement is not null) yield return new KeyValuePair<string,object>("language",LanguageElement);
         if (MapElement is not null) yield return new KeyValuePair<string,object>("map",MapElement);
-        if (Comment is not null) yield return new KeyValuePair<string,object>("comment",Comment);
+        if (CommentElement is not null) yield return new KeyValuePair<string,object>("comment",CommentElement);
       }
 
     }
@@ -3030,39 +3120,93 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("definition", InSummary=true, Order=120)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Definition
+    public Hl7.Fhir.Model.Markdown DefinitionElement
     {
-      get { return _Definition; }
-      set { _Definition = value; OnPropertyChanged("Definition"); }
+      get { return _DefinitionElement; }
+      set { _DefinitionElement = value; OnPropertyChanged("DefinitionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Definition;
+    private Hl7.Fhir.Model.Markdown _DefinitionElement;
+
+    /// <summary>
+    /// Full formal definition as narrative text
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Definition
+    {
+      get { return DefinitionElement != null ? DefinitionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DefinitionElement = null;
+        else
+          DefinitionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Definition");
+      }
+    }
 
     /// <summary>
     /// Comments about the use of this element
     /// </summary>
     [FhirElement("comment", InSummary=true, Order=130)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Comment
+    public Hl7.Fhir.Model.Markdown CommentElement
     {
-      get { return _Comment; }
-      set { _Comment = value; OnPropertyChanged("Comment"); }
+      get { return _CommentElement; }
+      set { _CommentElement = value; OnPropertyChanged("CommentElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Comment;
+    private Hl7.Fhir.Model.Markdown _CommentElement;
+
+    /// <summary>
+    /// Comments about the use of this element
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Comment
+    {
+      get { return CommentElement != null ? CommentElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CommentElement = null;
+        else
+          CommentElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Comment");
+      }
+    }
 
     /// <summary>
     /// Why this resource has been created
     /// </summary>
     [FhirElement("requirements", InSummary=true, Order=140)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Requirements
+    public Hl7.Fhir.Model.Markdown RequirementsElement
     {
-      get { return _Requirements; }
-      set { _Requirements = value; OnPropertyChanged("Requirements"); }
+      get { return _RequirementsElement; }
+      set { _RequirementsElement = value; OnPropertyChanged("RequirementsElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Requirements;
+    private Hl7.Fhir.Model.Markdown _RequirementsElement;
+
+    /// <summary>
+    /// Why this resource has been created
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Requirements
+    {
+      get { return RequirementsElement != null ? RequirementsElement.Value : null; }
+      set
+      {
+        if (value == null)
+          RequirementsElement = null;
+        else
+          RequirementsElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Requirements");
+      }
+    }
 
     /// <summary>
     /// Other names
@@ -3234,13 +3378,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("meaningWhenMissing", InSummary=true, Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown MeaningWhenMissing
+    public Hl7.Fhir.Model.Markdown MeaningWhenMissingElement
     {
-      get { return _MeaningWhenMissing; }
-      set { _MeaningWhenMissing = value; OnPropertyChanged("MeaningWhenMissing"); }
+      get { return _MeaningWhenMissingElement; }
+      set { _MeaningWhenMissingElement = value; OnPropertyChanged("MeaningWhenMissingElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _MeaningWhenMissing;
+    private Hl7.Fhir.Model.Markdown _MeaningWhenMissingElement;
+
+    /// <summary>
+    /// Implicit meaning when this element is missing
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string MeaningWhenMissing
+    {
+      get { return MeaningWhenMissingElement != null ? MeaningWhenMissingElement.Value : null; }
+      set
+      {
+        if (value == null)
+          MeaningWhenMissingElement = null;
+        else
+          MeaningWhenMissingElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("MeaningWhenMissing");
+      }
+    }
 
     /// <summary>
     /// What the order of the elements means
@@ -3666,9 +3828,9 @@ namespace Hl7.Fhir.Model
       if(Code != null) dest.Code = new List<Hl7.Fhir.Model.Coding>(Code.DeepCopy());
       if(Slicing != null) dest.Slicing = (Hl7.Fhir.Model.ElementDefinition.SlicingComponent)Slicing.DeepCopy();
       if(ShortElement != null) dest.ShortElement = (Hl7.Fhir.Model.FhirString)ShortElement.DeepCopy();
-      if(Definition != null) dest.Definition = (Hl7.Fhir.Model.Markdown)Definition.DeepCopy();
-      if(Comment != null) dest.Comment = (Hl7.Fhir.Model.Markdown)Comment.DeepCopy();
-      if(Requirements != null) dest.Requirements = (Hl7.Fhir.Model.Markdown)Requirements.DeepCopy();
+      if(DefinitionElement != null) dest.DefinitionElement = (Hl7.Fhir.Model.Markdown)DefinitionElement.DeepCopy();
+      if(CommentElement != null) dest.CommentElement = (Hl7.Fhir.Model.Markdown)CommentElement.DeepCopy();
+      if(RequirementsElement != null) dest.RequirementsElement = (Hl7.Fhir.Model.Markdown)RequirementsElement.DeepCopy();
       if(AliasElement != null) dest.AliasElement = new List<Hl7.Fhir.Model.FhirString>(AliasElement.DeepCopy());
       if(MinElement != null) dest.MinElement = (Hl7.Fhir.Model.UnsignedInt)MinElement.DeepCopy();
       if(MaxElement != null) dest.MaxElement = (Hl7.Fhir.Model.FhirString)MaxElement.DeepCopy();
@@ -3676,7 +3838,7 @@ namespace Hl7.Fhir.Model
       if(ContentReferenceElement != null) dest.ContentReferenceElement = (Hl7.Fhir.Model.FhirUri)ContentReferenceElement.DeepCopy();
       if(Type != null) dest.Type = new List<Hl7.Fhir.Model.ElementDefinition.TypeRefComponent>(Type.DeepCopy());
       if(DefaultValue != null) dest.DefaultValue = (Hl7.Fhir.Model.DataType)DefaultValue.DeepCopy();
-      if(MeaningWhenMissing != null) dest.MeaningWhenMissing = (Hl7.Fhir.Model.Markdown)MeaningWhenMissing.DeepCopy();
+      if(MeaningWhenMissingElement != null) dest.MeaningWhenMissingElement = (Hl7.Fhir.Model.Markdown)MeaningWhenMissingElement.DeepCopy();
       if(OrderMeaningElement != null) dest.OrderMeaningElement = (Hl7.Fhir.Model.FhirString)OrderMeaningElement.DeepCopy();
       if(Fixed != null) dest.Fixed = (Hl7.Fhir.Model.DataType)Fixed.DeepCopy();
       if(Pattern != null) dest.Pattern = (Hl7.Fhir.Model.DataType)Pattern.DeepCopy();
@@ -3718,9 +3880,9 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Code, otherT.Code)) return false;
       if( !DeepComparable.Matches(Slicing, otherT.Slicing)) return false;
       if( !DeepComparable.Matches(ShortElement, otherT.ShortElement)) return false;
-      if( !DeepComparable.Matches(Definition, otherT.Definition)) return false;
-      if( !DeepComparable.Matches(Comment, otherT.Comment)) return false;
-      if( !DeepComparable.Matches(Requirements, otherT.Requirements)) return false;
+      if( !DeepComparable.Matches(DefinitionElement, otherT.DefinitionElement)) return false;
+      if( !DeepComparable.Matches(CommentElement, otherT.CommentElement)) return false;
+      if( !DeepComparable.Matches(RequirementsElement, otherT.RequirementsElement)) return false;
       if( !DeepComparable.Matches(AliasElement, otherT.AliasElement)) return false;
       if( !DeepComparable.Matches(MinElement, otherT.MinElement)) return false;
       if( !DeepComparable.Matches(MaxElement, otherT.MaxElement)) return false;
@@ -3728,7 +3890,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(ContentReferenceElement, otherT.ContentReferenceElement)) return false;
       if( !DeepComparable.Matches(Type, otherT.Type)) return false;
       if( !DeepComparable.Matches(DefaultValue, otherT.DefaultValue)) return false;
-      if( !DeepComparable.Matches(MeaningWhenMissing, otherT.MeaningWhenMissing)) return false;
+      if( !DeepComparable.Matches(MeaningWhenMissingElement, otherT.MeaningWhenMissingElement)) return false;
       if( !DeepComparable.Matches(OrderMeaningElement, otherT.OrderMeaningElement)) return false;
       if( !DeepComparable.Matches(Fixed, otherT.Fixed)) return false;
       if( !DeepComparable.Matches(Pattern, otherT.Pattern)) return false;
@@ -3765,9 +3927,9 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Code, otherT.Code)) return false;
       if( !DeepComparable.IsExactly(Slicing, otherT.Slicing)) return false;
       if( !DeepComparable.IsExactly(ShortElement, otherT.ShortElement)) return false;
-      if( !DeepComparable.IsExactly(Definition, otherT.Definition)) return false;
-      if( !DeepComparable.IsExactly(Comment, otherT.Comment)) return false;
-      if( !DeepComparable.IsExactly(Requirements, otherT.Requirements)) return false;
+      if( !DeepComparable.IsExactly(DefinitionElement, otherT.DefinitionElement)) return false;
+      if( !DeepComparable.IsExactly(CommentElement, otherT.CommentElement)) return false;
+      if( !DeepComparable.IsExactly(RequirementsElement, otherT.RequirementsElement)) return false;
       if( !DeepComparable.IsExactly(AliasElement, otherT.AliasElement)) return false;
       if( !DeepComparable.IsExactly(MinElement, otherT.MinElement)) return false;
       if( !DeepComparable.IsExactly(MaxElement, otherT.MaxElement)) return false;
@@ -3775,7 +3937,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(ContentReferenceElement, otherT.ContentReferenceElement)) return false;
       if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
       if( !DeepComparable.IsExactly(DefaultValue, otherT.DefaultValue)) return false;
-      if( !DeepComparable.IsExactly(MeaningWhenMissing, otherT.MeaningWhenMissing)) return false;
+      if( !DeepComparable.IsExactly(MeaningWhenMissingElement, otherT.MeaningWhenMissingElement)) return false;
       if( !DeepComparable.IsExactly(OrderMeaningElement, otherT.OrderMeaningElement)) return false;
       if( !DeepComparable.IsExactly(Fixed, otherT.Fixed)) return false;
       if( !DeepComparable.IsExactly(Pattern, otherT.Pattern)) return false;
@@ -3812,9 +3974,9 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Code) { if (elem != null) yield return elem; }
         if (Slicing != null) yield return Slicing;
         if (ShortElement != null) yield return ShortElement;
-        if (Definition != null) yield return Definition;
-        if (Comment != null) yield return Comment;
-        if (Requirements != null) yield return Requirements;
+        if (DefinitionElement != null) yield return DefinitionElement;
+        if (CommentElement != null) yield return CommentElement;
+        if (RequirementsElement != null) yield return RequirementsElement;
         foreach (var elem in AliasElement) { if (elem != null) yield return elem; }
         if (MinElement != null) yield return MinElement;
         if (MaxElement != null) yield return MaxElement;
@@ -3822,7 +3984,7 @@ namespace Hl7.Fhir.Model
         if (ContentReferenceElement != null) yield return ContentReferenceElement;
         foreach (var elem in Type) { if (elem != null) yield return elem; }
         if (DefaultValue != null) yield return DefaultValue;
-        if (MeaningWhenMissing != null) yield return MeaningWhenMissing;
+        if (MeaningWhenMissingElement != null) yield return MeaningWhenMissingElement;
         if (OrderMeaningElement != null) yield return OrderMeaningElement;
         if (Fixed != null) yield return Fixed;
         if (Pattern != null) yield return Pattern;
@@ -3858,9 +4020,9 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Code) { if (elem != null) yield return new ElementValue("code", elem); }
         if (Slicing != null) yield return new ElementValue("slicing", Slicing);
         if (ShortElement != null) yield return new ElementValue("short", ShortElement);
-        if (Definition != null) yield return new ElementValue("definition", Definition);
-        if (Comment != null) yield return new ElementValue("comment", Comment);
-        if (Requirements != null) yield return new ElementValue("requirements", Requirements);
+        if (DefinitionElement != null) yield return new ElementValue("definition", DefinitionElement);
+        if (CommentElement != null) yield return new ElementValue("comment", CommentElement);
+        if (RequirementsElement != null) yield return new ElementValue("requirements", RequirementsElement);
         foreach (var elem in AliasElement) { if (elem != null) yield return new ElementValue("alias", elem); }
         if (MinElement != null) yield return new ElementValue("min", MinElement);
         if (MaxElement != null) yield return new ElementValue("max", MaxElement);
@@ -3868,7 +4030,7 @@ namespace Hl7.Fhir.Model
         if (ContentReferenceElement != null) yield return new ElementValue("contentReference", ContentReferenceElement);
         foreach (var elem in Type) { if (elem != null) yield return new ElementValue("type", elem); }
         if (DefaultValue != null) yield return new ElementValue("defaultValue", DefaultValue);
-        if (MeaningWhenMissing != null) yield return new ElementValue("meaningWhenMissing", MeaningWhenMissing);
+        if (MeaningWhenMissingElement != null) yield return new ElementValue("meaningWhenMissing", MeaningWhenMissingElement);
         if (OrderMeaningElement != null) yield return new ElementValue("orderMeaning", OrderMeaningElement);
         if (Fixed != null) yield return new ElementValue("fixed", Fixed);
         if (Pattern != null) yield return new ElementValue("pattern", Pattern);
@@ -3919,14 +4081,14 @@ namespace Hl7.Fhir.Model
           value = ShortElement;
           return ShortElement is not null;
         case "definition":
-          value = Definition;
-          return Definition is not null;
+          value = DefinitionElement;
+          return DefinitionElement is not null;
         case "comment":
-          value = Comment;
-          return Comment is not null;
+          value = CommentElement;
+          return CommentElement is not null;
         case "requirements":
-          value = Requirements;
-          return Requirements is not null;
+          value = RequirementsElement;
+          return RequirementsElement is not null;
         case "alias":
           value = AliasElement;
           return AliasElement?.Any() == true;
@@ -3949,8 +4111,8 @@ namespace Hl7.Fhir.Model
           value = DefaultValue;
           return DefaultValue is not null;
         case "meaningWhenMissing":
-          value = MeaningWhenMissing;
-          return MeaningWhenMissing is not null;
+          value = MeaningWhenMissingElement;
+          return MeaningWhenMissingElement is not null;
         case "orderMeaning":
           value = OrderMeaningElement;
           return OrderMeaningElement is not null;
@@ -4022,9 +4184,9 @@ namespace Hl7.Fhir.Model
       if (Code?.Any() == true) yield return new KeyValuePair<string,object>("code",Code);
       if (Slicing is not null) yield return new KeyValuePair<string,object>("slicing",Slicing);
       if (ShortElement is not null) yield return new KeyValuePair<string,object>("short",ShortElement);
-      if (Definition is not null) yield return new KeyValuePair<string,object>("definition",Definition);
-      if (Comment is not null) yield return new KeyValuePair<string,object>("comment",Comment);
-      if (Requirements is not null) yield return new KeyValuePair<string,object>("requirements",Requirements);
+      if (DefinitionElement is not null) yield return new KeyValuePair<string,object>("definition",DefinitionElement);
+      if (CommentElement is not null) yield return new KeyValuePair<string,object>("comment",CommentElement);
+      if (RequirementsElement is not null) yield return new KeyValuePair<string,object>("requirements",RequirementsElement);
       if (AliasElement?.Any() == true) yield return new KeyValuePair<string,object>("alias",AliasElement);
       if (MinElement is not null) yield return new KeyValuePair<string,object>("min",MinElement);
       if (MaxElement is not null) yield return new KeyValuePair<string,object>("max",MaxElement);
@@ -4032,7 +4194,7 @@ namespace Hl7.Fhir.Model
       if (ContentReferenceElement is not null) yield return new KeyValuePair<string,object>("contentReference",ContentReferenceElement);
       if (Type?.Any() == true) yield return new KeyValuePair<string,object>("type",Type);
       if (DefaultValue is not null) yield return new KeyValuePair<string,object>("defaultValue",DefaultValue);
-      if (MeaningWhenMissing is not null) yield return new KeyValuePair<string,object>("meaningWhenMissing",MeaningWhenMissing);
+      if (MeaningWhenMissingElement is not null) yield return new KeyValuePair<string,object>("meaningWhenMissing",MeaningWhenMissingElement);
       if (OrderMeaningElement is not null) yield return new KeyValuePair<string,object>("orderMeaning",OrderMeaningElement);
       if (Fixed is not null) yield return new KeyValuePair<string,object>("fixed",Fixed);
       if (Pattern is not null) yield return new KeyValuePair<string,object>("pattern",Pattern);

--- a/src/Hl7.Fhir.Conformance/Model/Generated/RelatedArtifact.cs
+++ b/src/Hl7.Fhir.Conformance/Model/Generated/RelatedArtifact.cs
@@ -395,13 +395,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("citation", InSummary=true, Order=70)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Citation
+    public Hl7.Fhir.Model.Markdown CitationElement
     {
-      get { return _Citation; }
-      set { _Citation = value; OnPropertyChanged("Citation"); }
+      get { return _CitationElement; }
+      set { _CitationElement = value; OnPropertyChanged("CitationElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Citation;
+    private Hl7.Fhir.Model.Markdown _CitationElement;
+
+    /// <summary>
+    /// Bibliographic citation for the artifact
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Citation
+    {
+      get { return CitationElement != null ? CitationElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CitationElement = null;
+        else
+          CitationElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Citation");
+      }
+    }
 
     /// <summary>
     /// Where the artifact can be accessed. Note: Element is deprecated since R5, do not use with R5 and newer releases.
@@ -571,7 +589,7 @@ namespace Hl7.Fhir.Model
       if(Classifier != null) dest.Classifier = new List<Hl7.Fhir.Model.CodeableConcept>(Classifier.DeepCopy());
       if(LabelElement != null) dest.LabelElement = (Hl7.Fhir.Model.FhirString)LabelElement.DeepCopy();
       if(DisplayElement != null) dest.DisplayElement = (Hl7.Fhir.Model.FhirString)DisplayElement.DeepCopy();
-      if(Citation != null) dest.Citation = (Hl7.Fhir.Model.Markdown)Citation.DeepCopy();
+      if(CitationElement != null) dest.CitationElement = (Hl7.Fhir.Model.Markdown)CitationElement.DeepCopy();
       if(UrlElement != null) dest.UrlElement = (Hl7.Fhir.Model.FhirUrl)UrlElement.DeepCopy();
       if(Document != null) dest.Document = (Hl7.Fhir.Model.Attachment)Document.DeepCopy();
       if(ResourceElement != null) dest.ResourceElement = (Hl7.Fhir.Model.Canonical)ResourceElement.DeepCopy();
@@ -597,7 +615,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Classifier, otherT.Classifier)) return false;
       if( !DeepComparable.Matches(LabelElement, otherT.LabelElement)) return false;
       if( !DeepComparable.Matches(DisplayElement, otherT.DisplayElement)) return false;
-      if( !DeepComparable.Matches(Citation, otherT.Citation)) return false;
+      if( !DeepComparable.Matches(CitationElement, otherT.CitationElement)) return false;
       if( !DeepComparable.Matches(UrlElement, otherT.UrlElement)) return false;
       if( !DeepComparable.Matches(Document, otherT.Document)) return false;
       if( !DeepComparable.Matches(ResourceElement, otherT.ResourceElement)) return false;
@@ -618,7 +636,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Classifier, otherT.Classifier)) return false;
       if( !DeepComparable.IsExactly(LabelElement, otherT.LabelElement)) return false;
       if( !DeepComparable.IsExactly(DisplayElement, otherT.DisplayElement)) return false;
-      if( !DeepComparable.IsExactly(Citation, otherT.Citation)) return false;
+      if( !DeepComparable.IsExactly(CitationElement, otherT.CitationElement)) return false;
       if( !DeepComparable.IsExactly(UrlElement, otherT.UrlElement)) return false;
       if( !DeepComparable.IsExactly(Document, otherT.Document)) return false;
       if( !DeepComparable.IsExactly(ResourceElement, otherT.ResourceElement)) return false;
@@ -639,7 +657,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Classifier) { if (elem != null) yield return elem; }
         if (LabelElement != null) yield return LabelElement;
         if (DisplayElement != null) yield return DisplayElement;
-        if (Citation != null) yield return Citation;
+        if (CitationElement != null) yield return CitationElement;
         if (UrlElement != null) yield return UrlElement;
         if (Document != null) yield return Document;
         if (ResourceElement != null) yield return ResourceElement;
@@ -659,7 +677,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Classifier) { if (elem != null) yield return new ElementValue("classifier", elem); }
         if (LabelElement != null) yield return new ElementValue("label", LabelElement);
         if (DisplayElement != null) yield return new ElementValue("display", DisplayElement);
-        if (Citation != null) yield return new ElementValue("citation", Citation);
+        if (CitationElement != null) yield return new ElementValue("citation", CitationElement);
         if (UrlElement != null) yield return new ElementValue("url", UrlElement);
         if (Document != null) yield return new ElementValue("document", Document);
         if (ResourceElement != null) yield return new ElementValue("resource", ResourceElement);
@@ -686,8 +704,8 @@ namespace Hl7.Fhir.Model
           value = DisplayElement;
           return DisplayElement is not null;
         case "citation":
-          value = Citation;
-          return Citation is not null;
+          value = CitationElement;
+          return CitationElement is not null;
         case "url":
           value = UrlElement;
           return UrlElement is not null;
@@ -719,7 +737,7 @@ namespace Hl7.Fhir.Model
       if (Classifier?.Any() == true) yield return new KeyValuePair<string,object>("classifier",Classifier);
       if (LabelElement is not null) yield return new KeyValuePair<string,object>("label",LabelElement);
       if (DisplayElement is not null) yield return new KeyValuePair<string,object>("display",DisplayElement);
-      if (Citation is not null) yield return new KeyValuePair<string,object>("citation",Citation);
+      if (CitationElement is not null) yield return new KeyValuePair<string,object>("citation",CitationElement);
       if (UrlElement is not null) yield return new KeyValuePair<string,object>("url",UrlElement);
       if (Document is not null) yield return new KeyValuePair<string,object>("document",Document);
       if (ResourceElement is not null) yield return new KeyValuePair<string,object>("resource",ResourceElement);

--- a/src/Hl7.Fhir.Conformance/Model/Generated/StructureDefinition.cs
+++ b/src/Hl7.Fhir.Conformance/Model/Generated/StructureDefinition.cs
@@ -1077,13 +1077,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the structure definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1118,26 +1136,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=230, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this structure definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=240)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Copyright holder and year(s). Note: Element was introduced in R5, do not use when working with older releases.
@@ -1483,11 +1537,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(CopyrightLabelElement != null) dest.CopyrightLabelElement = (Hl7.Fhir.Model.FhirString)CopyrightLabelElement.DeepCopy();
       if(Keyword != null) dest.Keyword = new List<Hl7.Fhir.Model.Coding>(Keyword.DeepCopy());
       if(FhirVersionElement != null) dest.FhirVersionElement = (Code<Hl7.Fhir.Model.FHIRVersion>)FhirVersionElement.DeepCopy();
@@ -1527,11 +1581,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.Matches(Keyword, otherT.Keyword)) return false;
       if( !DeepComparable.Matches(FhirVersionElement, otherT.FhirVersionElement)) return false;
@@ -1566,11 +1620,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.IsExactly(Keyword, otherT.Keyword)) return false;
       if( !DeepComparable.IsExactly(FhirVersionElement, otherT.FhirVersionElement)) return false;
@@ -1605,11 +1659,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (CopyrightLabelElement != null) yield return CopyrightLabelElement;
         foreach (var elem in Keyword) { if (elem != null) yield return elem; }
         if (FhirVersionElement != null) yield return FhirVersionElement;
@@ -1643,11 +1697,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (CopyrightLabelElement != null) yield return new ElementValue("copyrightLabel", CopyrightLabelElement);
         foreach (var elem in Keyword) { if (elem != null) yield return new ElementValue("keyword", elem); }
         if (FhirVersionElement != null) yield return new ElementValue("fhirVersion", FhirVersionElement);
@@ -1702,8 +1756,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1711,11 +1765,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "copyrightLabel":
           value = CopyrightLabelElement;
           return CopyrightLabelElement is not null;
@@ -1775,11 +1829,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (CopyrightLabelElement is not null) yield return new KeyValuePair<string,object>("copyrightLabel",CopyrightLabelElement);
       if (Keyword?.Any() == true) yield return new KeyValuePair<string,object>("keyword",Keyword);
       if (FhirVersionElement is not null) yield return new KeyValuePair<string,object>("fhirVersion",FhirVersionElement);

--- a/src/Hl7.Fhir.Conformance/Model/Generated/ValueSet.cs
+++ b/src/Hl7.Fhir.Conformance/Model/Generated/ValueSet.cs
@@ -3111,13 +3111,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the value set
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -3183,26 +3201,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=230, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this value set is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=240)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the ValueSet was approved by publisher. Note: Element was introduced in R5, do not use when working with older releases.
@@ -3422,12 +3476,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
       if(ImmutableElement != null) dest.ImmutableElement = (Hl7.Fhir.Model.FhirBoolean)ImmutableElement.DeepCopy();
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -3465,12 +3519,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.Matches(ImmutableElement, otherT.ImmutableElement)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -3503,12 +3557,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.IsExactly(ImmutableElement, otherT.ImmutableElement)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -3541,12 +3595,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
         if (ImmutableElement != null) yield return ImmutableElement;
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -3578,12 +3632,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
         if (ImmutableElement != null) yield return new ElementValue("immutable", ImmutableElement);
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -3634,8 +3688,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -3646,11 +3700,11 @@ namespace Hl7.Fhir.Model
           value = ImmutableElement;
           return ImmutableElement is not null;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -3706,12 +3760,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
       if (ImmutableElement is not null) yield return new KeyValuePair<string,object>("immutable",ImmutableElement);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/ElementDefnMerger.cs
@@ -110,9 +110,9 @@ namespace Hl7.Fhir.Specification.Snapshot
                 correctListMerge(originalDiscriminator, diff.Slicing?.Discriminator, list => snap.Slicing.Discriminator = list);
 
                 snap.ShortElement = mergePrimitiveElement(snap.ShortElement, diff.ShortElement);
-                snap.Definition = mergePrimitiveElement(snap.Definition, diff.Definition, true);
-                snap.Comment = mergePrimitiveElement(snap.Comment, diff.Comment, true);
-                snap.Requirements = mergePrimitiveElement(snap.Requirements, diff.Requirements, true);
+                snap.DefinitionElement = mergePrimitiveElement(snap.DefinitionElement, diff.DefinitionElement, true);
+                snap.CommentElement = mergePrimitiveElement(snap.CommentElement, diff.CommentElement, true);
+                snap.RequirementsElement = mergePrimitiveElement(snap.RequirementsElement, diff.RequirementsElement, true);
 
                 // Aliases are cumulative based on the string value
                 snap.AliasElement = mergePrimitiveCollection(snap.AliasElement, diff.AliasElement, matchStringValues);
@@ -130,7 +130,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 snap.Type = mergeElementTypes(snap.Type, diff.Type);
 
                 snap.DefaultValue = mergeComplexAttribute(snap.DefaultValue, diff.DefaultValue);
-                snap.MeaningWhenMissing = mergePrimitiveElement(snap.MeaningWhenMissing, diff.MeaningWhenMissing);
+                snap.MeaningWhenMissingElement = mergePrimitiveElement(snap.MeaningWhenMissingElement, diff.MeaningWhenMissingElement);
                 // [EK 20170301] Added this new STU3 element
                 snap.OrderMeaningElement = mergePrimitiveElement(snap.OrderMeaningElement, diff.OrderMeaningElement);
 
@@ -357,7 +357,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                     else if (!diff.IsExactly(snap))
                     {
                         snap.StrengthElement = mergePrimitiveElement(snap.StrengthElement, diff.StrengthElement);
-                        snap.Description = mergePrimitiveElement(snap.Description, diff.Description);
+                        snap.DescriptionElement = mergePrimitiveElement(snap.DescriptionElement, diff.DescriptionElement);
                         snap.ValueSetElement = mergeComplexAttribute(snap.ValueSetElement, diff.ValueSetElement);
                         snap.Extension = mergeExtensions(snap.Extension, diff.Extension);
                         onConstraint(result);

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
@@ -1433,8 +1433,8 @@ namespace Hl7.Fhir.Specification.Snapshot
             if (IsEqualPath(elem.Base?.Path, DOMAINRESOURCE_EXTENSION_PATH))
             {
                 elem.ShortElement?.RemoveConstrainedByDiffAnnotation();
-                elem.Comment?.RemoveConstrainedByDiffAnnotation();
-                elem.Definition?.RemoveConstrainedByDiffAnnotation();
+                elem.CommentElement?.RemoveConstrainedByDiffAnnotation();
+                elem.DefinitionElement?.RemoveConstrainedByDiffAnnotation();
             }
         }
 

--- a/src/Hl7.Fhir.R4/Model/Generated/ActivityDefinition.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/ActivityDefinition.cs
@@ -787,13 +787,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the activity definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -828,13 +846,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=240, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this activity definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the activity definition
@@ -872,13 +908,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=260)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the activity definition was approved by publisher
@@ -1458,12 +1512,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1519,12 +1573,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1575,12 +1629,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1631,12 +1685,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -1686,12 +1740,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -1764,8 +1818,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1773,14 +1827,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -1886,12 +1940,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4/Model/Generated/Annotation.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/Annotation.cs
@@ -108,13 +108,31 @@ namespace Hl7.Fhir.Model
     [FhirElement("text", InSummary=true, Order=50)]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Text
+    public Hl7.Fhir.Model.Markdown TextElement
     {
-      get { return _Text; }
-      set { _Text = value; OnPropertyChanged("Text"); }
+      get { return _TextElement; }
+      set { _TextElement = value; OnPropertyChanged("TextElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Text;
+    private Hl7.Fhir.Model.Markdown _TextElement;
+
+    /// <summary>
+    /// The annotation  - text content (as markdown)
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Text
+    {
+      get { return TextElement != null ? TextElement.Value : null; }
+      set
+      {
+        if (value == null)
+          TextElement = null;
+        else
+          TextElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Text");
+      }
+    }
 
     public override IDeepCopyable CopyTo(IDeepCopyable other)
     {
@@ -128,7 +146,7 @@ namespace Hl7.Fhir.Model
       base.CopyTo(dest);
       if(Author != null) dest.Author = (Hl7.Fhir.Model.DataType)Author.DeepCopy();
       if(TimeElement != null) dest.TimeElement = (Hl7.Fhir.Model.FhirDateTime)TimeElement.DeepCopy();
-      if(Text != null) dest.Text = (Hl7.Fhir.Model.Markdown)Text.DeepCopy();
+      if(TextElement != null) dest.TextElement = (Hl7.Fhir.Model.Markdown)TextElement.DeepCopy();
       return dest;
     }
 
@@ -146,7 +164,7 @@ namespace Hl7.Fhir.Model
       if(!base.Matches(otherT)) return false;
       if( !DeepComparable.Matches(Author, otherT.Author)) return false;
       if( !DeepComparable.Matches(TimeElement, otherT.TimeElement)) return false;
-      if( !DeepComparable.Matches(Text, otherT.Text)) return false;
+      if( !DeepComparable.Matches(TextElement, otherT.TextElement)) return false;
 
       return true;
     }
@@ -159,7 +177,7 @@ namespace Hl7.Fhir.Model
       if(!base.IsExactly(otherT)) return false;
       if( !DeepComparable.IsExactly(Author, otherT.Author)) return false;
       if( !DeepComparable.IsExactly(TimeElement, otherT.TimeElement)) return false;
-      if( !DeepComparable.IsExactly(Text, otherT.Text)) return false;
+      if( !DeepComparable.IsExactly(TextElement, otherT.TextElement)) return false;
 
       return true;
     }
@@ -172,7 +190,7 @@ namespace Hl7.Fhir.Model
         foreach (var item in base.Children) yield return item;
         if (Author != null) yield return Author;
         if (TimeElement != null) yield return TimeElement;
-        if (Text != null) yield return Text;
+        if (TextElement != null) yield return TextElement;
       }
     }
 
@@ -184,7 +202,7 @@ namespace Hl7.Fhir.Model
         foreach (var item in base.NamedChildren) yield return item;
         if (Author != null) yield return new ElementValue("author", Author);
         if (TimeElement != null) yield return new ElementValue("time", TimeElement);
-        if (Text != null) yield return new ElementValue("text", Text);
+        if (TextElement != null) yield return new ElementValue("text", TextElement);
       }
     }
 
@@ -199,8 +217,8 @@ namespace Hl7.Fhir.Model
           value = TimeElement;
           return TimeElement is not null;
         case "text":
-          value = Text;
-          return Text is not null;
+          value = TextElement;
+          return TextElement is not null;
         default:
           return base.TryGetValue(key, out value);
       }
@@ -212,7 +230,7 @@ namespace Hl7.Fhir.Model
       foreach (var kvp in base.GetElementPairs()) yield return kvp;
       if (Author is not null) yield return new KeyValuePair<string,object>("author",Author);
       if (TimeElement is not null) yield return new KeyValuePair<string,object>("time",TimeElement);
-      if (Text is not null) yield return new KeyValuePair<string,object>("text",Text);
+      if (TextElement is not null) yield return new KeyValuePair<string,object>("text",TextElement);
     }
 
   }

--- a/src/Hl7.Fhir.R4/Model/Generated/ChargeItemDefinition.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/ChargeItemDefinition.cs
@@ -957,13 +957,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the charge item definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -998,13 +1016,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=240)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the charge item definition was approved by publisher
@@ -1160,10 +1196,10 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1198,10 +1234,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1231,10 +1267,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1264,10 +1300,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -1296,10 +1332,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -1351,8 +1387,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1360,8 +1396,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -1404,10 +1440,10 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4/Model/Generated/CompartmentDefinition.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/CompartmentDefinition.cs
@@ -505,13 +505,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=170)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the compartment definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -532,13 +550,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=190, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this compartment definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Patient | Encounter | RelatedPerson | Practitioner | Device
@@ -637,9 +673,9 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(CodeElement != null) dest.CodeElement = (Code<Hl7.Fhir.Model.CompartmentType>)CodeElement.DeepCopy();
       if(SearchElement != null) dest.SearchElement = (Hl7.Fhir.Model.FhirBoolean)SearchElement.DeepCopy();
       if(Resource != null) dest.Resource = new List<Hl7.Fhir.Model.CompartmentDefinition.ResourceComponent>(Resource.DeepCopy());
@@ -666,9 +702,9 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(CodeElement, otherT.CodeElement)) return false;
       if( !DeepComparable.Matches(SearchElement, otherT.SearchElement)) return false;
       if( !DeepComparable.Matches(Resource, otherT.Resource)) return false;
@@ -690,9 +726,9 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(CodeElement, otherT.CodeElement)) return false;
       if( !DeepComparable.IsExactly(SearchElement, otherT.SearchElement)) return false;
       if( !DeepComparable.IsExactly(Resource, otherT.Resource)) return false;
@@ -714,9 +750,9 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (CodeElement != null) yield return CodeElement;
         if (SearchElement != null) yield return SearchElement;
         foreach (var elem in Resource) { if (elem != null) yield return elem; }
@@ -737,9 +773,9 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (CodeElement != null) yield return new ElementValue("code", CodeElement);
         if (SearchElement != null) yield return new ElementValue("search", SearchElement);
         foreach (var elem in Resource) { if (elem != null) yield return new ElementValue("resource", elem); }
@@ -775,14 +811,14 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "code":
           value = CodeElement;
           return CodeElement is not null;
@@ -809,9 +845,9 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (CodeElement is not null) yield return new KeyValuePair<string,object>("code",CodeElement);
       if (SearchElement is not null) yield return new KeyValuePair<string,object>("search",SearchElement);
       if (Resource?.Any() == true) yield return new KeyValuePair<string,object>("resource",Resource);

--- a/src/Hl7.Fhir.R4/Model/Generated/ConceptMap.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/ConceptMap.cs
@@ -1640,13 +1640,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the concept map
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1681,26 +1699,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this concept map is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// The source value set that contains the concepts that are being mapped
@@ -1766,11 +1820,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(Source != null) dest.Source = (Hl7.Fhir.Model.DataType)Source.DeepCopy();
       if(Target != null) dest.Target = (Hl7.Fhir.Model.DataType)Target.DeepCopy();
       if(Group != null) dest.Group = new List<Hl7.Fhir.Model.ConceptMap.GroupComponent>(Group.DeepCopy());
@@ -1799,11 +1853,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(Source, otherT.Source)) return false;
       if( !DeepComparable.Matches(Target, otherT.Target)) return false;
       if( !DeepComparable.Matches(Group, otherT.Group)) return false;
@@ -1827,11 +1881,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(Source, otherT.Source)) return false;
       if( !DeepComparable.IsExactly(Target, otherT.Target)) return false;
       if( !DeepComparable.IsExactly(Group, otherT.Group)) return false;
@@ -1855,11 +1909,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (Source != null) yield return Source;
         if (Target != null) yield return Target;
         foreach (var elem in Group) { if (elem != null) yield return elem; }
@@ -1882,11 +1936,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (Source != null) yield return new ElementValue("source", Source);
         if (Target != null) yield return new ElementValue("target", Target);
         foreach (var elem in Group) { if (elem != null) yield return new ElementValue("group", elem); }
@@ -1928,8 +1982,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1937,11 +1991,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "source":
           value = Source;
           return Source is not null;
@@ -1970,11 +2024,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (Source is not null) yield return new KeyValuePair<string,object>("source",Source);
       if (Target is not null) yield return new KeyValuePair<string,object>("target",Target);
       if (Group?.Any() == true) yield return new KeyValuePair<string,object>("group",Group);

--- a/src/Hl7.Fhir.R4/Model/Generated/Contract.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/Contract.cs
@@ -379,13 +379,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("copyright", Order=90)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Copyright
+      public Hl7.Fhir.Model.Markdown CopyrightElement
       {
-        get { return _Copyright; }
-        set { _Copyright = value; OnPropertyChanged("Copyright"); }
+        get { return _CopyrightElement; }
+        set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Copyright;
+      private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+      /// <summary>
+      /// Publication Ownership
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Copyright
+      {
+        get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+        set
+        {
+          if (value == null)
+            CopyrightElement = null;
+          else
+            CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Copyright");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -402,7 +420,7 @@ namespace Hl7.Fhir.Model
         if(Publisher != null) dest.Publisher = (Hl7.Fhir.Model.ResourceReference)Publisher.DeepCopy();
         if(PublicationDateElement != null) dest.PublicationDateElement = (Hl7.Fhir.Model.FhirDateTime)PublicationDateElement.DeepCopy();
         if(PublicationStatusElement != null) dest.PublicationStatusElement = (Code<Hl7.Fhir.Model.Contract.ContractResourcePublicationStatusCodes>)PublicationStatusElement.DeepCopy();
-        if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+        if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
         return dest;
       }
 
@@ -423,7 +441,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(Publisher, otherT.Publisher)) return false;
         if( !DeepComparable.Matches(PublicationDateElement, otherT.PublicationDateElement)) return false;
         if( !DeepComparable.Matches(PublicationStatusElement, otherT.PublicationStatusElement)) return false;
-        if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+        if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
 
         return true;
       }
@@ -439,7 +457,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(Publisher, otherT.Publisher)) return false;
         if( !DeepComparable.IsExactly(PublicationDateElement, otherT.PublicationDateElement)) return false;
         if( !DeepComparable.IsExactly(PublicationStatusElement, otherT.PublicationStatusElement)) return false;
-        if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+        if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
 
         return true;
       }
@@ -455,7 +473,7 @@ namespace Hl7.Fhir.Model
           if (Publisher != null) yield return Publisher;
           if (PublicationDateElement != null) yield return PublicationDateElement;
           if (PublicationStatusElement != null) yield return PublicationStatusElement;
-          if (Copyright != null) yield return Copyright;
+          if (CopyrightElement != null) yield return CopyrightElement;
         }
       }
 
@@ -470,7 +488,7 @@ namespace Hl7.Fhir.Model
           if (Publisher != null) yield return new ElementValue("publisher", Publisher);
           if (PublicationDateElement != null) yield return new ElementValue("publicationDate", PublicationDateElement);
           if (PublicationStatusElement != null) yield return new ElementValue("publicationStatus", PublicationStatusElement);
-          if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+          if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         }
       }
 
@@ -494,8 +512,8 @@ namespace Hl7.Fhir.Model
             value = PublicationStatusElement;
             return PublicationStatusElement is not null;
           case "copyright":
-            value = Copyright;
-            return Copyright is not null;
+            value = CopyrightElement;
+            return CopyrightElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -510,7 +528,7 @@ namespace Hl7.Fhir.Model
         if (Publisher is not null) yield return new KeyValuePair<string,object>("publisher",Publisher);
         if (PublicationDateElement is not null) yield return new KeyValuePair<string,object>("publicationDate",PublicationDateElement);
         if (PublicationStatusElement is not null) yield return new KeyValuePair<string,object>("publicationStatus",PublicationStatusElement);
-        if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+        if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       }
 
     }

--- a/src/Hl7.Fhir.R4/Model/Generated/EffectEvidenceSynthesis.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/EffectEvidenceSynthesis.cs
@@ -1547,13 +1547,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the effect evidence synthesis
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Used for footnotes or explanatory notes
@@ -1602,13 +1620,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the effect evidence synthesis was approved by publisher
@@ -1933,11 +1969,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(Note != null) dest.Note = new List<Hl7.Fhir.Model.Annotation>(Note.DeepCopy());
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1981,11 +2017,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(Note, otherT.Note)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -2024,11 +2060,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(Note, otherT.Note)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -2067,11 +2103,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in Note) { if (elem != null) yield return elem; }
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -2109,11 +2145,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in Note) { if (elem != null) yield return new ElementValue("note", elem); }
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -2168,8 +2204,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "note":
           value = Note;
           return Note?.Any() == true;
@@ -2180,8 +2216,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -2257,11 +2293,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (Note?.Any() == true) yield return new KeyValuePair<string,object>("note",Note);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4/Model/Generated/EventDefinition.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/EventDefinition.cs
@@ -385,13 +385,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the event definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -426,13 +444,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=240, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this event definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the event definition
@@ -470,13 +506,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=260)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the event definition was approved by publisher
@@ -673,12 +727,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -716,12 +770,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -754,12 +808,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -792,12 +846,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -829,12 +883,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -889,8 +943,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -898,14 +952,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -957,12 +1011,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4/Model/Generated/Evidence.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/Evidence.cs
@@ -369,13 +369,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the evidence
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Used for footnotes or explanatory notes
@@ -424,13 +442,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=240)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the evidence was approved by publisher
@@ -660,11 +696,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(Note != null) dest.Note = new List<Hl7.Fhir.Model.Annotation>(Note.DeepCopy());
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -703,11 +739,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(Note, otherT.Note)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -741,11 +777,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(Note, otherT.Note)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -779,11 +815,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in Note) { if (elem != null) yield return elem; }
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -816,11 +852,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in Note) { if (elem != null) yield return new ElementValue("note", elem); }
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -874,8 +910,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "note":
           value = Note;
           return Note?.Any() == true;
@@ -886,8 +922,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -944,11 +980,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (Note?.Any() == true) yield return new KeyValuePair<string,object>("note",Note);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4/Model/Generated/EvidenceVariable.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/EvidenceVariable.cs
@@ -672,13 +672,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the evidence variable
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Used for footnotes or explanatory notes
@@ -727,13 +745,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=240)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the evidence variable was approved by publisher
@@ -961,11 +997,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(Note != null) dest.Note = new List<Hl7.Fhir.Model.Annotation>(Note.DeepCopy());
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1003,11 +1039,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(Note, otherT.Note)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1040,11 +1076,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(Note, otherT.Note)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1077,11 +1113,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in Note) { if (elem != null) yield return elem; }
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -1113,11 +1149,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in Note) { if (elem != null) yield return new ElementValue("note", elem); }
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -1170,8 +1206,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "note":
           value = Note;
           return Note?.Any() == true;
@@ -1182,8 +1218,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -1237,11 +1273,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (Note?.Any() == true) yield return new KeyValuePair<string,object>("note",Note);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4/Model/Generated/ExampleScenario.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/ExampleScenario.cs
@@ -191,13 +191,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=70)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// The description of the actor
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -212,7 +230,7 @@ namespace Hl7.Fhir.Model
         if(ActorIdElement != null) dest.ActorIdElement = (Hl7.Fhir.Model.FhirString)ActorIdElement.DeepCopy();
         if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.ExampleScenario.ExampleScenarioActorType>)TypeElement.DeepCopy();
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         return dest;
       }
 
@@ -231,7 +249,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(ActorIdElement, otherT.ActorIdElement)) return false;
         if( !DeepComparable.Matches(TypeElement, otherT.TypeElement)) return false;
         if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
 
         return true;
       }
@@ -245,7 +263,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(ActorIdElement, otherT.ActorIdElement)) return false;
         if( !DeepComparable.IsExactly(TypeElement, otherT.TypeElement)) return false;
         if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
 
         return true;
       }
@@ -259,7 +277,7 @@ namespace Hl7.Fhir.Model
           if (ActorIdElement != null) yield return ActorIdElement;
           if (TypeElement != null) yield return TypeElement;
           if (NameElement != null) yield return NameElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
         }
       }
 
@@ -272,7 +290,7 @@ namespace Hl7.Fhir.Model
           if (ActorIdElement != null) yield return new ElementValue("actorId", ActorIdElement);
           if (TypeElement != null) yield return new ElementValue("type", TypeElement);
           if (NameElement != null) yield return new ElementValue("name", NameElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         }
       }
 
@@ -290,8 +308,8 @@ namespace Hl7.Fhir.Model
             value = NameElement;
             return NameElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -304,7 +322,7 @@ namespace Hl7.Fhir.Model
         if (ActorIdElement is not null) yield return new KeyValuePair<string,object>("actorId",ActorIdElement);
         if (TypeElement is not null) yield return new KeyValuePair<string,object>("type",TypeElement);
         if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       }
 
     }
@@ -423,13 +441,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=70)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Human-friendly description of the resource instance
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// A specific version of the resource
@@ -472,7 +508,7 @@ namespace Hl7.Fhir.Model
         if(ResourceIdElement != null) dest.ResourceIdElement = (Hl7.Fhir.Model.FhirString)ResourceIdElement.DeepCopy();
         if(ResourceTypeElement != null) dest.ResourceTypeElement = (Code<Hl7.Fhir.Model.ResourceType>)ResourceTypeElement.DeepCopy();
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(Version != null) dest.Version = new List<Hl7.Fhir.Model.ExampleScenario.VersionComponent>(Version.DeepCopy());
         if(ContainedInstance != null) dest.ContainedInstance = new List<Hl7.Fhir.Model.ExampleScenario.ContainedInstanceComponent>(ContainedInstance.DeepCopy());
         return dest;
@@ -493,7 +529,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(ResourceIdElement, otherT.ResourceIdElement)) return false;
         if( !DeepComparable.Matches(ResourceTypeElement, otherT.ResourceTypeElement)) return false;
         if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(Version, otherT.Version)) return false;
         if( !DeepComparable.Matches(ContainedInstance, otherT.ContainedInstance)) return false;
 
@@ -509,7 +545,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(ResourceIdElement, otherT.ResourceIdElement)) return false;
         if( !DeepComparable.IsExactly(ResourceTypeElement, otherT.ResourceTypeElement)) return false;
         if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(Version, otherT.Version)) return false;
         if( !DeepComparable.IsExactly(ContainedInstance, otherT.ContainedInstance)) return false;
 
@@ -525,7 +561,7 @@ namespace Hl7.Fhir.Model
           if (ResourceIdElement != null) yield return ResourceIdElement;
           if (ResourceTypeElement != null) yield return ResourceTypeElement;
           if (NameElement != null) yield return NameElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           foreach (var elem in Version) { if (elem != null) yield return elem; }
           foreach (var elem in ContainedInstance) { if (elem != null) yield return elem; }
         }
@@ -540,7 +576,7 @@ namespace Hl7.Fhir.Model
           if (ResourceIdElement != null) yield return new ElementValue("resourceId", ResourceIdElement);
           if (ResourceTypeElement != null) yield return new ElementValue("resourceType", ResourceTypeElement);
           if (NameElement != null) yield return new ElementValue("name", NameElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           foreach (var elem in Version) { if (elem != null) yield return new ElementValue("version", elem); }
           foreach (var elem in ContainedInstance) { if (elem != null) yield return new ElementValue("containedInstance", elem); }
         }
@@ -560,8 +596,8 @@ namespace Hl7.Fhir.Model
             value = NameElement;
             return NameElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "version":
             value = Version;
             return Version?.Any() == true;
@@ -580,7 +616,7 @@ namespace Hl7.Fhir.Model
         if (ResourceIdElement is not null) yield return new KeyValuePair<string,object>("resourceId",ResourceIdElement);
         if (ResourceTypeElement is not null) yield return new KeyValuePair<string,object>("resourceType",ResourceTypeElement);
         if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (Version?.Any() == true) yield return new KeyValuePair<string,object>("version",Version);
         if (ContainedInstance?.Any() == true) yield return new KeyValuePair<string,object>("containedInstance",ContainedInstance);
       }
@@ -638,13 +674,31 @@ namespace Hl7.Fhir.Model
       [FhirElement("description", Order=50)]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// The description of the resource version
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -657,7 +711,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(VersionIdElement != null) dest.VersionIdElement = (Hl7.Fhir.Model.FhirString)VersionIdElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         return dest;
       }
 
@@ -674,7 +728,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(VersionIdElement, otherT.VersionIdElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
 
         return true;
       }
@@ -686,7 +740,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(VersionIdElement, otherT.VersionIdElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
 
         return true;
       }
@@ -698,7 +752,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (VersionIdElement != null) yield return VersionIdElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
         }
       }
 
@@ -709,7 +763,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (VersionIdElement != null) yield return new ElementValue("versionId", VersionIdElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         }
       }
 
@@ -721,8 +775,8 @@ namespace Hl7.Fhir.Model
             value = VersionIdElement;
             return VersionIdElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -733,7 +787,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (VersionIdElement is not null) yield return new KeyValuePair<string,object>("versionId",VersionIdElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       }
 
     }
@@ -956,39 +1010,93 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// A longer description of the group of operations
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Description of initial status before the process starts
       /// </summary>
       [FhirElement("preConditions", Order=60)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown PreConditions
+      public Hl7.Fhir.Model.Markdown PreConditionsElement
       {
-        get { return _PreConditions; }
-        set { _PreConditions = value; OnPropertyChanged("PreConditions"); }
+        get { return _PreConditionsElement; }
+        set { _PreConditionsElement = value; OnPropertyChanged("PreConditionsElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _PreConditions;
+      private Hl7.Fhir.Model.Markdown _PreConditionsElement;
+
+      /// <summary>
+      /// Description of initial status before the process starts
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string PreConditions
+      {
+        get { return PreConditionsElement != null ? PreConditionsElement.Value : null; }
+        set
+        {
+          if (value == null)
+            PreConditionsElement = null;
+          else
+            PreConditionsElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("PreConditions");
+        }
+      }
 
       /// <summary>
       /// Description of final status after the process ends
       /// </summary>
       [FhirElement("postConditions", Order=70)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown PostConditions
+      public Hl7.Fhir.Model.Markdown PostConditionsElement
       {
-        get { return _PostConditions; }
-        set { _PostConditions = value; OnPropertyChanged("PostConditions"); }
+        get { return _PostConditionsElement; }
+        set { _PostConditionsElement = value; OnPropertyChanged("PostConditionsElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _PostConditions;
+      private Hl7.Fhir.Model.Markdown _PostConditionsElement;
+
+      /// <summary>
+      /// Description of final status after the process ends
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string PostConditions
+      {
+        get { return PostConditionsElement != null ? PostConditionsElement.Value : null; }
+        set
+        {
+          if (value == null)
+            PostConditionsElement = null;
+          else
+            PostConditionsElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("PostConditions");
+        }
+      }
 
       /// <summary>
       /// Each step of the process
@@ -1015,9 +1123,9 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(TitleElement != null) dest.TitleElement = (Hl7.Fhir.Model.FhirString)TitleElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
-        if(PreConditions != null) dest.PreConditions = (Hl7.Fhir.Model.Markdown)PreConditions.DeepCopy();
-        if(PostConditions != null) dest.PostConditions = (Hl7.Fhir.Model.Markdown)PostConditions.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
+        if(PreConditionsElement != null) dest.PreConditionsElement = (Hl7.Fhir.Model.Markdown)PreConditionsElement.DeepCopy();
+        if(PostConditionsElement != null) dest.PostConditionsElement = (Hl7.Fhir.Model.Markdown)PostConditionsElement.DeepCopy();
         if(Step != null) dest.Step = new List<Hl7.Fhir.Model.ExampleScenario.StepComponent>(Step.DeepCopy());
         return dest;
       }
@@ -1035,9 +1143,9 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
-        if( !DeepComparable.Matches(PreConditions, otherT.PreConditions)) return false;
-        if( !DeepComparable.Matches(PostConditions, otherT.PostConditions)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
+        if( !DeepComparable.Matches(PreConditionsElement, otherT.PreConditionsElement)) return false;
+        if( !DeepComparable.Matches(PostConditionsElement, otherT.PostConditionsElement)) return false;
         if( !DeepComparable.Matches(Step, otherT.Step)) return false;
 
         return true;
@@ -1050,9 +1158,9 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
-        if( !DeepComparable.IsExactly(PreConditions, otherT.PreConditions)) return false;
-        if( !DeepComparable.IsExactly(PostConditions, otherT.PostConditions)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
+        if( !DeepComparable.IsExactly(PreConditionsElement, otherT.PreConditionsElement)) return false;
+        if( !DeepComparable.IsExactly(PostConditionsElement, otherT.PostConditionsElement)) return false;
         if( !DeepComparable.IsExactly(Step, otherT.Step)) return false;
 
         return true;
@@ -1065,9 +1173,9 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (TitleElement != null) yield return TitleElement;
-          if (Description != null) yield return Description;
-          if (PreConditions != null) yield return PreConditions;
-          if (PostConditions != null) yield return PostConditions;
+          if (DescriptionElement != null) yield return DescriptionElement;
+          if (PreConditionsElement != null) yield return PreConditionsElement;
+          if (PostConditionsElement != null) yield return PostConditionsElement;
           foreach (var elem in Step) { if (elem != null) yield return elem; }
         }
       }
@@ -1079,9 +1187,9 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (TitleElement != null) yield return new ElementValue("title", TitleElement);
-          if (Description != null) yield return new ElementValue("description", Description);
-          if (PreConditions != null) yield return new ElementValue("preConditions", PreConditions);
-          if (PostConditions != null) yield return new ElementValue("postConditions", PostConditions);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
+          if (PreConditionsElement != null) yield return new ElementValue("preConditions", PreConditionsElement);
+          if (PostConditionsElement != null) yield return new ElementValue("postConditions", PostConditionsElement);
           foreach (var elem in Step) { if (elem != null) yield return new ElementValue("step", elem); }
         }
       }
@@ -1094,14 +1202,14 @@ namespace Hl7.Fhir.Model
             value = TitleElement;
             return TitleElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "preConditions":
-            value = PreConditions;
-            return PreConditions is not null;
+            value = PreConditionsElement;
+            return PreConditionsElement is not null;
           case "postConditions":
-            value = PostConditions;
-            return PostConditions is not null;
+            value = PostConditionsElement;
+            return PostConditionsElement is not null;
           case "step":
             value = Step;
             return Step?.Any() == true;
@@ -1115,9 +1223,9 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (TitleElement is not null) yield return new KeyValuePair<string,object>("title",TitleElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
-        if (PreConditions is not null) yield return new KeyValuePair<string,object>("preConditions",PreConditions);
-        if (PostConditions is not null) yield return new KeyValuePair<string,object>("postConditions",PostConditions);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
+        if (PreConditionsElement is not null) yield return new KeyValuePair<string,object>("preConditions",PreConditionsElement);
+        if (PostConditionsElement is not null) yield return new KeyValuePair<string,object>("postConditions",PostConditionsElement);
         if (Step?.Any() == true) yield return new KeyValuePair<string,object>("step",Step);
       }
 
@@ -1492,13 +1600,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=90)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// A comment to be inserted in the diagram
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Whether the initiator is deactivated right after the transaction
@@ -1603,7 +1729,7 @@ namespace Hl7.Fhir.Model
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
         if(InitiatorElement != null) dest.InitiatorElement = (Hl7.Fhir.Model.FhirString)InitiatorElement.DeepCopy();
         if(ReceiverElement != null) dest.ReceiverElement = (Hl7.Fhir.Model.FhirString)ReceiverElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(InitiatorActiveElement != null) dest.InitiatorActiveElement = (Hl7.Fhir.Model.FhirBoolean)InitiatorActiveElement.DeepCopy();
         if(ReceiverActiveElement != null) dest.ReceiverActiveElement = (Hl7.Fhir.Model.FhirBoolean)ReceiverActiveElement.DeepCopy();
         if(Request != null) dest.Request = (Hl7.Fhir.Model.ExampleScenario.ContainedInstanceComponent)Request.DeepCopy();
@@ -1628,7 +1754,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
         if( !DeepComparable.Matches(InitiatorElement, otherT.InitiatorElement)) return false;
         if( !DeepComparable.Matches(ReceiverElement, otherT.ReceiverElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(InitiatorActiveElement, otherT.InitiatorActiveElement)) return false;
         if( !DeepComparable.Matches(ReceiverActiveElement, otherT.ReceiverActiveElement)) return false;
         if( !DeepComparable.Matches(Request, otherT.Request)) return false;
@@ -1648,7 +1774,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
         if( !DeepComparable.IsExactly(InitiatorElement, otherT.InitiatorElement)) return false;
         if( !DeepComparable.IsExactly(ReceiverElement, otherT.ReceiverElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(InitiatorActiveElement, otherT.InitiatorActiveElement)) return false;
         if( !DeepComparable.IsExactly(ReceiverActiveElement, otherT.ReceiverActiveElement)) return false;
         if( !DeepComparable.IsExactly(Request, otherT.Request)) return false;
@@ -1668,7 +1794,7 @@ namespace Hl7.Fhir.Model
           if (NameElement != null) yield return NameElement;
           if (InitiatorElement != null) yield return InitiatorElement;
           if (ReceiverElement != null) yield return ReceiverElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           if (InitiatorActiveElement != null) yield return InitiatorActiveElement;
           if (ReceiverActiveElement != null) yield return ReceiverActiveElement;
           if (Request != null) yield return Request;
@@ -1687,7 +1813,7 @@ namespace Hl7.Fhir.Model
           if (NameElement != null) yield return new ElementValue("name", NameElement);
           if (InitiatorElement != null) yield return new ElementValue("initiator", InitiatorElement);
           if (ReceiverElement != null) yield return new ElementValue("receiver", ReceiverElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (InitiatorActiveElement != null) yield return new ElementValue("initiatorActive", InitiatorActiveElement);
           if (ReceiverActiveElement != null) yield return new ElementValue("receiverActive", ReceiverActiveElement);
           if (Request != null) yield return new ElementValue("request", Request);
@@ -1715,8 +1841,8 @@ namespace Hl7.Fhir.Model
             value = ReceiverElement;
             return ReceiverElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "initiatorActive":
             value = InitiatorActiveElement;
             return InitiatorActiveElement is not null;
@@ -1743,7 +1869,7 @@ namespace Hl7.Fhir.Model
         if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
         if (InitiatorElement is not null) yield return new KeyValuePair<string,object>("initiator",InitiatorElement);
         if (ReceiverElement is not null) yield return new KeyValuePair<string,object>("receiver",ReceiverElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (InitiatorActiveElement is not null) yield return new KeyValuePair<string,object>("initiatorActive",InitiatorActiveElement);
         if (ReceiverActiveElement is not null) yield return new KeyValuePair<string,object>("receiverActive",ReceiverActiveElement);
         if (Request is not null) yield return new KeyValuePair<string,object>("request",Request);
@@ -1802,13 +1928,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// A human-readable description of each option
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// What happens in each alternative option
@@ -1835,7 +1979,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(TitleElement != null) dest.TitleElement = (Hl7.Fhir.Model.FhirString)TitleElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(Step != null) dest.Step = new List<Hl7.Fhir.Model.ExampleScenario.StepComponent>(Step.DeepCopy());
         return dest;
       }
@@ -1853,7 +1997,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(Step, otherT.Step)) return false;
 
         return true;
@@ -1866,7 +2010,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(Step, otherT.Step)) return false;
 
         return true;
@@ -1879,7 +2023,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (TitleElement != null) yield return TitleElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           foreach (var elem in Step) { if (elem != null) yield return elem; }
         }
       }
@@ -1891,7 +2035,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (TitleElement != null) yield return new ElementValue("title", TitleElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           foreach (var elem in Step) { if (elem != null) yield return new ElementValue("step", elem); }
         }
       }
@@ -1904,8 +2048,8 @@ namespace Hl7.Fhir.Model
             value = TitleElement;
             return TitleElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "step":
             value = Step;
             return Step?.Any() == true;
@@ -1919,7 +2063,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (TitleElement is not null) yield return new KeyValuePair<string,object>("title",TitleElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (Step?.Any() == true) yield return new KeyValuePair<string,object>("step",Step);
       }
 
@@ -2205,26 +2349,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// The purpose of the example, e.g. to illustrate a scenario
     /// </summary>
     [FhirElement("purpose", Order=210, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// The purpose of the example, e.g. to illustrate a scenario
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Actor participating in the resource
@@ -2321,8 +2501,8 @@ namespace Hl7.Fhir.Model
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(Actor != null) dest.Actor = new List<Hl7.Fhir.Model.ExampleScenario.ActorComponent>(Actor.DeepCopy());
       if(Instance != null) dest.Instance = new List<Hl7.Fhir.Model.ExampleScenario.InstanceComponent>(Instance.DeepCopy());
       if(Process != null) dest.Process = new List<Hl7.Fhir.Model.ExampleScenario.ProcessComponent>(Process.DeepCopy());
@@ -2353,8 +2533,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(Actor, otherT.Actor)) return false;
       if( !DeepComparable.Matches(Instance, otherT.Instance)) return false;
       if( !DeepComparable.Matches(Process, otherT.Process)) return false;
@@ -2380,8 +2560,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(Actor, otherT.Actor)) return false;
       if( !DeepComparable.IsExactly(Instance, otherT.Instance)) return false;
       if( !DeepComparable.IsExactly(Process, otherT.Process)) return false;
@@ -2407,8 +2587,8 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
-        if (Purpose != null) yield return Purpose;
+        if (CopyrightElement != null) yield return CopyrightElement;
+        if (PurposeElement != null) yield return PurposeElement;
         foreach (var elem in Actor) { if (elem != null) yield return elem; }
         foreach (var elem in Instance) { if (elem != null) yield return elem; }
         foreach (var elem in Process) { if (elem != null) yield return elem; }
@@ -2433,8 +2613,8 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         foreach (var elem in Actor) { if (elem != null) yield return new ElementValue("actor", elem); }
         foreach (var elem in Instance) { if (elem != null) yield return new ElementValue("instance", elem); }
         foreach (var elem in Process) { if (elem != null) yield return new ElementValue("process", elem); }
@@ -2480,11 +2660,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "actor":
           value = Actor;
           return Actor?.Any() == true;
@@ -2517,8 +2697,8 @@ namespace Hl7.Fhir.Model
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (Actor?.Any() == true) yield return new KeyValuePair<string,object>("actor",Actor);
       if (Instance?.Any() == true) yield return new KeyValuePair<string,object>("instance",Instance);
       if (Process?.Any() == true) yield return new KeyValuePair<string,object>("process",Process);

--- a/src/Hl7.Fhir.R4/Model/Generated/GraphDefinition.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/GraphDefinition.cs
@@ -1208,13 +1208,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=170)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the graph definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1249,13 +1267,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=200, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this graph definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Type of resource at which the graph starts
@@ -1353,10 +1389,10 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(StartElement != null) dest.StartElement = (Code<Hl7.Fhir.Model.ResourceType>)StartElement.DeepCopy();
       if(ProfileElement != null) dest.ProfileElement = (Hl7.Fhir.Model.Canonical)ProfileElement.DeepCopy();
       if(Link != null) dest.Link = new List<Hl7.Fhir.Model.GraphDefinition.LinkComponent>(Link.DeepCopy());
@@ -1383,10 +1419,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(StartElement, otherT.StartElement)) return false;
       if( !DeepComparable.Matches(ProfileElement, otherT.ProfileElement)) return false;
       if( !DeepComparable.Matches(Link, otherT.Link)) return false;
@@ -1408,10 +1444,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(StartElement, otherT.StartElement)) return false;
       if( !DeepComparable.IsExactly(ProfileElement, otherT.ProfileElement)) return false;
       if( !DeepComparable.IsExactly(Link, otherT.Link)) return false;
@@ -1433,10 +1469,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (StartElement != null) yield return StartElement;
         if (ProfileElement != null) yield return ProfileElement;
         foreach (var elem in Link) { if (elem != null) yield return elem; }
@@ -1457,10 +1493,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (StartElement != null) yield return new ElementValue("start", StartElement);
         if (ProfileElement != null) yield return new ElementValue("profile", ProfileElement);
         foreach (var elem in Link) { if (elem != null) yield return new ElementValue("link", elem); }
@@ -1496,8 +1532,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1505,8 +1541,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "start":
           value = StartElement;
           return StartElement is not null;
@@ -1533,10 +1569,10 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (StartElement is not null) yield return new KeyValuePair<string,object>("start",StartElement);
       if (ProfileElement is not null) yield return new KeyValuePair<string,object>("profile",ProfileElement);
       if (Link?.Any() == true) yield return new KeyValuePair<string,object>("link",Link);

--- a/src/Hl7.Fhir.R4/Model/Generated/HealthcareService.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/HealthcareService.cs
@@ -86,13 +86,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("comment", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Comment
+      public Hl7.Fhir.Model.Markdown CommentElement
       {
-        get { return _Comment; }
-        set { _Comment = value; OnPropertyChanged("Comment"); }
+        get { return _CommentElement; }
+        set { _CommentElement = value; OnPropertyChanged("CommentElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Comment;
+      private Hl7.Fhir.Model.Markdown _CommentElement;
+
+      /// <summary>
+      /// Describes the eligibility conditions for the service
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Comment
+      {
+        get { return CommentElement != null ? CommentElement.Value : null; }
+        set
+        {
+          if (value == null)
+            CommentElement = null;
+          else
+            CommentElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Comment");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -105,7 +123,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(Code != null) dest.Code = (Hl7.Fhir.Model.CodeableConcept)Code.DeepCopy();
-        if(Comment != null) dest.Comment = (Hl7.Fhir.Model.Markdown)Comment.DeepCopy();
+        if(CommentElement != null) dest.CommentElement = (Hl7.Fhir.Model.Markdown)CommentElement.DeepCopy();
         return dest;
       }
 
@@ -122,7 +140,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(Code, otherT.Code)) return false;
-        if( !DeepComparable.Matches(Comment, otherT.Comment)) return false;
+        if( !DeepComparable.Matches(CommentElement, otherT.CommentElement)) return false;
 
         return true;
       }
@@ -134,7 +152,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(Code, otherT.Code)) return false;
-        if( !DeepComparable.IsExactly(Comment, otherT.Comment)) return false;
+        if( !DeepComparable.IsExactly(CommentElement, otherT.CommentElement)) return false;
 
         return true;
       }
@@ -146,7 +164,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (Code != null) yield return Code;
-          if (Comment != null) yield return Comment;
+          if (CommentElement != null) yield return CommentElement;
         }
       }
 
@@ -157,7 +175,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (Code != null) yield return new ElementValue("code", Code);
-          if (Comment != null) yield return new ElementValue("comment", Comment);
+          if (CommentElement != null) yield return new ElementValue("comment", CommentElement);
         }
       }
 
@@ -169,8 +187,8 @@ namespace Hl7.Fhir.Model
             value = Code;
             return Code is not null;
           case "comment":
-            value = Comment;
-            return Comment is not null;
+            value = CommentElement;
+            return CommentElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -181,7 +199,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (Code is not null) yield return new KeyValuePair<string,object>("code",Code);
-        if (Comment is not null) yield return new KeyValuePair<string,object>("comment",Comment);
+        if (CommentElement is not null) yield return new KeyValuePair<string,object>("comment",CommentElement);
       }
 
     }
@@ -770,13 +788,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("extraDetails", Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown ExtraDetails
+    public Hl7.Fhir.Model.Markdown ExtraDetailsElement
     {
-      get { return _ExtraDetails; }
-      set { _ExtraDetails = value; OnPropertyChanged("ExtraDetails"); }
+      get { return _ExtraDetailsElement; }
+      set { _ExtraDetailsElement = value; OnPropertyChanged("ExtraDetailsElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _ExtraDetails;
+    private Hl7.Fhir.Model.Markdown _ExtraDetailsElement;
+
+    /// <summary>
+    /// Extra details about the service that can't be placed in the other fields
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string ExtraDetails
+    {
+      get { return ExtraDetailsElement != null ? ExtraDetailsElement.Value : null; }
+      set
+      {
+        if (value == null)
+          ExtraDetailsElement = null;
+        else
+          ExtraDetailsElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("ExtraDetails");
+      }
+    }
 
     /// <summary>
     /// Facilitates quick identification of the service
@@ -1030,7 +1066,7 @@ namespace Hl7.Fhir.Model
       if(Location != null) dest.Location = new List<Hl7.Fhir.Model.ResourceReference>(Location.DeepCopy());
       if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
       if(CommentElement != null) dest.CommentElement = (Hl7.Fhir.Model.FhirString)CommentElement.DeepCopy();
-      if(ExtraDetails != null) dest.ExtraDetails = (Hl7.Fhir.Model.Markdown)ExtraDetails.DeepCopy();
+      if(ExtraDetailsElement != null) dest.ExtraDetailsElement = (Hl7.Fhir.Model.Markdown)ExtraDetailsElement.DeepCopy();
       if(Photo != null) dest.Photo = (Hl7.Fhir.Model.Attachment)Photo.DeepCopy();
       if(Telecom != null) dest.Telecom = new List<Hl7.Fhir.Model.ContactPoint>(Telecom.DeepCopy());
       if(CoverageArea != null) dest.CoverageArea = new List<Hl7.Fhir.Model.ResourceReference>(CoverageArea.DeepCopy());
@@ -1069,7 +1105,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Location, otherT.Location)) return false;
       if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
       if( !DeepComparable.Matches(CommentElement, otherT.CommentElement)) return false;
-      if( !DeepComparable.Matches(ExtraDetails, otherT.ExtraDetails)) return false;
+      if( !DeepComparable.Matches(ExtraDetailsElement, otherT.ExtraDetailsElement)) return false;
       if( !DeepComparable.Matches(Photo, otherT.Photo)) return false;
       if( !DeepComparable.Matches(Telecom, otherT.Telecom)) return false;
       if( !DeepComparable.Matches(CoverageArea, otherT.CoverageArea)) return false;
@@ -1103,7 +1139,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Location, otherT.Location)) return false;
       if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
       if( !DeepComparable.IsExactly(CommentElement, otherT.CommentElement)) return false;
-      if( !DeepComparable.IsExactly(ExtraDetails, otherT.ExtraDetails)) return false;
+      if( !DeepComparable.IsExactly(ExtraDetailsElement, otherT.ExtraDetailsElement)) return false;
       if( !DeepComparable.IsExactly(Photo, otherT.Photo)) return false;
       if( !DeepComparable.IsExactly(Telecom, otherT.Telecom)) return false;
       if( !DeepComparable.IsExactly(CoverageArea, otherT.CoverageArea)) return false;
@@ -1137,7 +1173,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Location) { if (elem != null) yield return elem; }
         if (NameElement != null) yield return NameElement;
         if (CommentElement != null) yield return CommentElement;
-        if (ExtraDetails != null) yield return ExtraDetails;
+        if (ExtraDetailsElement != null) yield return ExtraDetailsElement;
         if (Photo != null) yield return Photo;
         foreach (var elem in Telecom) { if (elem != null) yield return elem; }
         foreach (var elem in CoverageArea) { if (elem != null) yield return elem; }
@@ -1170,7 +1206,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Location) { if (elem != null) yield return new ElementValue("location", elem); }
         if (NameElement != null) yield return new ElementValue("name", NameElement);
         if (CommentElement != null) yield return new ElementValue("comment", CommentElement);
-        if (ExtraDetails != null) yield return new ElementValue("extraDetails", ExtraDetails);
+        if (ExtraDetailsElement != null) yield return new ElementValue("extraDetails", ExtraDetailsElement);
         if (Photo != null) yield return new ElementValue("photo", Photo);
         foreach (var elem in Telecom) { if (elem != null) yield return new ElementValue("telecom", elem); }
         foreach (var elem in CoverageArea) { if (elem != null) yield return new ElementValue("coverageArea", elem); }
@@ -1220,8 +1256,8 @@ namespace Hl7.Fhir.Model
           value = CommentElement;
           return CommentElement is not null;
         case "extraDetails":
-          value = ExtraDetails;
-          return ExtraDetails is not null;
+          value = ExtraDetailsElement;
+          return ExtraDetailsElement is not null;
         case "photo":
           value = Photo;
           return Photo is not null;
@@ -1282,7 +1318,7 @@ namespace Hl7.Fhir.Model
       if (Location?.Any() == true) yield return new KeyValuePair<string,object>("location",Location);
       if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
       if (CommentElement is not null) yield return new KeyValuePair<string,object>("comment",CommentElement);
-      if (ExtraDetails is not null) yield return new KeyValuePair<string,object>("extraDetails",ExtraDetails);
+      if (ExtraDetailsElement is not null) yield return new KeyValuePair<string,object>("extraDetails",ExtraDetailsElement);
       if (Photo is not null) yield return new KeyValuePair<string,object>("photo",Photo);
       if (Telecom?.Any() == true) yield return new KeyValuePair<string,object>("telecom",Telecom);
       if (CoverageArea?.Any() == true) yield return new KeyValuePair<string,object>("coverageArea",CoverageArea);

--- a/src/Hl7.Fhir.R4/Model/Generated/ImplementationGuide.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/ImplementationGuide.cs
@@ -4799,13 +4799,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the implementation guide
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -4840,13 +4858,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// NPM Package name for IG
@@ -5018,10 +5054,10 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(PackageIdElement != null) dest.PackageIdElement = (Hl7.Fhir.Model.Id)PackageIdElement.DeepCopy();
       if(LicenseElement != null) dest.LicenseElement = (Code<Hl7.Fhir.Model.ImplementationGuide.SPDXLicense>)LicenseElement.DeepCopy();
       if(FhirVersionElement != null) dest.FhirVersionElement = new List<Code<Hl7.Fhir.Model.FHIRVersion>>(FhirVersionElement.DeepCopy());
@@ -5053,10 +5089,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(PackageIdElement, otherT.PackageIdElement)) return false;
       if( !DeepComparable.Matches(LicenseElement, otherT.LicenseElement)) return false;
       if( !DeepComparable.Matches(FhirVersionElement, otherT.FhirVersionElement)) return false;
@@ -5083,10 +5119,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(PackageIdElement, otherT.PackageIdElement)) return false;
       if( !DeepComparable.IsExactly(LicenseElement, otherT.LicenseElement)) return false;
       if( !DeepComparable.IsExactly(FhirVersionElement, otherT.FhirVersionElement)) return false;
@@ -5113,10 +5149,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (PackageIdElement != null) yield return PackageIdElement;
         if (LicenseElement != null) yield return LicenseElement;
         foreach (var elem in FhirVersionElement) { if (elem != null) yield return elem; }
@@ -5142,10 +5178,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (PackageIdElement != null) yield return new ElementValue("packageId", PackageIdElement);
         if (LicenseElement != null) yield return new ElementValue("license", LicenseElement);
         foreach (var elem in FhirVersionElement) { if (elem != null) yield return new ElementValue("fhirVersion", elem); }
@@ -5188,8 +5224,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -5197,8 +5233,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "packageId":
           value = PackageIdElement;
           return PackageIdElement is not null;
@@ -5238,10 +5274,10 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (PackageIdElement is not null) yield return new KeyValuePair<string,object>("packageId",PackageIdElement);
       if (LicenseElement is not null) yield return new KeyValuePair<string,object>("license",LicenseElement);
       if (FhirVersionElement?.Any() == true) yield return new KeyValuePair<string,object>("fhirVersion",FhirVersionElement);

--- a/src/Hl7.Fhir.R4/Model/Generated/Invoice.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/Invoice.cs
@@ -873,13 +873,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("paymentTerms", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown PaymentTerms
+    public Hl7.Fhir.Model.Markdown PaymentTermsElement
     {
-      get { return _PaymentTerms; }
-      set { _PaymentTerms = value; OnPropertyChanged("PaymentTerms"); }
+      get { return _PaymentTermsElement; }
+      set { _PaymentTermsElement = value; OnPropertyChanged("PaymentTermsElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _PaymentTerms;
+    private Hl7.Fhir.Model.Markdown _PaymentTermsElement;
+
+    /// <summary>
+    /// Payment details
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string PaymentTerms
+    {
+      get { return PaymentTermsElement != null ? PaymentTermsElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PaymentTermsElement = null;
+        else
+          PaymentTermsElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("PaymentTerms");
+      }
+    }
 
     /// <summary>
     /// Comments made about the invoice
@@ -919,7 +937,7 @@ namespace Hl7.Fhir.Model
       if(TotalPriceComponent != null) dest.TotalPriceComponent = new List<Hl7.Fhir.Model.Invoice.PriceComponentComponent>(TotalPriceComponent.DeepCopy());
       if(TotalNet != null) dest.TotalNet = (Hl7.Fhir.Model.Money)TotalNet.DeepCopy();
       if(TotalGross != null) dest.TotalGross = (Hl7.Fhir.Model.Money)TotalGross.DeepCopy();
-      if(PaymentTerms != null) dest.PaymentTerms = (Hl7.Fhir.Model.Markdown)PaymentTerms.DeepCopy();
+      if(PaymentTermsElement != null) dest.PaymentTermsElement = (Hl7.Fhir.Model.Markdown)PaymentTermsElement.DeepCopy();
       if(Note != null) dest.Note = new List<Hl7.Fhir.Model.Annotation>(Note.DeepCopy());
       return dest;
     }
@@ -950,7 +968,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(TotalPriceComponent, otherT.TotalPriceComponent)) return false;
       if( !DeepComparable.Matches(TotalNet, otherT.TotalNet)) return false;
       if( !DeepComparable.Matches(TotalGross, otherT.TotalGross)) return false;
-      if( !DeepComparable.Matches(PaymentTerms, otherT.PaymentTerms)) return false;
+      if( !DeepComparable.Matches(PaymentTermsElement, otherT.PaymentTermsElement)) return false;
       if( !DeepComparable.Matches(Note, otherT.Note)) return false;
 
       return true;
@@ -976,7 +994,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(TotalPriceComponent, otherT.TotalPriceComponent)) return false;
       if( !DeepComparable.IsExactly(TotalNet, otherT.TotalNet)) return false;
       if( !DeepComparable.IsExactly(TotalGross, otherT.TotalGross)) return false;
-      if( !DeepComparable.IsExactly(PaymentTerms, otherT.PaymentTerms)) return false;
+      if( !DeepComparable.IsExactly(PaymentTermsElement, otherT.PaymentTermsElement)) return false;
       if( !DeepComparable.IsExactly(Note, otherT.Note)) return false;
 
       return true;
@@ -1002,7 +1020,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in TotalPriceComponent) { if (elem != null) yield return elem; }
         if (TotalNet != null) yield return TotalNet;
         if (TotalGross != null) yield return TotalGross;
-        if (PaymentTerms != null) yield return PaymentTerms;
+        if (PaymentTermsElement != null) yield return PaymentTermsElement;
         foreach (var elem in Note) { if (elem != null) yield return elem; }
       }
     }
@@ -1027,7 +1045,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in TotalPriceComponent) { if (elem != null) yield return new ElementValue("totalPriceComponent", elem); }
         if (TotalNet != null) yield return new ElementValue("totalNet", TotalNet);
         if (TotalGross != null) yield return new ElementValue("totalGross", TotalGross);
-        if (PaymentTerms != null) yield return new ElementValue("paymentTerms", PaymentTerms);
+        if (PaymentTermsElement != null) yield return new ElementValue("paymentTerms", PaymentTermsElement);
         foreach (var elem in Note) { if (elem != null) yield return new ElementValue("note", elem); }
       }
     }
@@ -1079,8 +1097,8 @@ namespace Hl7.Fhir.Model
           value = TotalGross;
           return TotalGross is not null;
         case "paymentTerms":
-          value = PaymentTerms;
-          return PaymentTerms is not null;
+          value = PaymentTermsElement;
+          return PaymentTermsElement is not null;
         case "note":
           value = Note;
           return Note?.Any() == true;
@@ -1107,7 +1125,7 @@ namespace Hl7.Fhir.Model
       if (TotalPriceComponent?.Any() == true) yield return new KeyValuePair<string,object>("totalPriceComponent",TotalPriceComponent);
       if (TotalNet is not null) yield return new KeyValuePair<string,object>("totalNet",TotalNet);
       if (TotalGross is not null) yield return new KeyValuePair<string,object>("totalGross",TotalGross);
-      if (PaymentTerms is not null) yield return new KeyValuePair<string,object>("paymentTerms",PaymentTerms);
+      if (PaymentTermsElement is not null) yield return new KeyValuePair<string,object>("paymentTerms",PaymentTermsElement);
       if (Note?.Any() == true) yield return new KeyValuePair<string,object>("note",Note);
     }
 

--- a/src/Hl7.Fhir.R4/Model/Generated/Library.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/Library.cs
@@ -399,13 +399,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the library
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -440,13 +458,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=250, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this library is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the library
@@ -484,13 +520,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=270)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the library was approved by publisher
@@ -716,12 +770,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -762,12 +816,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -803,12 +857,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -844,12 +898,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -884,12 +938,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -949,8 +1003,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -958,14 +1012,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -1024,12 +1078,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4/Model/Generated/Measure.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/Measure.cs
@@ -1313,13 +1313,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the measure
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1354,13 +1372,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=240, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this measure is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the measure
@@ -1398,13 +1434,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=260)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the measure was approved by publisher
@@ -1602,13 +1656,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("disclaimer", InSummary=true, Order=370)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Disclaimer
+    public Hl7.Fhir.Model.Markdown DisclaimerElement
     {
-      get { return _Disclaimer; }
-      set { _Disclaimer = value; OnPropertyChanged("Disclaimer"); }
+      get { return _DisclaimerElement; }
+      set { _DisclaimerElement = value; OnPropertyChanged("DisclaimerElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Disclaimer;
+    private Hl7.Fhir.Model.Markdown _DisclaimerElement;
+
+    /// <summary>
+    /// Disclaimer for use of the measure or its referenced content
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Disclaimer
+    {
+      get { return DisclaimerElement != null ? DisclaimerElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DisclaimerElement = null;
+        else
+          DisclaimerElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Disclaimer");
+      }
+    }
 
     /// <summary>
     /// proportion | ratio | continuous-variable | cohort
@@ -1717,26 +1789,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("rationale", InSummary=true, Order=430)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Rationale
+    public Hl7.Fhir.Model.Markdown RationaleElement
     {
-      get { return _Rationale; }
-      set { _Rationale = value; OnPropertyChanged("Rationale"); }
+      get { return _RationaleElement; }
+      set { _RationaleElement = value; OnPropertyChanged("RationaleElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Rationale;
+    private Hl7.Fhir.Model.Markdown _RationaleElement;
+
+    /// <summary>
+    /// Detailed description of why the measure exists
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Rationale
+    {
+      get { return RationaleElement != null ? RationaleElement.Value : null; }
+      set
+      {
+        if (value == null)
+          RationaleElement = null;
+        else
+          RationaleElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Rationale");
+      }
+    }
 
     /// <summary>
     /// Summary of clinical guidelines
     /// </summary>
     [FhirElement("clinicalRecommendationStatement", InSummary=true, Order=440)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown ClinicalRecommendationStatement
+    public Hl7.Fhir.Model.Markdown ClinicalRecommendationStatementElement
     {
-      get { return _ClinicalRecommendationStatement; }
-      set { _ClinicalRecommendationStatement = value; OnPropertyChanged("ClinicalRecommendationStatement"); }
+      get { return _ClinicalRecommendationStatementElement; }
+      set { _ClinicalRecommendationStatementElement = value; OnPropertyChanged("ClinicalRecommendationStatementElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _ClinicalRecommendationStatement;
+    private Hl7.Fhir.Model.Markdown _ClinicalRecommendationStatementElement;
+
+    /// <summary>
+    /// Summary of clinical guidelines
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string ClinicalRecommendationStatement
+    {
+      get { return ClinicalRecommendationStatementElement != null ? ClinicalRecommendationStatementElement.Value : null; }
+      set
+      {
+        if (value == null)
+          ClinicalRecommendationStatementElement = null;
+        else
+          ClinicalRecommendationStatementElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("ClinicalRecommendationStatement");
+      }
+    }
 
     /// <summary>
     /// increase | decrease
@@ -1757,26 +1865,62 @@ namespace Hl7.Fhir.Model
     [FhirElement("definition", InSummary=true, Order=460)]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
-    public List<Hl7.Fhir.Model.Markdown> Definition
+    public List<Hl7.Fhir.Model.Markdown> DefinitionElement
     {
-      get { if(_Definition==null) _Definition = new List<Hl7.Fhir.Model.Markdown>(); return _Definition; }
-      set { _Definition = value; OnPropertyChanged("Definition"); }
+      get { if(_DefinitionElement==null) _DefinitionElement = new List<Hl7.Fhir.Model.Markdown>(); return _DefinitionElement; }
+      set { _DefinitionElement = value; OnPropertyChanged("DefinitionElement"); }
     }
 
-    private List<Hl7.Fhir.Model.Markdown> _Definition;
+    private List<Hl7.Fhir.Model.Markdown> _DefinitionElement;
+
+    /// <summary>
+    /// Defined terms used in the measure documentation
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public IEnumerable<string> Definition
+    {
+      get { return DefinitionElement != null ? DefinitionElement.Select(elem => elem.Value) : null; }
+      set
+      {
+        if (value == null)
+          DefinitionElement = null;
+        else
+          DefinitionElement = new List<Hl7.Fhir.Model.Markdown>(value.Select(elem=>new Hl7.Fhir.Model.Markdown(elem)));
+        OnPropertyChanged("Definition");
+      }
+    }
 
     /// <summary>
     /// Additional guidance for implementers
     /// </summary>
     [FhirElement("guidance", InSummary=true, Order=470)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Guidance
+    public Hl7.Fhir.Model.Markdown GuidanceElement
     {
-      get { return _Guidance; }
-      set { _Guidance = value; OnPropertyChanged("Guidance"); }
+      get { return _GuidanceElement; }
+      set { _GuidanceElement = value; OnPropertyChanged("GuidanceElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Guidance;
+    private Hl7.Fhir.Model.Markdown _GuidanceElement;
+
+    /// <summary>
+    /// Additional guidance for implementers
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Guidance
+    {
+      get { return GuidanceElement != null ? GuidanceElement.Value : null; }
+      set
+      {
+        if (value == null)
+          GuidanceElement = null;
+        else
+          GuidanceElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Guidance");
+      }
+    }
 
     /// <summary>
     /// Population criteria group
@@ -1828,12 +1972,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1844,17 +1988,17 @@ namespace Hl7.Fhir.Model
       if(Endorser != null) dest.Endorser = new List<Hl7.Fhir.Model.ContactDetail>(Endorser.DeepCopy());
       if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
       if(LibraryElement != null) dest.LibraryElement = new List<Hl7.Fhir.Model.Canonical>(LibraryElement.DeepCopy());
-      if(Disclaimer != null) dest.Disclaimer = (Hl7.Fhir.Model.Markdown)Disclaimer.DeepCopy();
+      if(DisclaimerElement != null) dest.DisclaimerElement = (Hl7.Fhir.Model.Markdown)DisclaimerElement.DeepCopy();
       if(Scoring != null) dest.Scoring = (Hl7.Fhir.Model.CodeableConcept)Scoring.DeepCopy();
       if(CompositeScoring != null) dest.CompositeScoring = (Hl7.Fhir.Model.CodeableConcept)CompositeScoring.DeepCopy();
       if(Type != null) dest.Type = new List<Hl7.Fhir.Model.CodeableConcept>(Type.DeepCopy());
       if(RiskAdjustmentElement != null) dest.RiskAdjustmentElement = (Hl7.Fhir.Model.FhirString)RiskAdjustmentElement.DeepCopy();
       if(RateAggregationElement != null) dest.RateAggregationElement = (Hl7.Fhir.Model.FhirString)RateAggregationElement.DeepCopy();
-      if(Rationale != null) dest.Rationale = (Hl7.Fhir.Model.Markdown)Rationale.DeepCopy();
-      if(ClinicalRecommendationStatement != null) dest.ClinicalRecommendationStatement = (Hl7.Fhir.Model.Markdown)ClinicalRecommendationStatement.DeepCopy();
+      if(RationaleElement != null) dest.RationaleElement = (Hl7.Fhir.Model.Markdown)RationaleElement.DeepCopy();
+      if(ClinicalRecommendationStatementElement != null) dest.ClinicalRecommendationStatementElement = (Hl7.Fhir.Model.Markdown)ClinicalRecommendationStatementElement.DeepCopy();
       if(ImprovementNotation != null) dest.ImprovementNotation = (Hl7.Fhir.Model.CodeableConcept)ImprovementNotation.DeepCopy();
-      if(Definition != null) dest.Definition = new List<Hl7.Fhir.Model.Markdown>(Definition.DeepCopy());
-      if(Guidance != null) dest.Guidance = (Hl7.Fhir.Model.Markdown)Guidance.DeepCopy();
+      if(DefinitionElement != null) dest.DefinitionElement = new List<Hl7.Fhir.Model.Markdown>(DefinitionElement.DeepCopy());
+      if(GuidanceElement != null) dest.GuidanceElement = (Hl7.Fhir.Model.Markdown)GuidanceElement.DeepCopy();
       if(Group != null) dest.Group = new List<Hl7.Fhir.Model.Measure.GroupComponent>(Group.DeepCopy());
       if(SupplementalData != null) dest.SupplementalData = new List<Hl7.Fhir.Model.Measure.SupplementalDataComponent>(SupplementalData.DeepCopy());
       return dest;
@@ -1884,12 +2028,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1900,17 +2044,17 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Endorser, otherT.Endorser)) return false;
       if( !DeepComparable.Matches(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.Matches(LibraryElement, otherT.LibraryElement)) return false;
-      if( !DeepComparable.Matches(Disclaimer, otherT.Disclaimer)) return false;
+      if( !DeepComparable.Matches(DisclaimerElement, otherT.DisclaimerElement)) return false;
       if( !DeepComparable.Matches(Scoring, otherT.Scoring)) return false;
       if( !DeepComparable.Matches(CompositeScoring, otherT.CompositeScoring)) return false;
       if( !DeepComparable.Matches(Type, otherT.Type)) return false;
       if( !DeepComparable.Matches(RiskAdjustmentElement, otherT.RiskAdjustmentElement)) return false;
       if( !DeepComparable.Matches(RateAggregationElement, otherT.RateAggregationElement)) return false;
-      if( !DeepComparable.Matches(Rationale, otherT.Rationale)) return false;
-      if( !DeepComparable.Matches(ClinicalRecommendationStatement, otherT.ClinicalRecommendationStatement)) return false;
+      if( !DeepComparable.Matches(RationaleElement, otherT.RationaleElement)) return false;
+      if( !DeepComparable.Matches(ClinicalRecommendationStatementElement, otherT.ClinicalRecommendationStatementElement)) return false;
       if( !DeepComparable.Matches(ImprovementNotation, otherT.ImprovementNotation)) return false;
-      if( !DeepComparable.Matches(Definition, otherT.Definition)) return false;
-      if( !DeepComparable.Matches(Guidance, otherT.Guidance)) return false;
+      if( !DeepComparable.Matches(DefinitionElement, otherT.DefinitionElement)) return false;
+      if( !DeepComparable.Matches(GuidanceElement, otherT.GuidanceElement)) return false;
       if( !DeepComparable.Matches(Group, otherT.Group)) return false;
       if( !DeepComparable.Matches(SupplementalData, otherT.SupplementalData)) return false;
 
@@ -1935,12 +2079,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1951,17 +2095,17 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Endorser, otherT.Endorser)) return false;
       if( !DeepComparable.IsExactly(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.IsExactly(LibraryElement, otherT.LibraryElement)) return false;
-      if( !DeepComparable.IsExactly(Disclaimer, otherT.Disclaimer)) return false;
+      if( !DeepComparable.IsExactly(DisclaimerElement, otherT.DisclaimerElement)) return false;
       if( !DeepComparable.IsExactly(Scoring, otherT.Scoring)) return false;
       if( !DeepComparable.IsExactly(CompositeScoring, otherT.CompositeScoring)) return false;
       if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
       if( !DeepComparable.IsExactly(RiskAdjustmentElement, otherT.RiskAdjustmentElement)) return false;
       if( !DeepComparable.IsExactly(RateAggregationElement, otherT.RateAggregationElement)) return false;
-      if( !DeepComparable.IsExactly(Rationale, otherT.Rationale)) return false;
-      if( !DeepComparable.IsExactly(ClinicalRecommendationStatement, otherT.ClinicalRecommendationStatement)) return false;
+      if( !DeepComparable.IsExactly(RationaleElement, otherT.RationaleElement)) return false;
+      if( !DeepComparable.IsExactly(ClinicalRecommendationStatementElement, otherT.ClinicalRecommendationStatementElement)) return false;
       if( !DeepComparable.IsExactly(ImprovementNotation, otherT.ImprovementNotation)) return false;
-      if( !DeepComparable.IsExactly(Definition, otherT.Definition)) return false;
-      if( !DeepComparable.IsExactly(Guidance, otherT.Guidance)) return false;
+      if( !DeepComparable.IsExactly(DefinitionElement, otherT.DefinitionElement)) return false;
+      if( !DeepComparable.IsExactly(GuidanceElement, otherT.GuidanceElement)) return false;
       if( !DeepComparable.IsExactly(Group, otherT.Group)) return false;
       if( !DeepComparable.IsExactly(SupplementalData, otherT.SupplementalData)) return false;
 
@@ -1986,12 +2130,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -2002,17 +2146,17 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Endorser) { if (elem != null) yield return elem; }
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return elem; }
         foreach (var elem in LibraryElement) { if (elem != null) yield return elem; }
-        if (Disclaimer != null) yield return Disclaimer;
+        if (DisclaimerElement != null) yield return DisclaimerElement;
         if (Scoring != null) yield return Scoring;
         if (CompositeScoring != null) yield return CompositeScoring;
         foreach (var elem in Type) { if (elem != null) yield return elem; }
         if (RiskAdjustmentElement != null) yield return RiskAdjustmentElement;
         if (RateAggregationElement != null) yield return RateAggregationElement;
-        if (Rationale != null) yield return Rationale;
-        if (ClinicalRecommendationStatement != null) yield return ClinicalRecommendationStatement;
+        if (RationaleElement != null) yield return RationaleElement;
+        if (ClinicalRecommendationStatementElement != null) yield return ClinicalRecommendationStatementElement;
         if (ImprovementNotation != null) yield return ImprovementNotation;
-        foreach (var elem in Definition) { if (elem != null) yield return elem; }
-        if (Guidance != null) yield return Guidance;
+        foreach (var elem in DefinitionElement) { if (elem != null) yield return elem; }
+        if (GuidanceElement != null) yield return GuidanceElement;
         foreach (var elem in Group) { if (elem != null) yield return elem; }
         foreach (var elem in SupplementalData) { if (elem != null) yield return elem; }
       }
@@ -2036,12 +2180,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -2052,17 +2196,17 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Endorser) { if (elem != null) yield return new ElementValue("endorser", elem); }
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return new ElementValue("relatedArtifact", elem); }
         foreach (var elem in LibraryElement) { if (elem != null) yield return new ElementValue("library", elem); }
-        if (Disclaimer != null) yield return new ElementValue("disclaimer", Disclaimer);
+        if (DisclaimerElement != null) yield return new ElementValue("disclaimer", DisclaimerElement);
         if (Scoring != null) yield return new ElementValue("scoring", Scoring);
         if (CompositeScoring != null) yield return new ElementValue("compositeScoring", CompositeScoring);
         foreach (var elem in Type) { if (elem != null) yield return new ElementValue("type", elem); }
         if (RiskAdjustmentElement != null) yield return new ElementValue("riskAdjustment", RiskAdjustmentElement);
         if (RateAggregationElement != null) yield return new ElementValue("rateAggregation", RateAggregationElement);
-        if (Rationale != null) yield return new ElementValue("rationale", Rationale);
-        if (ClinicalRecommendationStatement != null) yield return new ElementValue("clinicalRecommendationStatement", ClinicalRecommendationStatement);
+        if (RationaleElement != null) yield return new ElementValue("rationale", RationaleElement);
+        if (ClinicalRecommendationStatementElement != null) yield return new ElementValue("clinicalRecommendationStatement", ClinicalRecommendationStatementElement);
         if (ImprovementNotation != null) yield return new ElementValue("improvementNotation", ImprovementNotation);
-        foreach (var elem in Definition) { if (elem != null) yield return new ElementValue("definition", elem); }
-        if (Guidance != null) yield return new ElementValue("guidance", Guidance);
+        foreach (var elem in DefinitionElement) { if (elem != null) yield return new ElementValue("definition", elem); }
+        if (GuidanceElement != null) yield return new ElementValue("guidance", GuidanceElement);
         foreach (var elem in Group) { if (elem != null) yield return new ElementValue("group", elem); }
         foreach (var elem in SupplementalData) { if (elem != null) yield return new ElementValue("supplementalData", elem); }
       }
@@ -2109,8 +2253,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2118,14 +2262,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -2157,8 +2301,8 @@ namespace Hl7.Fhir.Model
           value = LibraryElement;
           return LibraryElement?.Any() == true;
         case "disclaimer":
-          value = Disclaimer;
-          return Disclaimer is not null;
+          value = DisclaimerElement;
+          return DisclaimerElement is not null;
         case "scoring":
           value = Scoring;
           return Scoring is not null;
@@ -2175,20 +2319,20 @@ namespace Hl7.Fhir.Model
           value = RateAggregationElement;
           return RateAggregationElement is not null;
         case "rationale":
-          value = Rationale;
-          return Rationale is not null;
+          value = RationaleElement;
+          return RationaleElement is not null;
         case "clinicalRecommendationStatement":
-          value = ClinicalRecommendationStatement;
-          return ClinicalRecommendationStatement is not null;
+          value = ClinicalRecommendationStatementElement;
+          return ClinicalRecommendationStatementElement is not null;
         case "improvementNotation":
           value = ImprovementNotation;
           return ImprovementNotation is not null;
         case "definition":
-          value = Definition;
-          return Definition?.Any() == true;
+          value = DefinitionElement;
+          return DefinitionElement?.Any() == true;
         case "guidance":
-          value = Guidance;
-          return Guidance is not null;
+          value = GuidanceElement;
+          return GuidanceElement is not null;
         case "group":
           value = Group;
           return Group?.Any() == true;
@@ -2216,12 +2360,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);
@@ -2232,17 +2376,17 @@ namespace Hl7.Fhir.Model
       if (Endorser?.Any() == true) yield return new KeyValuePair<string,object>("endorser",Endorser);
       if (RelatedArtifact?.Any() == true) yield return new KeyValuePair<string,object>("relatedArtifact",RelatedArtifact);
       if (LibraryElement?.Any() == true) yield return new KeyValuePair<string,object>("library",LibraryElement);
-      if (Disclaimer is not null) yield return new KeyValuePair<string,object>("disclaimer",Disclaimer);
+      if (DisclaimerElement is not null) yield return new KeyValuePair<string,object>("disclaimer",DisclaimerElement);
       if (Scoring is not null) yield return new KeyValuePair<string,object>("scoring",Scoring);
       if (CompositeScoring is not null) yield return new KeyValuePair<string,object>("compositeScoring",CompositeScoring);
       if (Type?.Any() == true) yield return new KeyValuePair<string,object>("type",Type);
       if (RiskAdjustmentElement is not null) yield return new KeyValuePair<string,object>("riskAdjustment",RiskAdjustmentElement);
       if (RateAggregationElement is not null) yield return new KeyValuePair<string,object>("rateAggregation",RateAggregationElement);
-      if (Rationale is not null) yield return new KeyValuePair<string,object>("rationale",Rationale);
-      if (ClinicalRecommendationStatement is not null) yield return new KeyValuePair<string,object>("clinicalRecommendationStatement",ClinicalRecommendationStatement);
+      if (RationaleElement is not null) yield return new KeyValuePair<string,object>("rationale",RationaleElement);
+      if (ClinicalRecommendationStatementElement is not null) yield return new KeyValuePair<string,object>("clinicalRecommendationStatement",ClinicalRecommendationStatementElement);
       if (ImprovementNotation is not null) yield return new KeyValuePair<string,object>("improvementNotation",ImprovementNotation);
-      if (Definition?.Any() == true) yield return new KeyValuePair<string,object>("definition",Definition);
-      if (Guidance is not null) yield return new KeyValuePair<string,object>("guidance",Guidance);
+      if (DefinitionElement?.Any() == true) yield return new KeyValuePair<string,object>("definition",DefinitionElement);
+      if (GuidanceElement is not null) yield return new KeyValuePair<string,object>("guidance",GuidanceElement);
       if (Group?.Any() == true) yield return new KeyValuePair<string,object>("group",Group);
       if (SupplementalData?.Any() == true) yield return new KeyValuePair<string,object>("supplementalData",SupplementalData);
     }

--- a/src/Hl7.Fhir.R4/Model/Generated/MedicationKnowledge.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/MedicationKnowledge.cs
@@ -2612,13 +2612,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("preparationInstruction", Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown PreparationInstruction
+    public Hl7.Fhir.Model.Markdown PreparationInstructionElement
     {
-      get { return _PreparationInstruction; }
-      set { _PreparationInstruction = value; OnPropertyChanged("PreparationInstruction"); }
+      get { return _PreparationInstructionElement; }
+      set { _PreparationInstructionElement = value; OnPropertyChanged("PreparationInstructionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _PreparationInstruction;
+    private Hl7.Fhir.Model.Markdown _PreparationInstructionElement;
+
+    /// <summary>
+    /// The instructions for preparing the medication
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string PreparationInstruction
+    {
+      get { return PreparationInstructionElement != null ? PreparationInstructionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PreparationInstructionElement = null;
+        else
+          PreparationInstructionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("PreparationInstruction");
+      }
+    }
 
     /// <summary>
     /// The intended or approved route of administration
@@ -2782,7 +2800,7 @@ namespace Hl7.Fhir.Model
       if(ProductType != null) dest.ProductType = new List<Hl7.Fhir.Model.CodeableConcept>(ProductType.DeepCopy());
       if(Monograph != null) dest.Monograph = new List<Hl7.Fhir.Model.MedicationKnowledge.MonographComponent>(Monograph.DeepCopy());
       if(Ingredient != null) dest.Ingredient = new List<Hl7.Fhir.Model.MedicationKnowledge.IngredientComponent>(Ingredient.DeepCopy());
-      if(PreparationInstruction != null) dest.PreparationInstruction = (Hl7.Fhir.Model.Markdown)PreparationInstruction.DeepCopy();
+      if(PreparationInstructionElement != null) dest.PreparationInstructionElement = (Hl7.Fhir.Model.Markdown)PreparationInstructionElement.DeepCopy();
       if(IntendedRoute != null) dest.IntendedRoute = new List<Hl7.Fhir.Model.CodeableConcept>(IntendedRoute.DeepCopy());
       if(Cost != null) dest.Cost = new List<Hl7.Fhir.Model.MedicationKnowledge.CostComponent>(Cost.DeepCopy());
       if(MonitoringProgram != null) dest.MonitoringProgram = new List<Hl7.Fhir.Model.MedicationKnowledge.MonitoringProgramComponent>(MonitoringProgram.DeepCopy());
@@ -2819,7 +2837,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(ProductType, otherT.ProductType)) return false;
       if( !DeepComparable.Matches(Monograph, otherT.Monograph)) return false;
       if( !DeepComparable.Matches(Ingredient, otherT.Ingredient)) return false;
-      if( !DeepComparable.Matches(PreparationInstruction, otherT.PreparationInstruction)) return false;
+      if( !DeepComparable.Matches(PreparationInstructionElement, otherT.PreparationInstructionElement)) return false;
       if( !DeepComparable.Matches(IntendedRoute, otherT.IntendedRoute)) return false;
       if( !DeepComparable.Matches(Cost, otherT.Cost)) return false;
       if( !DeepComparable.Matches(MonitoringProgram, otherT.MonitoringProgram)) return false;
@@ -2851,7 +2869,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(ProductType, otherT.ProductType)) return false;
       if( !DeepComparable.IsExactly(Monograph, otherT.Monograph)) return false;
       if( !DeepComparable.IsExactly(Ingredient, otherT.Ingredient)) return false;
-      if( !DeepComparable.IsExactly(PreparationInstruction, otherT.PreparationInstruction)) return false;
+      if( !DeepComparable.IsExactly(PreparationInstructionElement, otherT.PreparationInstructionElement)) return false;
       if( !DeepComparable.IsExactly(IntendedRoute, otherT.IntendedRoute)) return false;
       if( !DeepComparable.IsExactly(Cost, otherT.Cost)) return false;
       if( !DeepComparable.IsExactly(MonitoringProgram, otherT.MonitoringProgram)) return false;
@@ -2883,7 +2901,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in ProductType) { if (elem != null) yield return elem; }
         foreach (var elem in Monograph) { if (elem != null) yield return elem; }
         foreach (var elem in Ingredient) { if (elem != null) yield return elem; }
-        if (PreparationInstruction != null) yield return PreparationInstruction;
+        if (PreparationInstructionElement != null) yield return PreparationInstructionElement;
         foreach (var elem in IntendedRoute) { if (elem != null) yield return elem; }
         foreach (var elem in Cost) { if (elem != null) yield return elem; }
         foreach (var elem in MonitoringProgram) { if (elem != null) yield return elem; }
@@ -2914,7 +2932,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in ProductType) { if (elem != null) yield return new ElementValue("productType", elem); }
         foreach (var elem in Monograph) { if (elem != null) yield return new ElementValue("monograph", elem); }
         foreach (var elem in Ingredient) { if (elem != null) yield return new ElementValue("ingredient", elem); }
-        if (PreparationInstruction != null) yield return new ElementValue("preparationInstruction", PreparationInstruction);
+        if (PreparationInstructionElement != null) yield return new ElementValue("preparationInstruction", PreparationInstructionElement);
         foreach (var elem in IntendedRoute) { if (elem != null) yield return new ElementValue("intendedRoute", elem); }
         foreach (var elem in Cost) { if (elem != null) yield return new ElementValue("cost", elem); }
         foreach (var elem in MonitoringProgram) { if (elem != null) yield return new ElementValue("monitoringProgram", elem); }
@@ -2966,8 +2984,8 @@ namespace Hl7.Fhir.Model
           value = Ingredient;
           return Ingredient?.Any() == true;
         case "preparationInstruction":
-          value = PreparationInstruction;
-          return PreparationInstruction is not null;
+          value = PreparationInstructionElement;
+          return PreparationInstructionElement is not null;
         case "intendedRoute":
           value = IntendedRoute;
           return IntendedRoute?.Any() == true;
@@ -3018,7 +3036,7 @@ namespace Hl7.Fhir.Model
       if (ProductType?.Any() == true) yield return new KeyValuePair<string,object>("productType",ProductType);
       if (Monograph?.Any() == true) yield return new KeyValuePair<string,object>("monograph",Monograph);
       if (Ingredient?.Any() == true) yield return new KeyValuePair<string,object>("ingredient",Ingredient);
-      if (PreparationInstruction is not null) yield return new KeyValuePair<string,object>("preparationInstruction",PreparationInstruction);
+      if (PreparationInstructionElement is not null) yield return new KeyValuePair<string,object>("preparationInstruction",PreparationInstructionElement);
       if (IntendedRoute?.Any() == true) yield return new KeyValuePair<string,object>("intendedRoute",IntendedRoute);
       if (Cost?.Any() == true) yield return new KeyValuePair<string,object>("cost",Cost);
       if (MonitoringProgram?.Any() == true) yield return new KeyValuePair<string,object>("monitoringProgram",MonitoringProgram);

--- a/src/Hl7.Fhir.R4/Model/Generated/MessageDefinition.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/MessageDefinition.cs
@@ -383,13 +383,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("situation", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Situation
+      public Hl7.Fhir.Model.Markdown SituationElement
       {
-        get { return _Situation; }
-        set { _Situation = value; OnPropertyChanged("Situation"); }
+        get { return _SituationElement; }
+        set { _SituationElement = value; OnPropertyChanged("SituationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Situation;
+      private Hl7.Fhir.Model.Markdown _SituationElement;
+
+      /// <summary>
+      /// When should this response be used
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Situation
+      {
+        get { return SituationElement != null ? SituationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            SituationElement = null;
+          else
+            SituationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Situation");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -402,7 +420,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(MessageElement != null) dest.MessageElement = (Hl7.Fhir.Model.Canonical)MessageElement.DeepCopy();
-        if(Situation != null) dest.Situation = (Hl7.Fhir.Model.Markdown)Situation.DeepCopy();
+        if(SituationElement != null) dest.SituationElement = (Hl7.Fhir.Model.Markdown)SituationElement.DeepCopy();
         return dest;
       }
 
@@ -419,7 +437,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(MessageElement, otherT.MessageElement)) return false;
-        if( !DeepComparable.Matches(Situation, otherT.Situation)) return false;
+        if( !DeepComparable.Matches(SituationElement, otherT.SituationElement)) return false;
 
         return true;
       }
@@ -431,7 +449,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(MessageElement, otherT.MessageElement)) return false;
-        if( !DeepComparable.IsExactly(Situation, otherT.Situation)) return false;
+        if( !DeepComparable.IsExactly(SituationElement, otherT.SituationElement)) return false;
 
         return true;
       }
@@ -443,7 +461,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (MessageElement != null) yield return MessageElement;
-          if (Situation != null) yield return Situation;
+          if (SituationElement != null) yield return SituationElement;
         }
       }
 
@@ -454,7 +472,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (MessageElement != null) yield return new ElementValue("message", MessageElement);
-          if (Situation != null) yield return new ElementValue("situation", Situation);
+          if (SituationElement != null) yield return new ElementValue("situation", SituationElement);
         }
       }
 
@@ -466,8 +484,8 @@ namespace Hl7.Fhir.Model
             value = MessageElement;
             return MessageElement is not null;
           case "situation":
-            value = Situation;
-            return Situation is not null;
+            value = SituationElement;
+            return SituationElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -478,7 +496,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (MessageElement is not null) yield return new KeyValuePair<string,object>("message",MessageElement);
-        if (Situation is not null) yield return new KeyValuePair<string,object>("situation",Situation);
+        if (SituationElement is not null) yield return new KeyValuePair<string,object>("situation",SituationElement);
       }
 
     }
@@ -799,13 +817,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the message definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -840,26 +876,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", InSummary=true, Order=230, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this message definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=240)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Definition this one is based on
@@ -1085,11 +1157,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(BaseElement != null) dest.BaseElement = (Hl7.Fhir.Model.Canonical)BaseElement.DeepCopy();
       if(ParentElement != null) dest.ParentElement = new List<Hl7.Fhir.Model.Canonical>(ParentElement.DeepCopy());
       if(Event != null) dest.Event = (Hl7.Fhir.Model.DataType)Event.DeepCopy();
@@ -1124,11 +1196,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.Matches(ParentElement, otherT.ParentElement)) return false;
       if( !DeepComparable.Matches(Event, otherT.Event)) return false;
@@ -1158,11 +1230,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.IsExactly(ParentElement, otherT.ParentElement)) return false;
       if( !DeepComparable.IsExactly(Event, otherT.Event)) return false;
@@ -1192,11 +1264,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (BaseElement != null) yield return BaseElement;
         foreach (var elem in ParentElement) { if (elem != null) yield return elem; }
         if (Event != null) yield return Event;
@@ -1225,11 +1297,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (BaseElement != null) yield return new ElementValue("base", BaseElement);
         foreach (var elem in ParentElement) { if (elem != null) yield return new ElementValue("parent", elem); }
         if (Event != null) yield return new ElementValue("event", Event);
@@ -1279,8 +1351,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1288,11 +1360,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "base":
           value = BaseElement;
           return BaseElement is not null;
@@ -1337,11 +1409,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (BaseElement is not null) yield return new KeyValuePair<string,object>("base",BaseElement);
       if (ParentElement?.Any() == true) yield return new KeyValuePair<string,object>("parent",ParentElement);
       if (Event is not null) yield return new KeyValuePair<string,object>("event",Event);

--- a/src/Hl7.Fhir.R4/Model/Generated/NamingSystem.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/NamingSystem.cs
@@ -613,13 +613,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=170)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the naming system
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -712,7 +730,7 @@ namespace Hl7.Fhir.Model
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
       if(ResponsibleElement != null) dest.ResponsibleElement = (Hl7.Fhir.Model.FhirString)ResponsibleElement.DeepCopy();
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
@@ -740,7 +758,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
       if( !DeepComparable.Matches(ResponsibleElement, otherT.ResponsibleElement)) return false;
       if( !DeepComparable.Matches(Type, otherT.Type)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
@@ -763,7 +781,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
       if( !DeepComparable.IsExactly(ResponsibleElement, otherT.ResponsibleElement)) return false;
       if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
@@ -786,7 +804,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
         if (ResponsibleElement != null) yield return ResponsibleElement;
         if (Type != null) yield return Type;
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
         if (UsageElement != null) yield return UsageElement;
@@ -808,7 +826,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
         if (ResponsibleElement != null) yield return new ElementValue("responsible", ResponsibleElement);
         if (Type != null) yield return new ElementValue("type", Type);
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
@@ -845,8 +863,8 @@ namespace Hl7.Fhir.Model
           value = Type;
           return Type is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -876,7 +894,7 @@ namespace Hl7.Fhir.Model
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
       if (ResponsibleElement is not null) yield return new KeyValuePair<string,object>("responsible",ResponsibleElement);
       if (Type is not null) yield return new KeyValuePair<string,object>("type",Type);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);

--- a/src/Hl7.Fhir.R4/Model/Generated/OperationDefinition.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/OperationDefinition.cs
@@ -1369,13 +1369,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the operation definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1410,13 +1428,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this operation definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Whether content is changed by the operation
@@ -1486,13 +1522,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("comment", Order=250)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Comment
+    public Hl7.Fhir.Model.Markdown CommentElement
     {
-      get { return _Comment; }
-      set { _Comment = value; OnPropertyChanged("Comment"); }
+      get { return _CommentElement; }
+      set { _CommentElement = value; OnPropertyChanged("CommentElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Comment;
+    private Hl7.Fhir.Model.Markdown _CommentElement;
+
+    /// <summary>
+    /// Additional information about use
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Comment
+    {
+      get { return CommentElement != null ? CommentElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CommentElement = null;
+        else
+          CommentElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Comment");
+      }
+    }
 
     /// <summary>
     /// Marks this as a profile of the base
@@ -1764,13 +1818,13 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(AffectsStateElement != null) dest.AffectsStateElement = (Hl7.Fhir.Model.FhirBoolean)AffectsStateElement.DeepCopy();
       if(CodeElement != null) dest.CodeElement = (Hl7.Fhir.Model.Code)CodeElement.DeepCopy();
-      if(Comment != null) dest.Comment = (Hl7.Fhir.Model.Markdown)Comment.DeepCopy();
+      if(CommentElement != null) dest.CommentElement = (Hl7.Fhir.Model.Markdown)CommentElement.DeepCopy();
       if(BaseElement != null) dest.BaseElement = (Hl7.Fhir.Model.Canonical)BaseElement.DeepCopy();
       if(ResourceElement != null) dest.ResourceElement = new List<Code<Hl7.Fhir.Model.ResourceType>>(ResourceElement.DeepCopy());
       if(SystemElement != null) dest.SystemElement = (Hl7.Fhir.Model.FhirBoolean)SystemElement.DeepCopy();
@@ -1805,13 +1859,13 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(AffectsStateElement, otherT.AffectsStateElement)) return false;
       if( !DeepComparable.Matches(CodeElement, otherT.CodeElement)) return false;
-      if( !DeepComparable.Matches(Comment, otherT.Comment)) return false;
+      if( !DeepComparable.Matches(CommentElement, otherT.CommentElement)) return false;
       if( !DeepComparable.Matches(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.Matches(ResourceElement, otherT.ResourceElement)) return false;
       if( !DeepComparable.Matches(SystemElement, otherT.SystemElement)) return false;
@@ -1841,13 +1895,13 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(AffectsStateElement, otherT.AffectsStateElement)) return false;
       if( !DeepComparable.IsExactly(CodeElement, otherT.CodeElement)) return false;
-      if( !DeepComparable.IsExactly(Comment, otherT.Comment)) return false;
+      if( !DeepComparable.IsExactly(CommentElement, otherT.CommentElement)) return false;
       if( !DeepComparable.IsExactly(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.IsExactly(ResourceElement, otherT.ResourceElement)) return false;
       if( !DeepComparable.IsExactly(SystemElement, otherT.SystemElement)) return false;
@@ -1877,13 +1931,13 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (AffectsStateElement != null) yield return AffectsStateElement;
         if (CodeElement != null) yield return CodeElement;
-        if (Comment != null) yield return Comment;
+        if (CommentElement != null) yield return CommentElement;
         if (BaseElement != null) yield return BaseElement;
         foreach (var elem in ResourceElement) { if (elem != null) yield return elem; }
         if (SystemElement != null) yield return SystemElement;
@@ -1912,13 +1966,13 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (AffectsStateElement != null) yield return new ElementValue("affectsState", AffectsStateElement);
         if (CodeElement != null) yield return new ElementValue("code", CodeElement);
-        if (Comment != null) yield return new ElementValue("comment", Comment);
+        if (CommentElement != null) yield return new ElementValue("comment", CommentElement);
         if (BaseElement != null) yield return new ElementValue("base", BaseElement);
         foreach (var elem in ResourceElement) { if (elem != null) yield return new ElementValue("resource", elem); }
         if (SystemElement != null) yield return new ElementValue("system", SystemElement);
@@ -1966,8 +2020,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1975,8 +2029,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "affectsState":
           value = AffectsStateElement;
           return AffectsStateElement is not null;
@@ -1984,8 +2038,8 @@ namespace Hl7.Fhir.Model
           value = CodeElement;
           return CodeElement is not null;
         case "comment":
-          value = Comment;
-          return Comment is not null;
+          value = CommentElement;
+          return CommentElement is not null;
         case "base":
           value = BaseElement;
           return BaseElement is not null;
@@ -2032,13 +2086,13 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (AffectsStateElement is not null) yield return new KeyValuePair<string,object>("affectsState",AffectsStateElement);
       if (CodeElement is not null) yield return new KeyValuePair<string,object>("code",CodeElement);
-      if (Comment is not null) yield return new KeyValuePair<string,object>("comment",Comment);
+      if (CommentElement is not null) yield return new KeyValuePair<string,object>("comment",CommentElement);
       if (BaseElement is not null) yield return new KeyValuePair<string,object>("base",BaseElement);
       if (ResourceElement?.Any() == true) yield return new KeyValuePair<string,object>("resource",ResourceElement);
       if (SystemElement is not null) yield return new KeyValuePair<string,object>("system",SystemElement);

--- a/src/Hl7.Fhir.R4/Model/Generated/PlanDefinition.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/PlanDefinition.cs
@@ -2365,13 +2365,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the plan definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -2406,13 +2424,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=250, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this plan definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the plan
@@ -2450,13 +2486,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=270)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the plan definition was approved by publisher
@@ -2700,12 +2754,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -2746,12 +2800,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -2787,12 +2841,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -2828,12 +2882,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -2868,12 +2922,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -2933,8 +2987,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2942,14 +2996,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -3008,12 +3062,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4/Model/Generated/Questionnaire.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/Questionnaire.cs
@@ -1697,13 +1697,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the questionnaire
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1738,26 +1756,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=240, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this questionnaire is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=250)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the questionnaire was approved by publisher
@@ -1884,11 +1938,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1921,11 +1975,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1953,11 +2007,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1985,11 +2039,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -2016,11 +2070,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -2070,8 +2124,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2079,11 +2133,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -2120,11 +2174,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4/Model/Generated/ResearchDefinition.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/ResearchDefinition.cs
@@ -416,13 +416,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the research definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Used for footnotes or explanatory notes
@@ -489,13 +507,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=260, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this research definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the ResearchDefinition
@@ -533,13 +569,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=280)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the research definition was approved by publisher
@@ -816,13 +870,13 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(CommentElement != null) dest.CommentElement = new List<Hl7.Fhir.Model.FhirString>(CommentElement.DeepCopy());
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -865,13 +919,13 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(CommentElement, otherT.CommentElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -909,13 +963,13 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(CommentElement, otherT.CommentElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -953,13 +1007,13 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in CommentElement) { if (elem != null) yield return elem; }
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -996,13 +1050,13 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in CommentElement) { if (elem != null) yield return new ElementValue("comment", elem); }
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -1064,8 +1118,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "comment":
           value = CommentElement;
           return CommentElement?.Any() == true;
@@ -1076,14 +1130,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -1148,13 +1202,13 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (CommentElement?.Any() == true) yield return new KeyValuePair<string,object>("comment",CommentElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4/Model/Generated/ResearchElementDefinition.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/ResearchElementDefinition.cs
@@ -895,13 +895,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the research element definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Used for footnotes or explanatory notes
@@ -968,13 +986,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=260, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this research element definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the ResearchElementDefinition
@@ -1012,13 +1048,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=280)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the research element definition was approved by publisher
@@ -1313,13 +1367,13 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(CommentElement != null) dest.CommentElement = new List<Hl7.Fhir.Model.FhirString>(CommentElement.DeepCopy());
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1361,13 +1415,13 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(CommentElement, otherT.CommentElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1404,13 +1458,13 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(CommentElement, otherT.CommentElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1447,13 +1501,13 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in CommentElement) { if (elem != null) yield return elem; }
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -1489,13 +1543,13 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in CommentElement) { if (elem != null) yield return new ElementValue("comment", elem); }
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -1556,8 +1610,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "comment":
           value = CommentElement;
           return CommentElement?.Any() == true;
@@ -1568,14 +1622,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -1637,13 +1691,13 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (CommentElement?.Any() == true) yield return new KeyValuePair<string,object>("comment",CommentElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4/Model/Generated/ResearchStudy.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/ResearchStudy.cs
@@ -710,13 +710,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// What this is study doing
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Inclusion &amp; exclusion criteria
@@ -872,7 +890,7 @@ namespace Hl7.Fhir.Model
       if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
       if(Keyword != null) dest.Keyword = new List<Hl7.Fhir.Model.CodeableConcept>(Keyword.DeepCopy());
       if(Location != null) dest.Location = new List<Hl7.Fhir.Model.CodeableConcept>(Location.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(Enrollment != null) dest.Enrollment = new List<Hl7.Fhir.Model.ResourceReference>(Enrollment.DeepCopy());
       if(Period != null) dest.Period = (Hl7.Fhir.Model.Period)Period.DeepCopy();
       if(Sponsor != null) dest.Sponsor = (Hl7.Fhir.Model.ResourceReference)Sponsor.DeepCopy();
@@ -911,7 +929,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.Matches(Keyword, otherT.Keyword)) return false;
       if( !DeepComparable.Matches(Location, otherT.Location)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(Enrollment, otherT.Enrollment)) return false;
       if( !DeepComparable.Matches(Period, otherT.Period)) return false;
       if( !DeepComparable.Matches(Sponsor, otherT.Sponsor)) return false;
@@ -945,7 +963,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.IsExactly(Keyword, otherT.Keyword)) return false;
       if( !DeepComparable.IsExactly(Location, otherT.Location)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(Enrollment, otherT.Enrollment)) return false;
       if( !DeepComparable.IsExactly(Period, otherT.Period)) return false;
       if( !DeepComparable.IsExactly(Sponsor, otherT.Sponsor)) return false;
@@ -979,7 +997,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return elem; }
         foreach (var elem in Keyword) { if (elem != null) yield return elem; }
         foreach (var elem in Location) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in Enrollment) { if (elem != null) yield return elem; }
         if (Period != null) yield return Period;
         if (Sponsor != null) yield return Sponsor;
@@ -1012,7 +1030,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return new ElementValue("relatedArtifact", elem); }
         foreach (var elem in Keyword) { if (elem != null) yield return new ElementValue("keyword", elem); }
         foreach (var elem in Location) { if (elem != null) yield return new ElementValue("location", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in Enrollment) { if (elem != null) yield return new ElementValue("enrollment", elem); }
         if (Period != null) yield return new ElementValue("period", Period);
         if (Sponsor != null) yield return new ElementValue("sponsor", Sponsor);
@@ -1072,8 +1090,8 @@ namespace Hl7.Fhir.Model
           value = Location;
           return Location?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "enrollment":
           value = Enrollment;
           return Enrollment?.Any() == true;
@@ -1124,7 +1142,7 @@ namespace Hl7.Fhir.Model
       if (RelatedArtifact?.Any() == true) yield return new KeyValuePair<string,object>("relatedArtifact",RelatedArtifact);
       if (Keyword?.Any() == true) yield return new KeyValuePair<string,object>("keyword",Keyword);
       if (Location?.Any() == true) yield return new KeyValuePair<string,object>("location",Location);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (Enrollment?.Any() == true) yield return new KeyValuePair<string,object>("enrollment",Enrollment);
       if (Period is not null) yield return new KeyValuePair<string,object>("period",Period);
       if (Sponsor is not null) yield return new KeyValuePair<string,object>("sponsor",Sponsor);

--- a/src/Hl7.Fhir.R4/Model/Generated/RiskEvidenceSynthesis.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/RiskEvidenceSynthesis.cs
@@ -1368,13 +1368,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the risk evidence synthesis
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Used for footnotes or explanatory notes
@@ -1423,13 +1441,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the risk evidence synthesis was approved by publisher
@@ -1722,11 +1758,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(Note != null) dest.Note = new List<Hl7.Fhir.Model.Annotation>(Note.DeepCopy());
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1768,11 +1804,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(Note, otherT.Note)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1809,11 +1845,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(Note, otherT.Note)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1850,11 +1886,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in Note) { if (elem != null) yield return elem; }
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -1890,11 +1926,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in Note) { if (elem != null) yield return new ElementValue("note", elem); }
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -1947,8 +1983,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "note":
           value = Note;
           return Note?.Any() == true;
@@ -1959,8 +1995,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -2030,11 +2066,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (Note?.Any() == true) yield return new KeyValuePair<string,object>("note",Note);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4/Model/Generated/SearchParameter.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/SearchParameter.cs
@@ -682,13 +682,31 @@ namespace Hl7.Fhir.Model
     [FhirElement("description", InSummary=true, Order=180)]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the search parameter
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -723,13 +741,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=210, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this search parameter is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Code used in URL
@@ -1149,10 +1185,10 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(CodeElement != null) dest.CodeElement = (Hl7.Fhir.Model.Code)CodeElement.DeepCopy();
       if(BaseElement != null) dest.BaseElement = new List<Code<Hl7.Fhir.Model.ResourceType>>(BaseElement.DeepCopy());
       if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.SearchParamType>)TypeElement.DeepCopy();
@@ -1190,10 +1226,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(CodeElement, otherT.CodeElement)) return false;
       if( !DeepComparable.Matches(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.Matches(TypeElement, otherT.TypeElement)) return false;
@@ -1226,10 +1262,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(CodeElement, otherT.CodeElement)) return false;
       if( !DeepComparable.IsExactly(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.IsExactly(TypeElement, otherT.TypeElement)) return false;
@@ -1262,10 +1298,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (CodeElement != null) yield return CodeElement;
         foreach (var elem in BaseElement) { if (elem != null) yield return elem; }
         if (TypeElement != null) yield return TypeElement;
@@ -1297,10 +1333,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (CodeElement != null) yield return new ElementValue("code", CodeElement);
         foreach (var elem in BaseElement) { if (elem != null) yield return new ElementValue("base", elem); }
         if (TypeElement != null) yield return new ElementValue("type", TypeElement);
@@ -1349,8 +1385,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1358,8 +1394,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "code":
           value = CodeElement;
           return CodeElement is not null;
@@ -1417,10 +1453,10 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (CodeElement is not null) yield return new KeyValuePair<string,object>("code",CodeElement);
       if (BaseElement?.Any() == true) yield return new KeyValuePair<string,object>("base",BaseElement);
       if (TypeElement is not null) yield return new KeyValuePair<string,object>("type",TypeElement);

--- a/src/Hl7.Fhir.R4/Model/Generated/StructureMap.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/StructureMap.cs
@@ -2876,13 +2876,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the structure map
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -2917,26 +2935,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this structure map is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Structure Definition used by this map
@@ -3018,11 +3072,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(Structure != null) dest.Structure = new List<Hl7.Fhir.Model.StructureMap.StructureComponent>(Structure.DeepCopy());
       if(ImportElement != null) dest.ImportElement = new List<Hl7.Fhir.Model.Canonical>(ImportElement.DeepCopy());
       if(Group != null) dest.Group = new List<Hl7.Fhir.Model.StructureMap.GroupComponent>(Group.DeepCopy());
@@ -3051,11 +3105,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(Structure, otherT.Structure)) return false;
       if( !DeepComparable.Matches(ImportElement, otherT.ImportElement)) return false;
       if( !DeepComparable.Matches(Group, otherT.Group)) return false;
@@ -3079,11 +3133,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(Structure, otherT.Structure)) return false;
       if( !DeepComparable.IsExactly(ImportElement, otherT.ImportElement)) return false;
       if( !DeepComparable.IsExactly(Group, otherT.Group)) return false;
@@ -3107,11 +3161,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         foreach (var elem in Structure) { if (elem != null) yield return elem; }
         foreach (var elem in ImportElement) { if (elem != null) yield return elem; }
         foreach (var elem in Group) { if (elem != null) yield return elem; }
@@ -3134,11 +3188,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         foreach (var elem in Structure) { if (elem != null) yield return new ElementValue("structure", elem); }
         foreach (var elem in ImportElement) { if (elem != null) yield return new ElementValue("import", elem); }
         foreach (var elem in Group) { if (elem != null) yield return new ElementValue("group", elem); }
@@ -3180,8 +3234,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -3189,11 +3243,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "structure":
           value = Structure;
           return Structure?.Any() == true;
@@ -3222,11 +3276,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (Structure?.Any() == true) yield return new KeyValuePair<string,object>("structure",Structure);
       if (ImportElement?.Any() == true) yield return new KeyValuePair<string,object>("import",ImportElement);
       if (Group?.Any() == true) yield return new KeyValuePair<string,object>("group",Group);

--- a/src/Hl7.Fhir.R4/Model/Generated/TerminologyCapabilities.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/TerminologyCapabilities.cs
@@ -1209,13 +1209,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("textFilter", Order=80)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown TextFilter
+      public Hl7.Fhir.Model.Markdown TextFilterElement
       {
-        get { return _TextFilter; }
-        set { _TextFilter = value; OnPropertyChanged("TextFilter"); }
+        get { return _TextFilterElement; }
+        set { _TextFilterElement = value; OnPropertyChanged("TextFilterElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _TextFilter;
+      private Hl7.Fhir.Model.Markdown _TextFilterElement;
+
+      /// <summary>
+      /// Documentation about text searching works
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string TextFilter
+      {
+        get { return TextFilterElement != null ? TextFilterElement.Value : null; }
+        set
+        {
+          if (value == null)
+            TextFilterElement = null;
+          else
+            TextFilterElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("TextFilter");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -1231,7 +1249,7 @@ namespace Hl7.Fhir.Model
         if(PagingElement != null) dest.PagingElement = (Hl7.Fhir.Model.FhirBoolean)PagingElement.DeepCopy();
         if(IncompleteElement != null) dest.IncompleteElement = (Hl7.Fhir.Model.FhirBoolean)IncompleteElement.DeepCopy();
         if(Parameter != null) dest.Parameter = new List<Hl7.Fhir.Model.TerminologyCapabilities.ParameterComponent>(Parameter.DeepCopy());
-        if(TextFilter != null) dest.TextFilter = (Hl7.Fhir.Model.Markdown)TextFilter.DeepCopy();
+        if(TextFilterElement != null) dest.TextFilterElement = (Hl7.Fhir.Model.Markdown)TextFilterElement.DeepCopy();
         return dest;
       }
 
@@ -1251,7 +1269,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(PagingElement, otherT.PagingElement)) return false;
         if( !DeepComparable.Matches(IncompleteElement, otherT.IncompleteElement)) return false;
         if( !DeepComparable.Matches(Parameter, otherT.Parameter)) return false;
-        if( !DeepComparable.Matches(TextFilter, otherT.TextFilter)) return false;
+        if( !DeepComparable.Matches(TextFilterElement, otherT.TextFilterElement)) return false;
 
         return true;
       }
@@ -1266,7 +1284,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(PagingElement, otherT.PagingElement)) return false;
         if( !DeepComparable.IsExactly(IncompleteElement, otherT.IncompleteElement)) return false;
         if( !DeepComparable.IsExactly(Parameter, otherT.Parameter)) return false;
-        if( !DeepComparable.IsExactly(TextFilter, otherT.TextFilter)) return false;
+        if( !DeepComparable.IsExactly(TextFilterElement, otherT.TextFilterElement)) return false;
 
         return true;
       }
@@ -1281,7 +1299,7 @@ namespace Hl7.Fhir.Model
           if (PagingElement != null) yield return PagingElement;
           if (IncompleteElement != null) yield return IncompleteElement;
           foreach (var elem in Parameter) { if (elem != null) yield return elem; }
-          if (TextFilter != null) yield return TextFilter;
+          if (TextFilterElement != null) yield return TextFilterElement;
         }
       }
 
@@ -1295,7 +1313,7 @@ namespace Hl7.Fhir.Model
           if (PagingElement != null) yield return new ElementValue("paging", PagingElement);
           if (IncompleteElement != null) yield return new ElementValue("incomplete", IncompleteElement);
           foreach (var elem in Parameter) { if (elem != null) yield return new ElementValue("parameter", elem); }
-          if (TextFilter != null) yield return new ElementValue("textFilter", TextFilter);
+          if (TextFilterElement != null) yield return new ElementValue("textFilter", TextFilterElement);
         }
       }
 
@@ -1316,8 +1334,8 @@ namespace Hl7.Fhir.Model
             value = Parameter;
             return Parameter?.Any() == true;
           case "textFilter":
-            value = TextFilter;
-            return TextFilter is not null;
+            value = TextFilterElement;
+            return TextFilterElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -1331,7 +1349,7 @@ namespace Hl7.Fhir.Model
         if (PagingElement is not null) yield return new KeyValuePair<string,object>("paging",PagingElement);
         if (IncompleteElement is not null) yield return new KeyValuePair<string,object>("incomplete",IncompleteElement);
         if (Parameter?.Any() == true) yield return new KeyValuePair<string,object>("parameter",Parameter);
-        if (TextFilter is not null) yield return new KeyValuePair<string,object>("textFilter",TextFilter);
+        if (TextFilterElement is not null) yield return new KeyValuePair<string,object>("textFilter",TextFilterElement);
       }
 
     }
@@ -2157,13 +2175,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the terminology capabilities
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -2198,26 +2234,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=210, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this terminology capabilities is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", InSummary=true, Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// instance | capability | requirements
@@ -2426,11 +2498,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(KindElement != null) dest.KindElement = (Code<Hl7.Fhir.Model.CapabilityStatementKind>)KindElement.DeepCopy();
       if(Software != null) dest.Software = (Hl7.Fhir.Model.TerminologyCapabilities.SoftwareComponent)Software.DeepCopy();
       if(Implementation != null) dest.Implementation = (Hl7.Fhir.Model.TerminologyCapabilities.ImplementationComponent)Implementation.DeepCopy();
@@ -2465,11 +2537,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(KindElement, otherT.KindElement)) return false;
       if( !DeepComparable.Matches(Software, otherT.Software)) return false;
       if( !DeepComparable.Matches(Implementation, otherT.Implementation)) return false;
@@ -2499,11 +2571,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(KindElement, otherT.KindElement)) return false;
       if( !DeepComparable.IsExactly(Software, otherT.Software)) return false;
       if( !DeepComparable.IsExactly(Implementation, otherT.Implementation)) return false;
@@ -2533,11 +2605,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (KindElement != null) yield return KindElement;
         if (Software != null) yield return Software;
         if (Implementation != null) yield return Implementation;
@@ -2566,11 +2638,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (KindElement != null) yield return new ElementValue("kind", KindElement);
         if (Software != null) yield return new ElementValue("software", Software);
         if (Implementation != null) yield return new ElementValue("implementation", Implementation);
@@ -2616,8 +2688,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2625,11 +2697,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "kind":
           value = KindElement;
           return KindElement is not null;
@@ -2678,11 +2750,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (KindElement is not null) yield return new KeyValuePair<string,object>("kind",KindElement);
       if (Software is not null) yield return new KeyValuePair<string,object>("software",Software);
       if (Implementation is not null) yield return new KeyValuePair<string,object>("implementation",Implementation);

--- a/src/Hl7.Fhir.R4/Model/Generated/TestReport.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/TestReport.cs
@@ -693,13 +693,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("message", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Message
+      public Hl7.Fhir.Model.Markdown MessageElement
       {
-        get { return _Message; }
-        set { _Message = value; OnPropertyChanged("Message"); }
+        get { return _MessageElement; }
+        set { _MessageElement = value; OnPropertyChanged("MessageElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Message;
+      private Hl7.Fhir.Model.Markdown _MessageElement;
+
+      /// <summary>
+      /// A message associated with the result
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Message
+      {
+        get { return MessageElement != null ? MessageElement.Value : null; }
+        set
+        {
+          if (value == null)
+            MessageElement = null;
+          else
+            MessageElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Message");
+        }
+      }
 
       /// <summary>
       /// A link to further details on the result
@@ -743,7 +761,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(ResultElement != null) dest.ResultElement = (Code<Hl7.Fhir.Model.TestReport.TestReportActionResult>)ResultElement.DeepCopy();
-        if(Message != null) dest.Message = (Hl7.Fhir.Model.Markdown)Message.DeepCopy();
+        if(MessageElement != null) dest.MessageElement = (Hl7.Fhir.Model.Markdown)MessageElement.DeepCopy();
         if(DetailElement != null) dest.DetailElement = (Hl7.Fhir.Model.FhirUri)DetailElement.DeepCopy();
         return dest;
       }
@@ -761,7 +779,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(ResultElement, otherT.ResultElement)) return false;
-        if( !DeepComparable.Matches(Message, otherT.Message)) return false;
+        if( !DeepComparable.Matches(MessageElement, otherT.MessageElement)) return false;
         if( !DeepComparable.Matches(DetailElement, otherT.DetailElement)) return false;
 
         return true;
@@ -774,7 +792,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(ResultElement, otherT.ResultElement)) return false;
-        if( !DeepComparable.IsExactly(Message, otherT.Message)) return false;
+        if( !DeepComparable.IsExactly(MessageElement, otherT.MessageElement)) return false;
         if( !DeepComparable.IsExactly(DetailElement, otherT.DetailElement)) return false;
 
         return true;
@@ -787,7 +805,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (ResultElement != null) yield return ResultElement;
-          if (Message != null) yield return Message;
+          if (MessageElement != null) yield return MessageElement;
           if (DetailElement != null) yield return DetailElement;
         }
       }
@@ -799,7 +817,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (ResultElement != null) yield return new ElementValue("result", ResultElement);
-          if (Message != null) yield return new ElementValue("message", Message);
+          if (MessageElement != null) yield return new ElementValue("message", MessageElement);
           if (DetailElement != null) yield return new ElementValue("detail", DetailElement);
         }
       }
@@ -812,8 +830,8 @@ namespace Hl7.Fhir.Model
             value = ResultElement;
             return ResultElement is not null;
           case "message":
-            value = Message;
-            return Message is not null;
+            value = MessageElement;
+            return MessageElement is not null;
           case "detail":
             value = DetailElement;
             return DetailElement is not null;
@@ -827,7 +845,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (ResultElement is not null) yield return new KeyValuePair<string,object>("result",ResultElement);
-        if (Message is not null) yield return new KeyValuePair<string,object>("message",Message);
+        if (MessageElement is not null) yield return new KeyValuePair<string,object>("message",MessageElement);
         if (DetailElement is not null) yield return new KeyValuePair<string,object>("detail",DetailElement);
       }
 
@@ -884,13 +902,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("message", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Message
+      public Hl7.Fhir.Model.Markdown MessageElement
       {
-        get { return _Message; }
-        set { _Message = value; OnPropertyChanged("Message"); }
+        get { return _MessageElement; }
+        set { _MessageElement = value; OnPropertyChanged("MessageElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Message;
+      private Hl7.Fhir.Model.Markdown _MessageElement;
+
+      /// <summary>
+      /// A message associated with the result
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Message
+      {
+        get { return MessageElement != null ? MessageElement.Value : null; }
+        set
+        {
+          if (value == null)
+            MessageElement = null;
+          else
+            MessageElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Message");
+        }
+      }
 
       /// <summary>
       /// A link to further details on the result
@@ -934,7 +970,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(ResultElement != null) dest.ResultElement = (Code<Hl7.Fhir.Model.TestReport.TestReportActionResult>)ResultElement.DeepCopy();
-        if(Message != null) dest.Message = (Hl7.Fhir.Model.Markdown)Message.DeepCopy();
+        if(MessageElement != null) dest.MessageElement = (Hl7.Fhir.Model.Markdown)MessageElement.DeepCopy();
         if(DetailElement != null) dest.DetailElement = (Hl7.Fhir.Model.FhirString)DetailElement.DeepCopy();
         return dest;
       }
@@ -952,7 +988,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(ResultElement, otherT.ResultElement)) return false;
-        if( !DeepComparable.Matches(Message, otherT.Message)) return false;
+        if( !DeepComparable.Matches(MessageElement, otherT.MessageElement)) return false;
         if( !DeepComparable.Matches(DetailElement, otherT.DetailElement)) return false;
 
         return true;
@@ -965,7 +1001,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(ResultElement, otherT.ResultElement)) return false;
-        if( !DeepComparable.IsExactly(Message, otherT.Message)) return false;
+        if( !DeepComparable.IsExactly(MessageElement, otherT.MessageElement)) return false;
         if( !DeepComparable.IsExactly(DetailElement, otherT.DetailElement)) return false;
 
         return true;
@@ -978,7 +1014,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (ResultElement != null) yield return ResultElement;
-          if (Message != null) yield return Message;
+          if (MessageElement != null) yield return MessageElement;
           if (DetailElement != null) yield return DetailElement;
         }
       }
@@ -990,7 +1026,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (ResultElement != null) yield return new ElementValue("result", ResultElement);
-          if (Message != null) yield return new ElementValue("message", Message);
+          if (MessageElement != null) yield return new ElementValue("message", MessageElement);
           if (DetailElement != null) yield return new ElementValue("detail", DetailElement);
         }
       }
@@ -1003,8 +1039,8 @@ namespace Hl7.Fhir.Model
             value = ResultElement;
             return ResultElement is not null;
           case "message":
-            value = Message;
-            return Message is not null;
+            value = MessageElement;
+            return MessageElement is not null;
           case "detail":
             value = DetailElement;
             return DetailElement is not null;
@@ -1018,7 +1054,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (ResultElement is not null) yield return new KeyValuePair<string,object>("result",ResultElement);
-        if (Message is not null) yield return new KeyValuePair<string,object>("message",Message);
+        if (MessageElement is not null) yield return new KeyValuePair<string,object>("message",MessageElement);
         if (DetailElement is not null) yield return new KeyValuePair<string,object>("detail",DetailElement);
       }
 

--- a/src/Hl7.Fhir.R4/Model/Generated/TestScript.cs
+++ b/src/Hl7.Fhir.R4/Model/Generated/TestScript.cs
@@ -4806,13 +4806,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the test script
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -4847,26 +4865,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this test script is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// An abstract server representing a client or sender in a message exchange
@@ -5013,11 +5067,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(Origin != null) dest.Origin = new List<Hl7.Fhir.Model.TestScript.OriginComponent>(Origin.DeepCopy());
       if(Destination != null) dest.Destination = new List<Hl7.Fhir.Model.TestScript.DestinationComponent>(Destination.DeepCopy());
       if(Metadata != null) dest.Metadata = (Hl7.Fhir.Model.TestScript.MetadataComponent)Metadata.DeepCopy();
@@ -5052,11 +5106,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(Origin, otherT.Origin)) return false;
       if( !DeepComparable.Matches(Destination, otherT.Destination)) return false;
       if( !DeepComparable.Matches(Metadata, otherT.Metadata)) return false;
@@ -5086,11 +5140,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(Origin, otherT.Origin)) return false;
       if( !DeepComparable.IsExactly(Destination, otherT.Destination)) return false;
       if( !DeepComparable.IsExactly(Metadata, otherT.Metadata)) return false;
@@ -5120,11 +5174,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         foreach (var elem in Origin) { if (elem != null) yield return elem; }
         foreach (var elem in Destination) { if (elem != null) yield return elem; }
         if (Metadata != null) yield return Metadata;
@@ -5153,11 +5207,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         foreach (var elem in Origin) { if (elem != null) yield return new ElementValue("origin", elem); }
         foreach (var elem in Destination) { if (elem != null) yield return new ElementValue("destination", elem); }
         if (Metadata != null) yield return new ElementValue("metadata", Metadata);
@@ -5205,8 +5259,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -5214,11 +5268,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "origin":
           value = Origin;
           return Origin?.Any() == true;
@@ -5265,11 +5319,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (Origin?.Any() == true) yield return new KeyValuePair<string,object>("origin",Origin);
       if (Destination?.Any() == true) yield return new KeyValuePair<string,object>("destination",Destination);
       if (Metadata is not null) yield return new KeyValuePair<string,object>("metadata",Metadata);

--- a/src/Hl7.Fhir.R4/Model/IConformanceResource.cs
+++ b/src/Hl7.Fhir.R4/Model/IConformanceResource.cs
@@ -51,11 +51,13 @@ namespace Hl7.Fhir.Model
     {
         //I think ImplementationGuide should have a purpose element.
         [Obsolete("This property is not a part of the official FHIR specification", true)]
-        public Markdown Purpose
+        public Markdown PurposeElement
         {
             get { return null; }
             set { throw new NotImplementedException(); }
         }
+
+        public string Purpose { get => null; set => throw new NotImplementedException(); }
     }
 
     public partial class CompartmentDefinition : IVersionableConformanceResource
@@ -103,7 +105,7 @@ namespace Hl7.Fhir.Model
     {
         // I think NamingSystem should have Experimental too
         [Obsolete("This property is not a part of the official FHIR specification", true)]
-        public Markdown Purpose
+        public Markdown PurposeElement
         {
             get { return null; }
             set { throw new NotImplementedException(); }
@@ -145,5 +147,7 @@ namespace Hl7.Fhir.Model
             }
             set { throw new NotImplementedException(); }
         }
+
+        public string Purpose { get => null; set => throw new NotImplementedException(); }
     }
 }

--- a/src/Hl7.Fhir.R4B/Model/Generated/ActivityDefinition.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/ActivityDefinition.cs
@@ -787,13 +787,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the activity definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -828,13 +846,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=240, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this activity definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the activity definition
@@ -872,13 +908,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=260)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the activity definition was approved by publisher
@@ -1458,12 +1512,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1519,12 +1573,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1575,12 +1629,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1631,12 +1685,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -1686,12 +1740,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -1764,8 +1818,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1773,14 +1827,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -1886,12 +1940,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4B/Model/Generated/Annotation.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/Annotation.cs
@@ -108,13 +108,31 @@ namespace Hl7.Fhir.Model
     [FhirElement("text", InSummary=true, Order=50)]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Text
+    public Hl7.Fhir.Model.Markdown TextElement
     {
-      get { return _Text; }
-      set { _Text = value; OnPropertyChanged("Text"); }
+      get { return _TextElement; }
+      set { _TextElement = value; OnPropertyChanged("TextElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Text;
+    private Hl7.Fhir.Model.Markdown _TextElement;
+
+    /// <summary>
+    /// The annotation  - text content (as markdown)
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Text
+    {
+      get { return TextElement != null ? TextElement.Value : null; }
+      set
+      {
+        if (value == null)
+          TextElement = null;
+        else
+          TextElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Text");
+      }
+    }
 
     public override IDeepCopyable CopyTo(IDeepCopyable other)
     {
@@ -128,7 +146,7 @@ namespace Hl7.Fhir.Model
       base.CopyTo(dest);
       if(Author != null) dest.Author = (Hl7.Fhir.Model.DataType)Author.DeepCopy();
       if(TimeElement != null) dest.TimeElement = (Hl7.Fhir.Model.FhirDateTime)TimeElement.DeepCopy();
-      if(Text != null) dest.Text = (Hl7.Fhir.Model.Markdown)Text.DeepCopy();
+      if(TextElement != null) dest.TextElement = (Hl7.Fhir.Model.Markdown)TextElement.DeepCopy();
       return dest;
     }
 
@@ -146,7 +164,7 @@ namespace Hl7.Fhir.Model
       if(!base.Matches(otherT)) return false;
       if( !DeepComparable.Matches(Author, otherT.Author)) return false;
       if( !DeepComparable.Matches(TimeElement, otherT.TimeElement)) return false;
-      if( !DeepComparable.Matches(Text, otherT.Text)) return false;
+      if( !DeepComparable.Matches(TextElement, otherT.TextElement)) return false;
 
       return true;
     }
@@ -159,7 +177,7 @@ namespace Hl7.Fhir.Model
       if(!base.IsExactly(otherT)) return false;
       if( !DeepComparable.IsExactly(Author, otherT.Author)) return false;
       if( !DeepComparable.IsExactly(TimeElement, otherT.TimeElement)) return false;
-      if( !DeepComparable.IsExactly(Text, otherT.Text)) return false;
+      if( !DeepComparable.IsExactly(TextElement, otherT.TextElement)) return false;
 
       return true;
     }
@@ -172,7 +190,7 @@ namespace Hl7.Fhir.Model
         foreach (var item in base.Children) yield return item;
         if (Author != null) yield return Author;
         if (TimeElement != null) yield return TimeElement;
-        if (Text != null) yield return Text;
+        if (TextElement != null) yield return TextElement;
       }
     }
 
@@ -184,7 +202,7 @@ namespace Hl7.Fhir.Model
         foreach (var item in base.NamedChildren) yield return item;
         if (Author != null) yield return new ElementValue("author", Author);
         if (TimeElement != null) yield return new ElementValue("time", TimeElement);
-        if (Text != null) yield return new ElementValue("text", Text);
+        if (TextElement != null) yield return new ElementValue("text", TextElement);
       }
     }
 
@@ -199,8 +217,8 @@ namespace Hl7.Fhir.Model
           value = TimeElement;
           return TimeElement is not null;
         case "text":
-          value = Text;
-          return Text is not null;
+          value = TextElement;
+          return TextElement is not null;
         default:
           return base.TryGetValue(key, out value);
       }
@@ -212,7 +230,7 @@ namespace Hl7.Fhir.Model
       foreach (var kvp in base.GetElementPairs()) yield return kvp;
       if (Author is not null) yield return new KeyValuePair<string,object>("author",Author);
       if (TimeElement is not null) yield return new KeyValuePair<string,object>("time",TimeElement);
-      if (Text is not null) yield return new KeyValuePair<string,object>("text",Text);
+      if (TextElement is not null) yield return new KeyValuePair<string,object>("text",TextElement);
     }
 
   }

--- a/src/Hl7.Fhir.R4B/Model/Generated/ChargeItemDefinition.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/ChargeItemDefinition.cs
@@ -957,13 +957,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the charge item definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -998,13 +1016,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=240)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the charge item definition was approved by publisher
@@ -1160,10 +1196,10 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1198,10 +1234,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1231,10 +1267,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1264,10 +1300,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -1296,10 +1332,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -1351,8 +1387,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1360,8 +1396,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -1404,10 +1440,10 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4B/Model/Generated/Citation.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/Citation.cs
@@ -87,13 +87,31 @@ namespace Hl7.Fhir.Model
       [FhirElement("text", InSummary=true, Order=50)]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Text
+      public Hl7.Fhir.Model.Markdown TextElement
       {
-        get { return _Text; }
-        set { _Text = value; OnPropertyChanged("Text"); }
+        get { return _TextElement; }
+        set { _TextElement = value; OnPropertyChanged("TextElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Text;
+      private Hl7.Fhir.Model.Markdown _TextElement;
+
+      /// <summary>
+      /// The human-readable display of the citation
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Text
+      {
+        get { return TextElement != null ? TextElement.Value : null; }
+        set
+        {
+          if (value == null)
+            TextElement = null;
+          else
+            TextElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Text");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -106,7 +124,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(Style != null) dest.Style = (Hl7.Fhir.Model.CodeableConcept)Style.DeepCopy();
-        if(Text != null) dest.Text = (Hl7.Fhir.Model.Markdown)Text.DeepCopy();
+        if(TextElement != null) dest.TextElement = (Hl7.Fhir.Model.Markdown)TextElement.DeepCopy();
         return dest;
       }
 
@@ -123,7 +141,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(Style, otherT.Style)) return false;
-        if( !DeepComparable.Matches(Text, otherT.Text)) return false;
+        if( !DeepComparable.Matches(TextElement, otherT.TextElement)) return false;
 
         return true;
       }
@@ -135,7 +153,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(Style, otherT.Style)) return false;
-        if( !DeepComparable.IsExactly(Text, otherT.Text)) return false;
+        if( !DeepComparable.IsExactly(TextElement, otherT.TextElement)) return false;
 
         return true;
       }
@@ -147,7 +165,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (Style != null) yield return Style;
-          if (Text != null) yield return Text;
+          if (TextElement != null) yield return TextElement;
         }
       }
 
@@ -158,7 +176,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (Style != null) yield return new ElementValue("style", Style);
-          if (Text != null) yield return new ElementValue("text", Text);
+          if (TextElement != null) yield return new ElementValue("text", TextElement);
         }
       }
 
@@ -170,8 +188,8 @@ namespace Hl7.Fhir.Model
             value = Style;
             return Style is not null;
           case "text":
-            value = Text;
-            return Text is not null;
+            value = TextElement;
+            return TextElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -182,7 +200,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (Style is not null) yield return new KeyValuePair<string,object>("style",Style);
-        if (Text is not null) yield return new KeyValuePair<string,object>("text",Text);
+        if (TextElement is not null) yield return new KeyValuePair<string,object>("text",TextElement);
       }
 
     }
@@ -1468,13 +1486,31 @@ namespace Hl7.Fhir.Model
       [FhirElement("text", Order=60)]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Text
+      public Hl7.Fhir.Model.Markdown TextElement
       {
-        get { return _Text; }
-        set { _Text = value; OnPropertyChanged("Text"); }
+        get { return _TextElement; }
+        set { _TextElement = value; OnPropertyChanged("TextElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Text;
+      private Hl7.Fhir.Model.Markdown _TextElement;
+
+      /// <summary>
+      /// The title of the article or artifact
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Text
+      {
+        get { return TextElement != null ? TextElement.Value : null; }
+        set
+        {
+          if (value == null)
+            TextElement = null;
+          else
+            TextElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Text");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -1488,7 +1524,7 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(Type != null) dest.Type = new List<Hl7.Fhir.Model.CodeableConcept>(Type.DeepCopy());
         if(Language != null) dest.Language = (Hl7.Fhir.Model.CodeableConcept)Language.DeepCopy();
-        if(Text != null) dest.Text = (Hl7.Fhir.Model.Markdown)Text.DeepCopy();
+        if(TextElement != null) dest.TextElement = (Hl7.Fhir.Model.Markdown)TextElement.DeepCopy();
         return dest;
       }
 
@@ -1506,7 +1542,7 @@ namespace Hl7.Fhir.Model
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(Type, otherT.Type)) return false;
         if( !DeepComparable.Matches(Language, otherT.Language)) return false;
-        if( !DeepComparable.Matches(Text, otherT.Text)) return false;
+        if( !DeepComparable.Matches(TextElement, otherT.TextElement)) return false;
 
         return true;
       }
@@ -1519,7 +1555,7 @@ namespace Hl7.Fhir.Model
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
         if( !DeepComparable.IsExactly(Language, otherT.Language)) return false;
-        if( !DeepComparable.IsExactly(Text, otherT.Text)) return false;
+        if( !DeepComparable.IsExactly(TextElement, otherT.TextElement)) return false;
 
         return true;
       }
@@ -1532,7 +1568,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.Children) yield return item;
           foreach (var elem in Type) { if (elem != null) yield return elem; }
           if (Language != null) yield return Language;
-          if (Text != null) yield return Text;
+          if (TextElement != null) yield return TextElement;
         }
       }
 
@@ -1544,7 +1580,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.NamedChildren) yield return item;
           foreach (var elem in Type) { if (elem != null) yield return new ElementValue("type", elem); }
           if (Language != null) yield return new ElementValue("language", Language);
-          if (Text != null) yield return new ElementValue("text", Text);
+          if (TextElement != null) yield return new ElementValue("text", TextElement);
         }
       }
 
@@ -1559,8 +1595,8 @@ namespace Hl7.Fhir.Model
             value = Language;
             return Language is not null;
           case "text":
-            value = Text;
-            return Text is not null;
+            value = TextElement;
+            return TextElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -1572,7 +1608,7 @@ namespace Hl7.Fhir.Model
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (Type?.Any() == true) yield return new KeyValuePair<string,object>("type",Type);
         if (Language is not null) yield return new KeyValuePair<string,object>("language",Language);
-        if (Text is not null) yield return new KeyValuePair<string,object>("text",Text);
+        if (TextElement is not null) yield return new KeyValuePair<string,object>("text",TextElement);
       }
 
     }
@@ -1622,26 +1658,62 @@ namespace Hl7.Fhir.Model
       [FhirElement("text", Order=60)]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Text
+      public Hl7.Fhir.Model.Markdown TextElement
       {
-        get { return _Text; }
-        set { _Text = value; OnPropertyChanged("Text"); }
+        get { return _TextElement; }
+        set { _TextElement = value; OnPropertyChanged("TextElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Text;
+      private Hl7.Fhir.Model.Markdown _TextElement;
+
+      /// <summary>
+      /// Abstract content
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Text
+      {
+        get { return TextElement != null ? TextElement.Value : null; }
+        set
+        {
+          if (value == null)
+            TextElement = null;
+          else
+            TextElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Text");
+        }
+      }
 
       /// <summary>
       /// Copyright notice for the abstract
       /// </summary>
       [FhirElement("copyright", Order=70)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Copyright
+      public Hl7.Fhir.Model.Markdown CopyrightElement
       {
-        get { return _Copyright; }
-        set { _Copyright = value; OnPropertyChanged("Copyright"); }
+        get { return _CopyrightElement; }
+        set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Copyright;
+      private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+      /// <summary>
+      /// Copyright notice for the abstract
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Copyright
+      {
+        get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+        set
+        {
+          if (value == null)
+            CopyrightElement = null;
+          else
+            CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Copyright");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -1655,8 +1727,8 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
         if(Language != null) dest.Language = (Hl7.Fhir.Model.CodeableConcept)Language.DeepCopy();
-        if(Text != null) dest.Text = (Hl7.Fhir.Model.Markdown)Text.DeepCopy();
-        if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+        if(TextElement != null) dest.TextElement = (Hl7.Fhir.Model.Markdown)TextElement.DeepCopy();
+        if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
         return dest;
       }
 
@@ -1674,8 +1746,8 @@ namespace Hl7.Fhir.Model
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(Type, otherT.Type)) return false;
         if( !DeepComparable.Matches(Language, otherT.Language)) return false;
-        if( !DeepComparable.Matches(Text, otherT.Text)) return false;
-        if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+        if( !DeepComparable.Matches(TextElement, otherT.TextElement)) return false;
+        if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
 
         return true;
       }
@@ -1688,8 +1760,8 @@ namespace Hl7.Fhir.Model
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
         if( !DeepComparable.IsExactly(Language, otherT.Language)) return false;
-        if( !DeepComparable.IsExactly(Text, otherT.Text)) return false;
-        if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+        if( !DeepComparable.IsExactly(TextElement, otherT.TextElement)) return false;
+        if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
 
         return true;
       }
@@ -1702,8 +1774,8 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.Children) yield return item;
           if (Type != null) yield return Type;
           if (Language != null) yield return Language;
-          if (Text != null) yield return Text;
-          if (Copyright != null) yield return Copyright;
+          if (TextElement != null) yield return TextElement;
+          if (CopyrightElement != null) yield return CopyrightElement;
         }
       }
 
@@ -1715,8 +1787,8 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.NamedChildren) yield return item;
           if (Type != null) yield return new ElementValue("type", Type);
           if (Language != null) yield return new ElementValue("language", Language);
-          if (Text != null) yield return new ElementValue("text", Text);
-          if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+          if (TextElement != null) yield return new ElementValue("text", TextElement);
+          if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         }
       }
 
@@ -1731,11 +1803,11 @@ namespace Hl7.Fhir.Model
             value = Language;
             return Language is not null;
           case "text":
-            value = Text;
-            return Text is not null;
+            value = TextElement;
+            return TextElement is not null;
           case "copyright":
-            value = Copyright;
-            return Copyright is not null;
+            value = CopyrightElement;
+            return CopyrightElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -1747,8 +1819,8 @@ namespace Hl7.Fhir.Model
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (Type is not null) yield return new KeyValuePair<string,object>("type",Type);
         if (Language is not null) yield return new KeyValuePair<string,object>("language",Language);
-        if (Text is not null) yield return new KeyValuePair<string,object>("text",Text);
-        if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+        if (TextElement is not null) yield return new KeyValuePair<string,object>("text",TextElement);
+        if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       }
 
     }
@@ -2360,13 +2432,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("copyright", Order=140)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Copyright
+      public Hl7.Fhir.Model.Markdown CopyrightElement
       {
-        get { return _Copyright; }
-        set { _Copyright = value; OnPropertyChanged("Copyright"); }
+        get { return _CopyrightElement; }
+        set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Copyright;
+      private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+      /// <summary>
+      /// Copyright notice for the full article or artifact
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Copyright
+      {
+        get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+        set
+        {
+          if (value == null)
+            CopyrightElement = null;
+          else
+            CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Copyright");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -2388,7 +2478,7 @@ namespace Hl7.Fhir.Model
         if(FirstPageElement != null) dest.FirstPageElement = (Hl7.Fhir.Model.FhirString)FirstPageElement.DeepCopy();
         if(LastPageElement != null) dest.LastPageElement = (Hl7.Fhir.Model.FhirString)LastPageElement.DeepCopy();
         if(PageCountElement != null) dest.PageCountElement = (Hl7.Fhir.Model.FhirString)PageCountElement.DeepCopy();
-        if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+        if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
         return dest;
       }
 
@@ -2414,7 +2504,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(FirstPageElement, otherT.FirstPageElement)) return false;
         if( !DeepComparable.Matches(LastPageElement, otherT.LastPageElement)) return false;
         if( !DeepComparable.Matches(PageCountElement, otherT.PageCountElement)) return false;
-        if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+        if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
 
         return true;
       }
@@ -2435,7 +2525,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(FirstPageElement, otherT.FirstPageElement)) return false;
         if( !DeepComparable.IsExactly(LastPageElement, otherT.LastPageElement)) return false;
         if( !DeepComparable.IsExactly(PageCountElement, otherT.PageCountElement)) return false;
-        if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+        if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
 
         return true;
       }
@@ -2456,7 +2546,7 @@ namespace Hl7.Fhir.Model
           if (FirstPageElement != null) yield return FirstPageElement;
           if (LastPageElement != null) yield return LastPageElement;
           if (PageCountElement != null) yield return PageCountElement;
-          if (Copyright != null) yield return Copyright;
+          if (CopyrightElement != null) yield return CopyrightElement;
         }
       }
 
@@ -2476,7 +2566,7 @@ namespace Hl7.Fhir.Model
           if (FirstPageElement != null) yield return new ElementValue("firstPage", FirstPageElement);
           if (LastPageElement != null) yield return new ElementValue("lastPage", LastPageElement);
           if (PageCountElement != null) yield return new ElementValue("pageCount", PageCountElement);
-          if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+          if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         }
       }
 
@@ -2515,8 +2605,8 @@ namespace Hl7.Fhir.Model
             value = PageCountElement;
             return PageCountElement is not null;
           case "copyright":
-            value = Copyright;
-            return Copyright is not null;
+            value = CopyrightElement;
+            return CopyrightElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -2536,7 +2626,7 @@ namespace Hl7.Fhir.Model
         if (FirstPageElement is not null) yield return new KeyValuePair<string,object>("firstPage",FirstPageElement);
         if (LastPageElement is not null) yield return new KeyValuePair<string,object>("lastPage",LastPageElement);
         if (PageCountElement is not null) yield return new KeyValuePair<string,object>("pageCount",PageCountElement);
-        if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+        if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       }
 
     }
@@ -4857,13 +4947,31 @@ namespace Hl7.Fhir.Model
       [FhirElement("value", Order=70)]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Value
+      public Hl7.Fhir.Model.Markdown ValueElement
       {
-        get { return _Value; }
-        set { _Value = value; OnPropertyChanged("Value"); }
+        get { return _ValueElement; }
+        set { _ValueElement = value; OnPropertyChanged("ValueElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Value;
+      private Hl7.Fhir.Model.Markdown _ValueElement;
+
+      /// <summary>
+      /// The display string for the author list, contributor list, or contributorship statement
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Value
+      {
+        get { return ValueElement != null ? ValueElement.Value : null; }
+        set
+        {
+          if (value == null)
+            ValueElement = null;
+          else
+            ValueElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Value");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -4878,7 +4986,7 @@ namespace Hl7.Fhir.Model
         if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
         if(Style != null) dest.Style = (Hl7.Fhir.Model.CodeableConcept)Style.DeepCopy();
         if(Source != null) dest.Source = (Hl7.Fhir.Model.CodeableConcept)Source.DeepCopy();
-        if(Value != null) dest.Value = (Hl7.Fhir.Model.Markdown)Value.DeepCopy();
+        if(ValueElement != null) dest.ValueElement = (Hl7.Fhir.Model.Markdown)ValueElement.DeepCopy();
         return dest;
       }
 
@@ -4897,7 +5005,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(Type, otherT.Type)) return false;
         if( !DeepComparable.Matches(Style, otherT.Style)) return false;
         if( !DeepComparable.Matches(Source, otherT.Source)) return false;
-        if( !DeepComparable.Matches(Value, otherT.Value)) return false;
+        if( !DeepComparable.Matches(ValueElement, otherT.ValueElement)) return false;
 
         return true;
       }
@@ -4911,7 +5019,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
         if( !DeepComparable.IsExactly(Style, otherT.Style)) return false;
         if( !DeepComparable.IsExactly(Source, otherT.Source)) return false;
-        if( !DeepComparable.IsExactly(Value, otherT.Value)) return false;
+        if( !DeepComparable.IsExactly(ValueElement, otherT.ValueElement)) return false;
 
         return true;
       }
@@ -4925,7 +5033,7 @@ namespace Hl7.Fhir.Model
           if (Type != null) yield return Type;
           if (Style != null) yield return Style;
           if (Source != null) yield return Source;
-          if (Value != null) yield return Value;
+          if (ValueElement != null) yield return ValueElement;
         }
       }
 
@@ -4938,7 +5046,7 @@ namespace Hl7.Fhir.Model
           if (Type != null) yield return new ElementValue("type", Type);
           if (Style != null) yield return new ElementValue("style", Style);
           if (Source != null) yield return new ElementValue("source", Source);
-          if (Value != null) yield return new ElementValue("value", Value);
+          if (ValueElement != null) yield return new ElementValue("value", ValueElement);
         }
       }
 
@@ -4956,8 +5064,8 @@ namespace Hl7.Fhir.Model
             value = Source;
             return Source is not null;
           case "value":
-            value = Value;
-            return Value is not null;
+            value = ValueElement;
+            return ValueElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -4970,7 +5078,7 @@ namespace Hl7.Fhir.Model
         if (Type is not null) yield return new KeyValuePair<string,object>("type",Type);
         if (Style is not null) yield return new KeyValuePair<string,object>("style",Style);
         if (Source is not null) yield return new KeyValuePair<string,object>("source",Source);
-        if (Value is not null) yield return new KeyValuePair<string,object>("value",Value);
+        if (ValueElement is not null) yield return new KeyValuePair<string,object>("value",ValueElement);
       }
 
     }
@@ -5258,13 +5366,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the citation
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the Citation Resource content is intended to support
@@ -5299,26 +5425,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this citation is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions for the Citation, not for the cited artifact
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions for the Citation, not for the cited artifact
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the citation was approved by publisher
@@ -5568,11 +5730,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -5612,11 +5774,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -5651,11 +5813,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -5690,11 +5852,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -5728,11 +5890,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -5785,8 +5947,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -5794,11 +5956,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -5860,11 +6022,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4B/Model/Generated/ClinicalUseDefinition.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/ClinicalUseDefinition.cs
@@ -1161,13 +1161,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", InSummary=true, Order=40)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// A textual definition of this warning, with formatting
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// A coded or unformatted textual definition of this warning
@@ -1192,7 +1210,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(Code != null) dest.Code = (Hl7.Fhir.Model.CodeableConcept)Code.DeepCopy();
         return dest;
       }
@@ -1209,7 +1227,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.Matches(otherT)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(Code, otherT.Code)) return false;
 
         return true;
@@ -1221,7 +1239,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.IsExactly(otherT)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(Code, otherT.Code)) return false;
 
         return true;
@@ -1233,7 +1251,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.Children) yield return item;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           if (Code != null) yield return Code;
         }
       }
@@ -1244,7 +1262,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.NamedChildren) yield return item;
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (Code != null) yield return new ElementValue("code", Code);
         }
       }
@@ -1254,8 +1272,8 @@ namespace Hl7.Fhir.Model
         switch (key)
         {
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "code":
             value = Code;
             return Code is not null;
@@ -1268,7 +1286,7 @@ namespace Hl7.Fhir.Model
       protected override IEnumerable<KeyValuePair<string, object>> GetElementPairs()
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (Code is not null) yield return new KeyValuePair<string,object>("code",Code);
       }
 

--- a/src/Hl7.Fhir.R4B/Model/Generated/CompartmentDefinition.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/CompartmentDefinition.cs
@@ -505,13 +505,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=170)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the compartment definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -532,13 +550,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=190, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this compartment definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Patient | Encounter | RelatedPerson | Practitioner | Device
@@ -637,9 +673,9 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(CodeElement != null) dest.CodeElement = (Code<Hl7.Fhir.Model.CompartmentType>)CodeElement.DeepCopy();
       if(SearchElement != null) dest.SearchElement = (Hl7.Fhir.Model.FhirBoolean)SearchElement.DeepCopy();
       if(Resource != null) dest.Resource = new List<Hl7.Fhir.Model.CompartmentDefinition.ResourceComponent>(Resource.DeepCopy());
@@ -666,9 +702,9 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(CodeElement, otherT.CodeElement)) return false;
       if( !DeepComparable.Matches(SearchElement, otherT.SearchElement)) return false;
       if( !DeepComparable.Matches(Resource, otherT.Resource)) return false;
@@ -690,9 +726,9 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(CodeElement, otherT.CodeElement)) return false;
       if( !DeepComparable.IsExactly(SearchElement, otherT.SearchElement)) return false;
       if( !DeepComparable.IsExactly(Resource, otherT.Resource)) return false;
@@ -714,9 +750,9 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (CodeElement != null) yield return CodeElement;
         if (SearchElement != null) yield return SearchElement;
         foreach (var elem in Resource) { if (elem != null) yield return elem; }
@@ -737,9 +773,9 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (CodeElement != null) yield return new ElementValue("code", CodeElement);
         if (SearchElement != null) yield return new ElementValue("search", SearchElement);
         foreach (var elem in Resource) { if (elem != null) yield return new ElementValue("resource", elem); }
@@ -775,14 +811,14 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "code":
           value = CodeElement;
           return CodeElement is not null;
@@ -809,9 +845,9 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (CodeElement is not null) yield return new KeyValuePair<string,object>("code",CodeElement);
       if (SearchElement is not null) yield return new KeyValuePair<string,object>("search",SearchElement);
       if (Resource?.Any() == true) yield return new KeyValuePair<string,object>("resource",Resource);

--- a/src/Hl7.Fhir.R4B/Model/Generated/ConceptMap.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/ConceptMap.cs
@@ -1640,13 +1640,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the concept map
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1681,26 +1699,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this concept map is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// The source value set that contains the concepts that are being mapped
@@ -1766,11 +1820,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(Source != null) dest.Source = (Hl7.Fhir.Model.DataType)Source.DeepCopy();
       if(Target != null) dest.Target = (Hl7.Fhir.Model.DataType)Target.DeepCopy();
       if(Group != null) dest.Group = new List<Hl7.Fhir.Model.ConceptMap.GroupComponent>(Group.DeepCopy());
@@ -1799,11 +1853,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(Source, otherT.Source)) return false;
       if( !DeepComparable.Matches(Target, otherT.Target)) return false;
       if( !DeepComparable.Matches(Group, otherT.Group)) return false;
@@ -1827,11 +1881,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(Source, otherT.Source)) return false;
       if( !DeepComparable.IsExactly(Target, otherT.Target)) return false;
       if( !DeepComparable.IsExactly(Group, otherT.Group)) return false;
@@ -1855,11 +1909,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (Source != null) yield return Source;
         if (Target != null) yield return Target;
         foreach (var elem in Group) { if (elem != null) yield return elem; }
@@ -1882,11 +1936,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (Source != null) yield return new ElementValue("source", Source);
         if (Target != null) yield return new ElementValue("target", Target);
         foreach (var elem in Group) { if (elem != null) yield return new ElementValue("group", elem); }
@@ -1928,8 +1982,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1937,11 +1991,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "source":
           value = Source;
           return Source is not null;
@@ -1970,11 +2024,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (Source is not null) yield return new KeyValuePair<string,object>("source",Source);
       if (Target is not null) yield return new KeyValuePair<string,object>("target",Target);
       if (Group?.Any() == true) yield return new KeyValuePair<string,object>("group",Group);

--- a/src/Hl7.Fhir.R4B/Model/Generated/Contract.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/Contract.cs
@@ -379,13 +379,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("copyright", Order=90)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Copyright
+      public Hl7.Fhir.Model.Markdown CopyrightElement
       {
-        get { return _Copyright; }
-        set { _Copyright = value; OnPropertyChanged("Copyright"); }
+        get { return _CopyrightElement; }
+        set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Copyright;
+      private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+      /// <summary>
+      /// Publication Ownership
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Copyright
+      {
+        get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+        set
+        {
+          if (value == null)
+            CopyrightElement = null;
+          else
+            CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Copyright");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -402,7 +420,7 @@ namespace Hl7.Fhir.Model
         if(Publisher != null) dest.Publisher = (Hl7.Fhir.Model.ResourceReference)Publisher.DeepCopy();
         if(PublicationDateElement != null) dest.PublicationDateElement = (Hl7.Fhir.Model.FhirDateTime)PublicationDateElement.DeepCopy();
         if(PublicationStatusElement != null) dest.PublicationStatusElement = (Code<Hl7.Fhir.Model.Contract.ContractResourcePublicationStatusCodes>)PublicationStatusElement.DeepCopy();
-        if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+        if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
         return dest;
       }
 
@@ -423,7 +441,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(Publisher, otherT.Publisher)) return false;
         if( !DeepComparable.Matches(PublicationDateElement, otherT.PublicationDateElement)) return false;
         if( !DeepComparable.Matches(PublicationStatusElement, otherT.PublicationStatusElement)) return false;
-        if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+        if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
 
         return true;
       }
@@ -439,7 +457,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(Publisher, otherT.Publisher)) return false;
         if( !DeepComparable.IsExactly(PublicationDateElement, otherT.PublicationDateElement)) return false;
         if( !DeepComparable.IsExactly(PublicationStatusElement, otherT.PublicationStatusElement)) return false;
-        if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+        if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
 
         return true;
       }
@@ -455,7 +473,7 @@ namespace Hl7.Fhir.Model
           if (Publisher != null) yield return Publisher;
           if (PublicationDateElement != null) yield return PublicationDateElement;
           if (PublicationStatusElement != null) yield return PublicationStatusElement;
-          if (Copyright != null) yield return Copyright;
+          if (CopyrightElement != null) yield return CopyrightElement;
         }
       }
 
@@ -470,7 +488,7 @@ namespace Hl7.Fhir.Model
           if (Publisher != null) yield return new ElementValue("publisher", Publisher);
           if (PublicationDateElement != null) yield return new ElementValue("publicationDate", PublicationDateElement);
           if (PublicationStatusElement != null) yield return new ElementValue("publicationStatus", PublicationStatusElement);
-          if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+          if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         }
       }
 
@@ -494,8 +512,8 @@ namespace Hl7.Fhir.Model
             value = PublicationStatusElement;
             return PublicationStatusElement is not null;
           case "copyright":
-            value = Copyright;
-            return Copyright is not null;
+            value = CopyrightElement;
+            return CopyrightElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -510,7 +528,7 @@ namespace Hl7.Fhir.Model
         if (Publisher is not null) yield return new KeyValuePair<string,object>("publisher",Publisher);
         if (PublicationDateElement is not null) yield return new KeyValuePair<string,object>("publicationDate",PublicationDateElement);
         if (PublicationStatusElement is not null) yield return new KeyValuePair<string,object>("publicationStatus",PublicationStatusElement);
-        if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+        if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       }
 
     }

--- a/src/Hl7.Fhir.R4B/Model/Generated/EventDefinition.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/EventDefinition.cs
@@ -385,13 +385,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the event definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -426,13 +444,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=240, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this event definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the event definition
@@ -470,13 +506,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=260)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the event definition was approved by publisher
@@ -673,12 +727,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -716,12 +770,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -754,12 +808,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -792,12 +846,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -829,12 +883,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -889,8 +943,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -898,14 +952,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -957,12 +1011,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4B/Model/Generated/Evidence.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/Evidence.cs
@@ -73,13 +73,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=40)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// A text description or summary of the variable
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Footnotes and/or explanatory notes
@@ -162,7 +180,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(Note != null) dest.Note = new List<Hl7.Fhir.Model.Annotation>(Note.DeepCopy());
         if(VariableRole != null) dest.VariableRole = (Hl7.Fhir.Model.CodeableConcept)VariableRole.DeepCopy();
         if(Observed != null) dest.Observed = (Hl7.Fhir.Model.ResourceReference)Observed.DeepCopy();
@@ -183,7 +201,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.Matches(otherT)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(Note, otherT.Note)) return false;
         if( !DeepComparable.Matches(VariableRole, otherT.VariableRole)) return false;
         if( !DeepComparable.Matches(Observed, otherT.Observed)) return false;
@@ -199,7 +217,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.IsExactly(otherT)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(Note, otherT.Note)) return false;
         if( !DeepComparable.IsExactly(VariableRole, otherT.VariableRole)) return false;
         if( !DeepComparable.IsExactly(Observed, otherT.Observed)) return false;
@@ -215,7 +233,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.Children) yield return item;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           foreach (var elem in Note) { if (elem != null) yield return elem; }
           if (VariableRole != null) yield return VariableRole;
           if (Observed != null) yield return Observed;
@@ -230,7 +248,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.NamedChildren) yield return item;
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           foreach (var elem in Note) { if (elem != null) yield return new ElementValue("note", elem); }
           if (VariableRole != null) yield return new ElementValue("variableRole", VariableRole);
           if (Observed != null) yield return new ElementValue("observed", Observed);
@@ -244,8 +262,8 @@ namespace Hl7.Fhir.Model
         switch (key)
         {
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "note":
             value = Note;
             return Note?.Any() == true;
@@ -270,7 +288,7 @@ namespace Hl7.Fhir.Model
       protected override IEnumerable<KeyValuePair<string, object>> GetElementPairs()
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (Note?.Any() == true) yield return new KeyValuePair<string,object>("note",Note);
         if (VariableRole is not null) yield return new KeyValuePair<string,object>("variableRole",VariableRole);
         if (Observed is not null) yield return new KeyValuePair<string,object>("observed",Observed);
@@ -2233,26 +2251,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=260)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Description of the particular summary
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Declarative description of the Evidence
     /// </summary>
     [FhirElement("assertion", Order=270)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Assertion
+    public Hl7.Fhir.Model.Markdown AssertionElement
     {
-      get { return _Assertion; }
-      set { _Assertion = value; OnPropertyChanged("Assertion"); }
+      get { return _AssertionElement; }
+      set { _AssertionElement = value; OnPropertyChanged("AssertionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Assertion;
+    private Hl7.Fhir.Model.Markdown _AssertionElement;
+
+    /// <summary>
+    /// Declarative description of the Evidence
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Assertion
+    {
+      get { return AssertionElement != null ? AssertionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          AssertionElement = null;
+        else
+          AssertionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Assertion");
+      }
+    }
 
     /// <summary>
     /// Footnotes and/or explanatory notes
@@ -2363,8 +2417,8 @@ namespace Hl7.Fhir.Model
       if(Reviewer != null) dest.Reviewer = new List<Hl7.Fhir.Model.ContactDetail>(Reviewer.DeepCopy());
       if(Endorser != null) dest.Endorser = new List<Hl7.Fhir.Model.ContactDetail>(Endorser.DeepCopy());
       if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
-      if(Assertion != null) dest.Assertion = (Hl7.Fhir.Model.Markdown)Assertion.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
+      if(AssertionElement != null) dest.AssertionElement = (Hl7.Fhir.Model.Markdown)AssertionElement.DeepCopy();
       if(Note != null) dest.Note = new List<Hl7.Fhir.Model.Annotation>(Note.DeepCopy());
       if(VariableDefinition != null) dest.VariableDefinition = new List<Hl7.Fhir.Model.Evidence.VariableDefinitionComponent>(VariableDefinition.DeepCopy());
       if(SynthesisType != null) dest.SynthesisType = (Hl7.Fhir.Model.CodeableConcept)SynthesisType.DeepCopy();
@@ -2403,8 +2457,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Reviewer, otherT.Reviewer)) return false;
       if( !DeepComparable.Matches(Endorser, otherT.Endorser)) return false;
       if( !DeepComparable.Matches(RelatedArtifact, otherT.RelatedArtifact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
-      if( !DeepComparable.Matches(Assertion, otherT.Assertion)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.Matches(AssertionElement, otherT.AssertionElement)) return false;
       if( !DeepComparable.Matches(Note, otherT.Note)) return false;
       if( !DeepComparable.Matches(VariableDefinition, otherT.VariableDefinition)) return false;
       if( !DeepComparable.Matches(SynthesisType, otherT.SynthesisType)) return false;
@@ -2438,8 +2492,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Reviewer, otherT.Reviewer)) return false;
       if( !DeepComparable.IsExactly(Endorser, otherT.Endorser)) return false;
       if( !DeepComparable.IsExactly(RelatedArtifact, otherT.RelatedArtifact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
-      if( !DeepComparable.IsExactly(Assertion, otherT.Assertion)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.IsExactly(AssertionElement, otherT.AssertionElement)) return false;
       if( !DeepComparable.IsExactly(Note, otherT.Note)) return false;
       if( !DeepComparable.IsExactly(VariableDefinition, otherT.VariableDefinition)) return false;
       if( !DeepComparable.IsExactly(SynthesisType, otherT.SynthesisType)) return false;
@@ -2473,8 +2527,8 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Reviewer) { if (elem != null) yield return elem; }
         foreach (var elem in Endorser) { if (elem != null) yield return elem; }
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
-        if (Assertion != null) yield return Assertion;
+        if (DescriptionElement != null) yield return DescriptionElement;
+        if (AssertionElement != null) yield return AssertionElement;
         foreach (var elem in Note) { if (elem != null) yield return elem; }
         foreach (var elem in VariableDefinition) { if (elem != null) yield return elem; }
         if (SynthesisType != null) yield return SynthesisType;
@@ -2507,8 +2561,8 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Reviewer) { if (elem != null) yield return new ElementValue("reviewer", elem); }
         foreach (var elem in Endorser) { if (elem != null) yield return new ElementValue("endorser", elem); }
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return new ElementValue("relatedArtifact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
-        if (Assertion != null) yield return new ElementValue("assertion", Assertion);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
+        if (AssertionElement != null) yield return new ElementValue("assertion", AssertionElement);
         foreach (var elem in Note) { if (elem != null) yield return new ElementValue("note", elem); }
         foreach (var elem in VariableDefinition) { if (elem != null) yield return new ElementValue("variableDefinition", elem); }
         if (SynthesisType != null) yield return new ElementValue("synthesisType", SynthesisType);
@@ -2574,11 +2628,11 @@ namespace Hl7.Fhir.Model
           value = RelatedArtifact;
           return RelatedArtifact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "assertion":
-          value = Assertion;
-          return Assertion is not null;
+          value = AssertionElement;
+          return AssertionElement is not null;
         case "note":
           value = Note;
           return Note?.Any() == true;
@@ -2623,8 +2677,8 @@ namespace Hl7.Fhir.Model
       if (Reviewer?.Any() == true) yield return new KeyValuePair<string,object>("reviewer",Reviewer);
       if (Endorser?.Any() == true) yield return new KeyValuePair<string,object>("endorser",Endorser);
       if (RelatedArtifact?.Any() == true) yield return new KeyValuePair<string,object>("relatedArtifact",RelatedArtifact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
-      if (Assertion is not null) yield return new KeyValuePair<string,object>("assertion",Assertion);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
+      if (AssertionElement is not null) yield return new KeyValuePair<string,object>("assertion",AssertionElement);
       if (Note?.Any() == true) yield return new KeyValuePair<string,object>("note",Note);
       if (VariableDefinition?.Any() == true) yield return new KeyValuePair<string,object>("variableDefinition",VariableDefinition);
       if (SynthesisType is not null) yield return new KeyValuePair<string,object>("synthesisType",SynthesisType);

--- a/src/Hl7.Fhir.R4B/Model/Generated/EvidenceVariable.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/EvidenceVariable.cs
@@ -993,13 +993,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the evidence variable
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Used for footnotes or explanatory notes
@@ -1286,7 +1304,7 @@ namespace Hl7.Fhir.Model
       if(SubtitleElement != null) dest.SubtitleElement = (Hl7.Fhir.Model.FhirString)SubtitleElement.DeepCopy();
       if(StatusElement != null) dest.StatusElement = (Code<Hl7.Fhir.Model.PublicationStatus>)StatusElement.DeepCopy();
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(Note != null) dest.Note = new List<Hl7.Fhir.Model.Annotation>(Note.DeepCopy());
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
@@ -1325,7 +1343,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(SubtitleElement, otherT.SubtitleElement)) return false;
       if( !DeepComparable.Matches(StatusElement, otherT.StatusElement)) return false;
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(Note, otherT.Note)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
@@ -1359,7 +1377,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(SubtitleElement, otherT.SubtitleElement)) return false;
       if( !DeepComparable.IsExactly(StatusElement, otherT.StatusElement)) return false;
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(Note, otherT.Note)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
@@ -1393,7 +1411,7 @@ namespace Hl7.Fhir.Model
         if (SubtitleElement != null) yield return SubtitleElement;
         if (StatusElement != null) yield return StatusElement;
         if (DateElement != null) yield return DateElement;
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in Note) { if (elem != null) yield return elem; }
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         if (PublisherElement != null) yield return PublisherElement;
@@ -1426,7 +1444,7 @@ namespace Hl7.Fhir.Model
         if (SubtitleElement != null) yield return new ElementValue("subtitle", SubtitleElement);
         if (StatusElement != null) yield return new ElementValue("status", StatusElement);
         if (DateElement != null) yield return new ElementValue("date", DateElement);
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in Note) { if (elem != null) yield return new ElementValue("note", elem); }
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
@@ -1476,8 +1494,8 @@ namespace Hl7.Fhir.Model
           value = DateElement;
           return DateElement is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "note":
           value = Note;
           return Note?.Any() == true;
@@ -1538,7 +1556,7 @@ namespace Hl7.Fhir.Model
       if (SubtitleElement is not null) yield return new KeyValuePair<string,object>("subtitle",SubtitleElement);
       if (StatusElement is not null) yield return new KeyValuePair<string,object>("status",StatusElement);
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (Note?.Any() == true) yield return new KeyValuePair<string,object>("note",Note);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);

--- a/src/Hl7.Fhir.R4B/Model/Generated/ExampleScenario.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/ExampleScenario.cs
@@ -191,13 +191,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=70)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// The description of the actor
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -212,7 +230,7 @@ namespace Hl7.Fhir.Model
         if(ActorIdElement != null) dest.ActorIdElement = (Hl7.Fhir.Model.FhirString)ActorIdElement.DeepCopy();
         if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.ExampleScenario.ExampleScenarioActorType>)TypeElement.DeepCopy();
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         return dest;
       }
 
@@ -231,7 +249,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(ActorIdElement, otherT.ActorIdElement)) return false;
         if( !DeepComparable.Matches(TypeElement, otherT.TypeElement)) return false;
         if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
 
         return true;
       }
@@ -245,7 +263,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(ActorIdElement, otherT.ActorIdElement)) return false;
         if( !DeepComparable.IsExactly(TypeElement, otherT.TypeElement)) return false;
         if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
 
         return true;
       }
@@ -259,7 +277,7 @@ namespace Hl7.Fhir.Model
           if (ActorIdElement != null) yield return ActorIdElement;
           if (TypeElement != null) yield return TypeElement;
           if (NameElement != null) yield return NameElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
         }
       }
 
@@ -272,7 +290,7 @@ namespace Hl7.Fhir.Model
           if (ActorIdElement != null) yield return new ElementValue("actorId", ActorIdElement);
           if (TypeElement != null) yield return new ElementValue("type", TypeElement);
           if (NameElement != null) yield return new ElementValue("name", NameElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         }
       }
 
@@ -290,8 +308,8 @@ namespace Hl7.Fhir.Model
             value = NameElement;
             return NameElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -304,7 +322,7 @@ namespace Hl7.Fhir.Model
         if (ActorIdElement is not null) yield return new KeyValuePair<string,object>("actorId",ActorIdElement);
         if (TypeElement is not null) yield return new KeyValuePair<string,object>("type",TypeElement);
         if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       }
 
     }
@@ -423,13 +441,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=70)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Human-friendly description of the resource instance
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// A specific version of the resource
@@ -472,7 +508,7 @@ namespace Hl7.Fhir.Model
         if(ResourceIdElement != null) dest.ResourceIdElement = (Hl7.Fhir.Model.FhirString)ResourceIdElement.DeepCopy();
         if(ResourceTypeElement != null) dest.ResourceTypeElement = (Code<Hl7.Fhir.Model.ResourceType>)ResourceTypeElement.DeepCopy();
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(Version != null) dest.Version = new List<Hl7.Fhir.Model.ExampleScenario.VersionComponent>(Version.DeepCopy());
         if(ContainedInstance != null) dest.ContainedInstance = new List<Hl7.Fhir.Model.ExampleScenario.ContainedInstanceComponent>(ContainedInstance.DeepCopy());
         return dest;
@@ -493,7 +529,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(ResourceIdElement, otherT.ResourceIdElement)) return false;
         if( !DeepComparable.Matches(ResourceTypeElement, otherT.ResourceTypeElement)) return false;
         if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(Version, otherT.Version)) return false;
         if( !DeepComparable.Matches(ContainedInstance, otherT.ContainedInstance)) return false;
 
@@ -509,7 +545,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(ResourceIdElement, otherT.ResourceIdElement)) return false;
         if( !DeepComparable.IsExactly(ResourceTypeElement, otherT.ResourceTypeElement)) return false;
         if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(Version, otherT.Version)) return false;
         if( !DeepComparable.IsExactly(ContainedInstance, otherT.ContainedInstance)) return false;
 
@@ -525,7 +561,7 @@ namespace Hl7.Fhir.Model
           if (ResourceIdElement != null) yield return ResourceIdElement;
           if (ResourceTypeElement != null) yield return ResourceTypeElement;
           if (NameElement != null) yield return NameElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           foreach (var elem in Version) { if (elem != null) yield return elem; }
           foreach (var elem in ContainedInstance) { if (elem != null) yield return elem; }
         }
@@ -540,7 +576,7 @@ namespace Hl7.Fhir.Model
           if (ResourceIdElement != null) yield return new ElementValue("resourceId", ResourceIdElement);
           if (ResourceTypeElement != null) yield return new ElementValue("resourceType", ResourceTypeElement);
           if (NameElement != null) yield return new ElementValue("name", NameElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           foreach (var elem in Version) { if (elem != null) yield return new ElementValue("version", elem); }
           foreach (var elem in ContainedInstance) { if (elem != null) yield return new ElementValue("containedInstance", elem); }
         }
@@ -560,8 +596,8 @@ namespace Hl7.Fhir.Model
             value = NameElement;
             return NameElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "version":
             value = Version;
             return Version?.Any() == true;
@@ -580,7 +616,7 @@ namespace Hl7.Fhir.Model
         if (ResourceIdElement is not null) yield return new KeyValuePair<string,object>("resourceId",ResourceIdElement);
         if (ResourceTypeElement is not null) yield return new KeyValuePair<string,object>("resourceType",ResourceTypeElement);
         if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (Version?.Any() == true) yield return new KeyValuePair<string,object>("version",Version);
         if (ContainedInstance?.Any() == true) yield return new KeyValuePair<string,object>("containedInstance",ContainedInstance);
       }
@@ -638,13 +674,31 @@ namespace Hl7.Fhir.Model
       [FhirElement("description", Order=50)]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// The description of the resource version
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -657,7 +711,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(VersionIdElement != null) dest.VersionIdElement = (Hl7.Fhir.Model.FhirString)VersionIdElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         return dest;
       }
 
@@ -674,7 +728,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(VersionIdElement, otherT.VersionIdElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
 
         return true;
       }
@@ -686,7 +740,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(VersionIdElement, otherT.VersionIdElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
 
         return true;
       }
@@ -698,7 +752,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (VersionIdElement != null) yield return VersionIdElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
         }
       }
 
@@ -709,7 +763,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (VersionIdElement != null) yield return new ElementValue("versionId", VersionIdElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         }
       }
 
@@ -721,8 +775,8 @@ namespace Hl7.Fhir.Model
             value = VersionIdElement;
             return VersionIdElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -733,7 +787,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (VersionIdElement is not null) yield return new KeyValuePair<string,object>("versionId",VersionIdElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       }
 
     }
@@ -956,39 +1010,93 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// A longer description of the group of operations
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Description of initial status before the process starts
       /// </summary>
       [FhirElement("preConditions", Order=60)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown PreConditions
+      public Hl7.Fhir.Model.Markdown PreConditionsElement
       {
-        get { return _PreConditions; }
-        set { _PreConditions = value; OnPropertyChanged("PreConditions"); }
+        get { return _PreConditionsElement; }
+        set { _PreConditionsElement = value; OnPropertyChanged("PreConditionsElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _PreConditions;
+      private Hl7.Fhir.Model.Markdown _PreConditionsElement;
+
+      /// <summary>
+      /// Description of initial status before the process starts
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string PreConditions
+      {
+        get { return PreConditionsElement != null ? PreConditionsElement.Value : null; }
+        set
+        {
+          if (value == null)
+            PreConditionsElement = null;
+          else
+            PreConditionsElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("PreConditions");
+        }
+      }
 
       /// <summary>
       /// Description of final status after the process ends
       /// </summary>
       [FhirElement("postConditions", Order=70)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown PostConditions
+      public Hl7.Fhir.Model.Markdown PostConditionsElement
       {
-        get { return _PostConditions; }
-        set { _PostConditions = value; OnPropertyChanged("PostConditions"); }
+        get { return _PostConditionsElement; }
+        set { _PostConditionsElement = value; OnPropertyChanged("PostConditionsElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _PostConditions;
+      private Hl7.Fhir.Model.Markdown _PostConditionsElement;
+
+      /// <summary>
+      /// Description of final status after the process ends
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string PostConditions
+      {
+        get { return PostConditionsElement != null ? PostConditionsElement.Value : null; }
+        set
+        {
+          if (value == null)
+            PostConditionsElement = null;
+          else
+            PostConditionsElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("PostConditions");
+        }
+      }
 
       /// <summary>
       /// Each step of the process
@@ -1015,9 +1123,9 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(TitleElement != null) dest.TitleElement = (Hl7.Fhir.Model.FhirString)TitleElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
-        if(PreConditions != null) dest.PreConditions = (Hl7.Fhir.Model.Markdown)PreConditions.DeepCopy();
-        if(PostConditions != null) dest.PostConditions = (Hl7.Fhir.Model.Markdown)PostConditions.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
+        if(PreConditionsElement != null) dest.PreConditionsElement = (Hl7.Fhir.Model.Markdown)PreConditionsElement.DeepCopy();
+        if(PostConditionsElement != null) dest.PostConditionsElement = (Hl7.Fhir.Model.Markdown)PostConditionsElement.DeepCopy();
         if(Step != null) dest.Step = new List<Hl7.Fhir.Model.ExampleScenario.StepComponent>(Step.DeepCopy());
         return dest;
       }
@@ -1035,9 +1143,9 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
-        if( !DeepComparable.Matches(PreConditions, otherT.PreConditions)) return false;
-        if( !DeepComparable.Matches(PostConditions, otherT.PostConditions)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
+        if( !DeepComparable.Matches(PreConditionsElement, otherT.PreConditionsElement)) return false;
+        if( !DeepComparable.Matches(PostConditionsElement, otherT.PostConditionsElement)) return false;
         if( !DeepComparable.Matches(Step, otherT.Step)) return false;
 
         return true;
@@ -1050,9 +1158,9 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
-        if( !DeepComparable.IsExactly(PreConditions, otherT.PreConditions)) return false;
-        if( !DeepComparable.IsExactly(PostConditions, otherT.PostConditions)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
+        if( !DeepComparable.IsExactly(PreConditionsElement, otherT.PreConditionsElement)) return false;
+        if( !DeepComparable.IsExactly(PostConditionsElement, otherT.PostConditionsElement)) return false;
         if( !DeepComparable.IsExactly(Step, otherT.Step)) return false;
 
         return true;
@@ -1065,9 +1173,9 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (TitleElement != null) yield return TitleElement;
-          if (Description != null) yield return Description;
-          if (PreConditions != null) yield return PreConditions;
-          if (PostConditions != null) yield return PostConditions;
+          if (DescriptionElement != null) yield return DescriptionElement;
+          if (PreConditionsElement != null) yield return PreConditionsElement;
+          if (PostConditionsElement != null) yield return PostConditionsElement;
           foreach (var elem in Step) { if (elem != null) yield return elem; }
         }
       }
@@ -1079,9 +1187,9 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (TitleElement != null) yield return new ElementValue("title", TitleElement);
-          if (Description != null) yield return new ElementValue("description", Description);
-          if (PreConditions != null) yield return new ElementValue("preConditions", PreConditions);
-          if (PostConditions != null) yield return new ElementValue("postConditions", PostConditions);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
+          if (PreConditionsElement != null) yield return new ElementValue("preConditions", PreConditionsElement);
+          if (PostConditionsElement != null) yield return new ElementValue("postConditions", PostConditionsElement);
           foreach (var elem in Step) { if (elem != null) yield return new ElementValue("step", elem); }
         }
       }
@@ -1094,14 +1202,14 @@ namespace Hl7.Fhir.Model
             value = TitleElement;
             return TitleElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "preConditions":
-            value = PreConditions;
-            return PreConditions is not null;
+            value = PreConditionsElement;
+            return PreConditionsElement is not null;
           case "postConditions":
-            value = PostConditions;
-            return PostConditions is not null;
+            value = PostConditionsElement;
+            return PostConditionsElement is not null;
           case "step":
             value = Step;
             return Step?.Any() == true;
@@ -1115,9 +1223,9 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (TitleElement is not null) yield return new KeyValuePair<string,object>("title",TitleElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
-        if (PreConditions is not null) yield return new KeyValuePair<string,object>("preConditions",PreConditions);
-        if (PostConditions is not null) yield return new KeyValuePair<string,object>("postConditions",PostConditions);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
+        if (PreConditionsElement is not null) yield return new KeyValuePair<string,object>("preConditions",PreConditionsElement);
+        if (PostConditionsElement is not null) yield return new KeyValuePair<string,object>("postConditions",PostConditionsElement);
         if (Step?.Any() == true) yield return new KeyValuePair<string,object>("step",Step);
       }
 
@@ -1492,13 +1600,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=90)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// A comment to be inserted in the diagram
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Whether the initiator is deactivated right after the transaction
@@ -1603,7 +1729,7 @@ namespace Hl7.Fhir.Model
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
         if(InitiatorElement != null) dest.InitiatorElement = (Hl7.Fhir.Model.FhirString)InitiatorElement.DeepCopy();
         if(ReceiverElement != null) dest.ReceiverElement = (Hl7.Fhir.Model.FhirString)ReceiverElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(InitiatorActiveElement != null) dest.InitiatorActiveElement = (Hl7.Fhir.Model.FhirBoolean)InitiatorActiveElement.DeepCopy();
         if(ReceiverActiveElement != null) dest.ReceiverActiveElement = (Hl7.Fhir.Model.FhirBoolean)ReceiverActiveElement.DeepCopy();
         if(Request != null) dest.Request = (Hl7.Fhir.Model.ExampleScenario.ContainedInstanceComponent)Request.DeepCopy();
@@ -1628,7 +1754,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
         if( !DeepComparable.Matches(InitiatorElement, otherT.InitiatorElement)) return false;
         if( !DeepComparable.Matches(ReceiverElement, otherT.ReceiverElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(InitiatorActiveElement, otherT.InitiatorActiveElement)) return false;
         if( !DeepComparable.Matches(ReceiverActiveElement, otherT.ReceiverActiveElement)) return false;
         if( !DeepComparable.Matches(Request, otherT.Request)) return false;
@@ -1648,7 +1774,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
         if( !DeepComparable.IsExactly(InitiatorElement, otherT.InitiatorElement)) return false;
         if( !DeepComparable.IsExactly(ReceiverElement, otherT.ReceiverElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(InitiatorActiveElement, otherT.InitiatorActiveElement)) return false;
         if( !DeepComparable.IsExactly(ReceiverActiveElement, otherT.ReceiverActiveElement)) return false;
         if( !DeepComparable.IsExactly(Request, otherT.Request)) return false;
@@ -1668,7 +1794,7 @@ namespace Hl7.Fhir.Model
           if (NameElement != null) yield return NameElement;
           if (InitiatorElement != null) yield return InitiatorElement;
           if (ReceiverElement != null) yield return ReceiverElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           if (InitiatorActiveElement != null) yield return InitiatorActiveElement;
           if (ReceiverActiveElement != null) yield return ReceiverActiveElement;
           if (Request != null) yield return Request;
@@ -1687,7 +1813,7 @@ namespace Hl7.Fhir.Model
           if (NameElement != null) yield return new ElementValue("name", NameElement);
           if (InitiatorElement != null) yield return new ElementValue("initiator", InitiatorElement);
           if (ReceiverElement != null) yield return new ElementValue("receiver", ReceiverElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (InitiatorActiveElement != null) yield return new ElementValue("initiatorActive", InitiatorActiveElement);
           if (ReceiverActiveElement != null) yield return new ElementValue("receiverActive", ReceiverActiveElement);
           if (Request != null) yield return new ElementValue("request", Request);
@@ -1715,8 +1841,8 @@ namespace Hl7.Fhir.Model
             value = ReceiverElement;
             return ReceiverElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "initiatorActive":
             value = InitiatorActiveElement;
             return InitiatorActiveElement is not null;
@@ -1743,7 +1869,7 @@ namespace Hl7.Fhir.Model
         if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
         if (InitiatorElement is not null) yield return new KeyValuePair<string,object>("initiator",InitiatorElement);
         if (ReceiverElement is not null) yield return new KeyValuePair<string,object>("receiver",ReceiverElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (InitiatorActiveElement is not null) yield return new KeyValuePair<string,object>("initiatorActive",InitiatorActiveElement);
         if (ReceiverActiveElement is not null) yield return new KeyValuePair<string,object>("receiverActive",ReceiverActiveElement);
         if (Request is not null) yield return new KeyValuePair<string,object>("request",Request);
@@ -1802,13 +1928,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// A human-readable description of each option
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// What happens in each alternative option
@@ -1835,7 +1979,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(TitleElement != null) dest.TitleElement = (Hl7.Fhir.Model.FhirString)TitleElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(Step != null) dest.Step = new List<Hl7.Fhir.Model.ExampleScenario.StepComponent>(Step.DeepCopy());
         return dest;
       }
@@ -1853,7 +1997,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(Step, otherT.Step)) return false;
 
         return true;
@@ -1866,7 +2010,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(Step, otherT.Step)) return false;
 
         return true;
@@ -1879,7 +2023,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (TitleElement != null) yield return TitleElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           foreach (var elem in Step) { if (elem != null) yield return elem; }
         }
       }
@@ -1891,7 +2035,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (TitleElement != null) yield return new ElementValue("title", TitleElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           foreach (var elem in Step) { if (elem != null) yield return new ElementValue("step", elem); }
         }
       }
@@ -1904,8 +2048,8 @@ namespace Hl7.Fhir.Model
             value = TitleElement;
             return TitleElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "step":
             value = Step;
             return Step?.Any() == true;
@@ -1919,7 +2063,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (TitleElement is not null) yield return new KeyValuePair<string,object>("title",TitleElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (Step?.Any() == true) yield return new KeyValuePair<string,object>("step",Step);
       }
 
@@ -2205,26 +2349,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// The purpose of the example, e.g. to illustrate a scenario
     /// </summary>
     [FhirElement("purpose", Order=210, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// The purpose of the example, e.g. to illustrate a scenario
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Actor participating in the resource
@@ -2321,8 +2501,8 @@ namespace Hl7.Fhir.Model
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(Actor != null) dest.Actor = new List<Hl7.Fhir.Model.ExampleScenario.ActorComponent>(Actor.DeepCopy());
       if(Instance != null) dest.Instance = new List<Hl7.Fhir.Model.ExampleScenario.InstanceComponent>(Instance.DeepCopy());
       if(Process != null) dest.Process = new List<Hl7.Fhir.Model.ExampleScenario.ProcessComponent>(Process.DeepCopy());
@@ -2353,8 +2533,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(Actor, otherT.Actor)) return false;
       if( !DeepComparable.Matches(Instance, otherT.Instance)) return false;
       if( !DeepComparable.Matches(Process, otherT.Process)) return false;
@@ -2380,8 +2560,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(Actor, otherT.Actor)) return false;
       if( !DeepComparable.IsExactly(Instance, otherT.Instance)) return false;
       if( !DeepComparable.IsExactly(Process, otherT.Process)) return false;
@@ -2407,8 +2587,8 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
-        if (Purpose != null) yield return Purpose;
+        if (CopyrightElement != null) yield return CopyrightElement;
+        if (PurposeElement != null) yield return PurposeElement;
         foreach (var elem in Actor) { if (elem != null) yield return elem; }
         foreach (var elem in Instance) { if (elem != null) yield return elem; }
         foreach (var elem in Process) { if (elem != null) yield return elem; }
@@ -2433,8 +2613,8 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         foreach (var elem in Actor) { if (elem != null) yield return new ElementValue("actor", elem); }
         foreach (var elem in Instance) { if (elem != null) yield return new ElementValue("instance", elem); }
         foreach (var elem in Process) { if (elem != null) yield return new ElementValue("process", elem); }
@@ -2480,11 +2660,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "actor":
           value = Actor;
           return Actor?.Any() == true;
@@ -2517,8 +2697,8 @@ namespace Hl7.Fhir.Model
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (Actor?.Any() == true) yield return new KeyValuePair<string,object>("actor",Actor);
       if (Instance?.Any() == true) yield return new KeyValuePair<string,object>("instance",Instance);
       if (Process?.Any() == true) yield return new KeyValuePair<string,object>("process",Process);

--- a/src/Hl7.Fhir.R4B/Model/Generated/GraphDefinition.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/GraphDefinition.cs
@@ -1208,13 +1208,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=170)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the graph definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1249,13 +1267,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=200, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this graph definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Type of resource at which the graph starts
@@ -1353,10 +1389,10 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(StartElement != null) dest.StartElement = (Code<Hl7.Fhir.Model.ResourceType>)StartElement.DeepCopy();
       if(ProfileElement != null) dest.ProfileElement = (Hl7.Fhir.Model.Canonical)ProfileElement.DeepCopy();
       if(Link != null) dest.Link = new List<Hl7.Fhir.Model.GraphDefinition.LinkComponent>(Link.DeepCopy());
@@ -1383,10 +1419,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(StartElement, otherT.StartElement)) return false;
       if( !DeepComparable.Matches(ProfileElement, otherT.ProfileElement)) return false;
       if( !DeepComparable.Matches(Link, otherT.Link)) return false;
@@ -1408,10 +1444,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(StartElement, otherT.StartElement)) return false;
       if( !DeepComparable.IsExactly(ProfileElement, otherT.ProfileElement)) return false;
       if( !DeepComparable.IsExactly(Link, otherT.Link)) return false;
@@ -1433,10 +1469,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (StartElement != null) yield return StartElement;
         if (ProfileElement != null) yield return ProfileElement;
         foreach (var elem in Link) { if (elem != null) yield return elem; }
@@ -1457,10 +1493,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (StartElement != null) yield return new ElementValue("start", StartElement);
         if (ProfileElement != null) yield return new ElementValue("profile", ProfileElement);
         foreach (var elem in Link) { if (elem != null) yield return new ElementValue("link", elem); }
@@ -1496,8 +1532,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1505,8 +1541,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "start":
           value = StartElement;
           return StartElement is not null;
@@ -1533,10 +1569,10 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (StartElement is not null) yield return new KeyValuePair<string,object>("start",StartElement);
       if (ProfileElement is not null) yield return new KeyValuePair<string,object>("profile",ProfileElement);
       if (Link?.Any() == true) yield return new KeyValuePair<string,object>("link",Link);

--- a/src/Hl7.Fhir.R4B/Model/Generated/HealthcareService.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/HealthcareService.cs
@@ -86,13 +86,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("comment", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Comment
+      public Hl7.Fhir.Model.Markdown CommentElement
       {
-        get { return _Comment; }
-        set { _Comment = value; OnPropertyChanged("Comment"); }
+        get { return _CommentElement; }
+        set { _CommentElement = value; OnPropertyChanged("CommentElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Comment;
+      private Hl7.Fhir.Model.Markdown _CommentElement;
+
+      /// <summary>
+      /// Describes the eligibility conditions for the service
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Comment
+      {
+        get { return CommentElement != null ? CommentElement.Value : null; }
+        set
+        {
+          if (value == null)
+            CommentElement = null;
+          else
+            CommentElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Comment");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -105,7 +123,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(Code != null) dest.Code = (Hl7.Fhir.Model.CodeableConcept)Code.DeepCopy();
-        if(Comment != null) dest.Comment = (Hl7.Fhir.Model.Markdown)Comment.DeepCopy();
+        if(CommentElement != null) dest.CommentElement = (Hl7.Fhir.Model.Markdown)CommentElement.DeepCopy();
         return dest;
       }
 
@@ -122,7 +140,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(Code, otherT.Code)) return false;
-        if( !DeepComparable.Matches(Comment, otherT.Comment)) return false;
+        if( !DeepComparable.Matches(CommentElement, otherT.CommentElement)) return false;
 
         return true;
       }
@@ -134,7 +152,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(Code, otherT.Code)) return false;
-        if( !DeepComparable.IsExactly(Comment, otherT.Comment)) return false;
+        if( !DeepComparable.IsExactly(CommentElement, otherT.CommentElement)) return false;
 
         return true;
       }
@@ -146,7 +164,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (Code != null) yield return Code;
-          if (Comment != null) yield return Comment;
+          if (CommentElement != null) yield return CommentElement;
         }
       }
 
@@ -157,7 +175,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (Code != null) yield return new ElementValue("code", Code);
-          if (Comment != null) yield return new ElementValue("comment", Comment);
+          if (CommentElement != null) yield return new ElementValue("comment", CommentElement);
         }
       }
 
@@ -169,8 +187,8 @@ namespace Hl7.Fhir.Model
             value = Code;
             return Code is not null;
           case "comment":
-            value = Comment;
-            return Comment is not null;
+            value = CommentElement;
+            return CommentElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -181,7 +199,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (Code is not null) yield return new KeyValuePair<string,object>("code",Code);
-        if (Comment is not null) yield return new KeyValuePair<string,object>("comment",Comment);
+        if (CommentElement is not null) yield return new KeyValuePair<string,object>("comment",CommentElement);
       }
 
     }
@@ -770,13 +788,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("extraDetails", Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown ExtraDetails
+    public Hl7.Fhir.Model.Markdown ExtraDetailsElement
     {
-      get { return _ExtraDetails; }
-      set { _ExtraDetails = value; OnPropertyChanged("ExtraDetails"); }
+      get { return _ExtraDetailsElement; }
+      set { _ExtraDetailsElement = value; OnPropertyChanged("ExtraDetailsElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _ExtraDetails;
+    private Hl7.Fhir.Model.Markdown _ExtraDetailsElement;
+
+    /// <summary>
+    /// Extra details about the service that can't be placed in the other fields
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string ExtraDetails
+    {
+      get { return ExtraDetailsElement != null ? ExtraDetailsElement.Value : null; }
+      set
+      {
+        if (value == null)
+          ExtraDetailsElement = null;
+        else
+          ExtraDetailsElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("ExtraDetails");
+      }
+    }
 
     /// <summary>
     /// Facilitates quick identification of the service
@@ -1030,7 +1066,7 @@ namespace Hl7.Fhir.Model
       if(Location != null) dest.Location = new List<Hl7.Fhir.Model.ResourceReference>(Location.DeepCopy());
       if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
       if(CommentElement != null) dest.CommentElement = (Hl7.Fhir.Model.FhirString)CommentElement.DeepCopy();
-      if(ExtraDetails != null) dest.ExtraDetails = (Hl7.Fhir.Model.Markdown)ExtraDetails.DeepCopy();
+      if(ExtraDetailsElement != null) dest.ExtraDetailsElement = (Hl7.Fhir.Model.Markdown)ExtraDetailsElement.DeepCopy();
       if(Photo != null) dest.Photo = (Hl7.Fhir.Model.Attachment)Photo.DeepCopy();
       if(Telecom != null) dest.Telecom = new List<Hl7.Fhir.Model.ContactPoint>(Telecom.DeepCopy());
       if(CoverageArea != null) dest.CoverageArea = new List<Hl7.Fhir.Model.ResourceReference>(CoverageArea.DeepCopy());
@@ -1069,7 +1105,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Location, otherT.Location)) return false;
       if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
       if( !DeepComparable.Matches(CommentElement, otherT.CommentElement)) return false;
-      if( !DeepComparable.Matches(ExtraDetails, otherT.ExtraDetails)) return false;
+      if( !DeepComparable.Matches(ExtraDetailsElement, otherT.ExtraDetailsElement)) return false;
       if( !DeepComparable.Matches(Photo, otherT.Photo)) return false;
       if( !DeepComparable.Matches(Telecom, otherT.Telecom)) return false;
       if( !DeepComparable.Matches(CoverageArea, otherT.CoverageArea)) return false;
@@ -1103,7 +1139,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Location, otherT.Location)) return false;
       if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
       if( !DeepComparable.IsExactly(CommentElement, otherT.CommentElement)) return false;
-      if( !DeepComparable.IsExactly(ExtraDetails, otherT.ExtraDetails)) return false;
+      if( !DeepComparable.IsExactly(ExtraDetailsElement, otherT.ExtraDetailsElement)) return false;
       if( !DeepComparable.IsExactly(Photo, otherT.Photo)) return false;
       if( !DeepComparable.IsExactly(Telecom, otherT.Telecom)) return false;
       if( !DeepComparable.IsExactly(CoverageArea, otherT.CoverageArea)) return false;
@@ -1137,7 +1173,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Location) { if (elem != null) yield return elem; }
         if (NameElement != null) yield return NameElement;
         if (CommentElement != null) yield return CommentElement;
-        if (ExtraDetails != null) yield return ExtraDetails;
+        if (ExtraDetailsElement != null) yield return ExtraDetailsElement;
         if (Photo != null) yield return Photo;
         foreach (var elem in Telecom) { if (elem != null) yield return elem; }
         foreach (var elem in CoverageArea) { if (elem != null) yield return elem; }
@@ -1170,7 +1206,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Location) { if (elem != null) yield return new ElementValue("location", elem); }
         if (NameElement != null) yield return new ElementValue("name", NameElement);
         if (CommentElement != null) yield return new ElementValue("comment", CommentElement);
-        if (ExtraDetails != null) yield return new ElementValue("extraDetails", ExtraDetails);
+        if (ExtraDetailsElement != null) yield return new ElementValue("extraDetails", ExtraDetailsElement);
         if (Photo != null) yield return new ElementValue("photo", Photo);
         foreach (var elem in Telecom) { if (elem != null) yield return new ElementValue("telecom", elem); }
         foreach (var elem in CoverageArea) { if (elem != null) yield return new ElementValue("coverageArea", elem); }
@@ -1220,8 +1256,8 @@ namespace Hl7.Fhir.Model
           value = CommentElement;
           return CommentElement is not null;
         case "extraDetails":
-          value = ExtraDetails;
-          return ExtraDetails is not null;
+          value = ExtraDetailsElement;
+          return ExtraDetailsElement is not null;
         case "photo":
           value = Photo;
           return Photo is not null;
@@ -1282,7 +1318,7 @@ namespace Hl7.Fhir.Model
       if (Location?.Any() == true) yield return new KeyValuePair<string,object>("location",Location);
       if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
       if (CommentElement is not null) yield return new KeyValuePair<string,object>("comment",CommentElement);
-      if (ExtraDetails is not null) yield return new KeyValuePair<string,object>("extraDetails",ExtraDetails);
+      if (ExtraDetailsElement is not null) yield return new KeyValuePair<string,object>("extraDetails",ExtraDetailsElement);
       if (Photo is not null) yield return new KeyValuePair<string,object>("photo",Photo);
       if (Telecom?.Any() == true) yield return new KeyValuePair<string,object>("telecom",Telecom);
       if (CoverageArea?.Any() == true) yield return new KeyValuePair<string,object>("coverageArea",CoverageArea);

--- a/src/Hl7.Fhir.R4B/Model/Generated/ImplementationGuide.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/ImplementationGuide.cs
@@ -4799,13 +4799,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the implementation guide
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -4840,13 +4858,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// NPM Package name for IG
@@ -5018,10 +5054,10 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(PackageIdElement != null) dest.PackageIdElement = (Hl7.Fhir.Model.Id)PackageIdElement.DeepCopy();
       if(LicenseElement != null) dest.LicenseElement = (Code<Hl7.Fhir.Model.ImplementationGuide.SPDXLicense>)LicenseElement.DeepCopy();
       if(FhirVersionElement != null) dest.FhirVersionElement = new List<Code<Hl7.Fhir.Model.FHIRVersion>>(FhirVersionElement.DeepCopy());
@@ -5053,10 +5089,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(PackageIdElement, otherT.PackageIdElement)) return false;
       if( !DeepComparable.Matches(LicenseElement, otherT.LicenseElement)) return false;
       if( !DeepComparable.Matches(FhirVersionElement, otherT.FhirVersionElement)) return false;
@@ -5083,10 +5119,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(PackageIdElement, otherT.PackageIdElement)) return false;
       if( !DeepComparable.IsExactly(LicenseElement, otherT.LicenseElement)) return false;
       if( !DeepComparable.IsExactly(FhirVersionElement, otherT.FhirVersionElement)) return false;
@@ -5113,10 +5149,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (PackageIdElement != null) yield return PackageIdElement;
         if (LicenseElement != null) yield return LicenseElement;
         foreach (var elem in FhirVersionElement) { if (elem != null) yield return elem; }
@@ -5142,10 +5178,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (PackageIdElement != null) yield return new ElementValue("packageId", PackageIdElement);
         if (LicenseElement != null) yield return new ElementValue("license", LicenseElement);
         foreach (var elem in FhirVersionElement) { if (elem != null) yield return new ElementValue("fhirVersion", elem); }
@@ -5188,8 +5224,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -5197,8 +5233,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "packageId":
           value = PackageIdElement;
           return PackageIdElement is not null;
@@ -5238,10 +5274,10 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (PackageIdElement is not null) yield return new KeyValuePair<string,object>("packageId",PackageIdElement);
       if (LicenseElement is not null) yield return new KeyValuePair<string,object>("license",LicenseElement);
       if (FhirVersionElement?.Any() == true) yield return new KeyValuePair<string,object>("fhirVersion",FhirVersionElement);

--- a/src/Hl7.Fhir.R4B/Model/Generated/Invoice.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/Invoice.cs
@@ -873,13 +873,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("paymentTerms", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown PaymentTerms
+    public Hl7.Fhir.Model.Markdown PaymentTermsElement
     {
-      get { return _PaymentTerms; }
-      set { _PaymentTerms = value; OnPropertyChanged("PaymentTerms"); }
+      get { return _PaymentTermsElement; }
+      set { _PaymentTermsElement = value; OnPropertyChanged("PaymentTermsElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _PaymentTerms;
+    private Hl7.Fhir.Model.Markdown _PaymentTermsElement;
+
+    /// <summary>
+    /// Payment details
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string PaymentTerms
+    {
+      get { return PaymentTermsElement != null ? PaymentTermsElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PaymentTermsElement = null;
+        else
+          PaymentTermsElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("PaymentTerms");
+      }
+    }
 
     /// <summary>
     /// Comments made about the invoice
@@ -919,7 +937,7 @@ namespace Hl7.Fhir.Model
       if(TotalPriceComponent != null) dest.TotalPriceComponent = new List<Hl7.Fhir.Model.Invoice.PriceComponentComponent>(TotalPriceComponent.DeepCopy());
       if(TotalNet != null) dest.TotalNet = (Hl7.Fhir.Model.Money)TotalNet.DeepCopy();
       if(TotalGross != null) dest.TotalGross = (Hl7.Fhir.Model.Money)TotalGross.DeepCopy();
-      if(PaymentTerms != null) dest.PaymentTerms = (Hl7.Fhir.Model.Markdown)PaymentTerms.DeepCopy();
+      if(PaymentTermsElement != null) dest.PaymentTermsElement = (Hl7.Fhir.Model.Markdown)PaymentTermsElement.DeepCopy();
       if(Note != null) dest.Note = new List<Hl7.Fhir.Model.Annotation>(Note.DeepCopy());
       return dest;
     }
@@ -950,7 +968,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(TotalPriceComponent, otherT.TotalPriceComponent)) return false;
       if( !DeepComparable.Matches(TotalNet, otherT.TotalNet)) return false;
       if( !DeepComparable.Matches(TotalGross, otherT.TotalGross)) return false;
-      if( !DeepComparable.Matches(PaymentTerms, otherT.PaymentTerms)) return false;
+      if( !DeepComparable.Matches(PaymentTermsElement, otherT.PaymentTermsElement)) return false;
       if( !DeepComparable.Matches(Note, otherT.Note)) return false;
 
       return true;
@@ -976,7 +994,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(TotalPriceComponent, otherT.TotalPriceComponent)) return false;
       if( !DeepComparable.IsExactly(TotalNet, otherT.TotalNet)) return false;
       if( !DeepComparable.IsExactly(TotalGross, otherT.TotalGross)) return false;
-      if( !DeepComparable.IsExactly(PaymentTerms, otherT.PaymentTerms)) return false;
+      if( !DeepComparable.IsExactly(PaymentTermsElement, otherT.PaymentTermsElement)) return false;
       if( !DeepComparable.IsExactly(Note, otherT.Note)) return false;
 
       return true;
@@ -1002,7 +1020,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in TotalPriceComponent) { if (elem != null) yield return elem; }
         if (TotalNet != null) yield return TotalNet;
         if (TotalGross != null) yield return TotalGross;
-        if (PaymentTerms != null) yield return PaymentTerms;
+        if (PaymentTermsElement != null) yield return PaymentTermsElement;
         foreach (var elem in Note) { if (elem != null) yield return elem; }
       }
     }
@@ -1027,7 +1045,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in TotalPriceComponent) { if (elem != null) yield return new ElementValue("totalPriceComponent", elem); }
         if (TotalNet != null) yield return new ElementValue("totalNet", TotalNet);
         if (TotalGross != null) yield return new ElementValue("totalGross", TotalGross);
-        if (PaymentTerms != null) yield return new ElementValue("paymentTerms", PaymentTerms);
+        if (PaymentTermsElement != null) yield return new ElementValue("paymentTerms", PaymentTermsElement);
         foreach (var elem in Note) { if (elem != null) yield return new ElementValue("note", elem); }
       }
     }
@@ -1079,8 +1097,8 @@ namespace Hl7.Fhir.Model
           value = TotalGross;
           return TotalGross is not null;
         case "paymentTerms":
-          value = PaymentTerms;
-          return PaymentTerms is not null;
+          value = PaymentTermsElement;
+          return PaymentTermsElement is not null;
         case "note":
           value = Note;
           return Note?.Any() == true;
@@ -1107,7 +1125,7 @@ namespace Hl7.Fhir.Model
       if (TotalPriceComponent?.Any() == true) yield return new KeyValuePair<string,object>("totalPriceComponent",TotalPriceComponent);
       if (TotalNet is not null) yield return new KeyValuePair<string,object>("totalNet",TotalNet);
       if (TotalGross is not null) yield return new KeyValuePair<string,object>("totalGross",TotalGross);
-      if (PaymentTerms is not null) yield return new KeyValuePair<string,object>("paymentTerms",PaymentTerms);
+      if (PaymentTermsElement is not null) yield return new KeyValuePair<string,object>("paymentTerms",PaymentTermsElement);
       if (Note?.Any() == true) yield return new KeyValuePair<string,object>("note",Note);
     }
 

--- a/src/Hl7.Fhir.R4B/Model/Generated/Library.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/Library.cs
@@ -399,13 +399,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the library
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -440,13 +458,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=250, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this library is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the library
@@ -484,13 +520,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=270)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the library was approved by publisher
@@ -716,12 +770,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -762,12 +816,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -803,12 +857,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -844,12 +898,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -884,12 +938,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -949,8 +1003,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -958,14 +1012,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -1024,12 +1078,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4B/Model/Generated/Measure.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/Measure.cs
@@ -1313,13 +1313,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the measure
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1354,13 +1372,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=240, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this measure is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the measure
@@ -1398,13 +1434,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=260)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the measure was approved by publisher
@@ -1602,13 +1656,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("disclaimer", InSummary=true, Order=370)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Disclaimer
+    public Hl7.Fhir.Model.Markdown DisclaimerElement
     {
-      get { return _Disclaimer; }
-      set { _Disclaimer = value; OnPropertyChanged("Disclaimer"); }
+      get { return _DisclaimerElement; }
+      set { _DisclaimerElement = value; OnPropertyChanged("DisclaimerElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Disclaimer;
+    private Hl7.Fhir.Model.Markdown _DisclaimerElement;
+
+    /// <summary>
+    /// Disclaimer for use of the measure or its referenced content
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Disclaimer
+    {
+      get { return DisclaimerElement != null ? DisclaimerElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DisclaimerElement = null;
+        else
+          DisclaimerElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Disclaimer");
+      }
+    }
 
     /// <summary>
     /// proportion | ratio | continuous-variable | cohort
@@ -1717,26 +1789,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("rationale", InSummary=true, Order=430)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Rationale
+    public Hl7.Fhir.Model.Markdown RationaleElement
     {
-      get { return _Rationale; }
-      set { _Rationale = value; OnPropertyChanged("Rationale"); }
+      get { return _RationaleElement; }
+      set { _RationaleElement = value; OnPropertyChanged("RationaleElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Rationale;
+    private Hl7.Fhir.Model.Markdown _RationaleElement;
+
+    /// <summary>
+    /// Detailed description of why the measure exists
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Rationale
+    {
+      get { return RationaleElement != null ? RationaleElement.Value : null; }
+      set
+      {
+        if (value == null)
+          RationaleElement = null;
+        else
+          RationaleElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Rationale");
+      }
+    }
 
     /// <summary>
     /// Summary of clinical guidelines
     /// </summary>
     [FhirElement("clinicalRecommendationStatement", InSummary=true, Order=440)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown ClinicalRecommendationStatement
+    public Hl7.Fhir.Model.Markdown ClinicalRecommendationStatementElement
     {
-      get { return _ClinicalRecommendationStatement; }
-      set { _ClinicalRecommendationStatement = value; OnPropertyChanged("ClinicalRecommendationStatement"); }
+      get { return _ClinicalRecommendationStatementElement; }
+      set { _ClinicalRecommendationStatementElement = value; OnPropertyChanged("ClinicalRecommendationStatementElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _ClinicalRecommendationStatement;
+    private Hl7.Fhir.Model.Markdown _ClinicalRecommendationStatementElement;
+
+    /// <summary>
+    /// Summary of clinical guidelines
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string ClinicalRecommendationStatement
+    {
+      get { return ClinicalRecommendationStatementElement != null ? ClinicalRecommendationStatementElement.Value : null; }
+      set
+      {
+        if (value == null)
+          ClinicalRecommendationStatementElement = null;
+        else
+          ClinicalRecommendationStatementElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("ClinicalRecommendationStatement");
+      }
+    }
 
     /// <summary>
     /// increase | decrease
@@ -1757,26 +1865,62 @@ namespace Hl7.Fhir.Model
     [FhirElement("definition", InSummary=true, Order=460)]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
-    public List<Hl7.Fhir.Model.Markdown> Definition
+    public List<Hl7.Fhir.Model.Markdown> DefinitionElement
     {
-      get { if(_Definition==null) _Definition = new List<Hl7.Fhir.Model.Markdown>(); return _Definition; }
-      set { _Definition = value; OnPropertyChanged("Definition"); }
+      get { if(_DefinitionElement==null) _DefinitionElement = new List<Hl7.Fhir.Model.Markdown>(); return _DefinitionElement; }
+      set { _DefinitionElement = value; OnPropertyChanged("DefinitionElement"); }
     }
 
-    private List<Hl7.Fhir.Model.Markdown> _Definition;
+    private List<Hl7.Fhir.Model.Markdown> _DefinitionElement;
+
+    /// <summary>
+    /// Defined terms used in the measure documentation
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public IEnumerable<string> Definition
+    {
+      get { return DefinitionElement != null ? DefinitionElement.Select(elem => elem.Value) : null; }
+      set
+      {
+        if (value == null)
+          DefinitionElement = null;
+        else
+          DefinitionElement = new List<Hl7.Fhir.Model.Markdown>(value.Select(elem=>new Hl7.Fhir.Model.Markdown(elem)));
+        OnPropertyChanged("Definition");
+      }
+    }
 
     /// <summary>
     /// Additional guidance for implementers
     /// </summary>
     [FhirElement("guidance", InSummary=true, Order=470)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Guidance
+    public Hl7.Fhir.Model.Markdown GuidanceElement
     {
-      get { return _Guidance; }
-      set { _Guidance = value; OnPropertyChanged("Guidance"); }
+      get { return _GuidanceElement; }
+      set { _GuidanceElement = value; OnPropertyChanged("GuidanceElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Guidance;
+    private Hl7.Fhir.Model.Markdown _GuidanceElement;
+
+    /// <summary>
+    /// Additional guidance for implementers
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Guidance
+    {
+      get { return GuidanceElement != null ? GuidanceElement.Value : null; }
+      set
+      {
+        if (value == null)
+          GuidanceElement = null;
+        else
+          GuidanceElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Guidance");
+      }
+    }
 
     /// <summary>
     /// Population criteria group
@@ -1828,12 +1972,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1844,17 +1988,17 @@ namespace Hl7.Fhir.Model
       if(Endorser != null) dest.Endorser = new List<Hl7.Fhir.Model.ContactDetail>(Endorser.DeepCopy());
       if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
       if(LibraryElement != null) dest.LibraryElement = new List<Hl7.Fhir.Model.Canonical>(LibraryElement.DeepCopy());
-      if(Disclaimer != null) dest.Disclaimer = (Hl7.Fhir.Model.Markdown)Disclaimer.DeepCopy();
+      if(DisclaimerElement != null) dest.DisclaimerElement = (Hl7.Fhir.Model.Markdown)DisclaimerElement.DeepCopy();
       if(Scoring != null) dest.Scoring = (Hl7.Fhir.Model.CodeableConcept)Scoring.DeepCopy();
       if(CompositeScoring != null) dest.CompositeScoring = (Hl7.Fhir.Model.CodeableConcept)CompositeScoring.DeepCopy();
       if(Type != null) dest.Type = new List<Hl7.Fhir.Model.CodeableConcept>(Type.DeepCopy());
       if(RiskAdjustmentElement != null) dest.RiskAdjustmentElement = (Hl7.Fhir.Model.FhirString)RiskAdjustmentElement.DeepCopy();
       if(RateAggregationElement != null) dest.RateAggregationElement = (Hl7.Fhir.Model.FhirString)RateAggregationElement.DeepCopy();
-      if(Rationale != null) dest.Rationale = (Hl7.Fhir.Model.Markdown)Rationale.DeepCopy();
-      if(ClinicalRecommendationStatement != null) dest.ClinicalRecommendationStatement = (Hl7.Fhir.Model.Markdown)ClinicalRecommendationStatement.DeepCopy();
+      if(RationaleElement != null) dest.RationaleElement = (Hl7.Fhir.Model.Markdown)RationaleElement.DeepCopy();
+      if(ClinicalRecommendationStatementElement != null) dest.ClinicalRecommendationStatementElement = (Hl7.Fhir.Model.Markdown)ClinicalRecommendationStatementElement.DeepCopy();
       if(ImprovementNotation != null) dest.ImprovementNotation = (Hl7.Fhir.Model.CodeableConcept)ImprovementNotation.DeepCopy();
-      if(Definition != null) dest.Definition = new List<Hl7.Fhir.Model.Markdown>(Definition.DeepCopy());
-      if(Guidance != null) dest.Guidance = (Hl7.Fhir.Model.Markdown)Guidance.DeepCopy();
+      if(DefinitionElement != null) dest.DefinitionElement = new List<Hl7.Fhir.Model.Markdown>(DefinitionElement.DeepCopy());
+      if(GuidanceElement != null) dest.GuidanceElement = (Hl7.Fhir.Model.Markdown)GuidanceElement.DeepCopy();
       if(Group != null) dest.Group = new List<Hl7.Fhir.Model.Measure.GroupComponent>(Group.DeepCopy());
       if(SupplementalData != null) dest.SupplementalData = new List<Hl7.Fhir.Model.Measure.SupplementalDataComponent>(SupplementalData.DeepCopy());
       return dest;
@@ -1884,12 +2028,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1900,17 +2044,17 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Endorser, otherT.Endorser)) return false;
       if( !DeepComparable.Matches(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.Matches(LibraryElement, otherT.LibraryElement)) return false;
-      if( !DeepComparable.Matches(Disclaimer, otherT.Disclaimer)) return false;
+      if( !DeepComparable.Matches(DisclaimerElement, otherT.DisclaimerElement)) return false;
       if( !DeepComparable.Matches(Scoring, otherT.Scoring)) return false;
       if( !DeepComparable.Matches(CompositeScoring, otherT.CompositeScoring)) return false;
       if( !DeepComparable.Matches(Type, otherT.Type)) return false;
       if( !DeepComparable.Matches(RiskAdjustmentElement, otherT.RiskAdjustmentElement)) return false;
       if( !DeepComparable.Matches(RateAggregationElement, otherT.RateAggregationElement)) return false;
-      if( !DeepComparable.Matches(Rationale, otherT.Rationale)) return false;
-      if( !DeepComparable.Matches(ClinicalRecommendationStatement, otherT.ClinicalRecommendationStatement)) return false;
+      if( !DeepComparable.Matches(RationaleElement, otherT.RationaleElement)) return false;
+      if( !DeepComparable.Matches(ClinicalRecommendationStatementElement, otherT.ClinicalRecommendationStatementElement)) return false;
       if( !DeepComparable.Matches(ImprovementNotation, otherT.ImprovementNotation)) return false;
-      if( !DeepComparable.Matches(Definition, otherT.Definition)) return false;
-      if( !DeepComparable.Matches(Guidance, otherT.Guidance)) return false;
+      if( !DeepComparable.Matches(DefinitionElement, otherT.DefinitionElement)) return false;
+      if( !DeepComparable.Matches(GuidanceElement, otherT.GuidanceElement)) return false;
       if( !DeepComparable.Matches(Group, otherT.Group)) return false;
       if( !DeepComparable.Matches(SupplementalData, otherT.SupplementalData)) return false;
 
@@ -1935,12 +2079,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1951,17 +2095,17 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Endorser, otherT.Endorser)) return false;
       if( !DeepComparable.IsExactly(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.IsExactly(LibraryElement, otherT.LibraryElement)) return false;
-      if( !DeepComparable.IsExactly(Disclaimer, otherT.Disclaimer)) return false;
+      if( !DeepComparable.IsExactly(DisclaimerElement, otherT.DisclaimerElement)) return false;
       if( !DeepComparable.IsExactly(Scoring, otherT.Scoring)) return false;
       if( !DeepComparable.IsExactly(CompositeScoring, otherT.CompositeScoring)) return false;
       if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
       if( !DeepComparable.IsExactly(RiskAdjustmentElement, otherT.RiskAdjustmentElement)) return false;
       if( !DeepComparable.IsExactly(RateAggregationElement, otherT.RateAggregationElement)) return false;
-      if( !DeepComparable.IsExactly(Rationale, otherT.Rationale)) return false;
-      if( !DeepComparable.IsExactly(ClinicalRecommendationStatement, otherT.ClinicalRecommendationStatement)) return false;
+      if( !DeepComparable.IsExactly(RationaleElement, otherT.RationaleElement)) return false;
+      if( !DeepComparable.IsExactly(ClinicalRecommendationStatementElement, otherT.ClinicalRecommendationStatementElement)) return false;
       if( !DeepComparable.IsExactly(ImprovementNotation, otherT.ImprovementNotation)) return false;
-      if( !DeepComparable.IsExactly(Definition, otherT.Definition)) return false;
-      if( !DeepComparable.IsExactly(Guidance, otherT.Guidance)) return false;
+      if( !DeepComparable.IsExactly(DefinitionElement, otherT.DefinitionElement)) return false;
+      if( !DeepComparable.IsExactly(GuidanceElement, otherT.GuidanceElement)) return false;
       if( !DeepComparable.IsExactly(Group, otherT.Group)) return false;
       if( !DeepComparable.IsExactly(SupplementalData, otherT.SupplementalData)) return false;
 
@@ -1986,12 +2130,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -2002,17 +2146,17 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Endorser) { if (elem != null) yield return elem; }
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return elem; }
         foreach (var elem in LibraryElement) { if (elem != null) yield return elem; }
-        if (Disclaimer != null) yield return Disclaimer;
+        if (DisclaimerElement != null) yield return DisclaimerElement;
         if (Scoring != null) yield return Scoring;
         if (CompositeScoring != null) yield return CompositeScoring;
         foreach (var elem in Type) { if (elem != null) yield return elem; }
         if (RiskAdjustmentElement != null) yield return RiskAdjustmentElement;
         if (RateAggregationElement != null) yield return RateAggregationElement;
-        if (Rationale != null) yield return Rationale;
-        if (ClinicalRecommendationStatement != null) yield return ClinicalRecommendationStatement;
+        if (RationaleElement != null) yield return RationaleElement;
+        if (ClinicalRecommendationStatementElement != null) yield return ClinicalRecommendationStatementElement;
         if (ImprovementNotation != null) yield return ImprovementNotation;
-        foreach (var elem in Definition) { if (elem != null) yield return elem; }
-        if (Guidance != null) yield return Guidance;
+        foreach (var elem in DefinitionElement) { if (elem != null) yield return elem; }
+        if (GuidanceElement != null) yield return GuidanceElement;
         foreach (var elem in Group) { if (elem != null) yield return elem; }
         foreach (var elem in SupplementalData) { if (elem != null) yield return elem; }
       }
@@ -2036,12 +2180,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -2052,17 +2196,17 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Endorser) { if (elem != null) yield return new ElementValue("endorser", elem); }
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return new ElementValue("relatedArtifact", elem); }
         foreach (var elem in LibraryElement) { if (elem != null) yield return new ElementValue("library", elem); }
-        if (Disclaimer != null) yield return new ElementValue("disclaimer", Disclaimer);
+        if (DisclaimerElement != null) yield return new ElementValue("disclaimer", DisclaimerElement);
         if (Scoring != null) yield return new ElementValue("scoring", Scoring);
         if (CompositeScoring != null) yield return new ElementValue("compositeScoring", CompositeScoring);
         foreach (var elem in Type) { if (elem != null) yield return new ElementValue("type", elem); }
         if (RiskAdjustmentElement != null) yield return new ElementValue("riskAdjustment", RiskAdjustmentElement);
         if (RateAggregationElement != null) yield return new ElementValue("rateAggregation", RateAggregationElement);
-        if (Rationale != null) yield return new ElementValue("rationale", Rationale);
-        if (ClinicalRecommendationStatement != null) yield return new ElementValue("clinicalRecommendationStatement", ClinicalRecommendationStatement);
+        if (RationaleElement != null) yield return new ElementValue("rationale", RationaleElement);
+        if (ClinicalRecommendationStatementElement != null) yield return new ElementValue("clinicalRecommendationStatement", ClinicalRecommendationStatementElement);
         if (ImprovementNotation != null) yield return new ElementValue("improvementNotation", ImprovementNotation);
-        foreach (var elem in Definition) { if (elem != null) yield return new ElementValue("definition", elem); }
-        if (Guidance != null) yield return new ElementValue("guidance", Guidance);
+        foreach (var elem in DefinitionElement) { if (elem != null) yield return new ElementValue("definition", elem); }
+        if (GuidanceElement != null) yield return new ElementValue("guidance", GuidanceElement);
         foreach (var elem in Group) { if (elem != null) yield return new ElementValue("group", elem); }
         foreach (var elem in SupplementalData) { if (elem != null) yield return new ElementValue("supplementalData", elem); }
       }
@@ -2109,8 +2253,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2118,14 +2262,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -2157,8 +2301,8 @@ namespace Hl7.Fhir.Model
           value = LibraryElement;
           return LibraryElement?.Any() == true;
         case "disclaimer":
-          value = Disclaimer;
-          return Disclaimer is not null;
+          value = DisclaimerElement;
+          return DisclaimerElement is not null;
         case "scoring":
           value = Scoring;
           return Scoring is not null;
@@ -2175,20 +2319,20 @@ namespace Hl7.Fhir.Model
           value = RateAggregationElement;
           return RateAggregationElement is not null;
         case "rationale":
-          value = Rationale;
-          return Rationale is not null;
+          value = RationaleElement;
+          return RationaleElement is not null;
         case "clinicalRecommendationStatement":
-          value = ClinicalRecommendationStatement;
-          return ClinicalRecommendationStatement is not null;
+          value = ClinicalRecommendationStatementElement;
+          return ClinicalRecommendationStatementElement is not null;
         case "improvementNotation":
           value = ImprovementNotation;
           return ImprovementNotation is not null;
         case "definition":
-          value = Definition;
-          return Definition?.Any() == true;
+          value = DefinitionElement;
+          return DefinitionElement?.Any() == true;
         case "guidance":
-          value = Guidance;
-          return Guidance is not null;
+          value = GuidanceElement;
+          return GuidanceElement is not null;
         case "group":
           value = Group;
           return Group?.Any() == true;
@@ -2216,12 +2360,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);
@@ -2232,17 +2376,17 @@ namespace Hl7.Fhir.Model
       if (Endorser?.Any() == true) yield return new KeyValuePair<string,object>("endorser",Endorser);
       if (RelatedArtifact?.Any() == true) yield return new KeyValuePair<string,object>("relatedArtifact",RelatedArtifact);
       if (LibraryElement?.Any() == true) yield return new KeyValuePair<string,object>("library",LibraryElement);
-      if (Disclaimer is not null) yield return new KeyValuePair<string,object>("disclaimer",Disclaimer);
+      if (DisclaimerElement is not null) yield return new KeyValuePair<string,object>("disclaimer",DisclaimerElement);
       if (Scoring is not null) yield return new KeyValuePair<string,object>("scoring",Scoring);
       if (CompositeScoring is not null) yield return new KeyValuePair<string,object>("compositeScoring",CompositeScoring);
       if (Type?.Any() == true) yield return new KeyValuePair<string,object>("type",Type);
       if (RiskAdjustmentElement is not null) yield return new KeyValuePair<string,object>("riskAdjustment",RiskAdjustmentElement);
       if (RateAggregationElement is not null) yield return new KeyValuePair<string,object>("rateAggregation",RateAggregationElement);
-      if (Rationale is not null) yield return new KeyValuePair<string,object>("rationale",Rationale);
-      if (ClinicalRecommendationStatement is not null) yield return new KeyValuePair<string,object>("clinicalRecommendationStatement",ClinicalRecommendationStatement);
+      if (RationaleElement is not null) yield return new KeyValuePair<string,object>("rationale",RationaleElement);
+      if (ClinicalRecommendationStatementElement is not null) yield return new KeyValuePair<string,object>("clinicalRecommendationStatement",ClinicalRecommendationStatementElement);
       if (ImprovementNotation is not null) yield return new KeyValuePair<string,object>("improvementNotation",ImprovementNotation);
-      if (Definition?.Any() == true) yield return new KeyValuePair<string,object>("definition",Definition);
-      if (Guidance is not null) yield return new KeyValuePair<string,object>("guidance",Guidance);
+      if (DefinitionElement?.Any() == true) yield return new KeyValuePair<string,object>("definition",DefinitionElement);
+      if (GuidanceElement is not null) yield return new KeyValuePair<string,object>("guidance",GuidanceElement);
       if (Group?.Any() == true) yield return new KeyValuePair<string,object>("group",Group);
       if (SupplementalData?.Any() == true) yield return new KeyValuePair<string,object>("supplementalData",SupplementalData);
     }

--- a/src/Hl7.Fhir.R4B/Model/Generated/MedicationKnowledge.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/MedicationKnowledge.cs
@@ -2612,13 +2612,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("preparationInstruction", Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown PreparationInstruction
+    public Hl7.Fhir.Model.Markdown PreparationInstructionElement
     {
-      get { return _PreparationInstruction; }
-      set { _PreparationInstruction = value; OnPropertyChanged("PreparationInstruction"); }
+      get { return _PreparationInstructionElement; }
+      set { _PreparationInstructionElement = value; OnPropertyChanged("PreparationInstructionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _PreparationInstruction;
+    private Hl7.Fhir.Model.Markdown _PreparationInstructionElement;
+
+    /// <summary>
+    /// The instructions for preparing the medication
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string PreparationInstruction
+    {
+      get { return PreparationInstructionElement != null ? PreparationInstructionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PreparationInstructionElement = null;
+        else
+          PreparationInstructionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("PreparationInstruction");
+      }
+    }
 
     /// <summary>
     /// The intended or approved route of administration
@@ -2782,7 +2800,7 @@ namespace Hl7.Fhir.Model
       if(ProductType != null) dest.ProductType = new List<Hl7.Fhir.Model.CodeableConcept>(ProductType.DeepCopy());
       if(Monograph != null) dest.Monograph = new List<Hl7.Fhir.Model.MedicationKnowledge.MonographComponent>(Monograph.DeepCopy());
       if(Ingredient != null) dest.Ingredient = new List<Hl7.Fhir.Model.MedicationKnowledge.IngredientComponent>(Ingredient.DeepCopy());
-      if(PreparationInstruction != null) dest.PreparationInstruction = (Hl7.Fhir.Model.Markdown)PreparationInstruction.DeepCopy();
+      if(PreparationInstructionElement != null) dest.PreparationInstructionElement = (Hl7.Fhir.Model.Markdown)PreparationInstructionElement.DeepCopy();
       if(IntendedRoute != null) dest.IntendedRoute = new List<Hl7.Fhir.Model.CodeableConcept>(IntendedRoute.DeepCopy());
       if(Cost != null) dest.Cost = new List<Hl7.Fhir.Model.MedicationKnowledge.CostComponent>(Cost.DeepCopy());
       if(MonitoringProgram != null) dest.MonitoringProgram = new List<Hl7.Fhir.Model.MedicationKnowledge.MonitoringProgramComponent>(MonitoringProgram.DeepCopy());
@@ -2819,7 +2837,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(ProductType, otherT.ProductType)) return false;
       if( !DeepComparable.Matches(Monograph, otherT.Monograph)) return false;
       if( !DeepComparable.Matches(Ingredient, otherT.Ingredient)) return false;
-      if( !DeepComparable.Matches(PreparationInstruction, otherT.PreparationInstruction)) return false;
+      if( !DeepComparable.Matches(PreparationInstructionElement, otherT.PreparationInstructionElement)) return false;
       if( !DeepComparable.Matches(IntendedRoute, otherT.IntendedRoute)) return false;
       if( !DeepComparable.Matches(Cost, otherT.Cost)) return false;
       if( !DeepComparable.Matches(MonitoringProgram, otherT.MonitoringProgram)) return false;
@@ -2851,7 +2869,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(ProductType, otherT.ProductType)) return false;
       if( !DeepComparable.IsExactly(Monograph, otherT.Monograph)) return false;
       if( !DeepComparable.IsExactly(Ingredient, otherT.Ingredient)) return false;
-      if( !DeepComparable.IsExactly(PreparationInstruction, otherT.PreparationInstruction)) return false;
+      if( !DeepComparable.IsExactly(PreparationInstructionElement, otherT.PreparationInstructionElement)) return false;
       if( !DeepComparable.IsExactly(IntendedRoute, otherT.IntendedRoute)) return false;
       if( !DeepComparable.IsExactly(Cost, otherT.Cost)) return false;
       if( !DeepComparable.IsExactly(MonitoringProgram, otherT.MonitoringProgram)) return false;
@@ -2883,7 +2901,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in ProductType) { if (elem != null) yield return elem; }
         foreach (var elem in Monograph) { if (elem != null) yield return elem; }
         foreach (var elem in Ingredient) { if (elem != null) yield return elem; }
-        if (PreparationInstruction != null) yield return PreparationInstruction;
+        if (PreparationInstructionElement != null) yield return PreparationInstructionElement;
         foreach (var elem in IntendedRoute) { if (elem != null) yield return elem; }
         foreach (var elem in Cost) { if (elem != null) yield return elem; }
         foreach (var elem in MonitoringProgram) { if (elem != null) yield return elem; }
@@ -2914,7 +2932,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in ProductType) { if (elem != null) yield return new ElementValue("productType", elem); }
         foreach (var elem in Monograph) { if (elem != null) yield return new ElementValue("monograph", elem); }
         foreach (var elem in Ingredient) { if (elem != null) yield return new ElementValue("ingredient", elem); }
-        if (PreparationInstruction != null) yield return new ElementValue("preparationInstruction", PreparationInstruction);
+        if (PreparationInstructionElement != null) yield return new ElementValue("preparationInstruction", PreparationInstructionElement);
         foreach (var elem in IntendedRoute) { if (elem != null) yield return new ElementValue("intendedRoute", elem); }
         foreach (var elem in Cost) { if (elem != null) yield return new ElementValue("cost", elem); }
         foreach (var elem in MonitoringProgram) { if (elem != null) yield return new ElementValue("monitoringProgram", elem); }
@@ -2966,8 +2984,8 @@ namespace Hl7.Fhir.Model
           value = Ingredient;
           return Ingredient?.Any() == true;
         case "preparationInstruction":
-          value = PreparationInstruction;
-          return PreparationInstruction is not null;
+          value = PreparationInstructionElement;
+          return PreparationInstructionElement is not null;
         case "intendedRoute":
           value = IntendedRoute;
           return IntendedRoute?.Any() == true;
@@ -3018,7 +3036,7 @@ namespace Hl7.Fhir.Model
       if (ProductType?.Any() == true) yield return new KeyValuePair<string,object>("productType",ProductType);
       if (Monograph?.Any() == true) yield return new KeyValuePair<string,object>("monograph",Monograph);
       if (Ingredient?.Any() == true) yield return new KeyValuePair<string,object>("ingredient",Ingredient);
-      if (PreparationInstruction is not null) yield return new KeyValuePair<string,object>("preparationInstruction",PreparationInstruction);
+      if (PreparationInstructionElement is not null) yield return new KeyValuePair<string,object>("preparationInstruction",PreparationInstructionElement);
       if (IntendedRoute?.Any() == true) yield return new KeyValuePair<string,object>("intendedRoute",IntendedRoute);
       if (Cost?.Any() == true) yield return new KeyValuePair<string,object>("cost",Cost);
       if (MonitoringProgram?.Any() == true) yield return new KeyValuePair<string,object>("monitoringProgram",MonitoringProgram);

--- a/src/Hl7.Fhir.R4B/Model/Generated/MedicinalProductDefinition.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/MedicinalProductDefinition.cs
@@ -1255,13 +1255,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=150)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// General description of this product
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The dose form for a single part product, or combined form of a multiple part product
@@ -1295,13 +1313,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("indication", InSummary=true, Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Indication
+    public Hl7.Fhir.Model.Markdown IndicationElement
     {
-      get { return _Indication; }
-      set { _Indication = value; OnPropertyChanged("Indication"); }
+      get { return _IndicationElement; }
+      set { _IndicationElement = value; OnPropertyChanged("IndicationElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Indication;
+    private Hl7.Fhir.Model.Markdown _IndicationElement;
+
+    /// <summary>
+    /// Description of indication(s) for this product, used when structured indications are not required
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Indication
+    {
+      get { return IndicationElement != null ? IndicationElement.Value : null; }
+      set
+      {
+        if (value == null)
+          IndicationElement = null;
+        else
+          IndicationElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Indication");
+      }
+    }
 
     /// <summary>
     /// The legal status of supply of the medicinal product as classified by the regulator
@@ -1574,10 +1610,10 @@ namespace Hl7.Fhir.Model
       if(VersionElement != null) dest.VersionElement = (Hl7.Fhir.Model.FhirString)VersionElement.DeepCopy();
       if(Status != null) dest.Status = (Hl7.Fhir.Model.CodeableConcept)Status.DeepCopy();
       if(StatusDateElement != null) dest.StatusDateElement = (Hl7.Fhir.Model.FhirDateTime)StatusDateElement.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(CombinedPharmaceuticalDoseForm != null) dest.CombinedPharmaceuticalDoseForm = (Hl7.Fhir.Model.CodeableConcept)CombinedPharmaceuticalDoseForm.DeepCopy();
       if(Route != null) dest.Route = new List<Hl7.Fhir.Model.CodeableConcept>(Route.DeepCopy());
-      if(Indication != null) dest.Indication = (Hl7.Fhir.Model.Markdown)Indication.DeepCopy();
+      if(IndicationElement != null) dest.IndicationElement = (Hl7.Fhir.Model.Markdown)IndicationElement.DeepCopy();
       if(LegalStatusOfSupply != null) dest.LegalStatusOfSupply = (Hl7.Fhir.Model.CodeableConcept)LegalStatusOfSupply.DeepCopy();
       if(AdditionalMonitoringIndicator != null) dest.AdditionalMonitoringIndicator = (Hl7.Fhir.Model.CodeableConcept)AdditionalMonitoringIndicator.DeepCopy();
       if(SpecialMeasures != null) dest.SpecialMeasures = new List<Hl7.Fhir.Model.CodeableConcept>(SpecialMeasures.DeepCopy());
@@ -1617,10 +1653,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(VersionElement, otherT.VersionElement)) return false;
       if( !DeepComparable.Matches(Status, otherT.Status)) return false;
       if( !DeepComparable.Matches(StatusDateElement, otherT.StatusDateElement)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(CombinedPharmaceuticalDoseForm, otherT.CombinedPharmaceuticalDoseForm)) return false;
       if( !DeepComparable.Matches(Route, otherT.Route)) return false;
-      if( !DeepComparable.Matches(Indication, otherT.Indication)) return false;
+      if( !DeepComparable.Matches(IndicationElement, otherT.IndicationElement)) return false;
       if( !DeepComparable.Matches(LegalStatusOfSupply, otherT.LegalStatusOfSupply)) return false;
       if( !DeepComparable.Matches(AdditionalMonitoringIndicator, otherT.AdditionalMonitoringIndicator)) return false;
       if( !DeepComparable.Matches(SpecialMeasures, otherT.SpecialMeasures)) return false;
@@ -1655,10 +1691,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(VersionElement, otherT.VersionElement)) return false;
       if( !DeepComparable.IsExactly(Status, otherT.Status)) return false;
       if( !DeepComparable.IsExactly(StatusDateElement, otherT.StatusDateElement)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(CombinedPharmaceuticalDoseForm, otherT.CombinedPharmaceuticalDoseForm)) return false;
       if( !DeepComparable.IsExactly(Route, otherT.Route)) return false;
-      if( !DeepComparable.IsExactly(Indication, otherT.Indication)) return false;
+      if( !DeepComparable.IsExactly(IndicationElement, otherT.IndicationElement)) return false;
       if( !DeepComparable.IsExactly(LegalStatusOfSupply, otherT.LegalStatusOfSupply)) return false;
       if( !DeepComparable.IsExactly(AdditionalMonitoringIndicator, otherT.AdditionalMonitoringIndicator)) return false;
       if( !DeepComparable.IsExactly(SpecialMeasures, otherT.SpecialMeasures)) return false;
@@ -1693,10 +1729,10 @@ namespace Hl7.Fhir.Model
         if (VersionElement != null) yield return VersionElement;
         if (Status != null) yield return Status;
         if (StatusDateElement != null) yield return StatusDateElement;
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         if (CombinedPharmaceuticalDoseForm != null) yield return CombinedPharmaceuticalDoseForm;
         foreach (var elem in Route) { if (elem != null) yield return elem; }
-        if (Indication != null) yield return Indication;
+        if (IndicationElement != null) yield return IndicationElement;
         if (LegalStatusOfSupply != null) yield return LegalStatusOfSupply;
         if (AdditionalMonitoringIndicator != null) yield return AdditionalMonitoringIndicator;
         foreach (var elem in SpecialMeasures) { if (elem != null) yield return elem; }
@@ -1730,10 +1766,10 @@ namespace Hl7.Fhir.Model
         if (VersionElement != null) yield return new ElementValue("version", VersionElement);
         if (Status != null) yield return new ElementValue("status", Status);
         if (StatusDateElement != null) yield return new ElementValue("statusDate", StatusDateElement);
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         if (CombinedPharmaceuticalDoseForm != null) yield return new ElementValue("combinedPharmaceuticalDoseForm", CombinedPharmaceuticalDoseForm);
         foreach (var elem in Route) { if (elem != null) yield return new ElementValue("route", elem); }
-        if (Indication != null) yield return new ElementValue("indication", Indication);
+        if (IndicationElement != null) yield return new ElementValue("indication", IndicationElement);
         if (LegalStatusOfSupply != null) yield return new ElementValue("legalStatusOfSupply", LegalStatusOfSupply);
         if (AdditionalMonitoringIndicator != null) yield return new ElementValue("additionalMonitoringIndicator", AdditionalMonitoringIndicator);
         foreach (var elem in SpecialMeasures) { if (elem != null) yield return new ElementValue("specialMeasures", elem); }
@@ -1778,8 +1814,8 @@ namespace Hl7.Fhir.Model
           value = StatusDateElement;
           return StatusDateElement is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "combinedPharmaceuticalDoseForm":
           value = CombinedPharmaceuticalDoseForm;
           return CombinedPharmaceuticalDoseForm is not null;
@@ -1787,8 +1823,8 @@ namespace Hl7.Fhir.Model
           value = Route;
           return Route?.Any() == true;
         case "indication":
-          value = Indication;
-          return Indication is not null;
+          value = IndicationElement;
+          return IndicationElement is not null;
         case "legalStatusOfSupply":
           value = LegalStatusOfSupply;
           return LegalStatusOfSupply is not null;
@@ -1858,10 +1894,10 @@ namespace Hl7.Fhir.Model
       if (VersionElement is not null) yield return new KeyValuePair<string,object>("version",VersionElement);
       if (Status is not null) yield return new KeyValuePair<string,object>("status",Status);
       if (StatusDateElement is not null) yield return new KeyValuePair<string,object>("statusDate",StatusDateElement);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (CombinedPharmaceuticalDoseForm is not null) yield return new KeyValuePair<string,object>("combinedPharmaceuticalDoseForm",CombinedPharmaceuticalDoseForm);
       if (Route?.Any() == true) yield return new KeyValuePair<string,object>("route",Route);
-      if (Indication is not null) yield return new KeyValuePair<string,object>("indication",Indication);
+      if (IndicationElement is not null) yield return new KeyValuePair<string,object>("indication",IndicationElement);
       if (LegalStatusOfSupply is not null) yield return new KeyValuePair<string,object>("legalStatusOfSupply",LegalStatusOfSupply);
       if (AdditionalMonitoringIndicator is not null) yield return new KeyValuePair<string,object>("additionalMonitoringIndicator",AdditionalMonitoringIndicator);
       if (SpecialMeasures?.Any() == true) yield return new KeyValuePair<string,object>("specialMeasures",SpecialMeasures);

--- a/src/Hl7.Fhir.R4B/Model/Generated/MessageDefinition.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/MessageDefinition.cs
@@ -383,13 +383,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("situation", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Situation
+      public Hl7.Fhir.Model.Markdown SituationElement
       {
-        get { return _Situation; }
-        set { _Situation = value; OnPropertyChanged("Situation"); }
+        get { return _SituationElement; }
+        set { _SituationElement = value; OnPropertyChanged("SituationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Situation;
+      private Hl7.Fhir.Model.Markdown _SituationElement;
+
+      /// <summary>
+      /// When should this response be used
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Situation
+      {
+        get { return SituationElement != null ? SituationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            SituationElement = null;
+          else
+            SituationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Situation");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -402,7 +420,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(MessageElement != null) dest.MessageElement = (Hl7.Fhir.Model.Canonical)MessageElement.DeepCopy();
-        if(Situation != null) dest.Situation = (Hl7.Fhir.Model.Markdown)Situation.DeepCopy();
+        if(SituationElement != null) dest.SituationElement = (Hl7.Fhir.Model.Markdown)SituationElement.DeepCopy();
         return dest;
       }
 
@@ -419,7 +437,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(MessageElement, otherT.MessageElement)) return false;
-        if( !DeepComparable.Matches(Situation, otherT.Situation)) return false;
+        if( !DeepComparable.Matches(SituationElement, otherT.SituationElement)) return false;
 
         return true;
       }
@@ -431,7 +449,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(MessageElement, otherT.MessageElement)) return false;
-        if( !DeepComparable.IsExactly(Situation, otherT.Situation)) return false;
+        if( !DeepComparable.IsExactly(SituationElement, otherT.SituationElement)) return false;
 
         return true;
       }
@@ -443,7 +461,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (MessageElement != null) yield return MessageElement;
-          if (Situation != null) yield return Situation;
+          if (SituationElement != null) yield return SituationElement;
         }
       }
 
@@ -454,7 +472,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (MessageElement != null) yield return new ElementValue("message", MessageElement);
-          if (Situation != null) yield return new ElementValue("situation", Situation);
+          if (SituationElement != null) yield return new ElementValue("situation", SituationElement);
         }
       }
 
@@ -466,8 +484,8 @@ namespace Hl7.Fhir.Model
             value = MessageElement;
             return MessageElement is not null;
           case "situation":
-            value = Situation;
-            return Situation is not null;
+            value = SituationElement;
+            return SituationElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -478,7 +496,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (MessageElement is not null) yield return new KeyValuePair<string,object>("message",MessageElement);
-        if (Situation is not null) yield return new KeyValuePair<string,object>("situation",Situation);
+        if (SituationElement is not null) yield return new KeyValuePair<string,object>("situation",SituationElement);
       }
 
     }
@@ -799,13 +817,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the message definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -840,26 +876,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", InSummary=true, Order=230, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this message definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=240)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Definition this one is based on
@@ -1085,11 +1157,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(BaseElement != null) dest.BaseElement = (Hl7.Fhir.Model.Canonical)BaseElement.DeepCopy();
       if(ParentElement != null) dest.ParentElement = new List<Hl7.Fhir.Model.Canonical>(ParentElement.DeepCopy());
       if(Event != null) dest.Event = (Hl7.Fhir.Model.DataType)Event.DeepCopy();
@@ -1124,11 +1196,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.Matches(ParentElement, otherT.ParentElement)) return false;
       if( !DeepComparable.Matches(Event, otherT.Event)) return false;
@@ -1158,11 +1230,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.IsExactly(ParentElement, otherT.ParentElement)) return false;
       if( !DeepComparable.IsExactly(Event, otherT.Event)) return false;
@@ -1192,11 +1264,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (BaseElement != null) yield return BaseElement;
         foreach (var elem in ParentElement) { if (elem != null) yield return elem; }
         if (Event != null) yield return Event;
@@ -1225,11 +1297,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (BaseElement != null) yield return new ElementValue("base", BaseElement);
         foreach (var elem in ParentElement) { if (elem != null) yield return new ElementValue("parent", elem); }
         if (Event != null) yield return new ElementValue("event", Event);
@@ -1279,8 +1351,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1288,11 +1360,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "base":
           value = BaseElement;
           return BaseElement is not null;
@@ -1337,11 +1409,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (BaseElement is not null) yield return new KeyValuePair<string,object>("base",BaseElement);
       if (ParentElement?.Any() == true) yield return new KeyValuePair<string,object>("parent",ParentElement);
       if (Event is not null) yield return new KeyValuePair<string,object>("event",Event);

--- a/src/Hl7.Fhir.R4B/Model/Generated/NamingSystem.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/NamingSystem.cs
@@ -613,13 +613,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=170)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the naming system
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -712,7 +730,7 @@ namespace Hl7.Fhir.Model
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
       if(ResponsibleElement != null) dest.ResponsibleElement = (Hl7.Fhir.Model.FhirString)ResponsibleElement.DeepCopy();
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
@@ -740,7 +758,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
       if( !DeepComparable.Matches(ResponsibleElement, otherT.ResponsibleElement)) return false;
       if( !DeepComparable.Matches(Type, otherT.Type)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
@@ -763,7 +781,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
       if( !DeepComparable.IsExactly(ResponsibleElement, otherT.ResponsibleElement)) return false;
       if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
@@ -786,7 +804,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
         if (ResponsibleElement != null) yield return ResponsibleElement;
         if (Type != null) yield return Type;
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
         if (UsageElement != null) yield return UsageElement;
@@ -808,7 +826,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
         if (ResponsibleElement != null) yield return new ElementValue("responsible", ResponsibleElement);
         if (Type != null) yield return new ElementValue("type", Type);
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
@@ -845,8 +863,8 @@ namespace Hl7.Fhir.Model
           value = Type;
           return Type is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -876,7 +894,7 @@ namespace Hl7.Fhir.Model
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
       if (ResponsibleElement is not null) yield return new KeyValuePair<string,object>("responsible",ResponsibleElement);
       if (Type is not null) yield return new KeyValuePair<string,object>("type",Type);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);

--- a/src/Hl7.Fhir.R4B/Model/Generated/OperationDefinition.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/OperationDefinition.cs
@@ -1369,13 +1369,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the operation definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1410,13 +1428,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this operation definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Whether content is changed by the operation
@@ -1486,13 +1522,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("comment", Order=250)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Comment
+    public Hl7.Fhir.Model.Markdown CommentElement
     {
-      get { return _Comment; }
-      set { _Comment = value; OnPropertyChanged("Comment"); }
+      get { return _CommentElement; }
+      set { _CommentElement = value; OnPropertyChanged("CommentElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Comment;
+    private Hl7.Fhir.Model.Markdown _CommentElement;
+
+    /// <summary>
+    /// Additional information about use
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Comment
+    {
+      get { return CommentElement != null ? CommentElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CommentElement = null;
+        else
+          CommentElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Comment");
+      }
+    }
 
     /// <summary>
     /// Marks this as a profile of the base
@@ -1764,13 +1818,13 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(AffectsStateElement != null) dest.AffectsStateElement = (Hl7.Fhir.Model.FhirBoolean)AffectsStateElement.DeepCopy();
       if(CodeElement != null) dest.CodeElement = (Hl7.Fhir.Model.Code)CodeElement.DeepCopy();
-      if(Comment != null) dest.Comment = (Hl7.Fhir.Model.Markdown)Comment.DeepCopy();
+      if(CommentElement != null) dest.CommentElement = (Hl7.Fhir.Model.Markdown)CommentElement.DeepCopy();
       if(BaseElement != null) dest.BaseElement = (Hl7.Fhir.Model.Canonical)BaseElement.DeepCopy();
       if(ResourceElement != null) dest.ResourceElement = new List<Code<Hl7.Fhir.Model.ResourceType>>(ResourceElement.DeepCopy());
       if(SystemElement != null) dest.SystemElement = (Hl7.Fhir.Model.FhirBoolean)SystemElement.DeepCopy();
@@ -1805,13 +1859,13 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(AffectsStateElement, otherT.AffectsStateElement)) return false;
       if( !DeepComparable.Matches(CodeElement, otherT.CodeElement)) return false;
-      if( !DeepComparable.Matches(Comment, otherT.Comment)) return false;
+      if( !DeepComparable.Matches(CommentElement, otherT.CommentElement)) return false;
       if( !DeepComparable.Matches(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.Matches(ResourceElement, otherT.ResourceElement)) return false;
       if( !DeepComparable.Matches(SystemElement, otherT.SystemElement)) return false;
@@ -1841,13 +1895,13 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(AffectsStateElement, otherT.AffectsStateElement)) return false;
       if( !DeepComparable.IsExactly(CodeElement, otherT.CodeElement)) return false;
-      if( !DeepComparable.IsExactly(Comment, otherT.Comment)) return false;
+      if( !DeepComparable.IsExactly(CommentElement, otherT.CommentElement)) return false;
       if( !DeepComparable.IsExactly(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.IsExactly(ResourceElement, otherT.ResourceElement)) return false;
       if( !DeepComparable.IsExactly(SystemElement, otherT.SystemElement)) return false;
@@ -1877,13 +1931,13 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (AffectsStateElement != null) yield return AffectsStateElement;
         if (CodeElement != null) yield return CodeElement;
-        if (Comment != null) yield return Comment;
+        if (CommentElement != null) yield return CommentElement;
         if (BaseElement != null) yield return BaseElement;
         foreach (var elem in ResourceElement) { if (elem != null) yield return elem; }
         if (SystemElement != null) yield return SystemElement;
@@ -1912,13 +1966,13 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (AffectsStateElement != null) yield return new ElementValue("affectsState", AffectsStateElement);
         if (CodeElement != null) yield return new ElementValue("code", CodeElement);
-        if (Comment != null) yield return new ElementValue("comment", Comment);
+        if (CommentElement != null) yield return new ElementValue("comment", CommentElement);
         if (BaseElement != null) yield return new ElementValue("base", BaseElement);
         foreach (var elem in ResourceElement) { if (elem != null) yield return new ElementValue("resource", elem); }
         if (SystemElement != null) yield return new ElementValue("system", SystemElement);
@@ -1966,8 +2020,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1975,8 +2029,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "affectsState":
           value = AffectsStateElement;
           return AffectsStateElement is not null;
@@ -1984,8 +2038,8 @@ namespace Hl7.Fhir.Model
           value = CodeElement;
           return CodeElement is not null;
         case "comment":
-          value = Comment;
-          return Comment is not null;
+          value = CommentElement;
+          return CommentElement is not null;
         case "base":
           value = BaseElement;
           return BaseElement is not null;
@@ -2032,13 +2086,13 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (AffectsStateElement is not null) yield return new KeyValuePair<string,object>("affectsState",AffectsStateElement);
       if (CodeElement is not null) yield return new KeyValuePair<string,object>("code",CodeElement);
-      if (Comment is not null) yield return new KeyValuePair<string,object>("comment",Comment);
+      if (CommentElement is not null) yield return new KeyValuePair<string,object>("comment",CommentElement);
       if (BaseElement is not null) yield return new KeyValuePair<string,object>("base",BaseElement);
       if (ResourceElement?.Any() == true) yield return new KeyValuePair<string,object>("resource",ResourceElement);
       if (SystemElement is not null) yield return new KeyValuePair<string,object>("system",SystemElement);

--- a/src/Hl7.Fhir.R4B/Model/Generated/PackagedProductDefinition.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/PackagedProductDefinition.cs
@@ -1080,13 +1080,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=160)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Textual description. Note that this is not the name of the package or product
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The legal status of supply of the packaged item as classified by the regulator
@@ -1207,7 +1225,7 @@ namespace Hl7.Fhir.Model
       if(Status != null) dest.Status = (Hl7.Fhir.Model.CodeableConcept)Status.DeepCopy();
       if(StatusDateElement != null) dest.StatusDateElement = (Hl7.Fhir.Model.FhirDateTime)StatusDateElement.DeepCopy();
       if(ContainedItemQuantity != null) dest.ContainedItemQuantity = new List<Hl7.Fhir.Model.Quantity>(ContainedItemQuantity.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(LegalStatusOfSupply != null) dest.LegalStatusOfSupply = new List<Hl7.Fhir.Model.PackagedProductDefinition.LegalStatusOfSupplyComponent>(LegalStatusOfSupply.DeepCopy());
       if(MarketingStatus != null) dest.MarketingStatus = new List<Hl7.Fhir.Model.MarketingStatus>(MarketingStatus.DeepCopy());
       if(Characteristic != null) dest.Characteristic = new List<Hl7.Fhir.Model.CodeableConcept>(Characteristic.DeepCopy());
@@ -1236,7 +1254,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Status, otherT.Status)) return false;
       if( !DeepComparable.Matches(StatusDateElement, otherT.StatusDateElement)) return false;
       if( !DeepComparable.Matches(ContainedItemQuantity, otherT.ContainedItemQuantity)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(LegalStatusOfSupply, otherT.LegalStatusOfSupply)) return false;
       if( !DeepComparable.Matches(MarketingStatus, otherT.MarketingStatus)) return false;
       if( !DeepComparable.Matches(Characteristic, otherT.Characteristic)) return false;
@@ -1260,7 +1278,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Status, otherT.Status)) return false;
       if( !DeepComparable.IsExactly(StatusDateElement, otherT.StatusDateElement)) return false;
       if( !DeepComparable.IsExactly(ContainedItemQuantity, otherT.ContainedItemQuantity)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(LegalStatusOfSupply, otherT.LegalStatusOfSupply)) return false;
       if( !DeepComparable.IsExactly(MarketingStatus, otherT.MarketingStatus)) return false;
       if( !DeepComparable.IsExactly(Characteristic, otherT.Characteristic)) return false;
@@ -1284,7 +1302,7 @@ namespace Hl7.Fhir.Model
         if (Status != null) yield return Status;
         if (StatusDateElement != null) yield return StatusDateElement;
         foreach (var elem in ContainedItemQuantity) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in LegalStatusOfSupply) { if (elem != null) yield return elem; }
         foreach (var elem in MarketingStatus) { if (elem != null) yield return elem; }
         foreach (var elem in Characteristic) { if (elem != null) yield return elem; }
@@ -1307,7 +1325,7 @@ namespace Hl7.Fhir.Model
         if (Status != null) yield return new ElementValue("status", Status);
         if (StatusDateElement != null) yield return new ElementValue("statusDate", StatusDateElement);
         foreach (var elem in ContainedItemQuantity) { if (elem != null) yield return new ElementValue("containedItemQuantity", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in LegalStatusOfSupply) { if (elem != null) yield return new ElementValue("legalStatusOfSupply", elem); }
         foreach (var elem in MarketingStatus) { if (elem != null) yield return new ElementValue("marketingStatus", elem); }
         foreach (var elem in Characteristic) { if (elem != null) yield return new ElementValue("characteristic", elem); }
@@ -1343,8 +1361,8 @@ namespace Hl7.Fhir.Model
           value = ContainedItemQuantity;
           return ContainedItemQuantity?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "legalStatusOfSupply":
           value = LegalStatusOfSupply;
           return LegalStatusOfSupply?.Any() == true;
@@ -1379,7 +1397,7 @@ namespace Hl7.Fhir.Model
       if (Status is not null) yield return new KeyValuePair<string,object>("status",Status);
       if (StatusDateElement is not null) yield return new KeyValuePair<string,object>("statusDate",StatusDateElement);
       if (ContainedItemQuantity?.Any() == true) yield return new KeyValuePair<string,object>("containedItemQuantity",ContainedItemQuantity);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (LegalStatusOfSupply?.Any() == true) yield return new KeyValuePair<string,object>("legalStatusOfSupply",LegalStatusOfSupply);
       if (MarketingStatus?.Any() == true) yield return new KeyValuePair<string,object>("marketingStatus",MarketingStatus);
       if (Characteristic?.Any() == true) yield return new KeyValuePair<string,object>("characteristic",Characteristic);

--- a/src/Hl7.Fhir.R4B/Model/Generated/PlanDefinition.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/PlanDefinition.cs
@@ -2365,13 +2365,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the plan definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -2406,13 +2424,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=250, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this plan definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the plan
@@ -2450,13 +2486,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=270)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the plan definition was approved by publisher
@@ -2700,12 +2754,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -2746,12 +2800,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -2787,12 +2841,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -2828,12 +2882,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -2868,12 +2922,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -2933,8 +2987,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2942,14 +2996,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -3008,12 +3062,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4B/Model/Generated/Questionnaire.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/Questionnaire.cs
@@ -1697,13 +1697,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the questionnaire
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1738,26 +1756,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=240, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this questionnaire is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=250)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the questionnaire was approved by publisher
@@ -1884,11 +1938,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1921,11 +1975,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1953,11 +2007,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1985,11 +2039,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -2016,11 +2070,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -2070,8 +2124,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2079,11 +2133,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -2120,11 +2174,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4B/Model/Generated/RegulatedAuthorization.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/RegulatedAuthorization.cs
@@ -303,13 +303,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=120)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// General textual supporting information
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The territory in which the authorization has been granted
@@ -478,7 +496,7 @@ namespace Hl7.Fhir.Model
       if(Identifier != null) dest.Identifier = new List<Hl7.Fhir.Model.Identifier>(Identifier.DeepCopy());
       if(Subject != null) dest.Subject = new List<Hl7.Fhir.Model.ResourceReference>(Subject.DeepCopy());
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(Region != null) dest.Region = new List<Hl7.Fhir.Model.CodeableConcept>(Region.DeepCopy());
       if(Status != null) dest.Status = (Hl7.Fhir.Model.CodeableConcept)Status.DeepCopy();
       if(StatusDateElement != null) dest.StatusDateElement = (Hl7.Fhir.Model.FhirDateTime)StatusDateElement.DeepCopy();
@@ -507,7 +525,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Identifier, otherT.Identifier)) return false;
       if( !DeepComparable.Matches(Subject, otherT.Subject)) return false;
       if( !DeepComparable.Matches(Type, otherT.Type)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(Region, otherT.Region)) return false;
       if( !DeepComparable.Matches(Status, otherT.Status)) return false;
       if( !DeepComparable.Matches(StatusDateElement, otherT.StatusDateElement)) return false;
@@ -531,7 +549,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Identifier, otherT.Identifier)) return false;
       if( !DeepComparable.IsExactly(Subject, otherT.Subject)) return false;
       if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(Region, otherT.Region)) return false;
       if( !DeepComparable.IsExactly(Status, otherT.Status)) return false;
       if( !DeepComparable.IsExactly(StatusDateElement, otherT.StatusDateElement)) return false;
@@ -555,7 +573,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Identifier) { if (elem != null) yield return elem; }
         foreach (var elem in Subject) { if (elem != null) yield return elem; }
         if (Type != null) yield return Type;
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in Region) { if (elem != null) yield return elem; }
         if (Status != null) yield return Status;
         if (StatusDateElement != null) yield return StatusDateElement;
@@ -578,7 +596,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Identifier) { if (elem != null) yield return new ElementValue("identifier", elem); }
         foreach (var elem in Subject) { if (elem != null) yield return new ElementValue("subject", elem); }
         if (Type != null) yield return new ElementValue("type", Type);
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in Region) { if (elem != null) yield return new ElementValue("region", elem); }
         if (Status != null) yield return new ElementValue("status", Status);
         if (StatusDateElement != null) yield return new ElementValue("statusDate", StatusDateElement);
@@ -606,8 +624,8 @@ namespace Hl7.Fhir.Model
           value = Type;
           return Type is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "region":
           value = Region;
           return Region?.Any() == true;
@@ -650,7 +668,7 @@ namespace Hl7.Fhir.Model
       if (Identifier?.Any() == true) yield return new KeyValuePair<string,object>("identifier",Identifier);
       if (Subject?.Any() == true) yield return new KeyValuePair<string,object>("subject",Subject);
       if (Type is not null) yield return new KeyValuePair<string,object>("type",Type);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (Region?.Any() == true) yield return new KeyValuePair<string,object>("region",Region);
       if (Status is not null) yield return new KeyValuePair<string,object>("status",Status);
       if (StatusDateElement is not null) yield return new KeyValuePair<string,object>("statusDate",StatusDateElement);

--- a/src/Hl7.Fhir.R4B/Model/Generated/ResearchDefinition.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/ResearchDefinition.cs
@@ -416,13 +416,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the research definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Used for footnotes or explanatory notes
@@ -489,13 +507,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=260, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this research definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the ResearchDefinition
@@ -533,13 +569,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=280)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the research definition was approved by publisher
@@ -816,13 +870,13 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(CommentElement != null) dest.CommentElement = new List<Hl7.Fhir.Model.FhirString>(CommentElement.DeepCopy());
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -865,13 +919,13 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(CommentElement, otherT.CommentElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -909,13 +963,13 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(CommentElement, otherT.CommentElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -953,13 +1007,13 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in CommentElement) { if (elem != null) yield return elem; }
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -996,13 +1050,13 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in CommentElement) { if (elem != null) yield return new ElementValue("comment", elem); }
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -1064,8 +1118,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "comment":
           value = CommentElement;
           return CommentElement?.Any() == true;
@@ -1076,14 +1130,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -1148,13 +1202,13 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (CommentElement?.Any() == true) yield return new KeyValuePair<string,object>("comment",CommentElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4B/Model/Generated/ResearchElementDefinition.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/ResearchElementDefinition.cs
@@ -923,13 +923,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the research element definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Used for footnotes or explanatory notes
@@ -996,13 +1014,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=260, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this research element definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the ResearchElementDefinition
@@ -1040,13 +1076,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=280)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the research element definition was approved by publisher
@@ -1341,13 +1395,13 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(CommentElement != null) dest.CommentElement = new List<Hl7.Fhir.Model.FhirString>(CommentElement.DeepCopy());
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1389,13 +1443,13 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(CommentElement, otherT.CommentElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1432,13 +1486,13 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(CommentElement, otherT.CommentElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1475,13 +1529,13 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in CommentElement) { if (elem != null) yield return elem; }
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -1517,13 +1571,13 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in CommentElement) { if (elem != null) yield return new ElementValue("comment", elem); }
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -1584,8 +1638,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "comment":
           value = CommentElement;
           return CommentElement?.Any() == true;
@@ -1596,14 +1650,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -1665,13 +1719,13 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (CommentElement?.Any() == true) yield return new KeyValuePair<string,object>("comment",CommentElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4B/Model/Generated/ResearchStudy.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/ResearchStudy.cs
@@ -710,13 +710,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// What this is study doing
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Inclusion &amp; exclusion criteria
@@ -872,7 +890,7 @@ namespace Hl7.Fhir.Model
       if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
       if(Keyword != null) dest.Keyword = new List<Hl7.Fhir.Model.CodeableConcept>(Keyword.DeepCopy());
       if(Location != null) dest.Location = new List<Hl7.Fhir.Model.CodeableConcept>(Location.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(Enrollment != null) dest.Enrollment = new List<Hl7.Fhir.Model.ResourceReference>(Enrollment.DeepCopy());
       if(Period != null) dest.Period = (Hl7.Fhir.Model.Period)Period.DeepCopy();
       if(Sponsor != null) dest.Sponsor = (Hl7.Fhir.Model.ResourceReference)Sponsor.DeepCopy();
@@ -911,7 +929,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.Matches(Keyword, otherT.Keyword)) return false;
       if( !DeepComparable.Matches(Location, otherT.Location)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(Enrollment, otherT.Enrollment)) return false;
       if( !DeepComparable.Matches(Period, otherT.Period)) return false;
       if( !DeepComparable.Matches(Sponsor, otherT.Sponsor)) return false;
@@ -945,7 +963,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.IsExactly(Keyword, otherT.Keyword)) return false;
       if( !DeepComparable.IsExactly(Location, otherT.Location)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(Enrollment, otherT.Enrollment)) return false;
       if( !DeepComparable.IsExactly(Period, otherT.Period)) return false;
       if( !DeepComparable.IsExactly(Sponsor, otherT.Sponsor)) return false;
@@ -979,7 +997,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return elem; }
         foreach (var elem in Keyword) { if (elem != null) yield return elem; }
         foreach (var elem in Location) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in Enrollment) { if (elem != null) yield return elem; }
         if (Period != null) yield return Period;
         if (Sponsor != null) yield return Sponsor;
@@ -1012,7 +1030,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return new ElementValue("relatedArtifact", elem); }
         foreach (var elem in Keyword) { if (elem != null) yield return new ElementValue("keyword", elem); }
         foreach (var elem in Location) { if (elem != null) yield return new ElementValue("location", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in Enrollment) { if (elem != null) yield return new ElementValue("enrollment", elem); }
         if (Period != null) yield return new ElementValue("period", Period);
         if (Sponsor != null) yield return new ElementValue("sponsor", Sponsor);
@@ -1072,8 +1090,8 @@ namespace Hl7.Fhir.Model
           value = Location;
           return Location?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "enrollment":
           value = Enrollment;
           return Enrollment?.Any() == true;
@@ -1124,7 +1142,7 @@ namespace Hl7.Fhir.Model
       if (RelatedArtifact?.Any() == true) yield return new KeyValuePair<string,object>("relatedArtifact",RelatedArtifact);
       if (Keyword?.Any() == true) yield return new KeyValuePair<string,object>("keyword",Keyword);
       if (Location?.Any() == true) yield return new KeyValuePair<string,object>("location",Location);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (Enrollment?.Any() == true) yield return new KeyValuePair<string,object>("enrollment",Enrollment);
       if (Period is not null) yield return new KeyValuePair<string,object>("period",Period);
       if (Sponsor is not null) yield return new KeyValuePair<string,object>("sponsor",Sponsor);

--- a/src/Hl7.Fhir.R4B/Model/Generated/SearchParameter.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/SearchParameter.cs
@@ -682,13 +682,31 @@ namespace Hl7.Fhir.Model
     [FhirElement("description", InSummary=true, Order=180)]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the search parameter
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -723,13 +741,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=210, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this search parameter is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Code used in URL
@@ -1149,10 +1185,10 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(CodeElement != null) dest.CodeElement = (Hl7.Fhir.Model.Code)CodeElement.DeepCopy();
       if(BaseElement != null) dest.BaseElement = new List<Code<Hl7.Fhir.Model.ResourceType>>(BaseElement.DeepCopy());
       if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.SearchParamType>)TypeElement.DeepCopy();
@@ -1190,10 +1226,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(CodeElement, otherT.CodeElement)) return false;
       if( !DeepComparable.Matches(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.Matches(TypeElement, otherT.TypeElement)) return false;
@@ -1226,10 +1262,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(CodeElement, otherT.CodeElement)) return false;
       if( !DeepComparable.IsExactly(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.IsExactly(TypeElement, otherT.TypeElement)) return false;
@@ -1262,10 +1298,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (CodeElement != null) yield return CodeElement;
         foreach (var elem in BaseElement) { if (elem != null) yield return elem; }
         if (TypeElement != null) yield return TypeElement;
@@ -1297,10 +1333,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (CodeElement != null) yield return new ElementValue("code", CodeElement);
         foreach (var elem in BaseElement) { if (elem != null) yield return new ElementValue("base", elem); }
         if (TypeElement != null) yield return new ElementValue("type", TypeElement);
@@ -1349,8 +1385,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1358,8 +1394,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "code":
           value = CodeElement;
           return CodeElement is not null;
@@ -1417,10 +1453,10 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (CodeElement is not null) yield return new KeyValuePair<string,object>("code",CodeElement);
       if (BaseElement?.Any() == true) yield return new KeyValuePair<string,object>("base",BaseElement);
       if (TypeElement is not null) yield return new KeyValuePair<string,object>("type",TypeElement);

--- a/src/Hl7.Fhir.R4B/Model/Generated/StructureMap.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/StructureMap.cs
@@ -2876,13 +2876,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the structure map
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -2917,26 +2935,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this structure map is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Structure Definition used by this map
@@ -3018,11 +3072,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(Structure != null) dest.Structure = new List<Hl7.Fhir.Model.StructureMap.StructureComponent>(Structure.DeepCopy());
       if(ImportElement != null) dest.ImportElement = new List<Hl7.Fhir.Model.Canonical>(ImportElement.DeepCopy());
       if(Group != null) dest.Group = new List<Hl7.Fhir.Model.StructureMap.GroupComponent>(Group.DeepCopy());
@@ -3051,11 +3105,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(Structure, otherT.Structure)) return false;
       if( !DeepComparable.Matches(ImportElement, otherT.ImportElement)) return false;
       if( !DeepComparable.Matches(Group, otherT.Group)) return false;
@@ -3079,11 +3133,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(Structure, otherT.Structure)) return false;
       if( !DeepComparable.IsExactly(ImportElement, otherT.ImportElement)) return false;
       if( !DeepComparable.IsExactly(Group, otherT.Group)) return false;
@@ -3107,11 +3161,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         foreach (var elem in Structure) { if (elem != null) yield return elem; }
         foreach (var elem in ImportElement) { if (elem != null) yield return elem; }
         foreach (var elem in Group) { if (elem != null) yield return elem; }
@@ -3134,11 +3188,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         foreach (var elem in Structure) { if (elem != null) yield return new ElementValue("structure", elem); }
         foreach (var elem in ImportElement) { if (elem != null) yield return new ElementValue("import", elem); }
         foreach (var elem in Group) { if (elem != null) yield return new ElementValue("group", elem); }
@@ -3180,8 +3234,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -3189,11 +3243,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "structure":
           value = Structure;
           return Structure?.Any() == true;
@@ -3222,11 +3276,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (Structure?.Any() == true) yield return new KeyValuePair<string,object>("structure",Structure);
       if (ImportElement?.Any() == true) yield return new KeyValuePair<string,object>("import",ImportElement);
       if (Group?.Any() == true) yield return new KeyValuePair<string,object>("group",Group);

--- a/src/Hl7.Fhir.R4B/Model/Generated/SubscriptionTopic.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/SubscriptionTopic.cs
@@ -223,13 +223,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", InSummary=true, Order=40)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Text representation of the resource trigger
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Data Type or Resource (reference to definition) for this trigger definition
@@ -350,7 +368,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(ResourceElement != null) dest.ResourceElement = (Hl7.Fhir.Model.FhirUri)ResourceElement.DeepCopy();
         if(SupportedInteractionElement != null) dest.SupportedInteractionElement = new List<Code<Hl7.Fhir.Model.SubscriptionTopic.InteractionTrigger>>(SupportedInteractionElement.DeepCopy());
         if(QueryCriteria != null) dest.QueryCriteria = (Hl7.Fhir.Model.SubscriptionTopic.QueryCriteriaComponent)QueryCriteria.DeepCopy();
@@ -370,7 +388,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.Matches(otherT)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(ResourceElement, otherT.ResourceElement)) return false;
         if( !DeepComparable.Matches(SupportedInteractionElement, otherT.SupportedInteractionElement)) return false;
         if( !DeepComparable.Matches(QueryCriteria, otherT.QueryCriteria)) return false;
@@ -385,7 +403,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.IsExactly(otherT)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(ResourceElement, otherT.ResourceElement)) return false;
         if( !DeepComparable.IsExactly(SupportedInteractionElement, otherT.SupportedInteractionElement)) return false;
         if( !DeepComparable.IsExactly(QueryCriteria, otherT.QueryCriteria)) return false;
@@ -400,7 +418,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.Children) yield return item;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           if (ResourceElement != null) yield return ResourceElement;
           foreach (var elem in SupportedInteractionElement) { if (elem != null) yield return elem; }
           if (QueryCriteria != null) yield return QueryCriteria;
@@ -414,7 +432,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.NamedChildren) yield return item;
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (ResourceElement != null) yield return new ElementValue("resource", ResourceElement);
           foreach (var elem in SupportedInteractionElement) { if (elem != null) yield return new ElementValue("supportedInteraction", elem); }
           if (QueryCriteria != null) yield return new ElementValue("queryCriteria", QueryCriteria);
@@ -427,8 +445,8 @@ namespace Hl7.Fhir.Model
         switch (key)
         {
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "resource":
             value = ResourceElement;
             return ResourceElement is not null;
@@ -450,7 +468,7 @@ namespace Hl7.Fhir.Model
       protected override IEnumerable<KeyValuePair<string, object>> GetElementPairs()
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (ResourceElement is not null) yield return new KeyValuePair<string,object>("resource",ResourceElement);
         if (SupportedInteractionElement?.Any() == true) yield return new KeyValuePair<string,object>("supportedInteraction",SupportedInteractionElement);
         if (QueryCriteria is not null) yield return new KeyValuePair<string,object>("queryCriteria",QueryCriteria);
@@ -766,13 +784,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", InSummary=true, Order=40)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Text representation of the event trigger
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Event which can trigger a notification from the SubscriptionTopic
@@ -830,7 +866,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(Event != null) dest.Event = (Hl7.Fhir.Model.CodeableConcept)Event.DeepCopy();
         if(ResourceElement != null) dest.ResourceElement = (Hl7.Fhir.Model.FhirUri)ResourceElement.DeepCopy();
         return dest;
@@ -848,7 +884,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.Matches(otherT)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(Event, otherT.Event)) return false;
         if( !DeepComparable.Matches(ResourceElement, otherT.ResourceElement)) return false;
 
@@ -861,7 +897,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.IsExactly(otherT)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(Event, otherT.Event)) return false;
         if( !DeepComparable.IsExactly(ResourceElement, otherT.ResourceElement)) return false;
 
@@ -874,7 +910,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.Children) yield return item;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           if (Event != null) yield return Event;
           if (ResourceElement != null) yield return ResourceElement;
         }
@@ -886,7 +922,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.NamedChildren) yield return item;
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (Event != null) yield return new ElementValue("event", Event);
           if (ResourceElement != null) yield return new ElementValue("resource", ResourceElement);
         }
@@ -897,8 +933,8 @@ namespace Hl7.Fhir.Model
         switch (key)
         {
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "event":
             value = Event;
             return Event is not null;
@@ -914,7 +950,7 @@ namespace Hl7.Fhir.Model
       protected override IEnumerable<KeyValuePair<string, object>> GetElementPairs()
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (Event is not null) yield return new KeyValuePair<string,object>("event",Event);
         if (ResourceElement is not null) yield return new KeyValuePair<string,object>("resource",ResourceElement);
       }
@@ -939,13 +975,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", InSummary=true, Order=40)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Description of this filter parameter
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// URL of the triggering Resource that this filter applies to
@@ -1084,7 +1138,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(ResourceElement != null) dest.ResourceElement = (Hl7.Fhir.Model.FhirUri)ResourceElement.DeepCopy();
         if(FilterParameterElement != null) dest.FilterParameterElement = (Hl7.Fhir.Model.FhirString)FilterParameterElement.DeepCopy();
         if(FilterDefinitionElement != null) dest.FilterDefinitionElement = (Hl7.Fhir.Model.FhirUri)FilterDefinitionElement.DeepCopy();
@@ -1104,7 +1158,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.Matches(otherT)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(ResourceElement, otherT.ResourceElement)) return false;
         if( !DeepComparable.Matches(FilterParameterElement, otherT.FilterParameterElement)) return false;
         if( !DeepComparable.Matches(FilterDefinitionElement, otherT.FilterDefinitionElement)) return false;
@@ -1119,7 +1173,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.IsExactly(otherT)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(ResourceElement, otherT.ResourceElement)) return false;
         if( !DeepComparable.IsExactly(FilterParameterElement, otherT.FilterParameterElement)) return false;
         if( !DeepComparable.IsExactly(FilterDefinitionElement, otherT.FilterDefinitionElement)) return false;
@@ -1134,7 +1188,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.Children) yield return item;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           if (ResourceElement != null) yield return ResourceElement;
           if (FilterParameterElement != null) yield return FilterParameterElement;
           if (FilterDefinitionElement != null) yield return FilterDefinitionElement;
@@ -1148,7 +1202,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.NamedChildren) yield return item;
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (ResourceElement != null) yield return new ElementValue("resource", ResourceElement);
           if (FilterParameterElement != null) yield return new ElementValue("filterParameter", FilterParameterElement);
           if (FilterDefinitionElement != null) yield return new ElementValue("filterDefinition", FilterDefinitionElement);
@@ -1161,8 +1215,8 @@ namespace Hl7.Fhir.Model
         switch (key)
         {
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "resource":
             value = ResourceElement;
             return ResourceElement is not null;
@@ -1184,7 +1238,7 @@ namespace Hl7.Fhir.Model
       protected override IEnumerable<KeyValuePair<string, object>> GetElementPairs()
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (ResourceElement is not null) yield return new KeyValuePair<string,object>("resource",ResourceElement);
         if (FilterParameterElement is not null) yield return new KeyValuePair<string,object>("filterParameter",FilterParameterElement);
         if (FilterDefinitionElement is not null) yield return new KeyValuePair<string,object>("filterDefinition",FilterDefinitionElement);
@@ -1688,13 +1742,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the SubscriptionTopic
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Content intends to support these contexts
@@ -1729,26 +1801,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this SubscriptionTopic is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When SubscriptionTopic is/was approved by publisher
@@ -1901,11 +2009,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1938,11 +2046,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1970,11 +2078,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -2002,11 +2110,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -2033,11 +2141,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -2083,8 +2191,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2092,11 +2200,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -2137,11 +2245,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R4B/Model/Generated/SubstanceDefinition.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/SubstanceDefinition.cs
@@ -2478,13 +2478,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=150)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Textual description of the substance
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Supporting literature
@@ -2674,7 +2692,7 @@ namespace Hl7.Fhir.Model
       if(Classification != null) dest.Classification = new List<Hl7.Fhir.Model.CodeableConcept>(Classification.DeepCopy());
       if(Domain != null) dest.Domain = (Hl7.Fhir.Model.CodeableConcept)Domain.DeepCopy();
       if(Grade != null) dest.Grade = new List<Hl7.Fhir.Model.CodeableConcept>(Grade.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(InformationSource != null) dest.InformationSource = new List<Hl7.Fhir.Model.ResourceReference>(InformationSource.DeepCopy());
       if(Note != null) dest.Note = new List<Hl7.Fhir.Model.Annotation>(Note.DeepCopy());
       if(Manufacturer != null) dest.Manufacturer = new List<Hl7.Fhir.Model.ResourceReference>(Manufacturer.DeepCopy());
@@ -2708,7 +2726,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Classification, otherT.Classification)) return false;
       if( !DeepComparable.Matches(Domain, otherT.Domain)) return false;
       if( !DeepComparable.Matches(Grade, otherT.Grade)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(InformationSource, otherT.InformationSource)) return false;
       if( !DeepComparable.Matches(Note, otherT.Note)) return false;
       if( !DeepComparable.Matches(Manufacturer, otherT.Manufacturer)) return false;
@@ -2737,7 +2755,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Classification, otherT.Classification)) return false;
       if( !DeepComparable.IsExactly(Domain, otherT.Domain)) return false;
       if( !DeepComparable.IsExactly(Grade, otherT.Grade)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(InformationSource, otherT.InformationSource)) return false;
       if( !DeepComparable.IsExactly(Note, otherT.Note)) return false;
       if( !DeepComparable.IsExactly(Manufacturer, otherT.Manufacturer)) return false;
@@ -2766,7 +2784,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Classification) { if (elem != null) yield return elem; }
         if (Domain != null) yield return Domain;
         foreach (var elem in Grade) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in InformationSource) { if (elem != null) yield return elem; }
         foreach (var elem in Note) { if (elem != null) yield return elem; }
         foreach (var elem in Manufacturer) { if (elem != null) yield return elem; }
@@ -2794,7 +2812,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Classification) { if (elem != null) yield return new ElementValue("classification", elem); }
         if (Domain != null) yield return new ElementValue("domain", Domain);
         foreach (var elem in Grade) { if (elem != null) yield return new ElementValue("grade", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in InformationSource) { if (elem != null) yield return new ElementValue("informationSource", elem); }
         foreach (var elem in Note) { if (elem != null) yield return new ElementValue("note", elem); }
         foreach (var elem in Manufacturer) { if (elem != null) yield return new ElementValue("manufacturer", elem); }
@@ -2833,8 +2851,8 @@ namespace Hl7.Fhir.Model
           value = Grade;
           return Grade?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "informationSource":
           value = InformationSource;
           return InformationSource?.Any() == true;
@@ -2886,7 +2904,7 @@ namespace Hl7.Fhir.Model
       if (Classification?.Any() == true) yield return new KeyValuePair<string,object>("classification",Classification);
       if (Domain is not null) yield return new KeyValuePair<string,object>("domain",Domain);
       if (Grade?.Any() == true) yield return new KeyValuePair<string,object>("grade",Grade);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (InformationSource?.Any() == true) yield return new KeyValuePair<string,object>("informationSource",InformationSource);
       if (Note?.Any() == true) yield return new KeyValuePair<string,object>("note",Note);
       if (Manufacturer?.Any() == true) yield return new KeyValuePair<string,object>("manufacturer",Manufacturer);

--- a/src/Hl7.Fhir.R4B/Model/Generated/TerminologyCapabilities.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/TerminologyCapabilities.cs
@@ -1209,13 +1209,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("textFilter", Order=80)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown TextFilter
+      public Hl7.Fhir.Model.Markdown TextFilterElement
       {
-        get { return _TextFilter; }
-        set { _TextFilter = value; OnPropertyChanged("TextFilter"); }
+        get { return _TextFilterElement; }
+        set { _TextFilterElement = value; OnPropertyChanged("TextFilterElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _TextFilter;
+      private Hl7.Fhir.Model.Markdown _TextFilterElement;
+
+      /// <summary>
+      /// Documentation about text searching works
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string TextFilter
+      {
+        get { return TextFilterElement != null ? TextFilterElement.Value : null; }
+        set
+        {
+          if (value == null)
+            TextFilterElement = null;
+          else
+            TextFilterElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("TextFilter");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -1231,7 +1249,7 @@ namespace Hl7.Fhir.Model
         if(PagingElement != null) dest.PagingElement = (Hl7.Fhir.Model.FhirBoolean)PagingElement.DeepCopy();
         if(IncompleteElement != null) dest.IncompleteElement = (Hl7.Fhir.Model.FhirBoolean)IncompleteElement.DeepCopy();
         if(Parameter != null) dest.Parameter = new List<Hl7.Fhir.Model.TerminologyCapabilities.ParameterComponent>(Parameter.DeepCopy());
-        if(TextFilter != null) dest.TextFilter = (Hl7.Fhir.Model.Markdown)TextFilter.DeepCopy();
+        if(TextFilterElement != null) dest.TextFilterElement = (Hl7.Fhir.Model.Markdown)TextFilterElement.DeepCopy();
         return dest;
       }
 
@@ -1251,7 +1269,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(PagingElement, otherT.PagingElement)) return false;
         if( !DeepComparable.Matches(IncompleteElement, otherT.IncompleteElement)) return false;
         if( !DeepComparable.Matches(Parameter, otherT.Parameter)) return false;
-        if( !DeepComparable.Matches(TextFilter, otherT.TextFilter)) return false;
+        if( !DeepComparable.Matches(TextFilterElement, otherT.TextFilterElement)) return false;
 
         return true;
       }
@@ -1266,7 +1284,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(PagingElement, otherT.PagingElement)) return false;
         if( !DeepComparable.IsExactly(IncompleteElement, otherT.IncompleteElement)) return false;
         if( !DeepComparable.IsExactly(Parameter, otherT.Parameter)) return false;
-        if( !DeepComparable.IsExactly(TextFilter, otherT.TextFilter)) return false;
+        if( !DeepComparable.IsExactly(TextFilterElement, otherT.TextFilterElement)) return false;
 
         return true;
       }
@@ -1281,7 +1299,7 @@ namespace Hl7.Fhir.Model
           if (PagingElement != null) yield return PagingElement;
           if (IncompleteElement != null) yield return IncompleteElement;
           foreach (var elem in Parameter) { if (elem != null) yield return elem; }
-          if (TextFilter != null) yield return TextFilter;
+          if (TextFilterElement != null) yield return TextFilterElement;
         }
       }
 
@@ -1295,7 +1313,7 @@ namespace Hl7.Fhir.Model
           if (PagingElement != null) yield return new ElementValue("paging", PagingElement);
           if (IncompleteElement != null) yield return new ElementValue("incomplete", IncompleteElement);
           foreach (var elem in Parameter) { if (elem != null) yield return new ElementValue("parameter", elem); }
-          if (TextFilter != null) yield return new ElementValue("textFilter", TextFilter);
+          if (TextFilterElement != null) yield return new ElementValue("textFilter", TextFilterElement);
         }
       }
 
@@ -1316,8 +1334,8 @@ namespace Hl7.Fhir.Model
             value = Parameter;
             return Parameter?.Any() == true;
           case "textFilter":
-            value = TextFilter;
-            return TextFilter is not null;
+            value = TextFilterElement;
+            return TextFilterElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -1331,7 +1349,7 @@ namespace Hl7.Fhir.Model
         if (PagingElement is not null) yield return new KeyValuePair<string,object>("paging",PagingElement);
         if (IncompleteElement is not null) yield return new KeyValuePair<string,object>("incomplete",IncompleteElement);
         if (Parameter?.Any() == true) yield return new KeyValuePair<string,object>("parameter",Parameter);
-        if (TextFilter is not null) yield return new KeyValuePair<string,object>("textFilter",TextFilter);
+        if (TextFilterElement is not null) yield return new KeyValuePair<string,object>("textFilter",TextFilterElement);
       }
 
     }
@@ -2157,13 +2175,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the terminology capabilities
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -2198,26 +2234,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=210, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this terminology capabilities is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", InSummary=true, Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// instance | capability | requirements
@@ -2426,11 +2498,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(KindElement != null) dest.KindElement = (Code<Hl7.Fhir.Model.CapabilityStatementKind>)KindElement.DeepCopy();
       if(Software != null) dest.Software = (Hl7.Fhir.Model.TerminologyCapabilities.SoftwareComponent)Software.DeepCopy();
       if(Implementation != null) dest.Implementation = (Hl7.Fhir.Model.TerminologyCapabilities.ImplementationComponent)Implementation.DeepCopy();
@@ -2465,11 +2537,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(KindElement, otherT.KindElement)) return false;
       if( !DeepComparable.Matches(Software, otherT.Software)) return false;
       if( !DeepComparable.Matches(Implementation, otherT.Implementation)) return false;
@@ -2499,11 +2571,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(KindElement, otherT.KindElement)) return false;
       if( !DeepComparable.IsExactly(Software, otherT.Software)) return false;
       if( !DeepComparable.IsExactly(Implementation, otherT.Implementation)) return false;
@@ -2533,11 +2605,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (KindElement != null) yield return KindElement;
         if (Software != null) yield return Software;
         if (Implementation != null) yield return Implementation;
@@ -2566,11 +2638,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (KindElement != null) yield return new ElementValue("kind", KindElement);
         if (Software != null) yield return new ElementValue("software", Software);
         if (Implementation != null) yield return new ElementValue("implementation", Implementation);
@@ -2616,8 +2688,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2625,11 +2697,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "kind":
           value = KindElement;
           return KindElement is not null;
@@ -2678,11 +2750,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (KindElement is not null) yield return new KeyValuePair<string,object>("kind",KindElement);
       if (Software is not null) yield return new KeyValuePair<string,object>("software",Software);
       if (Implementation is not null) yield return new KeyValuePair<string,object>("implementation",Implementation);

--- a/src/Hl7.Fhir.R4B/Model/Generated/TestReport.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/TestReport.cs
@@ -693,13 +693,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("message", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Message
+      public Hl7.Fhir.Model.Markdown MessageElement
       {
-        get { return _Message; }
-        set { _Message = value; OnPropertyChanged("Message"); }
+        get { return _MessageElement; }
+        set { _MessageElement = value; OnPropertyChanged("MessageElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Message;
+      private Hl7.Fhir.Model.Markdown _MessageElement;
+
+      /// <summary>
+      /// A message associated with the result
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Message
+      {
+        get { return MessageElement != null ? MessageElement.Value : null; }
+        set
+        {
+          if (value == null)
+            MessageElement = null;
+          else
+            MessageElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Message");
+        }
+      }
 
       /// <summary>
       /// A link to further details on the result
@@ -743,7 +761,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(ResultElement != null) dest.ResultElement = (Code<Hl7.Fhir.Model.TestReport.TestReportActionResult>)ResultElement.DeepCopy();
-        if(Message != null) dest.Message = (Hl7.Fhir.Model.Markdown)Message.DeepCopy();
+        if(MessageElement != null) dest.MessageElement = (Hl7.Fhir.Model.Markdown)MessageElement.DeepCopy();
         if(DetailElement != null) dest.DetailElement = (Hl7.Fhir.Model.FhirUri)DetailElement.DeepCopy();
         return dest;
       }
@@ -761,7 +779,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(ResultElement, otherT.ResultElement)) return false;
-        if( !DeepComparable.Matches(Message, otherT.Message)) return false;
+        if( !DeepComparable.Matches(MessageElement, otherT.MessageElement)) return false;
         if( !DeepComparable.Matches(DetailElement, otherT.DetailElement)) return false;
 
         return true;
@@ -774,7 +792,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(ResultElement, otherT.ResultElement)) return false;
-        if( !DeepComparable.IsExactly(Message, otherT.Message)) return false;
+        if( !DeepComparable.IsExactly(MessageElement, otherT.MessageElement)) return false;
         if( !DeepComparable.IsExactly(DetailElement, otherT.DetailElement)) return false;
 
         return true;
@@ -787,7 +805,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (ResultElement != null) yield return ResultElement;
-          if (Message != null) yield return Message;
+          if (MessageElement != null) yield return MessageElement;
           if (DetailElement != null) yield return DetailElement;
         }
       }
@@ -799,7 +817,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (ResultElement != null) yield return new ElementValue("result", ResultElement);
-          if (Message != null) yield return new ElementValue("message", Message);
+          if (MessageElement != null) yield return new ElementValue("message", MessageElement);
           if (DetailElement != null) yield return new ElementValue("detail", DetailElement);
         }
       }
@@ -812,8 +830,8 @@ namespace Hl7.Fhir.Model
             value = ResultElement;
             return ResultElement is not null;
           case "message":
-            value = Message;
-            return Message is not null;
+            value = MessageElement;
+            return MessageElement is not null;
           case "detail":
             value = DetailElement;
             return DetailElement is not null;
@@ -827,7 +845,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (ResultElement is not null) yield return new KeyValuePair<string,object>("result",ResultElement);
-        if (Message is not null) yield return new KeyValuePair<string,object>("message",Message);
+        if (MessageElement is not null) yield return new KeyValuePair<string,object>("message",MessageElement);
         if (DetailElement is not null) yield return new KeyValuePair<string,object>("detail",DetailElement);
       }
 
@@ -884,13 +902,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("message", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Message
+      public Hl7.Fhir.Model.Markdown MessageElement
       {
-        get { return _Message; }
-        set { _Message = value; OnPropertyChanged("Message"); }
+        get { return _MessageElement; }
+        set { _MessageElement = value; OnPropertyChanged("MessageElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Message;
+      private Hl7.Fhir.Model.Markdown _MessageElement;
+
+      /// <summary>
+      /// A message associated with the result
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Message
+      {
+        get { return MessageElement != null ? MessageElement.Value : null; }
+        set
+        {
+          if (value == null)
+            MessageElement = null;
+          else
+            MessageElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Message");
+        }
+      }
 
       /// <summary>
       /// A link to further details on the result
@@ -934,7 +970,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(ResultElement != null) dest.ResultElement = (Code<Hl7.Fhir.Model.TestReport.TestReportActionResult>)ResultElement.DeepCopy();
-        if(Message != null) dest.Message = (Hl7.Fhir.Model.Markdown)Message.DeepCopy();
+        if(MessageElement != null) dest.MessageElement = (Hl7.Fhir.Model.Markdown)MessageElement.DeepCopy();
         if(DetailElement != null) dest.DetailElement = (Hl7.Fhir.Model.FhirString)DetailElement.DeepCopy();
         return dest;
       }
@@ -952,7 +988,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(ResultElement, otherT.ResultElement)) return false;
-        if( !DeepComparable.Matches(Message, otherT.Message)) return false;
+        if( !DeepComparable.Matches(MessageElement, otherT.MessageElement)) return false;
         if( !DeepComparable.Matches(DetailElement, otherT.DetailElement)) return false;
 
         return true;
@@ -965,7 +1001,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(ResultElement, otherT.ResultElement)) return false;
-        if( !DeepComparable.IsExactly(Message, otherT.Message)) return false;
+        if( !DeepComparable.IsExactly(MessageElement, otherT.MessageElement)) return false;
         if( !DeepComparable.IsExactly(DetailElement, otherT.DetailElement)) return false;
 
         return true;
@@ -978,7 +1014,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (ResultElement != null) yield return ResultElement;
-          if (Message != null) yield return Message;
+          if (MessageElement != null) yield return MessageElement;
           if (DetailElement != null) yield return DetailElement;
         }
       }
@@ -990,7 +1026,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (ResultElement != null) yield return new ElementValue("result", ResultElement);
-          if (Message != null) yield return new ElementValue("message", Message);
+          if (MessageElement != null) yield return new ElementValue("message", MessageElement);
           if (DetailElement != null) yield return new ElementValue("detail", DetailElement);
         }
       }
@@ -1003,8 +1039,8 @@ namespace Hl7.Fhir.Model
             value = ResultElement;
             return ResultElement is not null;
           case "message":
-            value = Message;
-            return Message is not null;
+            value = MessageElement;
+            return MessageElement is not null;
           case "detail":
             value = DetailElement;
             return DetailElement is not null;
@@ -1018,7 +1054,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (ResultElement is not null) yield return new KeyValuePair<string,object>("result",ResultElement);
-        if (Message is not null) yield return new KeyValuePair<string,object>("message",Message);
+        if (MessageElement is not null) yield return new KeyValuePair<string,object>("message",MessageElement);
         if (DetailElement is not null) yield return new KeyValuePair<string,object>("detail",DetailElement);
       }
 

--- a/src/Hl7.Fhir.R4B/Model/Generated/TestScript.cs
+++ b/src/Hl7.Fhir.R4B/Model/Generated/TestScript.cs
@@ -4806,13 +4806,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the test script
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -4847,26 +4865,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this test script is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// An abstract server representing a client or sender in a message exchange
@@ -5013,11 +5067,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(Origin != null) dest.Origin = new List<Hl7.Fhir.Model.TestScript.OriginComponent>(Origin.DeepCopy());
       if(Destination != null) dest.Destination = new List<Hl7.Fhir.Model.TestScript.DestinationComponent>(Destination.DeepCopy());
       if(Metadata != null) dest.Metadata = (Hl7.Fhir.Model.TestScript.MetadataComponent)Metadata.DeepCopy();
@@ -5052,11 +5106,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(Origin, otherT.Origin)) return false;
       if( !DeepComparable.Matches(Destination, otherT.Destination)) return false;
       if( !DeepComparable.Matches(Metadata, otherT.Metadata)) return false;
@@ -5086,11 +5140,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(Origin, otherT.Origin)) return false;
       if( !DeepComparable.IsExactly(Destination, otherT.Destination)) return false;
       if( !DeepComparable.IsExactly(Metadata, otherT.Metadata)) return false;
@@ -5120,11 +5174,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         foreach (var elem in Origin) { if (elem != null) yield return elem; }
         foreach (var elem in Destination) { if (elem != null) yield return elem; }
         if (Metadata != null) yield return Metadata;
@@ -5153,11 +5207,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         foreach (var elem in Origin) { if (elem != null) yield return new ElementValue("origin", elem); }
         foreach (var elem in Destination) { if (elem != null) yield return new ElementValue("destination", elem); }
         if (Metadata != null) yield return new ElementValue("metadata", Metadata);
@@ -5205,8 +5259,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -5214,11 +5268,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "origin":
           value = Origin;
           return Origin?.Any() == true;
@@ -5265,11 +5319,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (Origin?.Any() == true) yield return new KeyValuePair<string,object>("origin",Origin);
       if (Destination?.Any() == true) yield return new KeyValuePair<string,object>("destination",Destination);
       if (Metadata is not null) yield return new KeyValuePair<string,object>("metadata",Metadata);

--- a/src/Hl7.Fhir.R4B/Model/IConformanceResource.cs
+++ b/src/Hl7.Fhir.R4B/Model/IConformanceResource.cs
@@ -51,11 +51,13 @@ namespace Hl7.Fhir.Model
     {
         //I think ImplementationGuide should have a purpose element.
         [Obsolete("This property is not a part of the official FHIR specification", true)]
-        public Markdown Purpose
+        public Markdown PurposeElement
         {
             get { return null; }
             set { throw new NotImplementedException(); }
         }
+
+        public string Purpose { get => null; set => throw new NotImplementedException(); }
     }
 
     public partial class CompartmentDefinition : IVersionableConformanceResource
@@ -94,7 +96,7 @@ namespace Hl7.Fhir.Model
     {
         // I think NamingSystem should have Experimental too
         [Obsolete("This property is not a part of the official FHIR specification", true)]
-        public Markdown Purpose
+        public Markdown PurposeElement
         {
             get { return null; }
             set { throw new NotImplementedException(); }
@@ -136,5 +138,7 @@ namespace Hl7.Fhir.Model
             }
             set { throw new NotImplementedException(); }
         }
+
+        public string Purpose { get => null; set => throw new NotImplementedException(); }
     }
 }

--- a/src/Hl7.Fhir.R5/Model/Generated/ActivityDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/ActivityDefinition.cs
@@ -878,13 +878,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the activity definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -919,13 +937,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=240, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this activity definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the activity definition
@@ -963,13 +999,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=260)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the activity definition was approved by publisher
@@ -1610,12 +1664,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1672,12 +1726,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1729,12 +1783,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1786,12 +1840,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -1842,12 +1896,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -1921,8 +1975,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1930,14 +1984,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -2046,12 +2100,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R5/Model/Generated/ActorDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/ActorDefinition.cs
@@ -338,13 +338,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the actor
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -379,26 +397,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this actor definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Copyright holder and year(s)
@@ -469,13 +523,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("documentation", Order=260)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Documentation
+    public Hl7.Fhir.Model.Markdown DocumentationElement
     {
-      get { return _Documentation; }
-      set { _Documentation = value; OnPropertyChanged("Documentation"); }
+      get { return _DocumentationElement; }
+      set { _DocumentationElement = value; OnPropertyChanged("DocumentationElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Documentation;
+    private Hl7.Fhir.Model.Markdown _DocumentationElement;
+
+    /// <summary>
+    /// Functionality associated with the actor
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Documentation
+    {
+      get { return DocumentationElement != null ? DocumentationElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DocumentationElement = null;
+        else
+          DocumentationElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Documentation");
+      }
+    }
 
     /// <summary>
     /// Reference to more information about the actor
@@ -592,14 +664,14 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(CopyrightLabelElement != null) dest.CopyrightLabelElement = (Hl7.Fhir.Model.FhirString)CopyrightLabelElement.DeepCopy();
       if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.ExampleScenarioActorType>)TypeElement.DeepCopy();
-      if(Documentation != null) dest.Documentation = (Hl7.Fhir.Model.Markdown)Documentation.DeepCopy();
+      if(DocumentationElement != null) dest.DocumentationElement = (Hl7.Fhir.Model.Markdown)DocumentationElement.DeepCopy();
       if(ReferenceElement != null) dest.ReferenceElement = new List<Hl7.Fhir.Model.FhirUrl>(ReferenceElement.DeepCopy());
       if(CapabilitiesElement != null) dest.CapabilitiesElement = (Hl7.Fhir.Model.Canonical)CapabilitiesElement.DeepCopy();
       if(DerivedFromElement != null) dest.DerivedFromElement = new List<Hl7.Fhir.Model.Canonical>(DerivedFromElement.DeepCopy());
@@ -628,14 +700,14 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.Matches(TypeElement, otherT.TypeElement)) return false;
-      if( !DeepComparable.Matches(Documentation, otherT.Documentation)) return false;
+      if( !DeepComparable.Matches(DocumentationElement, otherT.DocumentationElement)) return false;
       if( !DeepComparable.Matches(ReferenceElement, otherT.ReferenceElement)) return false;
       if( !DeepComparable.Matches(CapabilitiesElement, otherT.CapabilitiesElement)) return false;
       if( !DeepComparable.Matches(DerivedFromElement, otherT.DerivedFromElement)) return false;
@@ -659,14 +731,14 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.IsExactly(TypeElement, otherT.TypeElement)) return false;
-      if( !DeepComparable.IsExactly(Documentation, otherT.Documentation)) return false;
+      if( !DeepComparable.IsExactly(DocumentationElement, otherT.DocumentationElement)) return false;
       if( !DeepComparable.IsExactly(ReferenceElement, otherT.ReferenceElement)) return false;
       if( !DeepComparable.IsExactly(CapabilitiesElement, otherT.CapabilitiesElement)) return false;
       if( !DeepComparable.IsExactly(DerivedFromElement, otherT.DerivedFromElement)) return false;
@@ -690,14 +762,14 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (CopyrightLabelElement != null) yield return CopyrightLabelElement;
         if (TypeElement != null) yield return TypeElement;
-        if (Documentation != null) yield return Documentation;
+        if (DocumentationElement != null) yield return DocumentationElement;
         foreach (var elem in ReferenceElement) { if (elem != null) yield return elem; }
         if (CapabilitiesElement != null) yield return CapabilitiesElement;
         foreach (var elem in DerivedFromElement) { if (elem != null) yield return elem; }
@@ -720,14 +792,14 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (CopyrightLabelElement != null) yield return new ElementValue("copyrightLabel", CopyrightLabelElement);
         if (TypeElement != null) yield return new ElementValue("type", TypeElement);
-        if (Documentation != null) yield return new ElementValue("documentation", Documentation);
+        if (DocumentationElement != null) yield return new ElementValue("documentation", DocumentationElement);
         foreach (var elem in ReferenceElement) { if (elem != null) yield return new ElementValue("reference", elem); }
         if (CapabilitiesElement != null) yield return new ElementValue("capabilities", CapabilitiesElement);
         foreach (var elem in DerivedFromElement) { if (elem != null) yield return new ElementValue("derivedFrom", elem); }
@@ -769,8 +841,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -778,11 +850,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "copyrightLabel":
           value = CopyrightLabelElement;
           return CopyrightLabelElement is not null;
@@ -790,8 +862,8 @@ namespace Hl7.Fhir.Model
           value = TypeElement;
           return TypeElement is not null;
         case "documentation":
-          value = Documentation;
-          return Documentation is not null;
+          value = DocumentationElement;
+          return DocumentationElement is not null;
         case "reference":
           value = ReferenceElement;
           return ReferenceElement?.Any() == true;
@@ -820,14 +892,14 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (CopyrightLabelElement is not null) yield return new KeyValuePair<string,object>("copyrightLabel",CopyrightLabelElement);
       if (TypeElement is not null) yield return new KeyValuePair<string,object>("type",TypeElement);
-      if (Documentation is not null) yield return new KeyValuePair<string,object>("documentation",Documentation);
+      if (DocumentationElement is not null) yield return new KeyValuePair<string,object>("documentation",DocumentationElement);
       if (ReferenceElement?.Any() == true) yield return new KeyValuePair<string,object>("reference",ReferenceElement);
       if (CapabilitiesElement is not null) yield return new KeyValuePair<string,object>("capabilities",CapabilitiesElement);
       if (DerivedFromElement?.Any() == true) yield return new KeyValuePair<string,object>("derivedFrom",DerivedFromElement);

--- a/src/Hl7.Fhir.R5/Model/Generated/Annotation.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/Annotation.cs
@@ -108,13 +108,31 @@ namespace Hl7.Fhir.Model
     [FhirElement("text", InSummary=true, Order=50)]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Text
+    public Hl7.Fhir.Model.Markdown TextElement
     {
-      get { return _Text; }
-      set { _Text = value; OnPropertyChanged("Text"); }
+      get { return _TextElement; }
+      set { _TextElement = value; OnPropertyChanged("TextElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Text;
+    private Hl7.Fhir.Model.Markdown _TextElement;
+
+    /// <summary>
+    /// The annotation  - text content (as markdown)
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Text
+    {
+      get { return TextElement != null ? TextElement.Value : null; }
+      set
+      {
+        if (value == null)
+          TextElement = null;
+        else
+          TextElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Text");
+      }
+    }
 
     public override IDeepCopyable CopyTo(IDeepCopyable other)
     {
@@ -128,7 +146,7 @@ namespace Hl7.Fhir.Model
       base.CopyTo(dest);
       if(Author != null) dest.Author = (Hl7.Fhir.Model.DataType)Author.DeepCopy();
       if(TimeElement != null) dest.TimeElement = (Hl7.Fhir.Model.FhirDateTime)TimeElement.DeepCopy();
-      if(Text != null) dest.Text = (Hl7.Fhir.Model.Markdown)Text.DeepCopy();
+      if(TextElement != null) dest.TextElement = (Hl7.Fhir.Model.Markdown)TextElement.DeepCopy();
       return dest;
     }
 
@@ -146,7 +164,7 @@ namespace Hl7.Fhir.Model
       if(!base.Matches(otherT)) return false;
       if( !DeepComparable.Matches(Author, otherT.Author)) return false;
       if( !DeepComparable.Matches(TimeElement, otherT.TimeElement)) return false;
-      if( !DeepComparable.Matches(Text, otherT.Text)) return false;
+      if( !DeepComparable.Matches(TextElement, otherT.TextElement)) return false;
 
       return true;
     }
@@ -159,7 +177,7 @@ namespace Hl7.Fhir.Model
       if(!base.IsExactly(otherT)) return false;
       if( !DeepComparable.IsExactly(Author, otherT.Author)) return false;
       if( !DeepComparable.IsExactly(TimeElement, otherT.TimeElement)) return false;
-      if( !DeepComparable.IsExactly(Text, otherT.Text)) return false;
+      if( !DeepComparable.IsExactly(TextElement, otherT.TextElement)) return false;
 
       return true;
     }
@@ -172,7 +190,7 @@ namespace Hl7.Fhir.Model
         foreach (var item in base.Children) yield return item;
         if (Author != null) yield return Author;
         if (TimeElement != null) yield return TimeElement;
-        if (Text != null) yield return Text;
+        if (TextElement != null) yield return TextElement;
       }
     }
 
@@ -184,7 +202,7 @@ namespace Hl7.Fhir.Model
         foreach (var item in base.NamedChildren) yield return item;
         if (Author != null) yield return new ElementValue("author", Author);
         if (TimeElement != null) yield return new ElementValue("time", TimeElement);
-        if (Text != null) yield return new ElementValue("text", Text);
+        if (TextElement != null) yield return new ElementValue("text", TextElement);
       }
     }
 
@@ -199,8 +217,8 @@ namespace Hl7.Fhir.Model
           value = TimeElement;
           return TimeElement is not null;
         case "text":
-          value = Text;
-          return Text is not null;
+          value = TextElement;
+          return TextElement is not null;
         default:
           return base.TryGetValue(key, out value);
       }
@@ -212,7 +230,7 @@ namespace Hl7.Fhir.Model
       foreach (var kvp in base.GetElementPairs()) yield return kvp;
       if (Author is not null) yield return new KeyValuePair<string,object>("author",Author);
       if (TimeElement is not null) yield return new KeyValuePair<string,object>("time",TimeElement);
-      if (Text is not null) yield return new KeyValuePair<string,object>("text",Text);
+      if (TextElement is not null) yield return new KeyValuePair<string,object>("text",TextElement);
     }
 
   }

--- a/src/Hl7.Fhir.R5/Model/Generated/ArtifactAssessment.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/ArtifactAssessment.cs
@@ -255,13 +255,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("summary", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Summary
+      public Hl7.Fhir.Model.Markdown SummaryElement
       {
-        get { return _Summary; }
-        set { _Summary = value; OnPropertyChanged("Summary"); }
+        get { return _SummaryElement; }
+        set { _SummaryElement = value; OnPropertyChanged("SummaryElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Summary;
+      private Hl7.Fhir.Model.Markdown _SummaryElement;
+
+      /// <summary>
+      /// Brief summary of the content
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Summary
+      {
+        get { return SummaryElement != null ? SummaryElement.Value : null; }
+        set
+        {
+          if (value == null)
+            SummaryElement = null;
+          else
+            SummaryElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Summary");
+        }
+      }
 
       /// <summary>
       /// What type of content
@@ -407,7 +425,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(InformationTypeElement != null) dest.InformationTypeElement = (Code<Hl7.Fhir.Model.ArtifactAssessment.ArtifactAssessmentInformationType>)InformationTypeElement.DeepCopy();
-        if(Summary != null) dest.Summary = (Hl7.Fhir.Model.Markdown)Summary.DeepCopy();
+        if(SummaryElement != null) dest.SummaryElement = (Hl7.Fhir.Model.Markdown)SummaryElement.DeepCopy();
         if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
         if(Classifier != null) dest.Classifier = new List<Hl7.Fhir.Model.CodeableConcept>(Classifier.DeepCopy());
         if(Author != null) dest.Author = (Hl7.Fhir.Model.ResourceReference)Author.DeepCopy();
@@ -431,7 +449,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(InformationTypeElement, otherT.InformationTypeElement)) return false;
-        if( !DeepComparable.Matches(Summary, otherT.Summary)) return false;
+        if( !DeepComparable.Matches(SummaryElement, otherT.SummaryElement)) return false;
         if( !DeepComparable.Matches(Type, otherT.Type)) return false;
         if( !DeepComparable.Matches(Classifier, otherT.Classifier)) return false;
         if( !DeepComparable.Matches(Author, otherT.Author)) return false;
@@ -450,7 +468,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(InformationTypeElement, otherT.InformationTypeElement)) return false;
-        if( !DeepComparable.IsExactly(Summary, otherT.Summary)) return false;
+        if( !DeepComparable.IsExactly(SummaryElement, otherT.SummaryElement)) return false;
         if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
         if( !DeepComparable.IsExactly(Classifier, otherT.Classifier)) return false;
         if( !DeepComparable.IsExactly(Author, otherT.Author)) return false;
@@ -469,7 +487,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (InformationTypeElement != null) yield return InformationTypeElement;
-          if (Summary != null) yield return Summary;
+          if (SummaryElement != null) yield return SummaryElement;
           if (Type != null) yield return Type;
           foreach (var elem in Classifier) { if (elem != null) yield return elem; }
           if (Author != null) yield return Author;
@@ -487,7 +505,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (InformationTypeElement != null) yield return new ElementValue("informationType", InformationTypeElement);
-          if (Summary != null) yield return new ElementValue("summary", Summary);
+          if (SummaryElement != null) yield return new ElementValue("summary", SummaryElement);
           if (Type != null) yield return new ElementValue("type", Type);
           foreach (var elem in Classifier) { if (elem != null) yield return new ElementValue("classifier", elem); }
           if (Author != null) yield return new ElementValue("author", Author);
@@ -506,8 +524,8 @@ namespace Hl7.Fhir.Model
             value = InformationTypeElement;
             return InformationTypeElement is not null;
           case "summary":
-            value = Summary;
-            return Summary is not null;
+            value = SummaryElement;
+            return SummaryElement is not null;
           case "type":
             value = Type;
             return Type is not null;
@@ -539,7 +557,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (InformationTypeElement is not null) yield return new KeyValuePair<string,object>("informationType",InformationTypeElement);
-        if (Summary is not null) yield return new KeyValuePair<string,object>("summary",Summary);
+        if (SummaryElement is not null) yield return new KeyValuePair<string,object>("summary",SummaryElement);
         if (Type is not null) yield return new KeyValuePair<string,object>("type",Type);
         if (Classifier?.Any() == true) yield return new KeyValuePair<string,object>("classifier",Classifier);
         if (Author is not null) yield return new KeyValuePair<string,object>("author",Author);
@@ -617,13 +635,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=120)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the artifact assessment was approved by publisher
@@ -795,7 +831,7 @@ namespace Hl7.Fhir.Model
       if(Identifier != null) dest.Identifier = new List<Hl7.Fhir.Model.Identifier>(Identifier.DeepCopy());
       if(CiteAs != null) dest.CiteAs = (Hl7.Fhir.Model.DataType)CiteAs.DeepCopy();
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(Artifact != null) dest.Artifact = (Hl7.Fhir.Model.DataType)Artifact.DeepCopy();
@@ -820,7 +856,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Identifier, otherT.Identifier)) return false;
       if( !DeepComparable.Matches(CiteAs, otherT.CiteAs)) return false;
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(Artifact, otherT.Artifact)) return false;
@@ -840,7 +876,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Identifier, otherT.Identifier)) return false;
       if( !DeepComparable.IsExactly(CiteAs, otherT.CiteAs)) return false;
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(Artifact, otherT.Artifact)) return false;
@@ -860,7 +896,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Identifier) { if (elem != null) yield return elem; }
         if (CiteAs != null) yield return CiteAs;
         if (DateElement != null) yield return DateElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (Artifact != null) yield return Artifact;
@@ -879,7 +915,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Identifier) { if (elem != null) yield return new ElementValue("identifier", elem); }
         if (CiteAs != null) yield return new ElementValue("citeAs", CiteAs);
         if (DateElement != null) yield return new ElementValue("date", DateElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (Artifact != null) yield return new ElementValue("artifact", Artifact);
@@ -903,8 +939,8 @@ namespace Hl7.Fhir.Model
           value = DateElement;
           return DateElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -935,7 +971,7 @@ namespace Hl7.Fhir.Model
       if (Identifier?.Any() == true) yield return new KeyValuePair<string,object>("identifier",Identifier);
       if (CiteAs is not null) yield return new KeyValuePair<string,object>("citeAs",CiteAs);
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (Artifact is not null) yield return new KeyValuePair<string,object>("artifact",Artifact);

--- a/src/Hl7.Fhir.R5/Model/Generated/ChargeItemDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/ChargeItemDefinition.cs
@@ -721,13 +721,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the charge item definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -762,26 +780,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=250, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this charge item definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=260)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the charge item definition was approved by publisher
@@ -925,11 +979,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(Code != null) dest.Code = (Hl7.Fhir.Model.CodeableConcept)Code.DeepCopy();
@@ -964,11 +1018,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(Code, otherT.Code)) return false;
@@ -998,11 +1052,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(Code, otherT.Code)) return false;
@@ -1032,11 +1086,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (Code != null) yield return Code;
@@ -1065,11 +1119,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (Code != null) yield return new ElementValue("code", Code);
@@ -1123,8 +1177,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1132,11 +1186,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -1177,11 +1231,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (Code is not null) yield return new KeyValuePair<string,object>("code",Code);

--- a/src/Hl7.Fhir.R5/Model/Generated/Citation.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/Citation.cs
@@ -325,13 +325,31 @@ namespace Hl7.Fhir.Model
       [FhirElement("text", InSummary=true, Order=50)]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Text
+      public Hl7.Fhir.Model.Markdown TextElement
       {
-        get { return _Text; }
-        set { _Text = value; OnPropertyChanged("Text"); }
+        get { return _TextElement; }
+        set { _TextElement = value; OnPropertyChanged("TextElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Text;
+      private Hl7.Fhir.Model.Markdown _TextElement;
+
+      /// <summary>
+      /// The human-readable display of the citation summary
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Text
+      {
+        get { return TextElement != null ? TextElement.Value : null; }
+        set
+        {
+          if (value == null)
+            TextElement = null;
+          else
+            TextElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Text");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -344,7 +362,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(Style != null) dest.Style = (Hl7.Fhir.Model.CodeableConcept)Style.DeepCopy();
-        if(Text != null) dest.Text = (Hl7.Fhir.Model.Markdown)Text.DeepCopy();
+        if(TextElement != null) dest.TextElement = (Hl7.Fhir.Model.Markdown)TextElement.DeepCopy();
         return dest;
       }
 
@@ -361,7 +379,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(Style, otherT.Style)) return false;
-        if( !DeepComparable.Matches(Text, otherT.Text)) return false;
+        if( !DeepComparable.Matches(TextElement, otherT.TextElement)) return false;
 
         return true;
       }
@@ -373,7 +391,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(Style, otherT.Style)) return false;
-        if( !DeepComparable.IsExactly(Text, otherT.Text)) return false;
+        if( !DeepComparable.IsExactly(TextElement, otherT.TextElement)) return false;
 
         return true;
       }
@@ -385,7 +403,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (Style != null) yield return Style;
-          if (Text != null) yield return Text;
+          if (TextElement != null) yield return TextElement;
         }
       }
 
@@ -396,7 +414,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (Style != null) yield return new ElementValue("style", Style);
-          if (Text != null) yield return new ElementValue("text", Text);
+          if (TextElement != null) yield return new ElementValue("text", TextElement);
         }
       }
 
@@ -408,8 +426,8 @@ namespace Hl7.Fhir.Model
             value = Style;
             return Style is not null;
           case "text":
-            value = Text;
-            return Text is not null;
+            value = TextElement;
+            return TextElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -420,7 +438,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (Style is not null) yield return new KeyValuePair<string,object>("style",Style);
-        if (Text is not null) yield return new KeyValuePair<string,object>("text",Text);
+        if (TextElement is not null) yield return new KeyValuePair<string,object>("text",TextElement);
       }
 
     }
@@ -1547,13 +1565,31 @@ namespace Hl7.Fhir.Model
       [FhirElement("text", Order=60)]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Text
+      public Hl7.Fhir.Model.Markdown TextElement
       {
-        get { return _Text; }
-        set { _Text = value; OnPropertyChanged("Text"); }
+        get { return _TextElement; }
+        set { _TextElement = value; OnPropertyChanged("TextElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Text;
+      private Hl7.Fhir.Model.Markdown _TextElement;
+
+      /// <summary>
+      /// The title of the article or artifact
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Text
+      {
+        get { return TextElement != null ? TextElement.Value : null; }
+        set
+        {
+          if (value == null)
+            TextElement = null;
+          else
+            TextElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Text");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -1567,7 +1603,7 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(Type != null) dest.Type = new List<Hl7.Fhir.Model.CodeableConcept>(Type.DeepCopy());
         if(Language != null) dest.Language = (Hl7.Fhir.Model.CodeableConcept)Language.DeepCopy();
-        if(Text != null) dest.Text = (Hl7.Fhir.Model.Markdown)Text.DeepCopy();
+        if(TextElement != null) dest.TextElement = (Hl7.Fhir.Model.Markdown)TextElement.DeepCopy();
         return dest;
       }
 
@@ -1585,7 +1621,7 @@ namespace Hl7.Fhir.Model
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(Type, otherT.Type)) return false;
         if( !DeepComparable.Matches(Language, otherT.Language)) return false;
-        if( !DeepComparable.Matches(Text, otherT.Text)) return false;
+        if( !DeepComparable.Matches(TextElement, otherT.TextElement)) return false;
 
         return true;
       }
@@ -1598,7 +1634,7 @@ namespace Hl7.Fhir.Model
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
         if( !DeepComparable.IsExactly(Language, otherT.Language)) return false;
-        if( !DeepComparable.IsExactly(Text, otherT.Text)) return false;
+        if( !DeepComparable.IsExactly(TextElement, otherT.TextElement)) return false;
 
         return true;
       }
@@ -1611,7 +1647,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.Children) yield return item;
           foreach (var elem in Type) { if (elem != null) yield return elem; }
           if (Language != null) yield return Language;
-          if (Text != null) yield return Text;
+          if (TextElement != null) yield return TextElement;
         }
       }
 
@@ -1623,7 +1659,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.NamedChildren) yield return item;
           foreach (var elem in Type) { if (elem != null) yield return new ElementValue("type", elem); }
           if (Language != null) yield return new ElementValue("language", Language);
-          if (Text != null) yield return new ElementValue("text", Text);
+          if (TextElement != null) yield return new ElementValue("text", TextElement);
         }
       }
 
@@ -1638,8 +1674,8 @@ namespace Hl7.Fhir.Model
             value = Language;
             return Language is not null;
           case "text":
-            value = Text;
-            return Text is not null;
+            value = TextElement;
+            return TextElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -1651,7 +1687,7 @@ namespace Hl7.Fhir.Model
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (Type?.Any() == true) yield return new KeyValuePair<string,object>("type",Type);
         if (Language is not null) yield return new KeyValuePair<string,object>("language",Language);
-        if (Text is not null) yield return new KeyValuePair<string,object>("text",Text);
+        if (TextElement is not null) yield return new KeyValuePair<string,object>("text",TextElement);
       }
 
     }
@@ -1701,26 +1737,62 @@ namespace Hl7.Fhir.Model
       [FhirElement("text", Order=60)]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Text
+      public Hl7.Fhir.Model.Markdown TextElement
       {
-        get { return _Text; }
-        set { _Text = value; OnPropertyChanged("Text"); }
+        get { return _TextElement; }
+        set { _TextElement = value; OnPropertyChanged("TextElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Text;
+      private Hl7.Fhir.Model.Markdown _TextElement;
+
+      /// <summary>
+      /// Abstract content
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Text
+      {
+        get { return TextElement != null ? TextElement.Value : null; }
+        set
+        {
+          if (value == null)
+            TextElement = null;
+          else
+            TextElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Text");
+        }
+      }
 
       /// <summary>
       /// Copyright notice for the abstract
       /// </summary>
       [FhirElement("copyright", Order=70)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Copyright
+      public Hl7.Fhir.Model.Markdown CopyrightElement
       {
-        get { return _Copyright; }
-        set { _Copyright = value; OnPropertyChanged("Copyright"); }
+        get { return _CopyrightElement; }
+        set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Copyright;
+      private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+      /// <summary>
+      /// Copyright notice for the abstract
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Copyright
+      {
+        get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+        set
+        {
+          if (value == null)
+            CopyrightElement = null;
+          else
+            CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Copyright");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -1734,8 +1806,8 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
         if(Language != null) dest.Language = (Hl7.Fhir.Model.CodeableConcept)Language.DeepCopy();
-        if(Text != null) dest.Text = (Hl7.Fhir.Model.Markdown)Text.DeepCopy();
-        if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+        if(TextElement != null) dest.TextElement = (Hl7.Fhir.Model.Markdown)TextElement.DeepCopy();
+        if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
         return dest;
       }
 
@@ -1753,8 +1825,8 @@ namespace Hl7.Fhir.Model
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(Type, otherT.Type)) return false;
         if( !DeepComparable.Matches(Language, otherT.Language)) return false;
-        if( !DeepComparable.Matches(Text, otherT.Text)) return false;
-        if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+        if( !DeepComparable.Matches(TextElement, otherT.TextElement)) return false;
+        if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
 
         return true;
       }
@@ -1767,8 +1839,8 @@ namespace Hl7.Fhir.Model
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
         if( !DeepComparable.IsExactly(Language, otherT.Language)) return false;
-        if( !DeepComparable.IsExactly(Text, otherT.Text)) return false;
-        if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+        if( !DeepComparable.IsExactly(TextElement, otherT.TextElement)) return false;
+        if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
 
         return true;
       }
@@ -1781,8 +1853,8 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.Children) yield return item;
           if (Type != null) yield return Type;
           if (Language != null) yield return Language;
-          if (Text != null) yield return Text;
-          if (Copyright != null) yield return Copyright;
+          if (TextElement != null) yield return TextElement;
+          if (CopyrightElement != null) yield return CopyrightElement;
         }
       }
 
@@ -1794,8 +1866,8 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.NamedChildren) yield return item;
           if (Type != null) yield return new ElementValue("type", Type);
           if (Language != null) yield return new ElementValue("language", Language);
-          if (Text != null) yield return new ElementValue("text", Text);
-          if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+          if (TextElement != null) yield return new ElementValue("text", TextElement);
+          if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         }
       }
 
@@ -1810,11 +1882,11 @@ namespace Hl7.Fhir.Model
             value = Language;
             return Language is not null;
           case "text":
-            value = Text;
-            return Text is not null;
+            value = TextElement;
+            return TextElement is not null;
           case "copyright":
-            value = Copyright;
-            return Copyright is not null;
+            value = CopyrightElement;
+            return CopyrightElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -1826,8 +1898,8 @@ namespace Hl7.Fhir.Model
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (Type is not null) yield return new KeyValuePair<string,object>("type",Type);
         if (Language is not null) yield return new KeyValuePair<string,object>("language",Language);
-        if (Text is not null) yield return new KeyValuePair<string,object>("text",Text);
-        if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+        if (TextElement is not null) yield return new KeyValuePair<string,object>("text",TextElement);
+        if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       }
 
     }
@@ -2132,13 +2204,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("citation", Order=80)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Citation
+      public Hl7.Fhir.Model.Markdown CitationElement
       {
-        get { return _Citation; }
-        set { _Citation = value; OnPropertyChanged("Citation"); }
+        get { return _CitationElement; }
+        set { _CitationElement = value; OnPropertyChanged("CitationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Citation;
+      private Hl7.Fhir.Model.Markdown _CitationElement;
+
+      /// <summary>
+      /// Bibliographic citation for the artifact
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Citation
+      {
+        get { return CitationElement != null ? CitationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            CitationElement = null;
+          else
+            CitationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Citation");
+        }
+      }
 
       /// <summary>
       /// What document is being referenced
@@ -2211,7 +2301,7 @@ namespace Hl7.Fhir.Model
         if(Classifier != null) dest.Classifier = new List<Hl7.Fhir.Model.CodeableConcept>(Classifier.DeepCopy());
         if(LabelElement != null) dest.LabelElement = (Hl7.Fhir.Model.FhirString)LabelElement.DeepCopy();
         if(DisplayElement != null) dest.DisplayElement = (Hl7.Fhir.Model.FhirString)DisplayElement.DeepCopy();
-        if(Citation != null) dest.Citation = (Hl7.Fhir.Model.Markdown)Citation.DeepCopy();
+        if(CitationElement != null) dest.CitationElement = (Hl7.Fhir.Model.Markdown)CitationElement.DeepCopy();
         if(Document != null) dest.Document = (Hl7.Fhir.Model.Attachment)Document.DeepCopy();
         if(ResourceElement != null) dest.ResourceElement = (Hl7.Fhir.Model.Canonical)ResourceElement.DeepCopy();
         if(ResourceReference != null) dest.ResourceReference = (Hl7.Fhir.Model.ResourceReference)ResourceReference.DeepCopy();
@@ -2234,7 +2324,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(Classifier, otherT.Classifier)) return false;
         if( !DeepComparable.Matches(LabelElement, otherT.LabelElement)) return false;
         if( !DeepComparable.Matches(DisplayElement, otherT.DisplayElement)) return false;
-        if( !DeepComparable.Matches(Citation, otherT.Citation)) return false;
+        if( !DeepComparable.Matches(CitationElement, otherT.CitationElement)) return false;
         if( !DeepComparable.Matches(Document, otherT.Document)) return false;
         if( !DeepComparable.Matches(ResourceElement, otherT.ResourceElement)) return false;
         if( !DeepComparable.Matches(ResourceReference, otherT.ResourceReference)) return false;
@@ -2252,7 +2342,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(Classifier, otherT.Classifier)) return false;
         if( !DeepComparable.IsExactly(LabelElement, otherT.LabelElement)) return false;
         if( !DeepComparable.IsExactly(DisplayElement, otherT.DisplayElement)) return false;
-        if( !DeepComparable.IsExactly(Citation, otherT.Citation)) return false;
+        if( !DeepComparable.IsExactly(CitationElement, otherT.CitationElement)) return false;
         if( !DeepComparable.IsExactly(Document, otherT.Document)) return false;
         if( !DeepComparable.IsExactly(ResourceElement, otherT.ResourceElement)) return false;
         if( !DeepComparable.IsExactly(ResourceReference, otherT.ResourceReference)) return false;
@@ -2270,7 +2360,7 @@ namespace Hl7.Fhir.Model
           foreach (var elem in Classifier) { if (elem != null) yield return elem; }
           if (LabelElement != null) yield return LabelElement;
           if (DisplayElement != null) yield return DisplayElement;
-          if (Citation != null) yield return Citation;
+          if (CitationElement != null) yield return CitationElement;
           if (Document != null) yield return Document;
           if (ResourceElement != null) yield return ResourceElement;
           if (ResourceReference != null) yield return ResourceReference;
@@ -2287,7 +2377,7 @@ namespace Hl7.Fhir.Model
           foreach (var elem in Classifier) { if (elem != null) yield return new ElementValue("classifier", elem); }
           if (LabelElement != null) yield return new ElementValue("label", LabelElement);
           if (DisplayElement != null) yield return new ElementValue("display", DisplayElement);
-          if (Citation != null) yield return new ElementValue("citation", Citation);
+          if (CitationElement != null) yield return new ElementValue("citation", CitationElement);
           if (Document != null) yield return new ElementValue("document", Document);
           if (ResourceElement != null) yield return new ElementValue("resource", ResourceElement);
           if (ResourceReference != null) yield return new ElementValue("resourceReference", ResourceReference);
@@ -2311,8 +2401,8 @@ namespace Hl7.Fhir.Model
             value = DisplayElement;
             return DisplayElement is not null;
           case "citation":
-            value = Citation;
-            return Citation is not null;
+            value = CitationElement;
+            return CitationElement is not null;
           case "document":
             value = Document;
             return Document is not null;
@@ -2335,7 +2425,7 @@ namespace Hl7.Fhir.Model
         if (Classifier?.Any() == true) yield return new KeyValuePair<string,object>("classifier",Classifier);
         if (LabelElement is not null) yield return new KeyValuePair<string,object>("label",LabelElement);
         if (DisplayElement is not null) yield return new KeyValuePair<string,object>("display",DisplayElement);
-        if (Citation is not null) yield return new KeyValuePair<string,object>("citation",Citation);
+        if (CitationElement is not null) yield return new KeyValuePair<string,object>("citation",CitationElement);
         if (Document is not null) yield return new KeyValuePair<string,object>("document",Document);
         if (ResourceElement is not null) yield return new KeyValuePair<string,object>("resource",ResourceElement);
         if (ResourceReference is not null) yield return new KeyValuePair<string,object>("resourceReference",ResourceReference);
@@ -2835,13 +2925,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("copyright", Order=210)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Copyright
+      public Hl7.Fhir.Model.Markdown CopyrightElement
       {
-        get { return _Copyright; }
-        set { _Copyright = value; OnPropertyChanged("Copyright"); }
+        get { return _CopyrightElement; }
+        set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Copyright;
+      private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+      /// <summary>
+      /// Copyright notice for the full article or artifact
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Copyright
+      {
+        get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+        set
+        {
+          if (value == null)
+            CopyrightElement = null;
+          else
+            CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Copyright");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -2870,7 +2978,7 @@ namespace Hl7.Fhir.Model
         if(FirstPageElement != null) dest.FirstPageElement = (Hl7.Fhir.Model.FhirString)FirstPageElement.DeepCopy();
         if(LastPageElement != null) dest.LastPageElement = (Hl7.Fhir.Model.FhirString)LastPageElement.DeepCopy();
         if(PageCountElement != null) dest.PageCountElement = (Hl7.Fhir.Model.FhirString)PageCountElement.DeepCopy();
-        if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+        if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
         return dest;
       }
 
@@ -2903,7 +3011,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(FirstPageElement, otherT.FirstPageElement)) return false;
         if( !DeepComparable.Matches(LastPageElement, otherT.LastPageElement)) return false;
         if( !DeepComparable.Matches(PageCountElement, otherT.PageCountElement)) return false;
-        if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+        if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
 
         return true;
       }
@@ -2931,7 +3039,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(FirstPageElement, otherT.FirstPageElement)) return false;
         if( !DeepComparable.IsExactly(LastPageElement, otherT.LastPageElement)) return false;
         if( !DeepComparable.IsExactly(PageCountElement, otherT.PageCountElement)) return false;
-        if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+        if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
 
         return true;
       }
@@ -2959,7 +3067,7 @@ namespace Hl7.Fhir.Model
           if (FirstPageElement != null) yield return FirstPageElement;
           if (LastPageElement != null) yield return LastPageElement;
           if (PageCountElement != null) yield return PageCountElement;
-          if (Copyright != null) yield return Copyright;
+          if (CopyrightElement != null) yield return CopyrightElement;
         }
       }
 
@@ -2986,7 +3094,7 @@ namespace Hl7.Fhir.Model
           if (FirstPageElement != null) yield return new ElementValue("firstPage", FirstPageElement);
           if (LastPageElement != null) yield return new ElementValue("lastPage", LastPageElement);
           if (PageCountElement != null) yield return new ElementValue("pageCount", PageCountElement);
-          if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+          if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         }
       }
 
@@ -3046,8 +3154,8 @@ namespace Hl7.Fhir.Model
             value = PageCountElement;
             return PageCountElement is not null;
           case "copyright":
-            value = Copyright;
-            return Copyright is not null;
+            value = CopyrightElement;
+            return CopyrightElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -3074,7 +3182,7 @@ namespace Hl7.Fhir.Model
         if (FirstPageElement is not null) yield return new KeyValuePair<string,object>("firstPage",FirstPageElement);
         if (LastPageElement is not null) yield return new KeyValuePair<string,object>("lastPage",LastPageElement);
         if (PageCountElement is not null) yield return new KeyValuePair<string,object>("pageCount",PageCountElement);
-        if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+        if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       }
 
     }
@@ -4329,13 +4437,31 @@ namespace Hl7.Fhir.Model
       [FhirElement("value", Order=70)]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Value
+      public Hl7.Fhir.Model.Markdown ValueElement
       {
-        get { return _Value; }
-        set { _Value = value; OnPropertyChanged("Value"); }
+        get { return _ValueElement; }
+        set { _ValueElement = value; OnPropertyChanged("ValueElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Value;
+      private Hl7.Fhir.Model.Markdown _ValueElement;
+
+      /// <summary>
+      /// The display string for the author list, contributor list, or contributorship statement
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Value
+      {
+        get { return ValueElement != null ? ValueElement.Value : null; }
+        set
+        {
+          if (value == null)
+            ValueElement = null;
+          else
+            ValueElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Value");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -4350,7 +4476,7 @@ namespace Hl7.Fhir.Model
         if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
         if(Style != null) dest.Style = (Hl7.Fhir.Model.CodeableConcept)Style.DeepCopy();
         if(Source != null) dest.Source = (Hl7.Fhir.Model.CodeableConcept)Source.DeepCopy();
-        if(Value != null) dest.Value = (Hl7.Fhir.Model.Markdown)Value.DeepCopy();
+        if(ValueElement != null) dest.ValueElement = (Hl7.Fhir.Model.Markdown)ValueElement.DeepCopy();
         return dest;
       }
 
@@ -4369,7 +4495,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(Type, otherT.Type)) return false;
         if( !DeepComparable.Matches(Style, otherT.Style)) return false;
         if( !DeepComparable.Matches(Source, otherT.Source)) return false;
-        if( !DeepComparable.Matches(Value, otherT.Value)) return false;
+        if( !DeepComparable.Matches(ValueElement, otherT.ValueElement)) return false;
 
         return true;
       }
@@ -4383,7 +4509,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
         if( !DeepComparable.IsExactly(Style, otherT.Style)) return false;
         if( !DeepComparable.IsExactly(Source, otherT.Source)) return false;
-        if( !DeepComparable.IsExactly(Value, otherT.Value)) return false;
+        if( !DeepComparable.IsExactly(ValueElement, otherT.ValueElement)) return false;
 
         return true;
       }
@@ -4397,7 +4523,7 @@ namespace Hl7.Fhir.Model
           if (Type != null) yield return Type;
           if (Style != null) yield return Style;
           if (Source != null) yield return Source;
-          if (Value != null) yield return Value;
+          if (ValueElement != null) yield return ValueElement;
         }
       }
 
@@ -4410,7 +4536,7 @@ namespace Hl7.Fhir.Model
           if (Type != null) yield return new ElementValue("type", Type);
           if (Style != null) yield return new ElementValue("style", Style);
           if (Source != null) yield return new ElementValue("source", Source);
-          if (Value != null) yield return new ElementValue("value", Value);
+          if (ValueElement != null) yield return new ElementValue("value", ValueElement);
         }
       }
 
@@ -4428,8 +4554,8 @@ namespace Hl7.Fhir.Model
             value = Source;
             return Source is not null;
           case "value":
-            value = Value;
-            return Value is not null;
+            value = ValueElement;
+            return ValueElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -4442,7 +4568,7 @@ namespace Hl7.Fhir.Model
         if (Type is not null) yield return new KeyValuePair<string,object>("type",Type);
         if (Style is not null) yield return new KeyValuePair<string,object>("style",Style);
         if (Source is not null) yield return new KeyValuePair<string,object>("source",Source);
-        if (Value is not null) yield return new KeyValuePair<string,object>("value",Value);
+        if (ValueElement is not null) yield return new KeyValuePair<string,object>("value",ValueElement);
       }
 
     }
@@ -4730,13 +4856,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the citation
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the citation record content is intended to support
@@ -4771,26 +4915,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this citation is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions for the citation record, not for the cited artifact
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions for the citation record, not for the cited artifact
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the citation record was approved by publisher
@@ -5040,11 +5220,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -5084,11 +5264,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -5123,11 +5303,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -5162,11 +5342,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -5200,11 +5380,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -5257,8 +5437,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -5266,11 +5446,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -5332,11 +5512,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R5/Model/Generated/ClinicalUseDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/ClinicalUseDefinition.cs
@@ -1205,13 +1205,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", InSummary=true, Order=40)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// A textual definition of this warning, with formatting
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// A coded or unformatted textual definition of this warning
@@ -1236,7 +1254,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(Code != null) dest.Code = (Hl7.Fhir.Model.CodeableConcept)Code.DeepCopy();
         return dest;
       }
@@ -1253,7 +1271,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.Matches(otherT)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(Code, otherT.Code)) return false;
 
         return true;
@@ -1265,7 +1283,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.IsExactly(otherT)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(Code, otherT.Code)) return false;
 
         return true;
@@ -1277,7 +1295,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.Children) yield return item;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           if (Code != null) yield return Code;
         }
       }
@@ -1288,7 +1306,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.NamedChildren) yield return item;
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (Code != null) yield return new ElementValue("code", Code);
         }
       }
@@ -1298,8 +1316,8 @@ namespace Hl7.Fhir.Model
         switch (key)
         {
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "code":
             value = Code;
             return Code is not null;
@@ -1312,7 +1330,7 @@ namespace Hl7.Fhir.Model
       protected override IEnumerable<KeyValuePair<string, object>> GetElementPairs()
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (Code is not null) yield return new KeyValuePair<string,object>("code",Code);
       }
 

--- a/src/Hl7.Fhir.R5/Model/Generated/CompartmentDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/CompartmentDefinition.cs
@@ -631,13 +631,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the compartment definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -658,13 +676,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=210, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this compartment definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Patient | Encounter | RelatedPerson | Practitioner | Device
@@ -765,9 +801,9 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(CodeElement != null) dest.CodeElement = (Code<Hl7.Fhir.Model.CompartmentType>)CodeElement.DeepCopy();
       if(SearchElement != null) dest.SearchElement = (Hl7.Fhir.Model.FhirBoolean)SearchElement.DeepCopy();
       if(Resource != null) dest.Resource = new List<Hl7.Fhir.Model.CompartmentDefinition.ResourceComponent>(Resource.DeepCopy());
@@ -796,9 +832,9 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(CodeElement, otherT.CodeElement)) return false;
       if( !DeepComparable.Matches(SearchElement, otherT.SearchElement)) return false;
       if( !DeepComparable.Matches(Resource, otherT.Resource)) return false;
@@ -822,9 +858,9 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(CodeElement, otherT.CodeElement)) return false;
       if( !DeepComparable.IsExactly(SearchElement, otherT.SearchElement)) return false;
       if( !DeepComparable.IsExactly(Resource, otherT.Resource)) return false;
@@ -848,9 +884,9 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (CodeElement != null) yield return CodeElement;
         if (SearchElement != null) yield return SearchElement;
         foreach (var elem in Resource) { if (elem != null) yield return elem; }
@@ -873,9 +909,9 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (CodeElement != null) yield return new ElementValue("code", CodeElement);
         if (SearchElement != null) yield return new ElementValue("search", SearchElement);
         foreach (var elem in Resource) { if (elem != null) yield return new ElementValue("resource", elem); }
@@ -917,14 +953,14 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "code":
           value = CodeElement;
           return CodeElement is not null;
@@ -953,9 +989,9 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (CodeElement is not null) yield return new KeyValuePair<string,object>("code",CodeElement);
       if (SearchElement is not null) yield return new KeyValuePair<string,object>("search",SearchElement);
       if (Resource?.Any() == true) yield return new KeyValuePair<string,object>("resource",Resource);

--- a/src/Hl7.Fhir.R5/Model/Generated/ConceptMap.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/ConceptMap.cs
@@ -1745,13 +1745,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the concept map
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1786,26 +1804,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this concept map is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the ConceptMap was approved by publisher
@@ -2030,11 +2084,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -2072,11 +2126,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -2109,11 +2163,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -2146,11 +2200,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -2182,11 +2236,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -2237,8 +2291,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2246,11 +2300,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -2306,11 +2360,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R5/Model/Generated/ConditionDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/ConditionDefinition.cs
@@ -1145,13 +1145,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the condition definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1466,7 +1484,7 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
       if(Code != null) dest.Code = (Hl7.Fhir.Model.CodeableConcept)Code.DeepCopy();
@@ -1509,7 +1527,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.Matches(Code, otherT.Code)) return false;
@@ -1547,7 +1565,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.IsExactly(Code, otherT.Code)) return false;
@@ -1585,7 +1603,7 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
         if (Code != null) yield return Code;
@@ -1622,7 +1640,7 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
         if (Code != null) yield return new ElementValue("code", Code);
@@ -1680,8 +1698,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1750,7 +1768,7 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
       if (Code is not null) yield return new KeyValuePair<string,object>("code",Code);

--- a/src/Hl7.Fhir.R5/Model/Generated/Contract.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/Contract.cs
@@ -379,13 +379,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("copyright", Order=90)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Copyright
+      public Hl7.Fhir.Model.Markdown CopyrightElement
       {
-        get { return _Copyright; }
-        set { _Copyright = value; OnPropertyChanged("Copyright"); }
+        get { return _CopyrightElement; }
+        set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Copyright;
+      private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+      /// <summary>
+      /// Publication Ownership
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Copyright
+      {
+        get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+        set
+        {
+          if (value == null)
+            CopyrightElement = null;
+          else
+            CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Copyright");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -402,7 +420,7 @@ namespace Hl7.Fhir.Model
         if(Publisher != null) dest.Publisher = (Hl7.Fhir.Model.ResourceReference)Publisher.DeepCopy();
         if(PublicationDateElement != null) dest.PublicationDateElement = (Hl7.Fhir.Model.FhirDateTime)PublicationDateElement.DeepCopy();
         if(PublicationStatusElement != null) dest.PublicationStatusElement = (Code<Hl7.Fhir.Model.Contract.ContractResourcePublicationStatusCodes>)PublicationStatusElement.DeepCopy();
-        if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+        if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
         return dest;
       }
 
@@ -423,7 +441,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(Publisher, otherT.Publisher)) return false;
         if( !DeepComparable.Matches(PublicationDateElement, otherT.PublicationDateElement)) return false;
         if( !DeepComparable.Matches(PublicationStatusElement, otherT.PublicationStatusElement)) return false;
-        if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+        if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
 
         return true;
       }
@@ -439,7 +457,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(Publisher, otherT.Publisher)) return false;
         if( !DeepComparable.IsExactly(PublicationDateElement, otherT.PublicationDateElement)) return false;
         if( !DeepComparable.IsExactly(PublicationStatusElement, otherT.PublicationStatusElement)) return false;
-        if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+        if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
 
         return true;
       }
@@ -455,7 +473,7 @@ namespace Hl7.Fhir.Model
           if (Publisher != null) yield return Publisher;
           if (PublicationDateElement != null) yield return PublicationDateElement;
           if (PublicationStatusElement != null) yield return PublicationStatusElement;
-          if (Copyright != null) yield return Copyright;
+          if (CopyrightElement != null) yield return CopyrightElement;
         }
       }
 
@@ -470,7 +488,7 @@ namespace Hl7.Fhir.Model
           if (Publisher != null) yield return new ElementValue("publisher", Publisher);
           if (PublicationDateElement != null) yield return new ElementValue("publicationDate", PublicationDateElement);
           if (PublicationStatusElement != null) yield return new ElementValue("publicationStatus", PublicationStatusElement);
-          if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+          if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         }
       }
 
@@ -494,8 +512,8 @@ namespace Hl7.Fhir.Model
             value = PublicationStatusElement;
             return PublicationStatusElement is not null;
           case "copyright":
-            value = Copyright;
-            return Copyright is not null;
+            value = CopyrightElement;
+            return CopyrightElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -510,7 +528,7 @@ namespace Hl7.Fhir.Model
         if (Publisher is not null) yield return new KeyValuePair<string,object>("publisher",Publisher);
         if (PublicationDateElement is not null) yield return new KeyValuePair<string,object>("publicationDate",PublicationDateElement);
         if (PublicationStatusElement is not null) yield return new KeyValuePair<string,object>("publicationStatus",PublicationStatusElement);
-        if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+        if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       }
 
     }

--- a/src/Hl7.Fhir.R5/Model/Generated/DeviceDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/DeviceDefinition.cs
@@ -2302,13 +2302,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("usageInstruction", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown UsageInstruction
+      public Hl7.Fhir.Model.Markdown UsageInstructionElement
       {
-        get { return _UsageInstruction; }
-        set { _UsageInstruction = value; OnPropertyChanged("UsageInstruction"); }
+        get { return _UsageInstructionElement; }
+        set { _UsageInstructionElement = value; OnPropertyChanged("UsageInstructionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _UsageInstruction;
+      private Hl7.Fhir.Model.Markdown _UsageInstructionElement;
+
+      /// <summary>
+      /// Detailed written and visual directions for the user on how to use the device
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string UsageInstruction
+      {
+        get { return UsageInstructionElement != null ? UsageInstructionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            UsageInstructionElement = null;
+          else
+            UsageInstructionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("UsageInstruction");
+        }
+      }
 
       /// <summary>
       /// A source of information or reference for this guideline
@@ -2408,7 +2426,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
-        if(UsageInstruction != null) dest.UsageInstruction = (Hl7.Fhir.Model.Markdown)UsageInstruction.DeepCopy();
+        if(UsageInstructionElement != null) dest.UsageInstructionElement = (Hl7.Fhir.Model.Markdown)UsageInstructionElement.DeepCopy();
         if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
         if(Indication != null) dest.Indication = new List<Hl7.Fhir.Model.CodeableReference>(Indication.DeepCopy());
         if(Contraindication != null) dest.Contraindication = new List<Hl7.Fhir.Model.CodeableReference>(Contraindication.DeepCopy());
@@ -2430,7 +2448,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
-        if( !DeepComparable.Matches(UsageInstruction, otherT.UsageInstruction)) return false;
+        if( !DeepComparable.Matches(UsageInstructionElement, otherT.UsageInstructionElement)) return false;
         if( !DeepComparable.Matches(RelatedArtifact, otherT.RelatedArtifact)) return false;
         if( !DeepComparable.Matches(Indication, otherT.Indication)) return false;
         if( !DeepComparable.Matches(Contraindication, otherT.Contraindication)) return false;
@@ -2447,7 +2465,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
-        if( !DeepComparable.IsExactly(UsageInstruction, otherT.UsageInstruction)) return false;
+        if( !DeepComparable.IsExactly(UsageInstructionElement, otherT.UsageInstructionElement)) return false;
         if( !DeepComparable.IsExactly(RelatedArtifact, otherT.RelatedArtifact)) return false;
         if( !DeepComparable.IsExactly(Indication, otherT.Indication)) return false;
         if( !DeepComparable.IsExactly(Contraindication, otherT.Contraindication)) return false;
@@ -2464,7 +2482,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           foreach (var elem in UseContext) { if (elem != null) yield return elem; }
-          if (UsageInstruction != null) yield return UsageInstruction;
+          if (UsageInstructionElement != null) yield return UsageInstructionElement;
           foreach (var elem in RelatedArtifact) { if (elem != null) yield return elem; }
           foreach (var elem in Indication) { if (elem != null) yield return elem; }
           foreach (var elem in Contraindication) { if (elem != null) yield return elem; }
@@ -2480,7 +2498,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
-          if (UsageInstruction != null) yield return new ElementValue("usageInstruction", UsageInstruction);
+          if (UsageInstructionElement != null) yield return new ElementValue("usageInstruction", UsageInstructionElement);
           foreach (var elem in RelatedArtifact) { if (elem != null) yield return new ElementValue("relatedArtifact", elem); }
           foreach (var elem in Indication) { if (elem != null) yield return new ElementValue("indication", elem); }
           foreach (var elem in Contraindication) { if (elem != null) yield return new ElementValue("contraindication", elem); }
@@ -2497,8 +2515,8 @@ namespace Hl7.Fhir.Model
             value = UseContext;
             return UseContext?.Any() == true;
           case "usageInstruction":
-            value = UsageInstruction;
-            return UsageInstruction is not null;
+            value = UsageInstructionElement;
+            return UsageInstructionElement is not null;
           case "relatedArtifact":
             value = RelatedArtifact;
             return RelatedArtifact?.Any() == true;
@@ -2524,7 +2542,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
-        if (UsageInstruction is not null) yield return new KeyValuePair<string,object>("usageInstruction",UsageInstruction);
+        if (UsageInstructionElement is not null) yield return new KeyValuePair<string,object>("usageInstruction",UsageInstructionElement);
         if (RelatedArtifact?.Any() == true) yield return new KeyValuePair<string,object>("relatedArtifact",RelatedArtifact);
         if (Indication?.Any() == true) yield return new KeyValuePair<string,object>("indication",Indication);
         if (Contraindication?.Any() == true) yield return new KeyValuePair<string,object>("contraindication",Contraindication);
@@ -2909,13 +2927,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=90)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Additional information to describe the device
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Instance identifier
@@ -3345,7 +3381,7 @@ namespace Hl7.Fhir.Model
       }
 
       base.CopyTo(dest);
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(Identifier != null) dest.Identifier = new List<Hl7.Fhir.Model.Identifier>(Identifier.DeepCopy());
       if(UdiDeviceIdentifier != null) dest.UdiDeviceIdentifier = new List<Hl7.Fhir.Model.DeviceDefinition.UdiDeviceIdentifierComponent>(UdiDeviceIdentifier.DeepCopy());
       if(RegulatoryIdentifier != null) dest.RegulatoryIdentifier = new List<Hl7.Fhir.Model.DeviceDefinition.RegulatoryIdentifierComponent>(RegulatoryIdentifier.DeepCopy());
@@ -3387,7 +3423,7 @@ namespace Hl7.Fhir.Model
       if(otherT == null) return false;
 
       if(!base.Matches(otherT)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(Identifier, otherT.Identifier)) return false;
       if( !DeepComparable.Matches(UdiDeviceIdentifier, otherT.UdiDeviceIdentifier)) return false;
       if( !DeepComparable.Matches(RegulatoryIdentifier, otherT.RegulatoryIdentifier)) return false;
@@ -3424,7 +3460,7 @@ namespace Hl7.Fhir.Model
       if(otherT == null) return false;
 
       if(!base.IsExactly(otherT)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(Identifier, otherT.Identifier)) return false;
       if( !DeepComparable.IsExactly(UdiDeviceIdentifier, otherT.UdiDeviceIdentifier)) return false;
       if( !DeepComparable.IsExactly(RegulatoryIdentifier, otherT.RegulatoryIdentifier)) return false;
@@ -3461,7 +3497,7 @@ namespace Hl7.Fhir.Model
       get
       {
         foreach (var item in base.Children) yield return item;
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in Identifier) { if (elem != null) yield return elem; }
         foreach (var elem in UdiDeviceIdentifier) { if (elem != null) yield return elem; }
         foreach (var elem in RegulatoryIdentifier) { if (elem != null) yield return elem; }
@@ -3497,7 +3533,7 @@ namespace Hl7.Fhir.Model
       get
       {
         foreach (var item in base.NamedChildren) yield return item;
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in Identifier) { if (elem != null) yield return new ElementValue("identifier", elem); }
         foreach (var elem in UdiDeviceIdentifier) { if (elem != null) yield return new ElementValue("udiDeviceIdentifier", elem); }
         foreach (var elem in RegulatoryIdentifier) { if (elem != null) yield return new ElementValue("regulatoryIdentifier", elem); }
@@ -3532,8 +3568,8 @@ namespace Hl7.Fhir.Model
       switch (key)
       {
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "identifier":
           value = Identifier;
           return Identifier?.Any() == true;
@@ -3621,7 +3657,7 @@ namespace Hl7.Fhir.Model
     protected override IEnumerable<KeyValuePair<string, object>> GetElementPairs()
     {
       foreach (var kvp in base.GetElementPairs()) yield return kvp;
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (Identifier?.Any() == true) yield return new KeyValuePair<string,object>("identifier",Identifier);
       if (UdiDeviceIdentifier?.Any() == true) yield return new KeyValuePair<string,object>("udiDeviceIdentifier",UdiDeviceIdentifier);
       if (RegulatoryIdentifier?.Any() == true) yield return new KeyValuePair<string,object>("regulatoryIdentifier",RegulatoryIdentifier);

--- a/src/Hl7.Fhir.R5/Model/Generated/DocumentReference.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/DocumentReference.cs
@@ -910,13 +910,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=260)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Human-readable description
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Document security-tags
@@ -973,7 +991,7 @@ namespace Hl7.Fhir.Model
       if(Attester != null) dest.Attester = new List<Hl7.Fhir.Model.DocumentReference.AttesterComponent>(Attester.DeepCopy());
       if(Custodian != null) dest.Custodian = (Hl7.Fhir.Model.ResourceReference)Custodian.DeepCopy();
       if(RelatesTo != null) dest.RelatesTo = new List<Hl7.Fhir.Model.DocumentReference.RelatesToComponent>(RelatesTo.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(SecurityLabel != null) dest.SecurityLabel = new List<Hl7.Fhir.Model.CodeableConcept>(SecurityLabel.DeepCopy());
       if(Content != null) dest.Content = new List<Hl7.Fhir.Model.DocumentReference.ContentComponent>(Content.DeepCopy());
       return dest;
@@ -1008,7 +1026,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Attester, otherT.Attester)) return false;
       if( !DeepComparable.Matches(Custodian, otherT.Custodian)) return false;
       if( !DeepComparable.Matches(RelatesTo, otherT.RelatesTo)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(SecurityLabel, otherT.SecurityLabel)) return false;
       if( !DeepComparable.Matches(Content, otherT.Content)) return false;
 
@@ -1038,7 +1056,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Attester, otherT.Attester)) return false;
       if( !DeepComparable.IsExactly(Custodian, otherT.Custodian)) return false;
       if( !DeepComparable.IsExactly(RelatesTo, otherT.RelatesTo)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(SecurityLabel, otherT.SecurityLabel)) return false;
       if( !DeepComparable.IsExactly(Content, otherT.Content)) return false;
 
@@ -1068,7 +1086,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Attester) { if (elem != null) yield return elem; }
         if (Custodian != null) yield return Custodian;
         foreach (var elem in RelatesTo) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in SecurityLabel) { if (elem != null) yield return elem; }
         foreach (var elem in Content) { if (elem != null) yield return elem; }
       }
@@ -1097,7 +1115,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Attester) { if (elem != null) yield return new ElementValue("attester", elem); }
         if (Custodian != null) yield return new ElementValue("custodian", Custodian);
         foreach (var elem in RelatesTo) { if (elem != null) yield return new ElementValue("relatesTo", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in SecurityLabel) { if (elem != null) yield return new ElementValue("securityLabel", elem); }
         foreach (var elem in Content) { if (elem != null) yield return new ElementValue("content", elem); }
       }
@@ -1159,8 +1177,8 @@ namespace Hl7.Fhir.Model
           value = RelatesTo;
           return RelatesTo?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "securityLabel":
           value = SecurityLabel;
           return SecurityLabel?.Any() == true;
@@ -1193,7 +1211,7 @@ namespace Hl7.Fhir.Model
       if (Attester?.Any() == true) yield return new KeyValuePair<string,object>("attester",Attester);
       if (Custodian is not null) yield return new KeyValuePair<string,object>("custodian",Custodian);
       if (RelatesTo?.Any() == true) yield return new KeyValuePair<string,object>("relatesTo",RelatesTo);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (SecurityLabel?.Any() == true) yield return new KeyValuePair<string,object>("securityLabel",SecurityLabel);
       if (Content?.Any() == true) yield return new KeyValuePair<string,object>("content",Content);
     }

--- a/src/Hl7.Fhir.R5/Model/Generated/EventDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/EventDefinition.cs
@@ -385,13 +385,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the event definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -426,13 +444,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=240, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this event definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the event definition
@@ -470,13 +506,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=260)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the event definition was approved by publisher
@@ -673,12 +727,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -716,12 +770,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -754,12 +808,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -792,12 +846,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -829,12 +883,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -889,8 +943,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -898,14 +952,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -957,12 +1011,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R5/Model/Generated/Evidence.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/Evidence.cs
@@ -73,13 +73,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=40)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// A text description or summary of the variable
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Footnotes and/or explanatory notes
@@ -162,7 +180,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(Note != null) dest.Note = new List<Hl7.Fhir.Model.Annotation>(Note.DeepCopy());
         if(VariableRole != null) dest.VariableRole = (Hl7.Fhir.Model.CodeableConcept)VariableRole.DeepCopy();
         if(Observed != null) dest.Observed = (Hl7.Fhir.Model.ResourceReference)Observed.DeepCopy();
@@ -183,7 +201,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.Matches(otherT)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(Note, otherT.Note)) return false;
         if( !DeepComparable.Matches(VariableRole, otherT.VariableRole)) return false;
         if( !DeepComparable.Matches(Observed, otherT.Observed)) return false;
@@ -199,7 +217,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.IsExactly(otherT)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(Note, otherT.Note)) return false;
         if( !DeepComparable.IsExactly(VariableRole, otherT.VariableRole)) return false;
         if( !DeepComparable.IsExactly(Observed, otherT.Observed)) return false;
@@ -215,7 +233,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.Children) yield return item;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           foreach (var elem in Note) { if (elem != null) yield return elem; }
           if (VariableRole != null) yield return VariableRole;
           if (Observed != null) yield return Observed;
@@ -230,7 +248,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.NamedChildren) yield return item;
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           foreach (var elem in Note) { if (elem != null) yield return new ElementValue("note", elem); }
           if (VariableRole != null) yield return new ElementValue("variableRole", VariableRole);
           if (Observed != null) yield return new ElementValue("observed", Observed);
@@ -244,8 +262,8 @@ namespace Hl7.Fhir.Model
         switch (key)
         {
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "note":
             value = Note;
             return Note?.Any() == true;
@@ -270,7 +288,7 @@ namespace Hl7.Fhir.Model
       protected override IEnumerable<KeyValuePair<string, object>> GetElementPairs()
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (Note?.Any() == true) yield return new KeyValuePair<string,object>("note",Note);
         if (VariableRole is not null) yield return new KeyValuePair<string,object>("variableRole",VariableRole);
         if (Observed is not null) yield return new KeyValuePair<string,object>("observed",Observed);
@@ -2295,26 +2313,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=280)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Description of the particular summary
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Declarative description of the Evidence
     /// </summary>
     [FhirElement("assertion", Order=290)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Assertion
+    public Hl7.Fhir.Model.Markdown AssertionElement
     {
-      get { return _Assertion; }
-      set { _Assertion = value; OnPropertyChanged("Assertion"); }
+      get { return _AssertionElement; }
+      set { _AssertionElement = value; OnPropertyChanged("AssertionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Assertion;
+    private Hl7.Fhir.Model.Markdown _AssertionElement;
+
+    /// <summary>
+    /// Declarative description of the Evidence
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Assertion
+    {
+      get { return AssertionElement != null ? AssertionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          AssertionElement = null;
+        else
+          AssertionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Assertion");
+      }
+    }
 
     /// <summary>
     /// Footnotes and/or explanatory notes
@@ -2428,8 +2482,8 @@ namespace Hl7.Fhir.Model
       if(Reviewer != null) dest.Reviewer = new List<Hl7.Fhir.Model.ContactDetail>(Reviewer.DeepCopy());
       if(Endorser != null) dest.Endorser = new List<Hl7.Fhir.Model.ContactDetail>(Endorser.DeepCopy());
       if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
-      if(Assertion != null) dest.Assertion = (Hl7.Fhir.Model.Markdown)Assertion.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
+      if(AssertionElement != null) dest.AssertionElement = (Hl7.Fhir.Model.Markdown)AssertionElement.DeepCopy();
       if(Note != null) dest.Note = new List<Hl7.Fhir.Model.Annotation>(Note.DeepCopy());
       if(VariableDefinition != null) dest.VariableDefinition = new List<Hl7.Fhir.Model.Evidence.VariableDefinitionComponent>(VariableDefinition.DeepCopy());
       if(SynthesisType != null) dest.SynthesisType = (Hl7.Fhir.Model.CodeableConcept)SynthesisType.DeepCopy();
@@ -2470,8 +2524,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Reviewer, otherT.Reviewer)) return false;
       if( !DeepComparable.Matches(Endorser, otherT.Endorser)) return false;
       if( !DeepComparable.Matches(RelatedArtifact, otherT.RelatedArtifact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
-      if( !DeepComparable.Matches(Assertion, otherT.Assertion)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.Matches(AssertionElement, otherT.AssertionElement)) return false;
       if( !DeepComparable.Matches(Note, otherT.Note)) return false;
       if( !DeepComparable.Matches(VariableDefinition, otherT.VariableDefinition)) return false;
       if( !DeepComparable.Matches(SynthesisType, otherT.SynthesisType)) return false;
@@ -2507,8 +2561,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Reviewer, otherT.Reviewer)) return false;
       if( !DeepComparable.IsExactly(Endorser, otherT.Endorser)) return false;
       if( !DeepComparable.IsExactly(RelatedArtifact, otherT.RelatedArtifact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
-      if( !DeepComparable.IsExactly(Assertion, otherT.Assertion)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.IsExactly(AssertionElement, otherT.AssertionElement)) return false;
       if( !DeepComparable.IsExactly(Note, otherT.Note)) return false;
       if( !DeepComparable.IsExactly(VariableDefinition, otherT.VariableDefinition)) return false;
       if( !DeepComparable.IsExactly(SynthesisType, otherT.SynthesisType)) return false;
@@ -2544,8 +2598,8 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Reviewer) { if (elem != null) yield return elem; }
         foreach (var elem in Endorser) { if (elem != null) yield return elem; }
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
-        if (Assertion != null) yield return Assertion;
+        if (DescriptionElement != null) yield return DescriptionElement;
+        if (AssertionElement != null) yield return AssertionElement;
         foreach (var elem in Note) { if (elem != null) yield return elem; }
         foreach (var elem in VariableDefinition) { if (elem != null) yield return elem; }
         if (SynthesisType != null) yield return SynthesisType;
@@ -2580,8 +2634,8 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Reviewer) { if (elem != null) yield return new ElementValue("reviewer", elem); }
         foreach (var elem in Endorser) { if (elem != null) yield return new ElementValue("endorser", elem); }
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return new ElementValue("relatedArtifact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
-        if (Assertion != null) yield return new ElementValue("assertion", Assertion);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
+        if (AssertionElement != null) yield return new ElementValue("assertion", AssertionElement);
         foreach (var elem in Note) { if (elem != null) yield return new ElementValue("note", elem); }
         foreach (var elem in VariableDefinition) { if (elem != null) yield return new ElementValue("variableDefinition", elem); }
         if (SynthesisType != null) yield return new ElementValue("synthesisType", SynthesisType);
@@ -2653,11 +2707,11 @@ namespace Hl7.Fhir.Model
           value = RelatedArtifact;
           return RelatedArtifact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "assertion":
-          value = Assertion;
-          return Assertion is not null;
+          value = AssertionElement;
+          return AssertionElement is not null;
         case "note":
           value = Note;
           return Note?.Any() == true;
@@ -2704,8 +2758,8 @@ namespace Hl7.Fhir.Model
       if (Reviewer?.Any() == true) yield return new KeyValuePair<string,object>("reviewer",Reviewer);
       if (Endorser?.Any() == true) yield return new KeyValuePair<string,object>("endorser",Endorser);
       if (RelatedArtifact?.Any() == true) yield return new KeyValuePair<string,object>("relatedArtifact",RelatedArtifact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
-      if (Assertion is not null) yield return new KeyValuePair<string,object>("assertion",Assertion);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
+      if (AssertionElement is not null) yield return new KeyValuePair<string,object>("assertion",AssertionElement);
       if (Note?.Any() == true) yield return new KeyValuePair<string,object>("note",Note);
       if (VariableDefinition?.Any() == true) yield return new KeyValuePair<string,object>("variableDefinition",VariableDefinition);
       if (SynthesisType is not null) yield return new KeyValuePair<string,object>("synthesisType",SynthesisType);

--- a/src/Hl7.Fhir.R5/Model/Generated/EvidenceReport.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/EvidenceReport.cs
@@ -658,13 +658,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("display", Order=60)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Display
+      public Hl7.Fhir.Model.Markdown DisplayElement
       {
-        get { return _Display; }
-        set { _Display = value; OnPropertyChanged("Display"); }
+        get { return _DisplayElement; }
+        set { _DisplayElement = value; OnPropertyChanged("DisplayElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Display;
+      private Hl7.Fhir.Model.Markdown _DisplayElement;
+
+      /// <summary>
+      /// Target of the relationship Display
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Display
+      {
+        get { return DisplayElement != null ? DisplayElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DisplayElement = null;
+          else
+            DisplayElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Display");
+        }
+      }
 
       /// <summary>
       /// Target of the relationship Resource reference
@@ -693,7 +711,7 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(UrlElement != null) dest.UrlElement = (Hl7.Fhir.Model.FhirUri)UrlElement.DeepCopy();
         if(Identifier != null) dest.Identifier = (Hl7.Fhir.Model.Identifier)Identifier.DeepCopy();
-        if(Display != null) dest.Display = (Hl7.Fhir.Model.Markdown)Display.DeepCopy();
+        if(DisplayElement != null) dest.DisplayElement = (Hl7.Fhir.Model.Markdown)DisplayElement.DeepCopy();
         if(Resource != null) dest.Resource = (Hl7.Fhir.Model.ResourceReference)Resource.DeepCopy();
         return dest;
       }
@@ -712,7 +730,7 @@ namespace Hl7.Fhir.Model
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(UrlElement, otherT.UrlElement)) return false;
         if( !DeepComparable.Matches(Identifier, otherT.Identifier)) return false;
-        if( !DeepComparable.Matches(Display, otherT.Display)) return false;
+        if( !DeepComparable.Matches(DisplayElement, otherT.DisplayElement)) return false;
         if( !DeepComparable.Matches(Resource, otherT.Resource)) return false;
 
         return true;
@@ -726,7 +744,7 @@ namespace Hl7.Fhir.Model
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(UrlElement, otherT.UrlElement)) return false;
         if( !DeepComparable.IsExactly(Identifier, otherT.Identifier)) return false;
-        if( !DeepComparable.IsExactly(Display, otherT.Display)) return false;
+        if( !DeepComparable.IsExactly(DisplayElement, otherT.DisplayElement)) return false;
         if( !DeepComparable.IsExactly(Resource, otherT.Resource)) return false;
 
         return true;
@@ -740,7 +758,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.Children) yield return item;
           if (UrlElement != null) yield return UrlElement;
           if (Identifier != null) yield return Identifier;
-          if (Display != null) yield return Display;
+          if (DisplayElement != null) yield return DisplayElement;
           if (Resource != null) yield return Resource;
         }
       }
@@ -753,7 +771,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.NamedChildren) yield return item;
           if (UrlElement != null) yield return new ElementValue("url", UrlElement);
           if (Identifier != null) yield return new ElementValue("identifier", Identifier);
-          if (Display != null) yield return new ElementValue("display", Display);
+          if (DisplayElement != null) yield return new ElementValue("display", DisplayElement);
           if (Resource != null) yield return new ElementValue("resource", Resource);
         }
       }
@@ -769,8 +787,8 @@ namespace Hl7.Fhir.Model
             value = Identifier;
             return Identifier is not null;
           case "display":
-            value = Display;
-            return Display is not null;
+            value = DisplayElement;
+            return DisplayElement is not null;
           case "resource":
             value = Resource;
             return Resource is not null;
@@ -785,7 +803,7 @@ namespace Hl7.Fhir.Model
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (UrlElement is not null) yield return new KeyValuePair<string,object>("url",UrlElement);
         if (Identifier is not null) yield return new KeyValuePair<string,object>("identifier",Identifier);
-        if (Display is not null) yield return new KeyValuePair<string,object>("display",Display);
+        if (DisplayElement is not null) yield return new KeyValuePair<string,object>("display",DisplayElement);
         if (Resource is not null) yield return new KeyValuePair<string,object>("resource",Resource);
       }
 

--- a/src/Hl7.Fhir.R5/Model/Generated/EvidenceVariable.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/EvidenceVariable.cs
@@ -1662,13 +1662,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the evidence variable
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Used for footnotes or explanatory notes
@@ -1703,13 +1721,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=240)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the resource was approved by publisher
@@ -1969,10 +2005,10 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(Note != null) dest.Note = new List<Hl7.Fhir.Model.Annotation>(Note.DeepCopy());
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -2012,10 +2048,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(Note, otherT.Note)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -2050,10 +2086,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(Note, otherT.Note)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -2088,10 +2124,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in Note) { if (elem != null) yield return elem; }
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -2125,10 +2161,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in Note) { if (elem != null) yield return new ElementValue("note", elem); }
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -2185,8 +2221,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "note":
           value = Note;
           return Note?.Any() == true;
@@ -2194,8 +2230,8 @@ namespace Hl7.Fhir.Model
           value = UseContext;
           return UseContext?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -2253,10 +2289,10 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (Note?.Any() == true) yield return new KeyValuePair<string,object>("note",Note);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R5/Model/Generated/ExampleScenario.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/ExampleScenario.cs
@@ -170,13 +170,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=70)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Details about actor
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -191,7 +209,7 @@ namespace Hl7.Fhir.Model
         if(KeyElement != null) dest.KeyElement = (Hl7.Fhir.Model.FhirString)KeyElement.DeepCopy();
         if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.ExampleScenarioActorType>)TypeElement.DeepCopy();
         if(TitleElement != null) dest.TitleElement = (Hl7.Fhir.Model.FhirString)TitleElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         return dest;
       }
 
@@ -210,7 +228,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(KeyElement, otherT.KeyElement)) return false;
         if( !DeepComparable.Matches(TypeElement, otherT.TypeElement)) return false;
         if( !DeepComparable.Matches(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
 
         return true;
       }
@@ -224,7 +242,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(KeyElement, otherT.KeyElement)) return false;
         if( !DeepComparable.IsExactly(TypeElement, otherT.TypeElement)) return false;
         if( !DeepComparable.IsExactly(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
 
         return true;
       }
@@ -238,7 +256,7 @@ namespace Hl7.Fhir.Model
           if (KeyElement != null) yield return KeyElement;
           if (TypeElement != null) yield return TypeElement;
           if (TitleElement != null) yield return TitleElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
         }
       }
 
@@ -251,7 +269,7 @@ namespace Hl7.Fhir.Model
           if (KeyElement != null) yield return new ElementValue("key", KeyElement);
           if (TypeElement != null) yield return new ElementValue("type", TypeElement);
           if (TitleElement != null) yield return new ElementValue("title", TitleElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         }
       }
 
@@ -269,8 +287,8 @@ namespace Hl7.Fhir.Model
             value = TitleElement;
             return TitleElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -283,7 +301,7 @@ namespace Hl7.Fhir.Model
         if (KeyElement is not null) yield return new KeyValuePair<string,object>("key",KeyElement);
         if (TypeElement is not null) yield return new KeyValuePair<string,object>("type",TypeElement);
         if (TitleElement is not null) yield return new KeyValuePair<string,object>("title",TitleElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       }
 
     }
@@ -430,13 +448,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=90)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Human-friendly description of the instance
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Example instance data
@@ -494,7 +530,7 @@ namespace Hl7.Fhir.Model
         if(StructureVersionElement != null) dest.StructureVersionElement = (Hl7.Fhir.Model.FhirString)StructureVersionElement.DeepCopy();
         if(StructureProfile != null) dest.StructureProfile = (Hl7.Fhir.Model.DataType)StructureProfile.DeepCopy();
         if(TitleElement != null) dest.TitleElement = (Hl7.Fhir.Model.FhirString)TitleElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(Content != null) dest.Content = (Hl7.Fhir.Model.ResourceReference)Content.DeepCopy();
         if(Version != null) dest.Version = new List<Hl7.Fhir.Model.ExampleScenario.VersionComponent>(Version.DeepCopy());
         if(ContainedInstance != null) dest.ContainedInstance = new List<Hl7.Fhir.Model.ExampleScenario.ContainedInstanceComponent>(ContainedInstance.DeepCopy());
@@ -518,7 +554,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(StructureVersionElement, otherT.StructureVersionElement)) return false;
         if( !DeepComparable.Matches(StructureProfile, otherT.StructureProfile)) return false;
         if( !DeepComparable.Matches(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(Content, otherT.Content)) return false;
         if( !DeepComparable.Matches(Version, otherT.Version)) return false;
         if( !DeepComparable.Matches(ContainedInstance, otherT.ContainedInstance)) return false;
@@ -537,7 +573,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(StructureVersionElement, otherT.StructureVersionElement)) return false;
         if( !DeepComparable.IsExactly(StructureProfile, otherT.StructureProfile)) return false;
         if( !DeepComparable.IsExactly(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(Content, otherT.Content)) return false;
         if( !DeepComparable.IsExactly(Version, otherT.Version)) return false;
         if( !DeepComparable.IsExactly(ContainedInstance, otherT.ContainedInstance)) return false;
@@ -556,7 +592,7 @@ namespace Hl7.Fhir.Model
           if (StructureVersionElement != null) yield return StructureVersionElement;
           if (StructureProfile != null) yield return StructureProfile;
           if (TitleElement != null) yield return TitleElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           if (Content != null) yield return Content;
           foreach (var elem in Version) { if (elem != null) yield return elem; }
           foreach (var elem in ContainedInstance) { if (elem != null) yield return elem; }
@@ -574,7 +610,7 @@ namespace Hl7.Fhir.Model
           if (StructureVersionElement != null) yield return new ElementValue("structureVersion", StructureVersionElement);
           if (StructureProfile != null) yield return new ElementValue("structureProfile", StructureProfile);
           if (TitleElement != null) yield return new ElementValue("title", TitleElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (Content != null) yield return new ElementValue("content", Content);
           foreach (var elem in Version) { if (elem != null) yield return new ElementValue("version", elem); }
           foreach (var elem in ContainedInstance) { if (elem != null) yield return new ElementValue("containedInstance", elem); }
@@ -601,8 +637,8 @@ namespace Hl7.Fhir.Model
             value = TitleElement;
             return TitleElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "content":
             value = Content;
             return Content is not null;
@@ -626,7 +662,7 @@ namespace Hl7.Fhir.Model
         if (StructureVersionElement is not null) yield return new KeyValuePair<string,object>("structureVersion",StructureVersionElement);
         if (StructureProfile is not null) yield return new KeyValuePair<string,object>("structureProfile",StructureProfile);
         if (TitleElement is not null) yield return new KeyValuePair<string,object>("title",TitleElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (Content is not null) yield return new KeyValuePair<string,object>("content",Content);
         if (Version?.Any() == true) yield return new KeyValuePair<string,object>("version",Version);
         if (ContainedInstance?.Any() == true) yield return new KeyValuePair<string,object>("containedInstance",ContainedInstance);
@@ -716,13 +752,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=60)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Details about version
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Example instance version data
@@ -749,7 +803,7 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(KeyElement != null) dest.KeyElement = (Hl7.Fhir.Model.FhirString)KeyElement.DeepCopy();
         if(TitleElement != null) dest.TitleElement = (Hl7.Fhir.Model.FhirString)TitleElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(Content != null) dest.Content = (Hl7.Fhir.Model.ResourceReference)Content.DeepCopy();
         return dest;
       }
@@ -768,7 +822,7 @@ namespace Hl7.Fhir.Model
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(KeyElement, otherT.KeyElement)) return false;
         if( !DeepComparable.Matches(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(Content, otherT.Content)) return false;
 
         return true;
@@ -782,7 +836,7 @@ namespace Hl7.Fhir.Model
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(KeyElement, otherT.KeyElement)) return false;
         if( !DeepComparable.IsExactly(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(Content, otherT.Content)) return false;
 
         return true;
@@ -796,7 +850,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.Children) yield return item;
           if (KeyElement != null) yield return KeyElement;
           if (TitleElement != null) yield return TitleElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           if (Content != null) yield return Content;
         }
       }
@@ -809,7 +863,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.NamedChildren) yield return item;
           if (KeyElement != null) yield return new ElementValue("key", KeyElement);
           if (TitleElement != null) yield return new ElementValue("title", TitleElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (Content != null) yield return new ElementValue("content", Content);
         }
       }
@@ -825,8 +879,8 @@ namespace Hl7.Fhir.Model
             value = TitleElement;
             return TitleElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "content":
             value = Content;
             return Content is not null;
@@ -841,7 +895,7 @@ namespace Hl7.Fhir.Model
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (KeyElement is not null) yield return new KeyValuePair<string,object>("key",KeyElement);
         if (TitleElement is not null) yield return new KeyValuePair<string,object>("title",TitleElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (Content is not null) yield return new KeyValuePair<string,object>("content",Content);
       }
 
@@ -1065,39 +1119,93 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Human-friendly description of the process
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Status before process starts
       /// </summary>
       [FhirElement("preConditions", Order=60)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown PreConditions
+      public Hl7.Fhir.Model.Markdown PreConditionsElement
       {
-        get { return _PreConditions; }
-        set { _PreConditions = value; OnPropertyChanged("PreConditions"); }
+        get { return _PreConditionsElement; }
+        set { _PreConditionsElement = value; OnPropertyChanged("PreConditionsElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _PreConditions;
+      private Hl7.Fhir.Model.Markdown _PreConditionsElement;
+
+      /// <summary>
+      /// Status before process starts
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string PreConditions
+      {
+        get { return PreConditionsElement != null ? PreConditionsElement.Value : null; }
+        set
+        {
+          if (value == null)
+            PreConditionsElement = null;
+          else
+            PreConditionsElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("PreConditions");
+        }
+      }
 
       /// <summary>
       /// Status after successful completion
       /// </summary>
       [FhirElement("postConditions", Order=70)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown PostConditions
+      public Hl7.Fhir.Model.Markdown PostConditionsElement
       {
-        get { return _PostConditions; }
-        set { _PostConditions = value; OnPropertyChanged("PostConditions"); }
+        get { return _PostConditionsElement; }
+        set { _PostConditionsElement = value; OnPropertyChanged("PostConditionsElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _PostConditions;
+      private Hl7.Fhir.Model.Markdown _PostConditionsElement;
+
+      /// <summary>
+      /// Status after successful completion
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string PostConditions
+      {
+        get { return PostConditionsElement != null ? PostConditionsElement.Value : null; }
+        set
+        {
+          if (value == null)
+            PostConditionsElement = null;
+          else
+            PostConditionsElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("PostConditions");
+        }
+      }
 
       /// <summary>
       /// Event within of the process
@@ -1124,9 +1232,9 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(TitleElement != null) dest.TitleElement = (Hl7.Fhir.Model.FhirString)TitleElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
-        if(PreConditions != null) dest.PreConditions = (Hl7.Fhir.Model.Markdown)PreConditions.DeepCopy();
-        if(PostConditions != null) dest.PostConditions = (Hl7.Fhir.Model.Markdown)PostConditions.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
+        if(PreConditionsElement != null) dest.PreConditionsElement = (Hl7.Fhir.Model.Markdown)PreConditionsElement.DeepCopy();
+        if(PostConditionsElement != null) dest.PostConditionsElement = (Hl7.Fhir.Model.Markdown)PostConditionsElement.DeepCopy();
         if(Step != null) dest.Step = new List<Hl7.Fhir.Model.ExampleScenario.StepComponent>(Step.DeepCopy());
         return dest;
       }
@@ -1144,9 +1252,9 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
-        if( !DeepComparable.Matches(PreConditions, otherT.PreConditions)) return false;
-        if( !DeepComparable.Matches(PostConditions, otherT.PostConditions)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
+        if( !DeepComparable.Matches(PreConditionsElement, otherT.PreConditionsElement)) return false;
+        if( !DeepComparable.Matches(PostConditionsElement, otherT.PostConditionsElement)) return false;
         if( !DeepComparable.Matches(Step, otherT.Step)) return false;
 
         return true;
@@ -1159,9 +1267,9 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
-        if( !DeepComparable.IsExactly(PreConditions, otherT.PreConditions)) return false;
-        if( !DeepComparable.IsExactly(PostConditions, otherT.PostConditions)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
+        if( !DeepComparable.IsExactly(PreConditionsElement, otherT.PreConditionsElement)) return false;
+        if( !DeepComparable.IsExactly(PostConditionsElement, otherT.PostConditionsElement)) return false;
         if( !DeepComparable.IsExactly(Step, otherT.Step)) return false;
 
         return true;
@@ -1174,9 +1282,9 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (TitleElement != null) yield return TitleElement;
-          if (Description != null) yield return Description;
-          if (PreConditions != null) yield return PreConditions;
-          if (PostConditions != null) yield return PostConditions;
+          if (DescriptionElement != null) yield return DescriptionElement;
+          if (PreConditionsElement != null) yield return PreConditionsElement;
+          if (PostConditionsElement != null) yield return PostConditionsElement;
           foreach (var elem in Step) { if (elem != null) yield return elem; }
         }
       }
@@ -1188,9 +1296,9 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (TitleElement != null) yield return new ElementValue("title", TitleElement);
-          if (Description != null) yield return new ElementValue("description", Description);
-          if (PreConditions != null) yield return new ElementValue("preConditions", PreConditions);
-          if (PostConditions != null) yield return new ElementValue("postConditions", PostConditions);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
+          if (PreConditionsElement != null) yield return new ElementValue("preConditions", PreConditionsElement);
+          if (PostConditionsElement != null) yield return new ElementValue("postConditions", PostConditionsElement);
           foreach (var elem in Step) { if (elem != null) yield return new ElementValue("step", elem); }
         }
       }
@@ -1203,14 +1311,14 @@ namespace Hl7.Fhir.Model
             value = TitleElement;
             return TitleElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "preConditions":
-            value = PreConditions;
-            return PreConditions is not null;
+            value = PreConditionsElement;
+            return PreConditionsElement is not null;
           case "postConditions":
-            value = PostConditions;
-            return PostConditions is not null;
+            value = PostConditionsElement;
+            return PostConditionsElement is not null;
           case "step":
             value = Step;
             return Step?.Any() == true;
@@ -1224,9 +1332,9 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (TitleElement is not null) yield return new KeyValuePair<string,object>("title",TitleElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
-        if (PreConditions is not null) yield return new KeyValuePair<string,object>("preConditions",PreConditions);
-        if (PostConditions is not null) yield return new KeyValuePair<string,object>("postConditions",PostConditions);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
+        if (PreConditionsElement is not null) yield return new KeyValuePair<string,object>("preConditions",PreConditionsElement);
+        if (PostConditionsElement is not null) yield return new KeyValuePair<string,object>("postConditions",PostConditionsElement);
         if (Step?.Any() == true) yield return new KeyValuePair<string,object>("step",Step);
       }
 
@@ -1631,13 +1739,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=80)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Human-friendly description of the operation
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Initiator stays active?
@@ -1741,7 +1867,7 @@ namespace Hl7.Fhir.Model
         if(TitleElement != null) dest.TitleElement = (Hl7.Fhir.Model.FhirString)TitleElement.DeepCopy();
         if(InitiatorElement != null) dest.InitiatorElement = (Hl7.Fhir.Model.FhirString)InitiatorElement.DeepCopy();
         if(ReceiverElement != null) dest.ReceiverElement = (Hl7.Fhir.Model.FhirString)ReceiverElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(InitiatorActiveElement != null) dest.InitiatorActiveElement = (Hl7.Fhir.Model.FhirBoolean)InitiatorActiveElement.DeepCopy();
         if(ReceiverActiveElement != null) dest.ReceiverActiveElement = (Hl7.Fhir.Model.FhirBoolean)ReceiverActiveElement.DeepCopy();
         if(Request != null) dest.Request = (Hl7.Fhir.Model.ExampleScenario.ContainedInstanceComponent)Request.DeepCopy();
@@ -1765,7 +1891,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(TitleElement, otherT.TitleElement)) return false;
         if( !DeepComparable.Matches(InitiatorElement, otherT.InitiatorElement)) return false;
         if( !DeepComparable.Matches(ReceiverElement, otherT.ReceiverElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(InitiatorActiveElement, otherT.InitiatorActiveElement)) return false;
         if( !DeepComparable.Matches(ReceiverActiveElement, otherT.ReceiverActiveElement)) return false;
         if( !DeepComparable.Matches(Request, otherT.Request)) return false;
@@ -1784,7 +1910,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(TitleElement, otherT.TitleElement)) return false;
         if( !DeepComparable.IsExactly(InitiatorElement, otherT.InitiatorElement)) return false;
         if( !DeepComparable.IsExactly(ReceiverElement, otherT.ReceiverElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(InitiatorActiveElement, otherT.InitiatorActiveElement)) return false;
         if( !DeepComparable.IsExactly(ReceiverActiveElement, otherT.ReceiverActiveElement)) return false;
         if( !DeepComparable.IsExactly(Request, otherT.Request)) return false;
@@ -1803,7 +1929,7 @@ namespace Hl7.Fhir.Model
           if (TitleElement != null) yield return TitleElement;
           if (InitiatorElement != null) yield return InitiatorElement;
           if (ReceiverElement != null) yield return ReceiverElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           if (InitiatorActiveElement != null) yield return InitiatorActiveElement;
           if (ReceiverActiveElement != null) yield return ReceiverActiveElement;
           if (Request != null) yield return Request;
@@ -1821,7 +1947,7 @@ namespace Hl7.Fhir.Model
           if (TitleElement != null) yield return new ElementValue("title", TitleElement);
           if (InitiatorElement != null) yield return new ElementValue("initiator", InitiatorElement);
           if (ReceiverElement != null) yield return new ElementValue("receiver", ReceiverElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (InitiatorActiveElement != null) yield return new ElementValue("initiatorActive", InitiatorActiveElement);
           if (ReceiverActiveElement != null) yield return new ElementValue("receiverActive", ReceiverActiveElement);
           if (Request != null) yield return new ElementValue("request", Request);
@@ -1846,8 +1972,8 @@ namespace Hl7.Fhir.Model
             value = ReceiverElement;
             return ReceiverElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "initiatorActive":
             value = InitiatorActiveElement;
             return InitiatorActiveElement is not null;
@@ -1873,7 +1999,7 @@ namespace Hl7.Fhir.Model
         if (TitleElement is not null) yield return new KeyValuePair<string,object>("title",TitleElement);
         if (InitiatorElement is not null) yield return new KeyValuePair<string,object>("initiator",InitiatorElement);
         if (ReceiverElement is not null) yield return new KeyValuePair<string,object>("receiver",ReceiverElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (InitiatorActiveElement is not null) yield return new KeyValuePair<string,object>("initiatorActive",InitiatorActiveElement);
         if (ReceiverActiveElement is not null) yield return new KeyValuePair<string,object>("receiverActive",ReceiverActiveElement);
         if (Request is not null) yield return new KeyValuePair<string,object>("request",Request);
@@ -1932,13 +2058,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Human-readable description of option
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Alternative action(s)
@@ -1965,7 +2109,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(TitleElement != null) dest.TitleElement = (Hl7.Fhir.Model.FhirString)TitleElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(Step != null) dest.Step = new List<Hl7.Fhir.Model.ExampleScenario.StepComponent>(Step.DeepCopy());
         return dest;
       }
@@ -1983,7 +2127,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(Step, otherT.Step)) return false;
 
         return true;
@@ -1996,7 +2140,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(Step, otherT.Step)) return false;
 
         return true;
@@ -2009,7 +2153,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (TitleElement != null) yield return TitleElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           foreach (var elem in Step) { if (elem != null) yield return elem; }
         }
       }
@@ -2021,7 +2165,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (TitleElement != null) yield return new ElementValue("title", TitleElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           foreach (var elem in Step) { if (elem != null) yield return new ElementValue("step", elem); }
         }
       }
@@ -2034,8 +2178,8 @@ namespace Hl7.Fhir.Model
             value = TitleElement;
             return TitleElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "step":
             value = Step;
             return Step?.Any() == true;
@@ -2049,7 +2193,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (TitleElement is not null) yield return new KeyValuePair<string,object>("title",TitleElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (Step?.Any() == true) yield return new KeyValuePair<string,object>("step",Step);
       }
 
@@ -2353,13 +2497,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the ExampleScenario
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -2394,26 +2556,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=230, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// The purpose of the example, e.g. to illustrate a scenario
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=240)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Copyright holder and year(s)
@@ -2509,11 +2707,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(CopyrightLabelElement != null) dest.CopyrightLabelElement = (Hl7.Fhir.Model.FhirString)CopyrightLabelElement.DeepCopy();
       if(Actor != null) dest.Actor = new List<Hl7.Fhir.Model.ExampleScenario.ActorComponent>(Actor.DeepCopy());
       if(Instance != null) dest.Instance = new List<Hl7.Fhir.Model.ExampleScenario.InstanceComponent>(Instance.DeepCopy());
@@ -2544,11 +2742,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.Matches(Actor, otherT.Actor)) return false;
       if( !DeepComparable.Matches(Instance, otherT.Instance)) return false;
@@ -2574,11 +2772,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.IsExactly(Actor, otherT.Actor)) return false;
       if( !DeepComparable.IsExactly(Instance, otherT.Instance)) return false;
@@ -2604,11 +2802,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (CopyrightLabelElement != null) yield return CopyrightLabelElement;
         foreach (var elem in Actor) { if (elem != null) yield return elem; }
         foreach (var elem in Instance) { if (elem != null) yield return elem; }
@@ -2633,11 +2831,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (CopyrightLabelElement != null) yield return new ElementValue("copyrightLabel", CopyrightLabelElement);
         foreach (var elem in Actor) { if (elem != null) yield return new ElementValue("actor", elem); }
         foreach (var elem in Instance) { if (elem != null) yield return new ElementValue("instance", elem); }
@@ -2683,8 +2881,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2692,11 +2890,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "copyrightLabel":
           value = CopyrightLabelElement;
           return CopyrightLabelElement is not null;
@@ -2729,11 +2927,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (CopyrightLabelElement is not null) yield return new KeyValuePair<string,object>("copyrightLabel",CopyrightLabelElement);
       if (Actor?.Any() == true) yield return new KeyValuePair<string,object>("actor",Actor);
       if (Instance?.Any() == true) yield return new KeyValuePair<string,object>("instance",Instance);

--- a/src/Hl7.Fhir.R5/Model/Generated/GraphDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/GraphDefinition.cs
@@ -1371,13 +1371,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the graph definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1412,13 +1430,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this graph definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Starting Node
@@ -1499,10 +1535,10 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(StartElement != null) dest.StartElement = (Hl7.Fhir.Model.Id)StartElement.DeepCopy();
       if(Node != null) dest.Node = new List<Hl7.Fhir.Model.GraphDefinition.NodeComponent>(Node.DeepCopy());
       if(Link != null) dest.Link = new List<Hl7.Fhir.Model.GraphDefinition.LinkComponent>(Link.DeepCopy());
@@ -1531,10 +1567,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(StartElement, otherT.StartElement)) return false;
       if( !DeepComparable.Matches(Node, otherT.Node)) return false;
       if( !DeepComparable.Matches(Link, otherT.Link)) return false;
@@ -1558,10 +1594,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(StartElement, otherT.StartElement)) return false;
       if( !DeepComparable.IsExactly(Node, otherT.Node)) return false;
       if( !DeepComparable.IsExactly(Link, otherT.Link)) return false;
@@ -1585,10 +1621,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (StartElement != null) yield return StartElement;
         foreach (var elem in Node) { if (elem != null) yield return elem; }
         foreach (var elem in Link) { if (elem != null) yield return elem; }
@@ -1611,10 +1647,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (StartElement != null) yield return new ElementValue("start", StartElement);
         foreach (var elem in Node) { if (elem != null) yield return new ElementValue("node", elem); }
         foreach (var elem in Link) { if (elem != null) yield return new ElementValue("link", elem); }
@@ -1656,8 +1692,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1665,8 +1701,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "start":
           value = StartElement;
           return StartElement is not null;
@@ -1695,10 +1731,10 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (StartElement is not null) yield return new KeyValuePair<string,object>("start",StartElement);
       if (Node?.Any() == true) yield return new KeyValuePair<string,object>("node",Node);
       if (Link?.Any() == true) yield return new KeyValuePair<string,object>("link",Link);

--- a/src/Hl7.Fhir.R5/Model/Generated/Group.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/Group.cs
@@ -679,13 +679,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=150)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the group
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Number of members
@@ -777,7 +795,7 @@ namespace Hl7.Fhir.Model
       if(MembershipElement != null) dest.MembershipElement = (Code<Hl7.Fhir.Model.Group.GroupMembershipBasis>)MembershipElement.DeepCopy();
       if(Code != null) dest.Code = (Hl7.Fhir.Model.CodeableConcept)Code.DeepCopy();
       if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(QuantityElement != null) dest.QuantityElement = (Hl7.Fhir.Model.UnsignedInt)QuantityElement.DeepCopy();
       if(ManagingEntity != null) dest.ManagingEntity = (Hl7.Fhir.Model.ResourceReference)ManagingEntity.DeepCopy();
       if(Characteristic != null) dest.Characteristic = new List<Hl7.Fhir.Model.Group.CharacteristicComponent>(Characteristic.DeepCopy());
@@ -803,7 +821,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(MembershipElement, otherT.MembershipElement)) return false;
       if( !DeepComparable.Matches(Code, otherT.Code)) return false;
       if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(QuantityElement, otherT.QuantityElement)) return false;
       if( !DeepComparable.Matches(ManagingEntity, otherT.ManagingEntity)) return false;
       if( !DeepComparable.Matches(Characteristic, otherT.Characteristic)) return false;
@@ -824,7 +842,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(MembershipElement, otherT.MembershipElement)) return false;
       if( !DeepComparable.IsExactly(Code, otherT.Code)) return false;
       if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(QuantityElement, otherT.QuantityElement)) return false;
       if( !DeepComparable.IsExactly(ManagingEntity, otherT.ManagingEntity)) return false;
       if( !DeepComparable.IsExactly(Characteristic, otherT.Characteristic)) return false;
@@ -845,7 +863,7 @@ namespace Hl7.Fhir.Model
         if (MembershipElement != null) yield return MembershipElement;
         if (Code != null) yield return Code;
         if (NameElement != null) yield return NameElement;
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         if (QuantityElement != null) yield return QuantityElement;
         if (ManagingEntity != null) yield return ManagingEntity;
         foreach (var elem in Characteristic) { if (elem != null) yield return elem; }
@@ -865,7 +883,7 @@ namespace Hl7.Fhir.Model
         if (MembershipElement != null) yield return new ElementValue("membership", MembershipElement);
         if (Code != null) yield return new ElementValue("code", Code);
         if (NameElement != null) yield return new ElementValue("name", NameElement);
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         if (QuantityElement != null) yield return new ElementValue("quantity", QuantityElement);
         if (ManagingEntity != null) yield return new ElementValue("managingEntity", ManagingEntity);
         foreach (var elem in Characteristic) { if (elem != null) yield return new ElementValue("characteristic", elem); }
@@ -896,8 +914,8 @@ namespace Hl7.Fhir.Model
           value = NameElement;
           return NameElement is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "quantity":
           value = QuantityElement;
           return QuantityElement is not null;
@@ -925,7 +943,7 @@ namespace Hl7.Fhir.Model
       if (MembershipElement is not null) yield return new KeyValuePair<string,object>("membership",MembershipElement);
       if (Code is not null) yield return new KeyValuePair<string,object>("code",Code);
       if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (QuantityElement is not null) yield return new KeyValuePair<string,object>("quantity",QuantityElement);
       if (ManagingEntity is not null) yield return new KeyValuePair<string,object>("managingEntity",ManagingEntity);
       if (Characteristic?.Any() == true) yield return new KeyValuePair<string,object>("characteristic",Characteristic);

--- a/src/Hl7.Fhir.R5/Model/Generated/HealthcareService.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/HealthcareService.cs
@@ -86,13 +86,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("comment", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Comment
+      public Hl7.Fhir.Model.Markdown CommentElement
       {
-        get { return _Comment; }
-        set { _Comment = value; OnPropertyChanged("Comment"); }
+        get { return _CommentElement; }
+        set { _CommentElement = value; OnPropertyChanged("CommentElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Comment;
+      private Hl7.Fhir.Model.Markdown _CommentElement;
+
+      /// <summary>
+      /// Describes the eligibility conditions for the service
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Comment
+      {
+        get { return CommentElement != null ? CommentElement.Value : null; }
+        set
+        {
+          if (value == null)
+            CommentElement = null;
+          else
+            CommentElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Comment");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -105,7 +123,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(Code != null) dest.Code = (Hl7.Fhir.Model.CodeableConcept)Code.DeepCopy();
-        if(Comment != null) dest.Comment = (Hl7.Fhir.Model.Markdown)Comment.DeepCopy();
+        if(CommentElement != null) dest.CommentElement = (Hl7.Fhir.Model.Markdown)CommentElement.DeepCopy();
         return dest;
       }
 
@@ -122,7 +140,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(Code, otherT.Code)) return false;
-        if( !DeepComparable.Matches(Comment, otherT.Comment)) return false;
+        if( !DeepComparable.Matches(CommentElement, otherT.CommentElement)) return false;
 
         return true;
       }
@@ -134,7 +152,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(Code, otherT.Code)) return false;
-        if( !DeepComparable.IsExactly(Comment, otherT.Comment)) return false;
+        if( !DeepComparable.IsExactly(CommentElement, otherT.CommentElement)) return false;
 
         return true;
       }
@@ -146,7 +164,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (Code != null) yield return Code;
-          if (Comment != null) yield return Comment;
+          if (CommentElement != null) yield return CommentElement;
         }
       }
 
@@ -157,7 +175,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (Code != null) yield return new ElementValue("code", Code);
-          if (Comment != null) yield return new ElementValue("comment", Comment);
+          if (CommentElement != null) yield return new ElementValue("comment", CommentElement);
         }
       }
 
@@ -169,8 +187,8 @@ namespace Hl7.Fhir.Model
             value = Code;
             return Code is not null;
           case "comment":
-            value = Comment;
-            return Comment is not null;
+            value = CommentElement;
+            return CommentElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -181,7 +199,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (Code is not null) yield return new KeyValuePair<string,object>("code",Code);
-        if (Comment is not null) yield return new KeyValuePair<string,object>("comment",Comment);
+        if (CommentElement is not null) yield return new KeyValuePair<string,object>("comment",CommentElement);
       }
 
     }
@@ -387,13 +405,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("extraDetails", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown ExtraDetails
+    public Hl7.Fhir.Model.Markdown ExtraDetailsElement
     {
-      get { return _ExtraDetails; }
-      set { _ExtraDetails = value; OnPropertyChanged("ExtraDetails"); }
+      get { return _ExtraDetailsElement; }
+      set { _ExtraDetailsElement = value; OnPropertyChanged("ExtraDetailsElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _ExtraDetails;
+    private Hl7.Fhir.Model.Markdown _ExtraDetailsElement;
+
+    /// <summary>
+    /// Extra details about the service that can't be placed in the other fields
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string ExtraDetails
+    {
+      get { return ExtraDetailsElement != null ? ExtraDetailsElement.Value : null; }
+      set
+      {
+        if (value == null)
+          ExtraDetailsElement = null;
+        else
+          ExtraDetailsElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("ExtraDetails");
+      }
+    }
 
     /// <summary>
     /// Facilitates quick identification of the service
@@ -603,7 +639,7 @@ namespace Hl7.Fhir.Model
       if(Location != null) dest.Location = new List<Hl7.Fhir.Model.ResourceReference>(Location.DeepCopy());
       if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
       if(CommentElement != null) dest.CommentElement = (Hl7.Fhir.Model.FhirString)CommentElement.DeepCopy();
-      if(ExtraDetails != null) dest.ExtraDetails = (Hl7.Fhir.Model.Markdown)ExtraDetails.DeepCopy();
+      if(ExtraDetailsElement != null) dest.ExtraDetailsElement = (Hl7.Fhir.Model.Markdown)ExtraDetailsElement.DeepCopy();
       if(Photo != null) dest.Photo = (Hl7.Fhir.Model.Attachment)Photo.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ExtendedContactDetail>(Contact.DeepCopy());
       if(CoverageArea != null) dest.CoverageArea = new List<Hl7.Fhir.Model.ResourceReference>(CoverageArea.DeepCopy());
@@ -641,7 +677,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Location, otherT.Location)) return false;
       if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
       if( !DeepComparable.Matches(CommentElement, otherT.CommentElement)) return false;
-      if( !DeepComparable.Matches(ExtraDetails, otherT.ExtraDetails)) return false;
+      if( !DeepComparable.Matches(ExtraDetailsElement, otherT.ExtraDetailsElement)) return false;
       if( !DeepComparable.Matches(Photo, otherT.Photo)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
       if( !DeepComparable.Matches(CoverageArea, otherT.CoverageArea)) return false;
@@ -674,7 +710,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Location, otherT.Location)) return false;
       if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
       if( !DeepComparable.IsExactly(CommentElement, otherT.CommentElement)) return false;
-      if( !DeepComparable.IsExactly(ExtraDetails, otherT.ExtraDetails)) return false;
+      if( !DeepComparable.IsExactly(ExtraDetailsElement, otherT.ExtraDetailsElement)) return false;
       if( !DeepComparable.IsExactly(Photo, otherT.Photo)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
       if( !DeepComparable.IsExactly(CoverageArea, otherT.CoverageArea)) return false;
@@ -707,7 +743,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Location) { if (elem != null) yield return elem; }
         if (NameElement != null) yield return NameElement;
         if (CommentElement != null) yield return CommentElement;
-        if (ExtraDetails != null) yield return ExtraDetails;
+        if (ExtraDetailsElement != null) yield return ExtraDetailsElement;
         if (Photo != null) yield return Photo;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
         foreach (var elem in CoverageArea) { if (elem != null) yield return elem; }
@@ -739,7 +775,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Location) { if (elem != null) yield return new ElementValue("location", elem); }
         if (NameElement != null) yield return new ElementValue("name", NameElement);
         if (CommentElement != null) yield return new ElementValue("comment", CommentElement);
-        if (ExtraDetails != null) yield return new ElementValue("extraDetails", ExtraDetails);
+        if (ExtraDetailsElement != null) yield return new ElementValue("extraDetails", ExtraDetailsElement);
         if (Photo != null) yield return new ElementValue("photo", Photo);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
         foreach (var elem in CoverageArea) { if (elem != null) yield return new ElementValue("coverageArea", elem); }
@@ -790,8 +826,8 @@ namespace Hl7.Fhir.Model
           value = CommentElement;
           return CommentElement is not null;
         case "extraDetails":
-          value = ExtraDetails;
-          return ExtraDetails is not null;
+          value = ExtraDetailsElement;
+          return ExtraDetailsElement is not null;
         case "photo":
           value = Photo;
           return Photo is not null;
@@ -847,7 +883,7 @@ namespace Hl7.Fhir.Model
       if (Location?.Any() == true) yield return new KeyValuePair<string,object>("location",Location);
       if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
       if (CommentElement is not null) yield return new KeyValuePair<string,object>("comment",CommentElement);
-      if (ExtraDetails is not null) yield return new KeyValuePair<string,object>("extraDetails",ExtraDetails);
+      if (ExtraDetailsElement is not null) yield return new KeyValuePair<string,object>("extraDetails",ExtraDetailsElement);
       if (Photo is not null) yield return new KeyValuePair<string,object>("photo",Photo);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
       if (CoverageArea?.Any() == true) yield return new KeyValuePair<string,object>("coverageArea",CoverageArea);

--- a/src/Hl7.Fhir.R5/Model/Generated/ImplementationGuide.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/ImplementationGuide.cs
@@ -2287,13 +2287,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("reason", Order=70)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Reason
+      public Hl7.Fhir.Model.Markdown ReasonElement
       {
-        get { return _Reason; }
-        set { _Reason = value; OnPropertyChanged("Reason"); }
+        get { return _ReasonElement; }
+        set { _ReasonElement = value; OnPropertyChanged("ReasonElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Reason;
+      private Hl7.Fhir.Model.Markdown _ReasonElement;
+
+      /// <summary>
+      /// Why dependency exists
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Reason
+      {
+        get { return ReasonElement != null ? ReasonElement.Value : null; }
+        set
+        {
+          if (value == null)
+            ReasonElement = null;
+          else
+            ReasonElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Reason");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -2308,7 +2326,7 @@ namespace Hl7.Fhir.Model
         if(UriElement != null) dest.UriElement = (Hl7.Fhir.Model.Canonical)UriElement.DeepCopy();
         if(PackageIdElement != null) dest.PackageIdElement = (Hl7.Fhir.Model.Id)PackageIdElement.DeepCopy();
         if(VersionElement != null) dest.VersionElement = (Hl7.Fhir.Model.FhirString)VersionElement.DeepCopy();
-        if(Reason != null) dest.Reason = (Hl7.Fhir.Model.Markdown)Reason.DeepCopy();
+        if(ReasonElement != null) dest.ReasonElement = (Hl7.Fhir.Model.Markdown)ReasonElement.DeepCopy();
         return dest;
       }
 
@@ -2327,7 +2345,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(UriElement, otherT.UriElement)) return false;
         if( !DeepComparable.Matches(PackageIdElement, otherT.PackageIdElement)) return false;
         if( !DeepComparable.Matches(VersionElement, otherT.VersionElement)) return false;
-        if( !DeepComparable.Matches(Reason, otherT.Reason)) return false;
+        if( !DeepComparable.Matches(ReasonElement, otherT.ReasonElement)) return false;
 
         return true;
       }
@@ -2341,7 +2359,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(UriElement, otherT.UriElement)) return false;
         if( !DeepComparable.IsExactly(PackageIdElement, otherT.PackageIdElement)) return false;
         if( !DeepComparable.IsExactly(VersionElement, otherT.VersionElement)) return false;
-        if( !DeepComparable.IsExactly(Reason, otherT.Reason)) return false;
+        if( !DeepComparable.IsExactly(ReasonElement, otherT.ReasonElement)) return false;
 
         return true;
       }
@@ -2355,7 +2373,7 @@ namespace Hl7.Fhir.Model
           if (UriElement != null) yield return UriElement;
           if (PackageIdElement != null) yield return PackageIdElement;
           if (VersionElement != null) yield return VersionElement;
-          if (Reason != null) yield return Reason;
+          if (ReasonElement != null) yield return ReasonElement;
         }
       }
 
@@ -2368,7 +2386,7 @@ namespace Hl7.Fhir.Model
           if (UriElement != null) yield return new ElementValue("uri", UriElement);
           if (PackageIdElement != null) yield return new ElementValue("packageId", PackageIdElement);
           if (VersionElement != null) yield return new ElementValue("version", VersionElement);
-          if (Reason != null) yield return new ElementValue("reason", Reason);
+          if (ReasonElement != null) yield return new ElementValue("reason", ReasonElement);
         }
       }
 
@@ -2386,8 +2404,8 @@ namespace Hl7.Fhir.Model
             value = VersionElement;
             return VersionElement is not null;
           case "reason":
-            value = Reason;
-            return Reason is not null;
+            value = ReasonElement;
+            return ReasonElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -2400,7 +2418,7 @@ namespace Hl7.Fhir.Model
         if (UriElement is not null) yield return new KeyValuePair<string,object>("uri",UriElement);
         if (PackageIdElement is not null) yield return new KeyValuePair<string,object>("packageId",PackageIdElement);
         if (VersionElement is not null) yield return new KeyValuePair<string,object>("version",VersionElement);
-        if (Reason is not null) yield return new KeyValuePair<string,object>("reason",Reason);
+        if (ReasonElement is not null) yield return new KeyValuePair<string,object>("reason",ReasonElement);
       }
 
     }
@@ -2826,13 +2844,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Human readable text describing the package
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -2845,7 +2881,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         return dest;
       }
 
@@ -2862,7 +2898,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
 
         return true;
       }
@@ -2874,7 +2910,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
 
         return true;
       }
@@ -2886,7 +2922,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (NameElement != null) yield return NameElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
         }
       }
 
@@ -2897,7 +2933,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (NameElement != null) yield return new ElementValue("name", NameElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         }
       }
 
@@ -2909,8 +2945,8 @@ namespace Hl7.Fhir.Model
             value = NameElement;
             return NameElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -2921,7 +2957,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       }
 
     }
@@ -3024,13 +3060,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=70)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Reason why included in guide
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Is this an example
@@ -3139,7 +3193,7 @@ namespace Hl7.Fhir.Model
         if(Reference != null) dest.Reference = (Hl7.Fhir.Model.ResourceReference)Reference.DeepCopy();
         if(FhirVersionElement != null) dest.FhirVersionElement = new List<Code<Hl7.Fhir.Model.FHIRVersion>>(FhirVersionElement.DeepCopy());
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(IsExampleElement != null) dest.IsExampleElement = (Hl7.Fhir.Model.FhirBoolean)IsExampleElement.DeepCopy();
         if(ProfileElement != null) dest.ProfileElement = new List<Hl7.Fhir.Model.Canonical>(ProfileElement.DeepCopy());
         if(GroupingIdElement != null) dest.GroupingIdElement = (Hl7.Fhir.Model.Id)GroupingIdElement.DeepCopy();
@@ -3161,7 +3215,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(Reference, otherT.Reference)) return false;
         if( !DeepComparable.Matches(FhirVersionElement, otherT.FhirVersionElement)) return false;
         if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(IsExampleElement, otherT.IsExampleElement)) return false;
         if( !DeepComparable.Matches(ProfileElement, otherT.ProfileElement)) return false;
         if( !DeepComparable.Matches(GroupingIdElement, otherT.GroupingIdElement)) return false;
@@ -3178,7 +3232,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(Reference, otherT.Reference)) return false;
         if( !DeepComparable.IsExactly(FhirVersionElement, otherT.FhirVersionElement)) return false;
         if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(IsExampleElement, otherT.IsExampleElement)) return false;
         if( !DeepComparable.IsExactly(ProfileElement, otherT.ProfileElement)) return false;
         if( !DeepComparable.IsExactly(GroupingIdElement, otherT.GroupingIdElement)) return false;
@@ -3195,7 +3249,7 @@ namespace Hl7.Fhir.Model
           if (Reference != null) yield return Reference;
           foreach (var elem in FhirVersionElement) { if (elem != null) yield return elem; }
           if (NameElement != null) yield return NameElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           if (IsExampleElement != null) yield return IsExampleElement;
           foreach (var elem in ProfileElement) { if (elem != null) yield return elem; }
           if (GroupingIdElement != null) yield return GroupingIdElement;
@@ -3211,7 +3265,7 @@ namespace Hl7.Fhir.Model
           if (Reference != null) yield return new ElementValue("reference", Reference);
           foreach (var elem in FhirVersionElement) { if (elem != null) yield return new ElementValue("fhirVersion", elem); }
           if (NameElement != null) yield return new ElementValue("name", NameElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (IsExampleElement != null) yield return new ElementValue("isExample", IsExampleElement);
           foreach (var elem in ProfileElement) { if (elem != null) yield return new ElementValue("profile", elem); }
           if (GroupingIdElement != null) yield return new ElementValue("groupingId", GroupingIdElement);
@@ -3232,8 +3286,8 @@ namespace Hl7.Fhir.Model
             value = NameElement;
             return NameElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "isExample":
             value = IsExampleElement;
             return IsExampleElement is not null;
@@ -3255,7 +3309,7 @@ namespace Hl7.Fhir.Model
         if (Reference is not null) yield return new KeyValuePair<string,object>("reference",Reference);
         if (FhirVersionElement?.Any() == true) yield return new KeyValuePair<string,object>("fhirVersion",FhirVersionElement);
         if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (IsExampleElement is not null) yield return new KeyValuePair<string,object>("isExample",IsExampleElement);
         if (ProfileElement?.Any() == true) yield return new KeyValuePair<string,object>("profile",ProfileElement);
         if (GroupingIdElement is not null) yield return new KeyValuePair<string,object>("groupingId",GroupingIdElement);
@@ -4864,13 +4918,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the implementation guide
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -4905,13 +4977,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Copyright holder and year(s)
@@ -5115,10 +5205,10 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(CopyrightLabelElement != null) dest.CopyrightLabelElement = (Hl7.Fhir.Model.FhirString)CopyrightLabelElement.DeepCopy();
       if(PackageIdElement != null) dest.PackageIdElement = (Hl7.Fhir.Model.Id)PackageIdElement.DeepCopy();
       if(LicenseElement != null) dest.LicenseElement = (Code<Hl7.Fhir.Model.ImplementationGuide.SPDXLicense>)LicenseElement.DeepCopy();
@@ -5152,10 +5242,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.Matches(PackageIdElement, otherT.PackageIdElement)) return false;
       if( !DeepComparable.Matches(LicenseElement, otherT.LicenseElement)) return false;
@@ -5184,10 +5274,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.IsExactly(PackageIdElement, otherT.PackageIdElement)) return false;
       if( !DeepComparable.IsExactly(LicenseElement, otherT.LicenseElement)) return false;
@@ -5216,10 +5306,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (CopyrightLabelElement != null) yield return CopyrightLabelElement;
         if (PackageIdElement != null) yield return PackageIdElement;
         if (LicenseElement != null) yield return LicenseElement;
@@ -5247,10 +5337,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (CopyrightLabelElement != null) yield return new ElementValue("copyrightLabel", CopyrightLabelElement);
         if (PackageIdElement != null) yield return new ElementValue("packageId", PackageIdElement);
         if (LicenseElement != null) yield return new ElementValue("license", LicenseElement);
@@ -5297,8 +5387,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -5306,8 +5396,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "copyrightLabel":
           value = CopyrightLabelElement;
           return CopyrightLabelElement is not null;
@@ -5351,10 +5441,10 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (CopyrightLabelElement is not null) yield return new KeyValuePair<string,object>("copyrightLabel",CopyrightLabelElement);
       if (PackageIdElement is not null) yield return new KeyValuePair<string,object>("packageId",PackageIdElement);
       if (LicenseElement is not null) yield return new KeyValuePair<string,object>("license",LicenseElement);

--- a/src/Hl7.Fhir.R5/Model/Generated/Invoice.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/Invoice.cs
@@ -730,13 +730,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("paymentTerms", Order=250)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown PaymentTerms
+    public Hl7.Fhir.Model.Markdown PaymentTermsElement
     {
-      get { return _PaymentTerms; }
-      set { _PaymentTerms = value; OnPropertyChanged("PaymentTerms"); }
+      get { return _PaymentTermsElement; }
+      set { _PaymentTermsElement = value; OnPropertyChanged("PaymentTermsElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _PaymentTerms;
+    private Hl7.Fhir.Model.Markdown _PaymentTermsElement;
+
+    /// <summary>
+    /// Payment details
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string PaymentTerms
+    {
+      get { return PaymentTermsElement != null ? PaymentTermsElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PaymentTermsElement = null;
+        else
+          PaymentTermsElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("PaymentTerms");
+      }
+    }
 
     /// <summary>
     /// Comments made about the invoice
@@ -778,7 +796,7 @@ namespace Hl7.Fhir.Model
       if(TotalPriceComponent != null) dest.TotalPriceComponent = new List<Hl7.Fhir.Model.MonetaryComponent>(TotalPriceComponent.DeepCopy());
       if(TotalNet != null) dest.TotalNet = (Hl7.Fhir.Model.Money)TotalNet.DeepCopy();
       if(TotalGross != null) dest.TotalGross = (Hl7.Fhir.Model.Money)TotalGross.DeepCopy();
-      if(PaymentTerms != null) dest.PaymentTerms = (Hl7.Fhir.Model.Markdown)PaymentTerms.DeepCopy();
+      if(PaymentTermsElement != null) dest.PaymentTermsElement = (Hl7.Fhir.Model.Markdown)PaymentTermsElement.DeepCopy();
       if(Note != null) dest.Note = new List<Hl7.Fhir.Model.Annotation>(Note.DeepCopy());
       return dest;
     }
@@ -811,7 +829,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(TotalPriceComponent, otherT.TotalPriceComponent)) return false;
       if( !DeepComparable.Matches(TotalNet, otherT.TotalNet)) return false;
       if( !DeepComparable.Matches(TotalGross, otherT.TotalGross)) return false;
-      if( !DeepComparable.Matches(PaymentTerms, otherT.PaymentTerms)) return false;
+      if( !DeepComparable.Matches(PaymentTermsElement, otherT.PaymentTermsElement)) return false;
       if( !DeepComparable.Matches(Note, otherT.Note)) return false;
 
       return true;
@@ -839,7 +857,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(TotalPriceComponent, otherT.TotalPriceComponent)) return false;
       if( !DeepComparable.IsExactly(TotalNet, otherT.TotalNet)) return false;
       if( !DeepComparable.IsExactly(TotalGross, otherT.TotalGross)) return false;
-      if( !DeepComparable.IsExactly(PaymentTerms, otherT.PaymentTerms)) return false;
+      if( !DeepComparable.IsExactly(PaymentTermsElement, otherT.PaymentTermsElement)) return false;
       if( !DeepComparable.IsExactly(Note, otherT.Note)) return false;
 
       return true;
@@ -867,7 +885,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in TotalPriceComponent) { if (elem != null) yield return elem; }
         if (TotalNet != null) yield return TotalNet;
         if (TotalGross != null) yield return TotalGross;
-        if (PaymentTerms != null) yield return PaymentTerms;
+        if (PaymentTermsElement != null) yield return PaymentTermsElement;
         foreach (var elem in Note) { if (elem != null) yield return elem; }
       }
     }
@@ -894,7 +912,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in TotalPriceComponent) { if (elem != null) yield return new ElementValue("totalPriceComponent", elem); }
         if (TotalNet != null) yield return new ElementValue("totalNet", TotalNet);
         if (TotalGross != null) yield return new ElementValue("totalGross", TotalGross);
-        if (PaymentTerms != null) yield return new ElementValue("paymentTerms", PaymentTerms);
+        if (PaymentTermsElement != null) yield return new ElementValue("paymentTerms", PaymentTermsElement);
         foreach (var elem in Note) { if (elem != null) yield return new ElementValue("note", elem); }
       }
     }
@@ -952,8 +970,8 @@ namespace Hl7.Fhir.Model
           value = TotalGross;
           return TotalGross is not null;
         case "paymentTerms":
-          value = PaymentTerms;
-          return PaymentTerms is not null;
+          value = PaymentTermsElement;
+          return PaymentTermsElement is not null;
         case "note":
           value = Note;
           return Note?.Any() == true;
@@ -982,7 +1000,7 @@ namespace Hl7.Fhir.Model
       if (TotalPriceComponent?.Any() == true) yield return new KeyValuePair<string,object>("totalPriceComponent",TotalPriceComponent);
       if (TotalNet is not null) yield return new KeyValuePair<string,object>("totalNet",TotalNet);
       if (TotalGross is not null) yield return new KeyValuePair<string,object>("totalGross",TotalGross);
-      if (PaymentTerms is not null) yield return new KeyValuePair<string,object>("paymentTerms",PaymentTerms);
+      if (PaymentTermsElement is not null) yield return new KeyValuePair<string,object>("paymentTerms",PaymentTermsElement);
       if (Note?.Any() == true) yield return new KeyValuePair<string,object>("note",Note);
     }
 

--- a/src/Hl7.Fhir.R5/Model/Generated/Library.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/Library.cs
@@ -399,13 +399,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the library
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -440,13 +458,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=250, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this library is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the library
@@ -484,13 +520,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=270)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the library was approved by publisher
@@ -716,12 +770,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -762,12 +816,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -803,12 +857,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -844,12 +898,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -884,12 +938,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -949,8 +1003,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -958,14 +1012,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -1024,12 +1078,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R5/Model/Generated/Measure.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/Measure.cs
@@ -86,13 +86,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("definition", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Definition
+      public Hl7.Fhir.Model.Markdown DefinitionElement
       {
-        get { return _Definition; }
-        set { _Definition = value; OnPropertyChanged("Definition"); }
+        get { return _DefinitionElement; }
+        set { _DefinitionElement = value; OnPropertyChanged("DefinitionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Definition;
+      private Hl7.Fhir.Model.Markdown _DefinitionElement;
+
+      /// <summary>
+      /// Meaning of the term
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Definition
+      {
+        get { return DefinitionElement != null ? DefinitionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DefinitionElement = null;
+          else
+            DefinitionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Definition");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -105,7 +123,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(Code != null) dest.Code = (Hl7.Fhir.Model.CodeableConcept)Code.DeepCopy();
-        if(Definition != null) dest.Definition = (Hl7.Fhir.Model.Markdown)Definition.DeepCopy();
+        if(DefinitionElement != null) dest.DefinitionElement = (Hl7.Fhir.Model.Markdown)DefinitionElement.DeepCopy();
         return dest;
       }
 
@@ -122,7 +140,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(Code, otherT.Code)) return false;
-        if( !DeepComparable.Matches(Definition, otherT.Definition)) return false;
+        if( !DeepComparable.Matches(DefinitionElement, otherT.DefinitionElement)) return false;
 
         return true;
       }
@@ -134,7 +152,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(Code, otherT.Code)) return false;
-        if( !DeepComparable.IsExactly(Definition, otherT.Definition)) return false;
+        if( !DeepComparable.IsExactly(DefinitionElement, otherT.DefinitionElement)) return false;
 
         return true;
       }
@@ -146,7 +164,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (Code != null) yield return Code;
-          if (Definition != null) yield return Definition;
+          if (DefinitionElement != null) yield return DefinitionElement;
         }
       }
 
@@ -157,7 +175,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (Code != null) yield return new ElementValue("code", Code);
-          if (Definition != null) yield return new ElementValue("definition", Definition);
+          if (DefinitionElement != null) yield return new ElementValue("definition", DefinitionElement);
         }
       }
 
@@ -169,8 +187,8 @@ namespace Hl7.Fhir.Model
             value = Code;
             return Code is not null;
           case "definition":
-            value = Definition;
-            return Definition is not null;
+            value = DefinitionElement;
+            return DefinitionElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -181,7 +199,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (Code is not null) yield return new KeyValuePair<string,object>("code",Code);
-        if (Definition is not null) yield return new KeyValuePair<string,object>("definition",Definition);
+        if (DefinitionElement is not null) yield return new KeyValuePair<string,object>("definition",DefinitionElement);
       }
 
     }
@@ -1668,13 +1686,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the measure
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1709,13 +1745,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=250, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this measure is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the measure
@@ -1753,13 +1807,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=270)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the measure was approved by publisher
@@ -1957,13 +2029,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("disclaimer", InSummary=true, Order=380)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Disclaimer
+    public Hl7.Fhir.Model.Markdown DisclaimerElement
     {
-      get { return _Disclaimer; }
-      set { _Disclaimer = value; OnPropertyChanged("Disclaimer"); }
+      get { return _DisclaimerElement; }
+      set { _DisclaimerElement = value; OnPropertyChanged("DisclaimerElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Disclaimer;
+    private Hl7.Fhir.Model.Markdown _DisclaimerElement;
+
+    /// <summary>
+    /// Disclaimer for use of the measure or its referenced content
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Disclaimer
+    {
+      get { return DisclaimerElement != null ? DisclaimerElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DisclaimerElement = null;
+        else
+          DisclaimerElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Disclaimer");
+      }
+    }
 
     /// <summary>
     /// proportion | ratio | continuous-variable | cohort
@@ -2085,26 +2175,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("rationale", InSummary=true, Order=450)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Rationale
+    public Hl7.Fhir.Model.Markdown RationaleElement
     {
-      get { return _Rationale; }
-      set { _Rationale = value; OnPropertyChanged("Rationale"); }
+      get { return _RationaleElement; }
+      set { _RationaleElement = value; OnPropertyChanged("RationaleElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Rationale;
+    private Hl7.Fhir.Model.Markdown _RationaleElement;
+
+    /// <summary>
+    /// Detailed description of why the measure exists
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Rationale
+    {
+      get { return RationaleElement != null ? RationaleElement.Value : null; }
+      set
+      {
+        if (value == null)
+          RationaleElement = null;
+        else
+          RationaleElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Rationale");
+      }
+    }
 
     /// <summary>
     /// Summary of clinical guidelines
     /// </summary>
     [FhirElement("clinicalRecommendationStatement", InSummary=true, Order=460)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown ClinicalRecommendationStatement
+    public Hl7.Fhir.Model.Markdown ClinicalRecommendationStatementElement
     {
-      get { return _ClinicalRecommendationStatement; }
-      set { _ClinicalRecommendationStatement = value; OnPropertyChanged("ClinicalRecommendationStatement"); }
+      get { return _ClinicalRecommendationStatementElement; }
+      set { _ClinicalRecommendationStatementElement = value; OnPropertyChanged("ClinicalRecommendationStatementElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _ClinicalRecommendationStatement;
+    private Hl7.Fhir.Model.Markdown _ClinicalRecommendationStatementElement;
+
+    /// <summary>
+    /// Summary of clinical guidelines
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string ClinicalRecommendationStatement
+    {
+      get { return ClinicalRecommendationStatementElement != null ? ClinicalRecommendationStatementElement.Value : null; }
+      set
+      {
+        if (value == null)
+          ClinicalRecommendationStatementElement = null;
+        else
+          ClinicalRecommendationStatementElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("ClinicalRecommendationStatement");
+      }
+    }
 
     /// <summary>
     /// increase | decrease
@@ -2138,13 +2264,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("guidance", InSummary=true, Order=490)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Guidance
+    public Hl7.Fhir.Model.Markdown GuidanceElement
     {
-      get { return _Guidance; }
-      set { _Guidance = value; OnPropertyChanged("Guidance"); }
+      get { return _GuidanceElement; }
+      set { _GuidanceElement = value; OnPropertyChanged("GuidanceElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Guidance;
+    private Hl7.Fhir.Model.Markdown _GuidanceElement;
+
+    /// <summary>
+    /// Additional guidance for implementers
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Guidance
+    {
+      get { return GuidanceElement != null ? GuidanceElement.Value : null; }
+      set
+      {
+        if (value == null)
+          GuidanceElement = null;
+        else
+          GuidanceElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Guidance");
+      }
+    }
 
     /// <summary>
     /// Population criteria group
@@ -2197,12 +2341,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -2213,18 +2357,18 @@ namespace Hl7.Fhir.Model
       if(Endorser != null) dest.Endorser = new List<Hl7.Fhir.Model.ContactDetail>(Endorser.DeepCopy());
       if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
       if(LibraryElement != null) dest.LibraryElement = new List<Hl7.Fhir.Model.Canonical>(LibraryElement.DeepCopy());
-      if(Disclaimer != null) dest.Disclaimer = (Hl7.Fhir.Model.Markdown)Disclaimer.DeepCopy();
+      if(DisclaimerElement != null) dest.DisclaimerElement = (Hl7.Fhir.Model.Markdown)DisclaimerElement.DeepCopy();
       if(Scoring != null) dest.Scoring = (Hl7.Fhir.Model.CodeableConcept)Scoring.DeepCopy();
       if(ScoringUnit != null) dest.ScoringUnit = (Hl7.Fhir.Model.CodeableConcept)ScoringUnit.DeepCopy();
       if(CompositeScoring != null) dest.CompositeScoring = (Hl7.Fhir.Model.CodeableConcept)CompositeScoring.DeepCopy();
       if(Type != null) dest.Type = new List<Hl7.Fhir.Model.CodeableConcept>(Type.DeepCopy());
       if(RiskAdjustmentElement != null) dest.RiskAdjustmentElement = (Hl7.Fhir.Model.FhirString)RiskAdjustmentElement.DeepCopy();
       if(RateAggregationElement != null) dest.RateAggregationElement = (Hl7.Fhir.Model.FhirString)RateAggregationElement.DeepCopy();
-      if(Rationale != null) dest.Rationale = (Hl7.Fhir.Model.Markdown)Rationale.DeepCopy();
-      if(ClinicalRecommendationStatement != null) dest.ClinicalRecommendationStatement = (Hl7.Fhir.Model.Markdown)ClinicalRecommendationStatement.DeepCopy();
+      if(RationaleElement != null) dest.RationaleElement = (Hl7.Fhir.Model.Markdown)RationaleElement.DeepCopy();
+      if(ClinicalRecommendationStatementElement != null) dest.ClinicalRecommendationStatementElement = (Hl7.Fhir.Model.Markdown)ClinicalRecommendationStatementElement.DeepCopy();
       if(ImprovementNotation != null) dest.ImprovementNotation = (Hl7.Fhir.Model.CodeableConcept)ImprovementNotation.DeepCopy();
       if(Term != null) dest.Term = new List<Hl7.Fhir.Model.Measure.TermComponent>(Term.DeepCopy());
-      if(Guidance != null) dest.Guidance = (Hl7.Fhir.Model.Markdown)Guidance.DeepCopy();
+      if(GuidanceElement != null) dest.GuidanceElement = (Hl7.Fhir.Model.Markdown)GuidanceElement.DeepCopy();
       if(Group != null) dest.Group = new List<Hl7.Fhir.Model.Measure.GroupComponent>(Group.DeepCopy());
       if(SupplementalData != null) dest.SupplementalData = new List<Hl7.Fhir.Model.Measure.SupplementalDataComponent>(SupplementalData.DeepCopy());
       return dest;
@@ -2255,12 +2399,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -2271,18 +2415,18 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Endorser, otherT.Endorser)) return false;
       if( !DeepComparable.Matches(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.Matches(LibraryElement, otherT.LibraryElement)) return false;
-      if( !DeepComparable.Matches(Disclaimer, otherT.Disclaimer)) return false;
+      if( !DeepComparable.Matches(DisclaimerElement, otherT.DisclaimerElement)) return false;
       if( !DeepComparable.Matches(Scoring, otherT.Scoring)) return false;
       if( !DeepComparable.Matches(ScoringUnit, otherT.ScoringUnit)) return false;
       if( !DeepComparable.Matches(CompositeScoring, otherT.CompositeScoring)) return false;
       if( !DeepComparable.Matches(Type, otherT.Type)) return false;
       if( !DeepComparable.Matches(RiskAdjustmentElement, otherT.RiskAdjustmentElement)) return false;
       if( !DeepComparable.Matches(RateAggregationElement, otherT.RateAggregationElement)) return false;
-      if( !DeepComparable.Matches(Rationale, otherT.Rationale)) return false;
-      if( !DeepComparable.Matches(ClinicalRecommendationStatement, otherT.ClinicalRecommendationStatement)) return false;
+      if( !DeepComparable.Matches(RationaleElement, otherT.RationaleElement)) return false;
+      if( !DeepComparable.Matches(ClinicalRecommendationStatementElement, otherT.ClinicalRecommendationStatementElement)) return false;
       if( !DeepComparable.Matches(ImprovementNotation, otherT.ImprovementNotation)) return false;
       if( !DeepComparable.Matches(Term, otherT.Term)) return false;
-      if( !DeepComparable.Matches(Guidance, otherT.Guidance)) return false;
+      if( !DeepComparable.Matches(GuidanceElement, otherT.GuidanceElement)) return false;
       if( !DeepComparable.Matches(Group, otherT.Group)) return false;
       if( !DeepComparable.Matches(SupplementalData, otherT.SupplementalData)) return false;
 
@@ -2308,12 +2452,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -2324,18 +2468,18 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Endorser, otherT.Endorser)) return false;
       if( !DeepComparable.IsExactly(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.IsExactly(LibraryElement, otherT.LibraryElement)) return false;
-      if( !DeepComparable.IsExactly(Disclaimer, otherT.Disclaimer)) return false;
+      if( !DeepComparable.IsExactly(DisclaimerElement, otherT.DisclaimerElement)) return false;
       if( !DeepComparable.IsExactly(Scoring, otherT.Scoring)) return false;
       if( !DeepComparable.IsExactly(ScoringUnit, otherT.ScoringUnit)) return false;
       if( !DeepComparable.IsExactly(CompositeScoring, otherT.CompositeScoring)) return false;
       if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
       if( !DeepComparable.IsExactly(RiskAdjustmentElement, otherT.RiskAdjustmentElement)) return false;
       if( !DeepComparable.IsExactly(RateAggregationElement, otherT.RateAggregationElement)) return false;
-      if( !DeepComparable.IsExactly(Rationale, otherT.Rationale)) return false;
-      if( !DeepComparable.IsExactly(ClinicalRecommendationStatement, otherT.ClinicalRecommendationStatement)) return false;
+      if( !DeepComparable.IsExactly(RationaleElement, otherT.RationaleElement)) return false;
+      if( !DeepComparable.IsExactly(ClinicalRecommendationStatementElement, otherT.ClinicalRecommendationStatementElement)) return false;
       if( !DeepComparable.IsExactly(ImprovementNotation, otherT.ImprovementNotation)) return false;
       if( !DeepComparable.IsExactly(Term, otherT.Term)) return false;
-      if( !DeepComparable.IsExactly(Guidance, otherT.Guidance)) return false;
+      if( !DeepComparable.IsExactly(GuidanceElement, otherT.GuidanceElement)) return false;
       if( !DeepComparable.IsExactly(Group, otherT.Group)) return false;
       if( !DeepComparable.IsExactly(SupplementalData, otherT.SupplementalData)) return false;
 
@@ -2361,12 +2505,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -2377,18 +2521,18 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Endorser) { if (elem != null) yield return elem; }
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return elem; }
         foreach (var elem in LibraryElement) { if (elem != null) yield return elem; }
-        if (Disclaimer != null) yield return Disclaimer;
+        if (DisclaimerElement != null) yield return DisclaimerElement;
         if (Scoring != null) yield return Scoring;
         if (ScoringUnit != null) yield return ScoringUnit;
         if (CompositeScoring != null) yield return CompositeScoring;
         foreach (var elem in Type) { if (elem != null) yield return elem; }
         if (RiskAdjustmentElement != null) yield return RiskAdjustmentElement;
         if (RateAggregationElement != null) yield return RateAggregationElement;
-        if (Rationale != null) yield return Rationale;
-        if (ClinicalRecommendationStatement != null) yield return ClinicalRecommendationStatement;
+        if (RationaleElement != null) yield return RationaleElement;
+        if (ClinicalRecommendationStatementElement != null) yield return ClinicalRecommendationStatementElement;
         if (ImprovementNotation != null) yield return ImprovementNotation;
         foreach (var elem in Term) { if (elem != null) yield return elem; }
-        if (Guidance != null) yield return Guidance;
+        if (GuidanceElement != null) yield return GuidanceElement;
         foreach (var elem in Group) { if (elem != null) yield return elem; }
         foreach (var elem in SupplementalData) { if (elem != null) yield return elem; }
       }
@@ -2413,12 +2557,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -2429,18 +2573,18 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Endorser) { if (elem != null) yield return new ElementValue("endorser", elem); }
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return new ElementValue("relatedArtifact", elem); }
         foreach (var elem in LibraryElement) { if (elem != null) yield return new ElementValue("library", elem); }
-        if (Disclaimer != null) yield return new ElementValue("disclaimer", Disclaimer);
+        if (DisclaimerElement != null) yield return new ElementValue("disclaimer", DisclaimerElement);
         if (Scoring != null) yield return new ElementValue("scoring", Scoring);
         if (ScoringUnit != null) yield return new ElementValue("scoringUnit", ScoringUnit);
         if (CompositeScoring != null) yield return new ElementValue("compositeScoring", CompositeScoring);
         foreach (var elem in Type) { if (elem != null) yield return new ElementValue("type", elem); }
         if (RiskAdjustmentElement != null) yield return new ElementValue("riskAdjustment", RiskAdjustmentElement);
         if (RateAggregationElement != null) yield return new ElementValue("rateAggregation", RateAggregationElement);
-        if (Rationale != null) yield return new ElementValue("rationale", Rationale);
-        if (ClinicalRecommendationStatement != null) yield return new ElementValue("clinicalRecommendationStatement", ClinicalRecommendationStatement);
+        if (RationaleElement != null) yield return new ElementValue("rationale", RationaleElement);
+        if (ClinicalRecommendationStatementElement != null) yield return new ElementValue("clinicalRecommendationStatement", ClinicalRecommendationStatementElement);
         if (ImprovementNotation != null) yield return new ElementValue("improvementNotation", ImprovementNotation);
         foreach (var elem in Term) { if (elem != null) yield return new ElementValue("term", elem); }
-        if (Guidance != null) yield return new ElementValue("guidance", Guidance);
+        if (GuidanceElement != null) yield return new ElementValue("guidance", GuidanceElement);
         foreach (var elem in Group) { if (elem != null) yield return new ElementValue("group", elem); }
         foreach (var elem in SupplementalData) { if (elem != null) yield return new ElementValue("supplementalData", elem); }
       }
@@ -2490,8 +2634,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2499,14 +2643,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -2538,8 +2682,8 @@ namespace Hl7.Fhir.Model
           value = LibraryElement;
           return LibraryElement?.Any() == true;
         case "disclaimer":
-          value = Disclaimer;
-          return Disclaimer is not null;
+          value = DisclaimerElement;
+          return DisclaimerElement is not null;
         case "scoring":
           value = Scoring;
           return Scoring is not null;
@@ -2559,11 +2703,11 @@ namespace Hl7.Fhir.Model
           value = RateAggregationElement;
           return RateAggregationElement is not null;
         case "rationale":
-          value = Rationale;
-          return Rationale is not null;
+          value = RationaleElement;
+          return RationaleElement is not null;
         case "clinicalRecommendationStatement":
-          value = ClinicalRecommendationStatement;
-          return ClinicalRecommendationStatement is not null;
+          value = ClinicalRecommendationStatementElement;
+          return ClinicalRecommendationStatementElement is not null;
         case "improvementNotation":
           value = ImprovementNotation;
           return ImprovementNotation is not null;
@@ -2571,8 +2715,8 @@ namespace Hl7.Fhir.Model
           value = Term;
           return Term?.Any() == true;
         case "guidance":
-          value = Guidance;
-          return Guidance is not null;
+          value = GuidanceElement;
+          return GuidanceElement is not null;
         case "group":
           value = Group;
           return Group?.Any() == true;
@@ -2601,12 +2745,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);
@@ -2617,18 +2761,18 @@ namespace Hl7.Fhir.Model
       if (Endorser?.Any() == true) yield return new KeyValuePair<string,object>("endorser",Endorser);
       if (RelatedArtifact?.Any() == true) yield return new KeyValuePair<string,object>("relatedArtifact",RelatedArtifact);
       if (LibraryElement?.Any() == true) yield return new KeyValuePair<string,object>("library",LibraryElement);
-      if (Disclaimer is not null) yield return new KeyValuePair<string,object>("disclaimer",Disclaimer);
+      if (DisclaimerElement is not null) yield return new KeyValuePair<string,object>("disclaimer",DisclaimerElement);
       if (Scoring is not null) yield return new KeyValuePair<string,object>("scoring",Scoring);
       if (ScoringUnit is not null) yield return new KeyValuePair<string,object>("scoringUnit",ScoringUnit);
       if (CompositeScoring is not null) yield return new KeyValuePair<string,object>("compositeScoring",CompositeScoring);
       if (Type?.Any() == true) yield return new KeyValuePair<string,object>("type",Type);
       if (RiskAdjustmentElement is not null) yield return new KeyValuePair<string,object>("riskAdjustment",RiskAdjustmentElement);
       if (RateAggregationElement is not null) yield return new KeyValuePair<string,object>("rateAggregation",RateAggregationElement);
-      if (Rationale is not null) yield return new KeyValuePair<string,object>("rationale",Rationale);
-      if (ClinicalRecommendationStatement is not null) yield return new KeyValuePair<string,object>("clinicalRecommendationStatement",ClinicalRecommendationStatement);
+      if (RationaleElement is not null) yield return new KeyValuePair<string,object>("rationale",RationaleElement);
+      if (ClinicalRecommendationStatementElement is not null) yield return new KeyValuePair<string,object>("clinicalRecommendationStatement",ClinicalRecommendationStatementElement);
       if (ImprovementNotation is not null) yield return new KeyValuePair<string,object>("improvementNotation",ImprovementNotation);
       if (Term?.Any() == true) yield return new KeyValuePair<string,object>("term",Term);
-      if (Guidance is not null) yield return new KeyValuePair<string,object>("guidance",Guidance);
+      if (GuidanceElement is not null) yield return new KeyValuePair<string,object>("guidance",GuidanceElement);
       if (Group?.Any() == true) yield return new KeyValuePair<string,object>("group",Group);
       if (SupplementalData?.Any() == true) yield return new KeyValuePair<string,object>("supplementalData",SupplementalData);
     }

--- a/src/Hl7.Fhir.R5/Model/Generated/MedicationKnowledge.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/MedicationKnowledge.cs
@@ -3034,13 +3034,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("preparationInstruction", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown PreparationInstruction
+    public Hl7.Fhir.Model.Markdown PreparationInstructionElement
     {
-      get { return _PreparationInstruction; }
-      set { _PreparationInstruction = value; OnPropertyChanged("PreparationInstruction"); }
+      get { return _PreparationInstructionElement; }
+      set { _PreparationInstructionElement = value; OnPropertyChanged("PreparationInstructionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _PreparationInstruction;
+    private Hl7.Fhir.Model.Markdown _PreparationInstructionElement;
+
+    /// <summary>
+    /// The instructions for preparing the medication
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string PreparationInstruction
+    {
+      get { return PreparationInstructionElement != null ? PreparationInstructionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PreparationInstructionElement = null;
+        else
+          PreparationInstructionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("PreparationInstruction");
+      }
+    }
 
     /// <summary>
     /// The pricing of the medication
@@ -3189,7 +3207,7 @@ namespace Hl7.Fhir.Model
       if(AssociatedMedication != null) dest.AssociatedMedication = new List<Hl7.Fhir.Model.ResourceReference>(AssociatedMedication.DeepCopy());
       if(ProductType != null) dest.ProductType = new List<Hl7.Fhir.Model.CodeableConcept>(ProductType.DeepCopy());
       if(Monograph != null) dest.Monograph = new List<Hl7.Fhir.Model.MedicationKnowledge.MonographComponent>(Monograph.DeepCopy());
-      if(PreparationInstruction != null) dest.PreparationInstruction = (Hl7.Fhir.Model.Markdown)PreparationInstruction.DeepCopy();
+      if(PreparationInstructionElement != null) dest.PreparationInstructionElement = (Hl7.Fhir.Model.Markdown)PreparationInstructionElement.DeepCopy();
       if(Cost != null) dest.Cost = new List<Hl7.Fhir.Model.MedicationKnowledge.CostComponent>(Cost.DeepCopy());
       if(MonitoringProgram != null) dest.MonitoringProgram = new List<Hl7.Fhir.Model.MedicationKnowledge.MonitoringProgramComponent>(MonitoringProgram.DeepCopy());
       if(IndicationGuideline != null) dest.IndicationGuideline = new List<Hl7.Fhir.Model.MedicationKnowledge.IndicationGuidelineComponent>(IndicationGuideline.DeepCopy());
@@ -3224,7 +3242,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(AssociatedMedication, otherT.AssociatedMedication)) return false;
       if( !DeepComparable.Matches(ProductType, otherT.ProductType)) return false;
       if( !DeepComparable.Matches(Monograph, otherT.Monograph)) return false;
-      if( !DeepComparable.Matches(PreparationInstruction, otherT.PreparationInstruction)) return false;
+      if( !DeepComparable.Matches(PreparationInstructionElement, otherT.PreparationInstructionElement)) return false;
       if( !DeepComparable.Matches(Cost, otherT.Cost)) return false;
       if( !DeepComparable.Matches(MonitoringProgram, otherT.MonitoringProgram)) return false;
       if( !DeepComparable.Matches(IndicationGuideline, otherT.IndicationGuideline)) return false;
@@ -3254,7 +3272,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(AssociatedMedication, otherT.AssociatedMedication)) return false;
       if( !DeepComparable.IsExactly(ProductType, otherT.ProductType)) return false;
       if( !DeepComparable.IsExactly(Monograph, otherT.Monograph)) return false;
-      if( !DeepComparable.IsExactly(PreparationInstruction, otherT.PreparationInstruction)) return false;
+      if( !DeepComparable.IsExactly(PreparationInstructionElement, otherT.PreparationInstructionElement)) return false;
       if( !DeepComparable.IsExactly(Cost, otherT.Cost)) return false;
       if( !DeepComparable.IsExactly(MonitoringProgram, otherT.MonitoringProgram)) return false;
       if( !DeepComparable.IsExactly(IndicationGuideline, otherT.IndicationGuideline)) return false;
@@ -3284,7 +3302,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in AssociatedMedication) { if (elem != null) yield return elem; }
         foreach (var elem in ProductType) { if (elem != null) yield return elem; }
         foreach (var elem in Monograph) { if (elem != null) yield return elem; }
-        if (PreparationInstruction != null) yield return PreparationInstruction;
+        if (PreparationInstructionElement != null) yield return PreparationInstructionElement;
         foreach (var elem in Cost) { if (elem != null) yield return elem; }
         foreach (var elem in MonitoringProgram) { if (elem != null) yield return elem; }
         foreach (var elem in IndicationGuideline) { if (elem != null) yield return elem; }
@@ -3313,7 +3331,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in AssociatedMedication) { if (elem != null) yield return new ElementValue("associatedMedication", elem); }
         foreach (var elem in ProductType) { if (elem != null) yield return new ElementValue("productType", elem); }
         foreach (var elem in Monograph) { if (elem != null) yield return new ElementValue("monograph", elem); }
-        if (PreparationInstruction != null) yield return new ElementValue("preparationInstruction", PreparationInstruction);
+        if (PreparationInstructionElement != null) yield return new ElementValue("preparationInstruction", PreparationInstructionElement);
         foreach (var elem in Cost) { if (elem != null) yield return new ElementValue("cost", elem); }
         foreach (var elem in MonitoringProgram) { if (elem != null) yield return new ElementValue("monitoringProgram", elem); }
         foreach (var elem in IndicationGuideline) { if (elem != null) yield return new ElementValue("indicationGuideline", elem); }
@@ -3361,8 +3379,8 @@ namespace Hl7.Fhir.Model
           value = Monograph;
           return Monograph?.Any() == true;
         case "preparationInstruction":
-          value = PreparationInstruction;
-          return PreparationInstruction is not null;
+          value = PreparationInstructionElement;
+          return PreparationInstructionElement is not null;
         case "cost":
           value = Cost;
           return Cost?.Any() == true;
@@ -3409,7 +3427,7 @@ namespace Hl7.Fhir.Model
       if (AssociatedMedication?.Any() == true) yield return new KeyValuePair<string,object>("associatedMedication",AssociatedMedication);
       if (ProductType?.Any() == true) yield return new KeyValuePair<string,object>("productType",ProductType);
       if (Monograph?.Any() == true) yield return new KeyValuePair<string,object>("monograph",Monograph);
-      if (PreparationInstruction is not null) yield return new KeyValuePair<string,object>("preparationInstruction",PreparationInstruction);
+      if (PreparationInstructionElement is not null) yield return new KeyValuePair<string,object>("preparationInstruction",PreparationInstructionElement);
       if (Cost?.Any() == true) yield return new KeyValuePair<string,object>("cost",Cost);
       if (MonitoringProgram?.Any() == true) yield return new KeyValuePair<string,object>("monitoringProgram",MonitoringProgram);
       if (IndicationGuideline?.Any() == true) yield return new KeyValuePair<string,object>("indicationGuideline",IndicationGuideline);

--- a/src/Hl7.Fhir.R5/Model/Generated/MedicinalProductDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/MedicinalProductDefinition.cs
@@ -1255,13 +1255,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=150)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// General description of this product
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The dose form for a single part product, or combined form of a multiple part product
@@ -1295,13 +1313,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("indication", InSummary=true, Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Indication
+    public Hl7.Fhir.Model.Markdown IndicationElement
     {
-      get { return _Indication; }
-      set { _Indication = value; OnPropertyChanged("Indication"); }
+      get { return _IndicationElement; }
+      set { _IndicationElement = value; OnPropertyChanged("IndicationElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Indication;
+    private Hl7.Fhir.Model.Markdown _IndicationElement;
+
+    /// <summary>
+    /// Description of indication(s) for this product, used when structured indications are not required
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Indication
+    {
+      get { return IndicationElement != null ? IndicationElement.Value : null; }
+      set
+      {
+        if (value == null)
+          IndicationElement = null;
+        else
+          IndicationElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Indication");
+      }
+    }
 
     /// <summary>
     /// The legal status of supply of the medicinal product as classified by the regulator
@@ -1590,10 +1626,10 @@ namespace Hl7.Fhir.Model
       if(VersionElement != null) dest.VersionElement = (Hl7.Fhir.Model.FhirString)VersionElement.DeepCopy();
       if(Status != null) dest.Status = (Hl7.Fhir.Model.CodeableConcept)Status.DeepCopy();
       if(StatusDateElement != null) dest.StatusDateElement = (Hl7.Fhir.Model.FhirDateTime)StatusDateElement.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(CombinedPharmaceuticalDoseForm != null) dest.CombinedPharmaceuticalDoseForm = (Hl7.Fhir.Model.CodeableConcept)CombinedPharmaceuticalDoseForm.DeepCopy();
       if(Route != null) dest.Route = new List<Hl7.Fhir.Model.CodeableConcept>(Route.DeepCopy());
-      if(Indication != null) dest.Indication = (Hl7.Fhir.Model.Markdown)Indication.DeepCopy();
+      if(IndicationElement != null) dest.IndicationElement = (Hl7.Fhir.Model.Markdown)IndicationElement.DeepCopy();
       if(LegalStatusOfSupply != null) dest.LegalStatusOfSupply = (Hl7.Fhir.Model.CodeableConcept)LegalStatusOfSupply.DeepCopy();
       if(AdditionalMonitoringIndicator != null) dest.AdditionalMonitoringIndicator = (Hl7.Fhir.Model.CodeableConcept)AdditionalMonitoringIndicator.DeepCopy();
       if(SpecialMeasures != null) dest.SpecialMeasures = new List<Hl7.Fhir.Model.CodeableConcept>(SpecialMeasures.DeepCopy());
@@ -1634,10 +1670,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(VersionElement, otherT.VersionElement)) return false;
       if( !DeepComparable.Matches(Status, otherT.Status)) return false;
       if( !DeepComparable.Matches(StatusDateElement, otherT.StatusDateElement)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(CombinedPharmaceuticalDoseForm, otherT.CombinedPharmaceuticalDoseForm)) return false;
       if( !DeepComparable.Matches(Route, otherT.Route)) return false;
-      if( !DeepComparable.Matches(Indication, otherT.Indication)) return false;
+      if( !DeepComparable.Matches(IndicationElement, otherT.IndicationElement)) return false;
       if( !DeepComparable.Matches(LegalStatusOfSupply, otherT.LegalStatusOfSupply)) return false;
       if( !DeepComparable.Matches(AdditionalMonitoringIndicator, otherT.AdditionalMonitoringIndicator)) return false;
       if( !DeepComparable.Matches(SpecialMeasures, otherT.SpecialMeasures)) return false;
@@ -1673,10 +1709,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(VersionElement, otherT.VersionElement)) return false;
       if( !DeepComparable.IsExactly(Status, otherT.Status)) return false;
       if( !DeepComparable.IsExactly(StatusDateElement, otherT.StatusDateElement)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(CombinedPharmaceuticalDoseForm, otherT.CombinedPharmaceuticalDoseForm)) return false;
       if( !DeepComparable.IsExactly(Route, otherT.Route)) return false;
-      if( !DeepComparable.IsExactly(Indication, otherT.Indication)) return false;
+      if( !DeepComparable.IsExactly(IndicationElement, otherT.IndicationElement)) return false;
       if( !DeepComparable.IsExactly(LegalStatusOfSupply, otherT.LegalStatusOfSupply)) return false;
       if( !DeepComparable.IsExactly(AdditionalMonitoringIndicator, otherT.AdditionalMonitoringIndicator)) return false;
       if( !DeepComparable.IsExactly(SpecialMeasures, otherT.SpecialMeasures)) return false;
@@ -1712,10 +1748,10 @@ namespace Hl7.Fhir.Model
         if (VersionElement != null) yield return VersionElement;
         if (Status != null) yield return Status;
         if (StatusDateElement != null) yield return StatusDateElement;
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         if (CombinedPharmaceuticalDoseForm != null) yield return CombinedPharmaceuticalDoseForm;
         foreach (var elem in Route) { if (elem != null) yield return elem; }
-        if (Indication != null) yield return Indication;
+        if (IndicationElement != null) yield return IndicationElement;
         if (LegalStatusOfSupply != null) yield return LegalStatusOfSupply;
         if (AdditionalMonitoringIndicator != null) yield return AdditionalMonitoringIndicator;
         foreach (var elem in SpecialMeasures) { if (elem != null) yield return elem; }
@@ -1750,10 +1786,10 @@ namespace Hl7.Fhir.Model
         if (VersionElement != null) yield return new ElementValue("version", VersionElement);
         if (Status != null) yield return new ElementValue("status", Status);
         if (StatusDateElement != null) yield return new ElementValue("statusDate", StatusDateElement);
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         if (CombinedPharmaceuticalDoseForm != null) yield return new ElementValue("combinedPharmaceuticalDoseForm", CombinedPharmaceuticalDoseForm);
         foreach (var elem in Route) { if (elem != null) yield return new ElementValue("route", elem); }
-        if (Indication != null) yield return new ElementValue("indication", Indication);
+        if (IndicationElement != null) yield return new ElementValue("indication", IndicationElement);
         if (LegalStatusOfSupply != null) yield return new ElementValue("legalStatusOfSupply", LegalStatusOfSupply);
         if (AdditionalMonitoringIndicator != null) yield return new ElementValue("additionalMonitoringIndicator", AdditionalMonitoringIndicator);
         foreach (var elem in SpecialMeasures) { if (elem != null) yield return new ElementValue("specialMeasures", elem); }
@@ -1799,8 +1835,8 @@ namespace Hl7.Fhir.Model
           value = StatusDateElement;
           return StatusDateElement is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "combinedPharmaceuticalDoseForm":
           value = CombinedPharmaceuticalDoseForm;
           return CombinedPharmaceuticalDoseForm is not null;
@@ -1808,8 +1844,8 @@ namespace Hl7.Fhir.Model
           value = Route;
           return Route?.Any() == true;
         case "indication":
-          value = Indication;
-          return Indication is not null;
+          value = IndicationElement;
+          return IndicationElement is not null;
         case "legalStatusOfSupply":
           value = LegalStatusOfSupply;
           return LegalStatusOfSupply is not null;
@@ -1882,10 +1918,10 @@ namespace Hl7.Fhir.Model
       if (VersionElement is not null) yield return new KeyValuePair<string,object>("version",VersionElement);
       if (Status is not null) yield return new KeyValuePair<string,object>("status",Status);
       if (StatusDateElement is not null) yield return new KeyValuePair<string,object>("statusDate",StatusDateElement);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (CombinedPharmaceuticalDoseForm is not null) yield return new KeyValuePair<string,object>("combinedPharmaceuticalDoseForm",CombinedPharmaceuticalDoseForm);
       if (Route?.Any() == true) yield return new KeyValuePair<string,object>("route",Route);
-      if (Indication is not null) yield return new KeyValuePair<string,object>("indication",Indication);
+      if (IndicationElement is not null) yield return new KeyValuePair<string,object>("indication",IndicationElement);
       if (LegalStatusOfSupply is not null) yield return new KeyValuePair<string,object>("legalStatusOfSupply",LegalStatusOfSupply);
       if (AdditionalMonitoringIndicator is not null) yield return new KeyValuePair<string,object>("additionalMonitoringIndicator",AdditionalMonitoringIndicator);
       if (SpecialMeasures?.Any() == true) yield return new KeyValuePair<string,object>("specialMeasures",SpecialMeasures);

--- a/src/Hl7.Fhir.R5/Model/Generated/MessageDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/MessageDefinition.cs
@@ -383,13 +383,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("situation", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Situation
+      public Hl7.Fhir.Model.Markdown SituationElement
       {
-        get { return _Situation; }
-        set { _Situation = value; OnPropertyChanged("Situation"); }
+        get { return _SituationElement; }
+        set { _SituationElement = value; OnPropertyChanged("SituationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Situation;
+      private Hl7.Fhir.Model.Markdown _SituationElement;
+
+      /// <summary>
+      /// When should this response be used
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Situation
+      {
+        get { return SituationElement != null ? SituationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            SituationElement = null;
+          else
+            SituationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Situation");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -402,7 +420,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(MessageElement != null) dest.MessageElement = (Hl7.Fhir.Model.Canonical)MessageElement.DeepCopy();
-        if(Situation != null) dest.Situation = (Hl7.Fhir.Model.Markdown)Situation.DeepCopy();
+        if(SituationElement != null) dest.SituationElement = (Hl7.Fhir.Model.Markdown)SituationElement.DeepCopy();
         return dest;
       }
 
@@ -419,7 +437,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(MessageElement, otherT.MessageElement)) return false;
-        if( !DeepComparable.Matches(Situation, otherT.Situation)) return false;
+        if( !DeepComparable.Matches(SituationElement, otherT.SituationElement)) return false;
 
         return true;
       }
@@ -431,7 +449,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(MessageElement, otherT.MessageElement)) return false;
-        if( !DeepComparable.IsExactly(Situation, otherT.Situation)) return false;
+        if( !DeepComparable.IsExactly(SituationElement, otherT.SituationElement)) return false;
 
         return true;
       }
@@ -443,7 +461,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (MessageElement != null) yield return MessageElement;
-          if (Situation != null) yield return Situation;
+          if (SituationElement != null) yield return SituationElement;
         }
       }
 
@@ -454,7 +472,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (MessageElement != null) yield return new ElementValue("message", MessageElement);
-          if (Situation != null) yield return new ElementValue("situation", Situation);
+          if (SituationElement != null) yield return new ElementValue("situation", SituationElement);
         }
       }
 
@@ -466,8 +484,8 @@ namespace Hl7.Fhir.Model
             value = MessageElement;
             return MessageElement is not null;
           case "situation":
-            value = Situation;
-            return Situation is not null;
+            value = SituationElement;
+            return SituationElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -478,7 +496,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (MessageElement is not null) yield return new KeyValuePair<string,object>("message",MessageElement);
-        if (Situation is not null) yield return new KeyValuePair<string,object>("situation",Situation);
+        if (SituationElement is not null) yield return new KeyValuePair<string,object>("situation",SituationElement);
       }
 
     }
@@ -799,13 +817,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the message definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -840,26 +876,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", InSummary=true, Order=230, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this message definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=240)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Definition this one is based on
@@ -1084,11 +1156,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(BaseElement != null) dest.BaseElement = (Hl7.Fhir.Model.Canonical)BaseElement.DeepCopy();
       if(ParentElement != null) dest.ParentElement = new List<Hl7.Fhir.Model.Canonical>(ParentElement.DeepCopy());
       if(Event != null) dest.Event = (Hl7.Fhir.Model.DataType)Event.DeepCopy();
@@ -1123,11 +1195,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.Matches(ParentElement, otherT.ParentElement)) return false;
       if( !DeepComparable.Matches(Event, otherT.Event)) return false;
@@ -1157,11 +1229,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.IsExactly(ParentElement, otherT.ParentElement)) return false;
       if( !DeepComparable.IsExactly(Event, otherT.Event)) return false;
@@ -1191,11 +1263,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (BaseElement != null) yield return BaseElement;
         foreach (var elem in ParentElement) { if (elem != null) yield return elem; }
         if (Event != null) yield return Event;
@@ -1224,11 +1296,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (BaseElement != null) yield return new ElementValue("base", BaseElement);
         foreach (var elem in ParentElement) { if (elem != null) yield return new ElementValue("parent", elem); }
         if (Event != null) yield return new ElementValue("event", Event);
@@ -1278,8 +1350,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1287,11 +1359,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "base":
           value = BaseElement;
           return BaseElement is not null;
@@ -1336,11 +1408,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (BaseElement is not null) yield return new KeyValuePair<string,object>("base",BaseElement);
       if (ParentElement?.Any() == true) yield return new KeyValuePair<string,object>("parent",ParentElement);
       if (Event is not null) yield return new KeyValuePair<string,object>("event",Event);

--- a/src/Hl7.Fhir.R5/Model/Generated/NamingSystem.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/NamingSystem.cs
@@ -797,13 +797,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the naming system
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -838,26 +856,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=250, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this naming system is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=260)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the NamingSystem was approved by publisher
@@ -1086,11 +1140,11 @@ namespace Hl7.Fhir.Model
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
       if(ResponsibleElement != null) dest.ResponsibleElement = (Hl7.Fhir.Model.FhirString)ResponsibleElement.DeepCopy();
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1130,11 +1184,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
       if( !DeepComparable.Matches(ResponsibleElement, otherT.ResponsibleElement)) return false;
       if( !DeepComparable.Matches(Type, otherT.Type)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1169,11 +1223,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
       if( !DeepComparable.IsExactly(ResponsibleElement, otherT.ResponsibleElement)) return false;
       if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1208,11 +1262,11 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
         if (ResponsibleElement != null) yield return ResponsibleElement;
         if (Type != null) yield return Type;
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -1246,11 +1300,11 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
         if (ResponsibleElement != null) yield return new ElementValue("responsible", ResponsibleElement);
         if (Type != null) yield return new ElementValue("type", Type);
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -1309,8 +1363,8 @@ namespace Hl7.Fhir.Model
           value = Type;
           return Type is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1318,11 +1372,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -1378,11 +1432,11 @@ namespace Hl7.Fhir.Model
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
       if (ResponsibleElement is not null) yield return new KeyValuePair<string,object>("responsible",ResponsibleElement);
       if (Type is not null) yield return new KeyValuePair<string,object>("type",Type);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R5/Model/Generated/ObservationDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/ObservationDefinition.cs
@@ -1329,13 +1329,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the ObservationDefinition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Content intends to support these contexts
@@ -1370,26 +1388,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this ObservationDefinition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When ObservationDefinition was approved by publisher
@@ -1815,11 +1869,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1865,11 +1919,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1910,11 +1964,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1955,11 +2009,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -1999,11 +2053,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -2062,8 +2116,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2071,11 +2125,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -2155,11 +2209,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R5/Model/Generated/OperationDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/OperationDefinition.cs
@@ -285,13 +285,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("documentation", Order=90)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Documentation
+      public Hl7.Fhir.Model.Markdown DocumentationElement
       {
-        get { return _Documentation; }
-        set { _Documentation = value; OnPropertyChanged("Documentation"); }
+        get { return _DocumentationElement; }
+        set { _DocumentationElement = value; OnPropertyChanged("DocumentationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Documentation;
+      private Hl7.Fhir.Model.Markdown _DocumentationElement;
+
+      /// <summary>
+      /// Description of meaning/use
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Documentation
+      {
+        get { return DocumentationElement != null ? DocumentationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DocumentationElement = null;
+          else
+            DocumentationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Documentation");
+        }
+      }
 
       /// <summary>
       /// What type this parameter has
@@ -478,7 +496,7 @@ namespace Hl7.Fhir.Model
         if(ScopeElement != null) dest.ScopeElement = new List<Code<Hl7.Fhir.Model.OperationDefinition.OperationParameterScope>>(ScopeElement.DeepCopy());
         if(MinElement != null) dest.MinElement = (Hl7.Fhir.Model.Integer)MinElement.DeepCopy();
         if(MaxElement != null) dest.MaxElement = (Hl7.Fhir.Model.FhirString)MaxElement.DeepCopy();
-        if(Documentation != null) dest.Documentation = (Hl7.Fhir.Model.Markdown)Documentation.DeepCopy();
+        if(DocumentationElement != null) dest.DocumentationElement = (Hl7.Fhir.Model.Markdown)DocumentationElement.DeepCopy();
         if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.FHIRAllTypes>)TypeElement.DeepCopy();
         if(AllowedTypeElement != null) dest.AllowedTypeElement = new List<Code<Hl7.Fhir.Model.FHIRAllTypes>>(AllowedTypeElement.DeepCopy());
         if(TargetProfileElement != null) dest.TargetProfileElement = new List<Hl7.Fhir.Model.Canonical>(TargetProfileElement.DeepCopy());
@@ -506,7 +524,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(ScopeElement, otherT.ScopeElement)) return false;
         if( !DeepComparable.Matches(MinElement, otherT.MinElement)) return false;
         if( !DeepComparable.Matches(MaxElement, otherT.MaxElement)) return false;
-        if( !DeepComparable.Matches(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.Matches(DocumentationElement, otherT.DocumentationElement)) return false;
         if( !DeepComparable.Matches(TypeElement, otherT.TypeElement)) return false;
         if( !DeepComparable.Matches(AllowedTypeElement, otherT.AllowedTypeElement)) return false;
         if( !DeepComparable.Matches(TargetProfileElement, otherT.TargetProfileElement)) return false;
@@ -529,7 +547,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(ScopeElement, otherT.ScopeElement)) return false;
         if( !DeepComparable.IsExactly(MinElement, otherT.MinElement)) return false;
         if( !DeepComparable.IsExactly(MaxElement, otherT.MaxElement)) return false;
-        if( !DeepComparable.IsExactly(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.IsExactly(DocumentationElement, otherT.DocumentationElement)) return false;
         if( !DeepComparable.IsExactly(TypeElement, otherT.TypeElement)) return false;
         if( !DeepComparable.IsExactly(AllowedTypeElement, otherT.AllowedTypeElement)) return false;
         if( !DeepComparable.IsExactly(TargetProfileElement, otherT.TargetProfileElement)) return false;
@@ -552,7 +570,7 @@ namespace Hl7.Fhir.Model
           foreach (var elem in ScopeElement) { if (elem != null) yield return elem; }
           if (MinElement != null) yield return MinElement;
           if (MaxElement != null) yield return MaxElement;
-          if (Documentation != null) yield return Documentation;
+          if (DocumentationElement != null) yield return DocumentationElement;
           if (TypeElement != null) yield return TypeElement;
           foreach (var elem in AllowedTypeElement) { if (elem != null) yield return elem; }
           foreach (var elem in TargetProfileElement) { if (elem != null) yield return elem; }
@@ -574,7 +592,7 @@ namespace Hl7.Fhir.Model
           foreach (var elem in ScopeElement) { if (elem != null) yield return new ElementValue("scope", elem); }
           if (MinElement != null) yield return new ElementValue("min", MinElement);
           if (MaxElement != null) yield return new ElementValue("max", MaxElement);
-          if (Documentation != null) yield return new ElementValue("documentation", Documentation);
+          if (DocumentationElement != null) yield return new ElementValue("documentation", DocumentationElement);
           if (TypeElement != null) yield return new ElementValue("type", TypeElement);
           foreach (var elem in AllowedTypeElement) { if (elem != null) yield return new ElementValue("allowedType", elem); }
           foreach (var elem in TargetProfileElement) { if (elem != null) yield return new ElementValue("targetProfile", elem); }
@@ -605,8 +623,8 @@ namespace Hl7.Fhir.Model
             value = MaxElement;
             return MaxElement is not null;
           case "documentation":
-            value = Documentation;
-            return Documentation is not null;
+            value = DocumentationElement;
+            return DocumentationElement is not null;
           case "type":
             value = TypeElement;
             return TypeElement is not null;
@@ -642,7 +660,7 @@ namespace Hl7.Fhir.Model
         if (ScopeElement?.Any() == true) yield return new KeyValuePair<string,object>("scope",ScopeElement);
         if (MinElement is not null) yield return new KeyValuePair<string,object>("min",MinElement);
         if (MaxElement is not null) yield return new KeyValuePair<string,object>("max",MaxElement);
-        if (Documentation is not null) yield return new KeyValuePair<string,object>("documentation",Documentation);
+        if (DocumentationElement is not null) yield return new KeyValuePair<string,object>("documentation",DocumentationElement);
         if (TypeElement is not null) yield return new KeyValuePair<string,object>("type",TypeElement);
         if (AllowedTypeElement?.Any() == true) yield return new KeyValuePair<string,object>("allowedType",AllowedTypeElement);
         if (TargetProfileElement?.Any() == true) yield return new KeyValuePair<string,object>("targetProfile",TargetProfileElement);
@@ -1478,13 +1496,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the operation definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1519,26 +1555,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=230, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this operation definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=240)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Copyright holder and year(s)
@@ -1639,13 +1711,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("comment", Order=280)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Comment
+    public Hl7.Fhir.Model.Markdown CommentElement
     {
-      get { return _Comment; }
-      set { _Comment = value; OnPropertyChanged("Comment"); }
+      get { return _CommentElement; }
+      set { _CommentElement = value; OnPropertyChanged("CommentElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Comment;
+    private Hl7.Fhir.Model.Markdown _CommentElement;
+
+    /// <summary>
+    /// Additional information about use
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Comment
+    {
+      get { return CommentElement != null ? CommentElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CommentElement = null;
+        else
+          CommentElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Comment");
+      }
+    }
 
     /// <summary>
     /// Marks this as a profile of the base
@@ -1918,15 +2008,15 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(CopyrightLabelElement != null) dest.CopyrightLabelElement = (Hl7.Fhir.Model.FhirString)CopyrightLabelElement.DeepCopy();
       if(AffectsStateElement != null) dest.AffectsStateElement = (Hl7.Fhir.Model.FhirBoolean)AffectsStateElement.DeepCopy();
       if(CodeElement != null) dest.CodeElement = (Hl7.Fhir.Model.Code)CodeElement.DeepCopy();
-      if(Comment != null) dest.Comment = (Hl7.Fhir.Model.Markdown)Comment.DeepCopy();
+      if(CommentElement != null) dest.CommentElement = (Hl7.Fhir.Model.Markdown)CommentElement.DeepCopy();
       if(BaseElement != null) dest.BaseElement = (Hl7.Fhir.Model.Canonical)BaseElement.DeepCopy();
       if(ResourceElement != null) dest.ResourceElement = new List<Code<Hl7.Fhir.Model.ResourceType>>(ResourceElement.DeepCopy());
       if(SystemElement != null) dest.SystemElement = (Hl7.Fhir.Model.FhirBoolean)SystemElement.DeepCopy();
@@ -1962,15 +2052,15 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.Matches(AffectsStateElement, otherT.AffectsStateElement)) return false;
       if( !DeepComparable.Matches(CodeElement, otherT.CodeElement)) return false;
-      if( !DeepComparable.Matches(Comment, otherT.Comment)) return false;
+      if( !DeepComparable.Matches(CommentElement, otherT.CommentElement)) return false;
       if( !DeepComparable.Matches(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.Matches(ResourceElement, otherT.ResourceElement)) return false;
       if( !DeepComparable.Matches(SystemElement, otherT.SystemElement)) return false;
@@ -2001,15 +2091,15 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.IsExactly(AffectsStateElement, otherT.AffectsStateElement)) return false;
       if( !DeepComparable.IsExactly(CodeElement, otherT.CodeElement)) return false;
-      if( !DeepComparable.IsExactly(Comment, otherT.Comment)) return false;
+      if( !DeepComparable.IsExactly(CommentElement, otherT.CommentElement)) return false;
       if( !DeepComparable.IsExactly(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.IsExactly(ResourceElement, otherT.ResourceElement)) return false;
       if( !DeepComparable.IsExactly(SystemElement, otherT.SystemElement)) return false;
@@ -2040,15 +2130,15 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (CopyrightLabelElement != null) yield return CopyrightLabelElement;
         if (AffectsStateElement != null) yield return AffectsStateElement;
         if (CodeElement != null) yield return CodeElement;
-        if (Comment != null) yield return Comment;
+        if (CommentElement != null) yield return CommentElement;
         if (BaseElement != null) yield return BaseElement;
         foreach (var elem in ResourceElement) { if (elem != null) yield return elem; }
         if (SystemElement != null) yield return SystemElement;
@@ -2078,15 +2168,15 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (CopyrightLabelElement != null) yield return new ElementValue("copyrightLabel", CopyrightLabelElement);
         if (AffectsStateElement != null) yield return new ElementValue("affectsState", AffectsStateElement);
         if (CodeElement != null) yield return new ElementValue("code", CodeElement);
-        if (Comment != null) yield return new ElementValue("comment", Comment);
+        if (CommentElement != null) yield return new ElementValue("comment", CommentElement);
         if (BaseElement != null) yield return new ElementValue("base", BaseElement);
         foreach (var elem in ResourceElement) { if (elem != null) yield return new ElementValue("resource", elem); }
         if (SystemElement != null) yield return new ElementValue("system", SystemElement);
@@ -2137,8 +2227,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2146,11 +2236,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "copyrightLabel":
           value = CopyrightLabelElement;
           return CopyrightLabelElement is not null;
@@ -2161,8 +2251,8 @@ namespace Hl7.Fhir.Model
           value = CodeElement;
           return CodeElement is not null;
         case "comment":
-          value = Comment;
-          return Comment is not null;
+          value = CommentElement;
+          return CommentElement is not null;
         case "base":
           value = BaseElement;
           return BaseElement is not null;
@@ -2210,15 +2300,15 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (CopyrightLabelElement is not null) yield return new KeyValuePair<string,object>("copyrightLabel",CopyrightLabelElement);
       if (AffectsStateElement is not null) yield return new KeyValuePair<string,object>("affectsState",AffectsStateElement);
       if (CodeElement is not null) yield return new KeyValuePair<string,object>("code",CodeElement);
-      if (Comment is not null) yield return new KeyValuePair<string,object>("comment",Comment);
+      if (CommentElement is not null) yield return new KeyValuePair<string,object>("comment",CommentElement);
       if (BaseElement is not null) yield return new KeyValuePair<string,object>("base",BaseElement);
       if (ResourceElement?.Any() == true) yield return new KeyValuePair<string,object>("resource",ResourceElement);
       if (SystemElement is not null) yield return new KeyValuePair<string,object>("system",SystemElement);

--- a/src/Hl7.Fhir.R5/Model/Generated/PackagedProductDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/PackagedProductDefinition.cs
@@ -964,13 +964,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=160)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Textual description. Note that this is not the name of the package or product
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The legal status of supply of the packaged item as classified by the regulator
@@ -1107,7 +1125,7 @@ namespace Hl7.Fhir.Model
       if(Status != null) dest.Status = (Hl7.Fhir.Model.CodeableConcept)Status.DeepCopy();
       if(StatusDateElement != null) dest.StatusDateElement = (Hl7.Fhir.Model.FhirDateTime)StatusDateElement.DeepCopy();
       if(ContainedItemQuantity != null) dest.ContainedItemQuantity = new List<Hl7.Fhir.Model.Quantity>(ContainedItemQuantity.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(LegalStatusOfSupply != null) dest.LegalStatusOfSupply = new List<Hl7.Fhir.Model.PackagedProductDefinition.LegalStatusOfSupplyComponent>(LegalStatusOfSupply.DeepCopy());
       if(MarketingStatus != null) dest.MarketingStatus = new List<Hl7.Fhir.Model.MarketingStatus>(MarketingStatus.DeepCopy());
       if(CopackagedIndicatorElement != null) dest.CopackagedIndicatorElement = (Hl7.Fhir.Model.FhirBoolean)CopackagedIndicatorElement.DeepCopy();
@@ -1137,7 +1155,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Status, otherT.Status)) return false;
       if( !DeepComparable.Matches(StatusDateElement, otherT.StatusDateElement)) return false;
       if( !DeepComparable.Matches(ContainedItemQuantity, otherT.ContainedItemQuantity)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(LegalStatusOfSupply, otherT.LegalStatusOfSupply)) return false;
       if( !DeepComparable.Matches(MarketingStatus, otherT.MarketingStatus)) return false;
       if( !DeepComparable.Matches(CopackagedIndicatorElement, otherT.CopackagedIndicatorElement)) return false;
@@ -1162,7 +1180,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Status, otherT.Status)) return false;
       if( !DeepComparable.IsExactly(StatusDateElement, otherT.StatusDateElement)) return false;
       if( !DeepComparable.IsExactly(ContainedItemQuantity, otherT.ContainedItemQuantity)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(LegalStatusOfSupply, otherT.LegalStatusOfSupply)) return false;
       if( !DeepComparable.IsExactly(MarketingStatus, otherT.MarketingStatus)) return false;
       if( !DeepComparable.IsExactly(CopackagedIndicatorElement, otherT.CopackagedIndicatorElement)) return false;
@@ -1187,7 +1205,7 @@ namespace Hl7.Fhir.Model
         if (Status != null) yield return Status;
         if (StatusDateElement != null) yield return StatusDateElement;
         foreach (var elem in ContainedItemQuantity) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in LegalStatusOfSupply) { if (elem != null) yield return elem; }
         foreach (var elem in MarketingStatus) { if (elem != null) yield return elem; }
         if (CopackagedIndicatorElement != null) yield return CopackagedIndicatorElement;
@@ -1211,7 +1229,7 @@ namespace Hl7.Fhir.Model
         if (Status != null) yield return new ElementValue("status", Status);
         if (StatusDateElement != null) yield return new ElementValue("statusDate", StatusDateElement);
         foreach (var elem in ContainedItemQuantity) { if (elem != null) yield return new ElementValue("containedItemQuantity", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in LegalStatusOfSupply) { if (elem != null) yield return new ElementValue("legalStatusOfSupply", elem); }
         foreach (var elem in MarketingStatus) { if (elem != null) yield return new ElementValue("marketingStatus", elem); }
         if (CopackagedIndicatorElement != null) yield return new ElementValue("copackagedIndicator", CopackagedIndicatorElement);
@@ -1248,8 +1266,8 @@ namespace Hl7.Fhir.Model
           value = ContainedItemQuantity;
           return ContainedItemQuantity?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "legalStatusOfSupply":
           value = LegalStatusOfSupply;
           return LegalStatusOfSupply?.Any() == true;
@@ -1287,7 +1305,7 @@ namespace Hl7.Fhir.Model
       if (Status is not null) yield return new KeyValuePair<string,object>("status",Status);
       if (StatusDateElement is not null) yield return new KeyValuePair<string,object>("statusDate",StatusDateElement);
       if (ContainedItemQuantity?.Any() == true) yield return new KeyValuePair<string,object>("containedItemQuantity",ContainedItemQuantity);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (LegalStatusOfSupply?.Any() == true) yield return new KeyValuePair<string,object>("legalStatusOfSupply",LegalStatusOfSupply);
       if (MarketingStatus?.Any() == true) yield return new KeyValuePair<string,object>("marketingStatus",MarketingStatus);
       if (CopackagedIndicatorElement is not null) yield return new KeyValuePair<string,object>("copackagedIndicator",CopackagedIndicatorElement);

--- a/src/Hl7.Fhir.R5/Model/Generated/PlanDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/PlanDefinition.cs
@@ -504,13 +504,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Describes the actor
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Who or what can be this actor
@@ -537,7 +555,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(TitleElement != null) dest.TitleElement = (Hl7.Fhir.Model.FhirString)TitleElement.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(Option != null) dest.Option = new List<Hl7.Fhir.Model.PlanDefinition.OptionComponent>(Option.DeepCopy());
         return dest;
       }
@@ -555,7 +573,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(Option, otherT.Option)) return false;
 
         return true;
@@ -568,7 +586,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(TitleElement, otherT.TitleElement)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(Option, otherT.Option)) return false;
 
         return true;
@@ -581,7 +599,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (TitleElement != null) yield return TitleElement;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           foreach (var elem in Option) { if (elem != null) yield return elem; }
         }
       }
@@ -593,7 +611,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (TitleElement != null) yield return new ElementValue("title", TitleElement);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           foreach (var elem in Option) { if (elem != null) yield return new ElementValue("option", elem); }
         }
       }
@@ -606,8 +624,8 @@ namespace Hl7.Fhir.Model
             value = TitleElement;
             return TitleElement is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "option":
             value = Option;
             return Option?.Any() == true;
@@ -621,7 +639,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (TitleElement is not null) yield return new KeyValuePair<string,object>("title",TitleElement);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (Option?.Any() == true) yield return new KeyValuePair<string,object>("option",Option);
       }
 
@@ -3315,13 +3333,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the plan definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -3356,13 +3392,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=250, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this plan definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the plan
@@ -3400,13 +3454,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=270)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When the plan definition was approved by publisher
@@ -3679,12 +3751,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -3727,12 +3799,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -3770,12 +3842,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -3813,12 +3885,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -3855,12 +3927,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -3922,8 +3994,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -3931,14 +4003,14 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -4003,12 +4075,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R5/Model/Generated/Questionnaire.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/Questionnaire.cs
@@ -1838,13 +1838,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the questionnaire
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -1879,26 +1897,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=250, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this questionnaire is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=260)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Copyright holder and year(s)
@@ -2057,11 +2111,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(CopyrightLabelElement != null) dest.CopyrightLabelElement = (Hl7.Fhir.Model.FhirString)CopyrightLabelElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
@@ -2096,11 +2150,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
@@ -2130,11 +2184,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
@@ -2164,11 +2218,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (CopyrightLabelElement != null) yield return CopyrightLabelElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
@@ -2197,11 +2251,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (CopyrightLabelElement != null) yield return new ElementValue("copyrightLabel", CopyrightLabelElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
@@ -2255,8 +2309,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2264,11 +2318,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "copyrightLabel":
           value = CopyrightLabelElement;
           return CopyrightLabelElement is not null;
@@ -2309,11 +2363,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (CopyrightLabelElement is not null) yield return new KeyValuePair<string,object>("copyrightLabel",CopyrightLabelElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);

--- a/src/Hl7.Fhir.R5/Model/Generated/RegulatedAuthorization.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/RegulatedAuthorization.cs
@@ -303,13 +303,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=120)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// General textual supporting information
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The territory in which the authorization has been granted
@@ -495,7 +513,7 @@ namespace Hl7.Fhir.Model
       if(Identifier != null) dest.Identifier = new List<Hl7.Fhir.Model.Identifier>(Identifier.DeepCopy());
       if(Subject != null) dest.Subject = new List<Hl7.Fhir.Model.ResourceReference>(Subject.DeepCopy());
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(Region != null) dest.Region = new List<Hl7.Fhir.Model.CodeableConcept>(Region.DeepCopy());
       if(Status != null) dest.Status = (Hl7.Fhir.Model.CodeableConcept)Status.DeepCopy();
       if(StatusDateElement != null) dest.StatusDateElement = (Hl7.Fhir.Model.FhirDateTime)StatusDateElement.DeepCopy();
@@ -525,7 +543,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Identifier, otherT.Identifier)) return false;
       if( !DeepComparable.Matches(Subject, otherT.Subject)) return false;
       if( !DeepComparable.Matches(Type, otherT.Type)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(Region, otherT.Region)) return false;
       if( !DeepComparable.Matches(Status, otherT.Status)) return false;
       if( !DeepComparable.Matches(StatusDateElement, otherT.StatusDateElement)) return false;
@@ -550,7 +568,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Identifier, otherT.Identifier)) return false;
       if( !DeepComparable.IsExactly(Subject, otherT.Subject)) return false;
       if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(Region, otherT.Region)) return false;
       if( !DeepComparable.IsExactly(Status, otherT.Status)) return false;
       if( !DeepComparable.IsExactly(StatusDateElement, otherT.StatusDateElement)) return false;
@@ -575,7 +593,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Identifier) { if (elem != null) yield return elem; }
         foreach (var elem in Subject) { if (elem != null) yield return elem; }
         if (Type != null) yield return Type;
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in Region) { if (elem != null) yield return elem; }
         if (Status != null) yield return Status;
         if (StatusDateElement != null) yield return StatusDateElement;
@@ -599,7 +617,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Identifier) { if (elem != null) yield return new ElementValue("identifier", elem); }
         foreach (var elem in Subject) { if (elem != null) yield return new ElementValue("subject", elem); }
         if (Type != null) yield return new ElementValue("type", Type);
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in Region) { if (elem != null) yield return new ElementValue("region", elem); }
         if (Status != null) yield return new ElementValue("status", Status);
         if (StatusDateElement != null) yield return new ElementValue("statusDate", StatusDateElement);
@@ -628,8 +646,8 @@ namespace Hl7.Fhir.Model
           value = Type;
           return Type is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "region":
           value = Region;
           return Region?.Any() == true;
@@ -675,7 +693,7 @@ namespace Hl7.Fhir.Model
       if (Identifier?.Any() == true) yield return new KeyValuePair<string,object>("identifier",Identifier);
       if (Subject?.Any() == true) yield return new KeyValuePair<string,object>("subject",Subject);
       if (Type is not null) yield return new KeyValuePair<string,object>("type",Type);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (Region?.Any() == true) yield return new KeyValuePair<string,object>("region",Region);
       if (Status is not null) yield return new KeyValuePair<string,object>("status",Status);
       if (StatusDateElement is not null) yield return new KeyValuePair<string,object>("statusDate",StatusDateElement);

--- a/src/Hl7.Fhir.R5/Model/Generated/Requirements.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/Requirements.cs
@@ -235,13 +235,31 @@ namespace Hl7.Fhir.Model
       [FhirElement("requirement", Order=80)]
       [Cardinality(Min=1,Max=1)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Requirement
+      public Hl7.Fhir.Model.Markdown RequirementElement
       {
-        get { return _Requirement; }
-        set { _Requirement = value; OnPropertyChanged("Requirement"); }
+        get { return _RequirementElement; }
+        set { _RequirementElement = value; OnPropertyChanged("RequirementElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Requirement;
+      private Hl7.Fhir.Model.Markdown _RequirementElement;
+
+      /// <summary>
+      /// The actual requirement
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Requirement
+      {
+        get { return RequirementElement != null ? RequirementElement.Value : null; }
+        set
+        {
+          if (value == null)
+            RequirementElement = null;
+          else
+            RequirementElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Requirement");
+        }
+      }
 
       /// <summary>
       /// Another statement this clarifies/restricts ([url#]key)
@@ -399,7 +417,7 @@ namespace Hl7.Fhir.Model
         if(LabelElement != null) dest.LabelElement = (Hl7.Fhir.Model.FhirString)LabelElement.DeepCopy();
         if(ConformanceElement != null) dest.ConformanceElement = new List<Code<Hl7.Fhir.Model.Requirements.ConformanceExpectation>>(ConformanceElement.DeepCopy());
         if(ConditionalityElement != null) dest.ConditionalityElement = (Hl7.Fhir.Model.FhirBoolean)ConditionalityElement.DeepCopy();
-        if(Requirement != null) dest.Requirement = (Hl7.Fhir.Model.Markdown)Requirement.DeepCopy();
+        if(RequirementElement != null) dest.RequirementElement = (Hl7.Fhir.Model.Markdown)RequirementElement.DeepCopy();
         if(DerivedFromElement != null) dest.DerivedFromElement = (Hl7.Fhir.Model.FhirString)DerivedFromElement.DeepCopy();
         if(ParentElement != null) dest.ParentElement = (Hl7.Fhir.Model.FhirString)ParentElement.DeepCopy();
         if(SatisfiedByElement != null) dest.SatisfiedByElement = new List<Hl7.Fhir.Model.FhirUrl>(SatisfiedByElement.DeepCopy());
@@ -424,7 +442,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(LabelElement, otherT.LabelElement)) return false;
         if( !DeepComparable.Matches(ConformanceElement, otherT.ConformanceElement)) return false;
         if( !DeepComparable.Matches(ConditionalityElement, otherT.ConditionalityElement)) return false;
-        if( !DeepComparable.Matches(Requirement, otherT.Requirement)) return false;
+        if( !DeepComparable.Matches(RequirementElement, otherT.RequirementElement)) return false;
         if( !DeepComparable.Matches(DerivedFromElement, otherT.DerivedFromElement)) return false;
         if( !DeepComparable.Matches(ParentElement, otherT.ParentElement)) return false;
         if( !DeepComparable.Matches(SatisfiedByElement, otherT.SatisfiedByElement)) return false;
@@ -444,7 +462,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(LabelElement, otherT.LabelElement)) return false;
         if( !DeepComparable.IsExactly(ConformanceElement, otherT.ConformanceElement)) return false;
         if( !DeepComparable.IsExactly(ConditionalityElement, otherT.ConditionalityElement)) return false;
-        if( !DeepComparable.IsExactly(Requirement, otherT.Requirement)) return false;
+        if( !DeepComparable.IsExactly(RequirementElement, otherT.RequirementElement)) return false;
         if( !DeepComparable.IsExactly(DerivedFromElement, otherT.DerivedFromElement)) return false;
         if( !DeepComparable.IsExactly(ParentElement, otherT.ParentElement)) return false;
         if( !DeepComparable.IsExactly(SatisfiedByElement, otherT.SatisfiedByElement)) return false;
@@ -464,7 +482,7 @@ namespace Hl7.Fhir.Model
           if (LabelElement != null) yield return LabelElement;
           foreach (var elem in ConformanceElement) { if (elem != null) yield return elem; }
           if (ConditionalityElement != null) yield return ConditionalityElement;
-          if (Requirement != null) yield return Requirement;
+          if (RequirementElement != null) yield return RequirementElement;
           if (DerivedFromElement != null) yield return DerivedFromElement;
           if (ParentElement != null) yield return ParentElement;
           foreach (var elem in SatisfiedByElement) { if (elem != null) yield return elem; }
@@ -483,7 +501,7 @@ namespace Hl7.Fhir.Model
           if (LabelElement != null) yield return new ElementValue("label", LabelElement);
           foreach (var elem in ConformanceElement) { if (elem != null) yield return new ElementValue("conformance", elem); }
           if (ConditionalityElement != null) yield return new ElementValue("conditionality", ConditionalityElement);
-          if (Requirement != null) yield return new ElementValue("requirement", Requirement);
+          if (RequirementElement != null) yield return new ElementValue("requirement", RequirementElement);
           if (DerivedFromElement != null) yield return new ElementValue("derivedFrom", DerivedFromElement);
           if (ParentElement != null) yield return new ElementValue("parent", ParentElement);
           foreach (var elem in SatisfiedByElement) { if (elem != null) yield return new ElementValue("satisfiedBy", elem); }
@@ -509,8 +527,8 @@ namespace Hl7.Fhir.Model
             value = ConditionalityElement;
             return ConditionalityElement is not null;
           case "requirement":
-            value = Requirement;
-            return Requirement is not null;
+            value = RequirementElement;
+            return RequirementElement is not null;
           case "derivedFrom":
             value = DerivedFromElement;
             return DerivedFromElement is not null;
@@ -539,7 +557,7 @@ namespace Hl7.Fhir.Model
         if (LabelElement is not null) yield return new KeyValuePair<string,object>("label",LabelElement);
         if (ConformanceElement?.Any() == true) yield return new KeyValuePair<string,object>("conformance",ConformanceElement);
         if (ConditionalityElement is not null) yield return new KeyValuePair<string,object>("conditionality",ConditionalityElement);
-        if (Requirement is not null) yield return new KeyValuePair<string,object>("requirement",Requirement);
+        if (RequirementElement is not null) yield return new KeyValuePair<string,object>("requirement",RequirementElement);
         if (DerivedFromElement is not null) yield return new KeyValuePair<string,object>("derivedFrom",DerivedFromElement);
         if (ParentElement is not null) yield return new KeyValuePair<string,object>("parent",ParentElement);
         if (SatisfiedByElement?.Any() == true) yield return new KeyValuePair<string,object>("satisfiedBy",SatisfiedByElement);
@@ -832,13 +850,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the actor
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -873,26 +909,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this Requirements is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Copyright holder and year(s)
@@ -1023,11 +1095,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(CopyrightLabelElement != null) dest.CopyrightLabelElement = (Hl7.Fhir.Model.FhirString)CopyrightLabelElement.DeepCopy();
       if(DerivedFromElement != null) dest.DerivedFromElement = new List<Hl7.Fhir.Model.Canonical>(DerivedFromElement.DeepCopy());
       if(ActorElement != null) dest.ActorElement = new List<Hl7.Fhir.Model.Canonical>(ActorElement.DeepCopy());
@@ -1057,11 +1129,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.Matches(DerivedFromElement, otherT.DerivedFromElement)) return false;
       if( !DeepComparable.Matches(ActorElement, otherT.ActorElement)) return false;
@@ -1086,11 +1158,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.IsExactly(DerivedFromElement, otherT.DerivedFromElement)) return false;
       if( !DeepComparable.IsExactly(ActorElement, otherT.ActorElement)) return false;
@@ -1115,11 +1187,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (CopyrightLabelElement != null) yield return CopyrightLabelElement;
         foreach (var elem in DerivedFromElement) { if (elem != null) yield return elem; }
         foreach (var elem in ActorElement) { if (elem != null) yield return elem; }
@@ -1143,11 +1215,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (CopyrightLabelElement != null) yield return new ElementValue("copyrightLabel", CopyrightLabelElement);
         foreach (var elem in DerivedFromElement) { if (elem != null) yield return new ElementValue("derivedFrom", elem); }
         foreach (var elem in ActorElement) { if (elem != null) yield return new ElementValue("actor", elem); }
@@ -1190,8 +1262,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1199,11 +1271,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "copyrightLabel":
           value = CopyrightLabelElement;
           return CopyrightLabelElement is not null;
@@ -1235,11 +1307,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (CopyrightLabelElement is not null) yield return new KeyValuePair<string,object>("copyrightLabel",CopyrightLabelElement);
       if (DerivedFromElement?.Any() == true) yield return new KeyValuePair<string,object>("derivedFrom",DerivedFromElement);
       if (ActorElement?.Any() == true) yield return new KeyValuePair<string,object>("actor",ActorElement);

--- a/src/Hl7.Fhir.R5/Model/Generated/ResearchStudy.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/ResearchStudy.cs
@@ -888,13 +888,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=70)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Short explanation of study path
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Interventions or exposures in this comparisonGroup or cohort
@@ -940,7 +958,7 @@ namespace Hl7.Fhir.Model
         if(Identifier != null) dest.Identifier = new List<Hl7.Fhir.Model.Identifier>(Identifier.DeepCopy());
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
         if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(IntendedExposure != null) dest.IntendedExposure = new List<Hl7.Fhir.Model.ResourceReference>(IntendedExposure.DeepCopy());
         if(ObservedGroup != null) dest.ObservedGroup = (Hl7.Fhir.Model.ResourceReference)ObservedGroup.DeepCopy();
         return dest;
@@ -961,7 +979,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(Identifier, otherT.Identifier)) return false;
         if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
         if( !DeepComparable.Matches(Type, otherT.Type)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(IntendedExposure, otherT.IntendedExposure)) return false;
         if( !DeepComparable.Matches(ObservedGroup, otherT.ObservedGroup)) return false;
 
@@ -977,7 +995,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(Identifier, otherT.Identifier)) return false;
         if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
         if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(IntendedExposure, otherT.IntendedExposure)) return false;
         if( !DeepComparable.IsExactly(ObservedGroup, otherT.ObservedGroup)) return false;
 
@@ -993,7 +1011,7 @@ namespace Hl7.Fhir.Model
           foreach (var elem in Identifier) { if (elem != null) yield return elem; }
           if (NameElement != null) yield return NameElement;
           if (Type != null) yield return Type;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           foreach (var elem in IntendedExposure) { if (elem != null) yield return elem; }
           if (ObservedGroup != null) yield return ObservedGroup;
         }
@@ -1008,7 +1026,7 @@ namespace Hl7.Fhir.Model
           foreach (var elem in Identifier) { if (elem != null) yield return new ElementValue("identifier", elem); }
           if (NameElement != null) yield return new ElementValue("name", NameElement);
           if (Type != null) yield return new ElementValue("type", Type);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           foreach (var elem in IntendedExposure) { if (elem != null) yield return new ElementValue("intendedExposure", elem); }
           if (ObservedGroup != null) yield return new ElementValue("observedGroup", ObservedGroup);
         }
@@ -1028,8 +1046,8 @@ namespace Hl7.Fhir.Model
             value = Type;
             return Type is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "intendedExposure":
             value = IntendedExposure;
             return IntendedExposure?.Any() == true;
@@ -1048,7 +1066,7 @@ namespace Hl7.Fhir.Model
         if (Identifier?.Any() == true) yield return new KeyValuePair<string,object>("identifier",Identifier);
         if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
         if (Type is not null) yield return new KeyValuePair<string,object>("type",Type);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (IntendedExposure?.Any() == true) yield return new KeyValuePair<string,object>("intendedExposure",IntendedExposure);
         if (ObservedGroup is not null) yield return new KeyValuePair<string,object>("observedGroup",ObservedGroup);
       }
@@ -1117,13 +1135,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=60)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Description of the objective
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -1137,7 +1173,7 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
         if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         return dest;
       }
 
@@ -1155,7 +1191,7 @@ namespace Hl7.Fhir.Model
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
         if( !DeepComparable.Matches(Type, otherT.Type)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
 
         return true;
       }
@@ -1168,7 +1204,7 @@ namespace Hl7.Fhir.Model
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
         if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
 
         return true;
       }
@@ -1181,7 +1217,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.Children) yield return item;
           if (NameElement != null) yield return NameElement;
           if (Type != null) yield return Type;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
         }
       }
 
@@ -1193,7 +1229,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.NamedChildren) yield return item;
           if (NameElement != null) yield return new ElementValue("name", NameElement);
           if (Type != null) yield return new ElementValue("type", Type);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         }
       }
 
@@ -1208,8 +1244,8 @@ namespace Hl7.Fhir.Model
             value = Type;
             return Type is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -1221,7 +1257,7 @@ namespace Hl7.Fhir.Model
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
         if (Type is not null) yield return new KeyValuePair<string,object>("type",Type);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       }
 
     }
@@ -1289,13 +1325,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", Order=60)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Description of the outcome
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Structured outcome definition
@@ -1324,7 +1378,7 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(NameElement != null) dest.NameElement = (Hl7.Fhir.Model.FhirString)NameElement.DeepCopy();
         if(Type != null) dest.Type = new List<Hl7.Fhir.Model.CodeableConcept>(Type.DeepCopy());
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(Reference != null) dest.Reference = (Hl7.Fhir.Model.ResourceReference)Reference.DeepCopy();
         return dest;
       }
@@ -1343,7 +1397,7 @@ namespace Hl7.Fhir.Model
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(NameElement, otherT.NameElement)) return false;
         if( !DeepComparable.Matches(Type, otherT.Type)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(Reference, otherT.Reference)) return false;
 
         return true;
@@ -1357,7 +1411,7 @@ namespace Hl7.Fhir.Model
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(NameElement, otherT.NameElement)) return false;
         if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(Reference, otherT.Reference)) return false;
 
         return true;
@@ -1371,7 +1425,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.Children) yield return item;
           if (NameElement != null) yield return NameElement;
           foreach (var elem in Type) { if (elem != null) yield return elem; }
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           if (Reference != null) yield return Reference;
         }
       }
@@ -1384,7 +1438,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.NamedChildren) yield return item;
           if (NameElement != null) yield return new ElementValue("name", NameElement);
           foreach (var elem in Type) { if (elem != null) yield return new ElementValue("type", elem); }
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (Reference != null) yield return new ElementValue("reference", Reference);
         }
       }
@@ -1400,8 +1454,8 @@ namespace Hl7.Fhir.Model
             value = Type;
             return Type?.Any() == true;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "reference":
             value = Reference;
             return Reference is not null;
@@ -1416,7 +1470,7 @@ namespace Hl7.Fhir.Model
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (NameElement is not null) yield return new KeyValuePair<string,object>("name",NameElement);
         if (Type?.Any() == true) yield return new KeyValuePair<string,object>("type",Type);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (Reference is not null) yield return new KeyValuePair<string,object>("reference",Reference);
       }
 
@@ -1785,26 +1839,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("descriptionSummary", Order=270)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown DescriptionSummary
+    public Hl7.Fhir.Model.Markdown DescriptionSummaryElement
     {
-      get { return _DescriptionSummary; }
-      set { _DescriptionSummary = value; OnPropertyChanged("DescriptionSummary"); }
+      get { return _DescriptionSummaryElement; }
+      set { _DescriptionSummaryElement = value; OnPropertyChanged("DescriptionSummaryElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _DescriptionSummary;
+    private Hl7.Fhir.Model.Markdown _DescriptionSummaryElement;
+
+    /// <summary>
+    /// Brief text explaining the study
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string DescriptionSummary
+    {
+      get { return DescriptionSummaryElement != null ? DescriptionSummaryElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionSummaryElement = null;
+        else
+          DescriptionSummaryElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("DescriptionSummary");
+      }
+    }
 
     /// <summary>
     /// Detailed narrative of the study
     /// </summary>
     [FhirElement("description", Order=280)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Detailed narrative of the study
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// When the study began and ended
@@ -2003,8 +2093,8 @@ namespace Hl7.Fhir.Model
       if(Condition != null) dest.Condition = new List<Hl7.Fhir.Model.CodeableConcept>(Condition.DeepCopy());
       if(Keyword != null) dest.Keyword = new List<Hl7.Fhir.Model.CodeableConcept>(Keyword.DeepCopy());
       if(Region != null) dest.Region = new List<Hl7.Fhir.Model.CodeableConcept>(Region.DeepCopy());
-      if(DescriptionSummary != null) dest.DescriptionSummary = (Hl7.Fhir.Model.Markdown)DescriptionSummary.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionSummaryElement != null) dest.DescriptionSummaryElement = (Hl7.Fhir.Model.Markdown)DescriptionSummaryElement.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(Period != null) dest.Period = (Hl7.Fhir.Model.Period)Period.DeepCopy();
       if(Site != null) dest.Site = new List<Hl7.Fhir.Model.ResourceReference>(Site.DeepCopy());
       if(Note != null) dest.Note = new List<Hl7.Fhir.Model.Annotation>(Note.DeepCopy());
@@ -2050,8 +2140,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Condition, otherT.Condition)) return false;
       if( !DeepComparable.Matches(Keyword, otherT.Keyword)) return false;
       if( !DeepComparable.Matches(Region, otherT.Region)) return false;
-      if( !DeepComparable.Matches(DescriptionSummary, otherT.DescriptionSummary)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionSummaryElement, otherT.DescriptionSummaryElement)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(Period, otherT.Period)) return false;
       if( !DeepComparable.Matches(Site, otherT.Site)) return false;
       if( !DeepComparable.Matches(Note, otherT.Note)) return false;
@@ -2092,8 +2182,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Condition, otherT.Condition)) return false;
       if( !DeepComparable.IsExactly(Keyword, otherT.Keyword)) return false;
       if( !DeepComparable.IsExactly(Region, otherT.Region)) return false;
-      if( !DeepComparable.IsExactly(DescriptionSummary, otherT.DescriptionSummary)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionSummaryElement, otherT.DescriptionSummaryElement)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(Period, otherT.Period)) return false;
       if( !DeepComparable.IsExactly(Site, otherT.Site)) return false;
       if( !DeepComparable.IsExactly(Note, otherT.Note)) return false;
@@ -2134,8 +2224,8 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Condition) { if (elem != null) yield return elem; }
         foreach (var elem in Keyword) { if (elem != null) yield return elem; }
         foreach (var elem in Region) { if (elem != null) yield return elem; }
-        if (DescriptionSummary != null) yield return DescriptionSummary;
-        if (Description != null) yield return Description;
+        if (DescriptionSummaryElement != null) yield return DescriptionSummaryElement;
+        if (DescriptionElement != null) yield return DescriptionElement;
         if (Period != null) yield return Period;
         foreach (var elem in Site) { if (elem != null) yield return elem; }
         foreach (var elem in Note) { if (elem != null) yield return elem; }
@@ -2175,8 +2265,8 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Condition) { if (elem != null) yield return new ElementValue("condition", elem); }
         foreach (var elem in Keyword) { if (elem != null) yield return new ElementValue("keyword", elem); }
         foreach (var elem in Region) { if (elem != null) yield return new ElementValue("region", elem); }
-        if (DescriptionSummary != null) yield return new ElementValue("descriptionSummary", DescriptionSummary);
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionSummaryElement != null) yield return new ElementValue("descriptionSummary", DescriptionSummaryElement);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         if (Period != null) yield return new ElementValue("period", Period);
         foreach (var elem in Site) { if (elem != null) yield return new ElementValue("site", elem); }
         foreach (var elem in Note) { if (elem != null) yield return new ElementValue("note", elem); }
@@ -2251,11 +2341,11 @@ namespace Hl7.Fhir.Model
           value = Region;
           return Region?.Any() == true;
         case "descriptionSummary":
-          value = DescriptionSummary;
-          return DescriptionSummary is not null;
+          value = DescriptionSummaryElement;
+          return DescriptionSummaryElement is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "period":
           value = Period;
           return Period is not null;
@@ -2319,8 +2409,8 @@ namespace Hl7.Fhir.Model
       if (Condition?.Any() == true) yield return new KeyValuePair<string,object>("condition",Condition);
       if (Keyword?.Any() == true) yield return new KeyValuePair<string,object>("keyword",Keyword);
       if (Region?.Any() == true) yield return new KeyValuePair<string,object>("region",Region);
-      if (DescriptionSummary is not null) yield return new KeyValuePair<string,object>("descriptionSummary",DescriptionSummary);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionSummaryElement is not null) yield return new KeyValuePair<string,object>("descriptionSummary",DescriptionSummaryElement);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (Period is not null) yield return new KeyValuePair<string,object>("period",Period);
       if (Site?.Any() == true) yield return new KeyValuePair<string,object>("site",Site);
       if (Note?.Any() == true) yield return new KeyValuePair<string,object>("note",Note);

--- a/src/Hl7.Fhir.R5/Model/Generated/SearchParameter.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/SearchParameter.cs
@@ -734,13 +734,31 @@ namespace Hl7.Fhir.Model
     [FhirElement("description", InSummary=true, Order=200)]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the search parameter
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -775,13 +793,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=230, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this search parameter is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Recommended name for parameter in search url
@@ -1203,10 +1239,10 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(CodeElement != null) dest.CodeElement = (Hl7.Fhir.Model.Code)CodeElement.DeepCopy();
       if(BaseElement != null) dest.BaseElement = new List<Code<Hl7.Fhir.Model.AllResourceTypes>>(BaseElement.DeepCopy());
       if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.SearchParamType>)TypeElement.DeepCopy();
@@ -1246,10 +1282,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(CodeElement, otherT.CodeElement)) return false;
       if( !DeepComparable.Matches(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.Matches(TypeElement, otherT.TypeElement)) return false;
@@ -1284,10 +1320,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(CodeElement, otherT.CodeElement)) return false;
       if( !DeepComparable.IsExactly(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.IsExactly(TypeElement, otherT.TypeElement)) return false;
@@ -1322,10 +1358,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (CodeElement != null) yield return CodeElement;
         foreach (var elem in BaseElement) { if (elem != null) yield return elem; }
         if (TypeElement != null) yield return TypeElement;
@@ -1359,10 +1395,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (CodeElement != null) yield return new ElementValue("code", CodeElement);
         foreach (var elem in BaseElement) { if (elem != null) yield return new ElementValue("base", elem); }
         if (TypeElement != null) yield return new ElementValue("type", TypeElement);
@@ -1417,8 +1453,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1426,8 +1462,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "code":
           value = CodeElement;
           return CodeElement is not null;
@@ -1487,10 +1523,10 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (CodeElement is not null) yield return new KeyValuePair<string,object>("code",CodeElement);
       if (BaseElement?.Any() == true) yield return new KeyValuePair<string,object>("base",BaseElement);
       if (TypeElement is not null) yield return new KeyValuePair<string,object>("type",TypeElement);

--- a/src/Hl7.Fhir.R5/Model/Generated/SpecimenDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/SpecimenDefinition.cs
@@ -1400,13 +1400,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the SpecimenDefinition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Content intends to support these contexts
@@ -1441,26 +1459,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=240)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this SpecimenDefinition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=250)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// When SpecimenDefinition was approved by publisher
@@ -1645,11 +1699,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
@@ -1685,11 +1739,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1720,11 +1774,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
@@ -1755,11 +1809,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
@@ -1789,11 +1843,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
@@ -1846,8 +1900,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1855,11 +1909,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -1905,11 +1959,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);

--- a/src/Hl7.Fhir.R5/Model/Generated/StructureMap.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/StructureMap.cs
@@ -2818,13 +2818,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the structure map
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -2859,26 +2877,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=230, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this structure map is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=240)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Copyright holder and year(s)
@@ -2992,11 +3046,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(CopyrightLabelElement != null) dest.CopyrightLabelElement = (Hl7.Fhir.Model.FhirString)CopyrightLabelElement.DeepCopy();
       if(Structure != null) dest.Structure = new List<Hl7.Fhir.Model.StructureMap.StructureComponent>(Structure.DeepCopy());
       if(ImportElement != null) dest.ImportElement = new List<Hl7.Fhir.Model.Canonical>(ImportElement.DeepCopy());
@@ -3027,11 +3081,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.Matches(Structure, otherT.Structure)) return false;
       if( !DeepComparable.Matches(ImportElement, otherT.ImportElement)) return false;
@@ -3057,11 +3111,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.IsExactly(Structure, otherT.Structure)) return false;
       if( !DeepComparable.IsExactly(ImportElement, otherT.ImportElement)) return false;
@@ -3087,11 +3141,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (CopyrightLabelElement != null) yield return CopyrightLabelElement;
         foreach (var elem in Structure) { if (elem != null) yield return elem; }
         foreach (var elem in ImportElement) { if (elem != null) yield return elem; }
@@ -3116,11 +3170,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (CopyrightLabelElement != null) yield return new ElementValue("copyrightLabel", CopyrightLabelElement);
         foreach (var elem in Structure) { if (elem != null) yield return new ElementValue("structure", elem); }
         foreach (var elem in ImportElement) { if (elem != null) yield return new ElementValue("import", elem); }
@@ -3166,8 +3220,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -3175,11 +3229,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "copyrightLabel":
           value = CopyrightLabelElement;
           return CopyrightLabelElement is not null;
@@ -3212,11 +3266,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (CopyrightLabelElement is not null) yield return new KeyValuePair<string,object>("copyrightLabel",CopyrightLabelElement);
       if (Structure?.Any() == true) yield return new KeyValuePair<string,object>("structure",Structure);
       if (ImportElement?.Any() == true) yield return new KeyValuePair<string,object>("import",ImportElement);

--- a/src/Hl7.Fhir.R5/Model/Generated/SubscriptionTopic.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/SubscriptionTopic.cs
@@ -123,13 +123,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", InSummary=true, Order=40)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Text representation of the resource trigger
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Data Type or Resource (reference to definition) for this trigger definition
@@ -250,7 +268,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(ResourceElement != null) dest.ResourceElement = (Hl7.Fhir.Model.FhirUri)ResourceElement.DeepCopy();
         if(SupportedInteractionElement != null) dest.SupportedInteractionElement = new List<Code<Hl7.Fhir.Model.SubscriptionTopic.InteractionTrigger>>(SupportedInteractionElement.DeepCopy());
         if(QueryCriteria != null) dest.QueryCriteria = (Hl7.Fhir.Model.SubscriptionTopic.QueryCriteriaComponent)QueryCriteria.DeepCopy();
@@ -270,7 +288,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.Matches(otherT)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(ResourceElement, otherT.ResourceElement)) return false;
         if( !DeepComparable.Matches(SupportedInteractionElement, otherT.SupportedInteractionElement)) return false;
         if( !DeepComparable.Matches(QueryCriteria, otherT.QueryCriteria)) return false;
@@ -285,7 +303,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.IsExactly(otherT)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(ResourceElement, otherT.ResourceElement)) return false;
         if( !DeepComparable.IsExactly(SupportedInteractionElement, otherT.SupportedInteractionElement)) return false;
         if( !DeepComparable.IsExactly(QueryCriteria, otherT.QueryCriteria)) return false;
@@ -300,7 +318,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.Children) yield return item;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           if (ResourceElement != null) yield return ResourceElement;
           foreach (var elem in SupportedInteractionElement) { if (elem != null) yield return elem; }
           if (QueryCriteria != null) yield return QueryCriteria;
@@ -314,7 +332,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.NamedChildren) yield return item;
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (ResourceElement != null) yield return new ElementValue("resource", ResourceElement);
           foreach (var elem in SupportedInteractionElement) { if (elem != null) yield return new ElementValue("supportedInteraction", elem); }
           if (QueryCriteria != null) yield return new ElementValue("queryCriteria", QueryCriteria);
@@ -327,8 +345,8 @@ namespace Hl7.Fhir.Model
         switch (key)
         {
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "resource":
             value = ResourceElement;
             return ResourceElement is not null;
@@ -350,7 +368,7 @@ namespace Hl7.Fhir.Model
       protected override IEnumerable<KeyValuePair<string, object>> GetElementPairs()
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (ResourceElement is not null) yield return new KeyValuePair<string,object>("resource",ResourceElement);
         if (SupportedInteractionElement?.Any() == true) yield return new KeyValuePair<string,object>("supportedInteraction",SupportedInteractionElement);
         if (QueryCriteria is not null) yield return new KeyValuePair<string,object>("queryCriteria",QueryCriteria);
@@ -666,13 +684,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", InSummary=true, Order=40)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Text representation of the event trigger
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// Event which can trigger a notification from the SubscriptionTopic
@@ -730,7 +766,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(Event != null) dest.Event = (Hl7.Fhir.Model.CodeableConcept)Event.DeepCopy();
         if(ResourceElement != null) dest.ResourceElement = (Hl7.Fhir.Model.FhirUri)ResourceElement.DeepCopy();
         return dest;
@@ -748,7 +784,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.Matches(otherT)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(Event, otherT.Event)) return false;
         if( !DeepComparable.Matches(ResourceElement, otherT.ResourceElement)) return false;
 
@@ -761,7 +797,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.IsExactly(otherT)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(Event, otherT.Event)) return false;
         if( !DeepComparable.IsExactly(ResourceElement, otherT.ResourceElement)) return false;
 
@@ -774,7 +810,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.Children) yield return item;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           if (Event != null) yield return Event;
           if (ResourceElement != null) yield return ResourceElement;
         }
@@ -786,7 +822,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.NamedChildren) yield return item;
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (Event != null) yield return new ElementValue("event", Event);
           if (ResourceElement != null) yield return new ElementValue("resource", ResourceElement);
         }
@@ -797,8 +833,8 @@ namespace Hl7.Fhir.Model
         switch (key)
         {
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "event":
             value = Event;
             return Event is not null;
@@ -814,7 +850,7 @@ namespace Hl7.Fhir.Model
       protected override IEnumerable<KeyValuePair<string, object>> GetElementPairs()
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (Event is not null) yield return new KeyValuePair<string,object>("event",Event);
         if (ResourceElement is not null) yield return new KeyValuePair<string,object>("resource",ResourceElement);
       }
@@ -839,13 +875,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", InSummary=true, Order=40)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Description of this filter parameter
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// URL of the triggering Resource that this filter applies to
@@ -984,7 +1038,7 @@ namespace Hl7.Fhir.Model
         }
 
         base.CopyTo(dest);
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(ResourceElement != null) dest.ResourceElement = (Hl7.Fhir.Model.FhirUri)ResourceElement.DeepCopy();
         if(FilterParameterElement != null) dest.FilterParameterElement = (Hl7.Fhir.Model.FhirString)FilterParameterElement.DeepCopy();
         if(FilterDefinitionElement != null) dest.FilterDefinitionElement = (Hl7.Fhir.Model.FhirUri)FilterDefinitionElement.DeepCopy();
@@ -1004,7 +1058,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.Matches(otherT)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(ResourceElement, otherT.ResourceElement)) return false;
         if( !DeepComparable.Matches(FilterParameterElement, otherT.FilterParameterElement)) return false;
         if( !DeepComparable.Matches(FilterDefinitionElement, otherT.FilterDefinitionElement)) return false;
@@ -1019,7 +1073,7 @@ namespace Hl7.Fhir.Model
         if(otherT == null) return false;
 
         if(!base.IsExactly(otherT)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(ResourceElement, otherT.ResourceElement)) return false;
         if( !DeepComparable.IsExactly(FilterParameterElement, otherT.FilterParameterElement)) return false;
         if( !DeepComparable.IsExactly(FilterDefinitionElement, otherT.FilterDefinitionElement)) return false;
@@ -1034,7 +1088,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.Children) yield return item;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           if (ResourceElement != null) yield return ResourceElement;
           if (FilterParameterElement != null) yield return FilterParameterElement;
           if (FilterDefinitionElement != null) yield return FilterDefinitionElement;
@@ -1048,7 +1102,7 @@ namespace Hl7.Fhir.Model
         get
         {
           foreach (var item in base.NamedChildren) yield return item;
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           if (ResourceElement != null) yield return new ElementValue("resource", ResourceElement);
           if (FilterParameterElement != null) yield return new ElementValue("filterParameter", FilterParameterElement);
           if (FilterDefinitionElement != null) yield return new ElementValue("filterDefinition", FilterDefinitionElement);
@@ -1061,8 +1115,8 @@ namespace Hl7.Fhir.Model
         switch (key)
         {
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "resource":
             value = ResourceElement;
             return ResourceElement is not null;
@@ -1084,7 +1138,7 @@ namespace Hl7.Fhir.Model
       protected override IEnumerable<KeyValuePair<string, object>> GetElementPairs()
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (ResourceElement is not null) yield return new KeyValuePair<string,object>("resource",ResourceElement);
         if (FilterParameterElement is not null) yield return new KeyValuePair<string,object>("filterParameter",FilterParameterElement);
         if (FilterDefinitionElement is not null) yield return new KeyValuePair<string,object>("filterDefinition",FilterDefinitionElement);
@@ -1588,13 +1642,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the SubscriptionTopic
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Content intends to support these contexts
@@ -1629,26 +1701,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this SubscriptionTopic is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Copyright holder and year(s)
@@ -1832,11 +1940,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(CopyrightLabelElement != null) dest.CopyrightLabelElement = (Hl7.Fhir.Model.FhirString)CopyrightLabelElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
@@ -1870,11 +1978,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
@@ -1903,11 +2011,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
@@ -1936,11 +2044,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (CopyrightLabelElement != null) yield return CopyrightLabelElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
@@ -1968,11 +2076,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (CopyrightLabelElement != null) yield return new ElementValue("copyrightLabel", CopyrightLabelElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
@@ -2019,8 +2127,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2028,11 +2136,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "copyrightLabel":
           value = CopyrightLabelElement;
           return CopyrightLabelElement is not null;
@@ -2076,11 +2184,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (CopyrightLabelElement is not null) yield return new KeyValuePair<string,object>("copyrightLabel",CopyrightLabelElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);

--- a/src/Hl7.Fhir.R5/Model/Generated/SubstanceDefinition.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/SubstanceDefinition.cs
@@ -400,13 +400,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("description", InSummary=true, Order=60)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Description
+      public Hl7.Fhir.Model.Markdown DescriptionElement
       {
-        get { return _Description; }
-        set { _Description = value; OnPropertyChanged("Description"); }
+        get { return _DescriptionElement; }
+        set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Description;
+      private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+      /// <summary>
+      /// Narrative text, data, tables about the characterization
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Description
+      {
+        get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DescriptionElement = null;
+          else
+            DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Description");
+        }
+      }
 
       /// <summary>
       /// An image or data file that characterizes this substance
@@ -434,7 +452,7 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(Technique != null) dest.Technique = (Hl7.Fhir.Model.CodeableConcept)Technique.DeepCopy();
         if(Form != null) dest.Form = (Hl7.Fhir.Model.CodeableConcept)Form.DeepCopy();
-        if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+        if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
         if(File != null) dest.File = new List<Hl7.Fhir.Model.Attachment>(File.DeepCopy());
         return dest;
       }
@@ -453,7 +471,7 @@ namespace Hl7.Fhir.Model
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(Technique, otherT.Technique)) return false;
         if( !DeepComparable.Matches(Form, otherT.Form)) return false;
-        if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+        if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.Matches(File, otherT.File)) return false;
 
         return true;
@@ -467,7 +485,7 @@ namespace Hl7.Fhir.Model
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(Technique, otherT.Technique)) return false;
         if( !DeepComparable.IsExactly(Form, otherT.Form)) return false;
-        if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+        if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
         if( !DeepComparable.IsExactly(File, otherT.File)) return false;
 
         return true;
@@ -481,7 +499,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.Children) yield return item;
           if (Technique != null) yield return Technique;
           if (Form != null) yield return Form;
-          if (Description != null) yield return Description;
+          if (DescriptionElement != null) yield return DescriptionElement;
           foreach (var elem in File) { if (elem != null) yield return elem; }
         }
       }
@@ -494,7 +512,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.NamedChildren) yield return item;
           if (Technique != null) yield return new ElementValue("technique", Technique);
           if (Form != null) yield return new ElementValue("form", Form);
-          if (Description != null) yield return new ElementValue("description", Description);
+          if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
           foreach (var elem in File) { if (elem != null) yield return new ElementValue("file", elem); }
         }
       }
@@ -510,8 +528,8 @@ namespace Hl7.Fhir.Model
             value = Form;
             return Form is not null;
           case "description":
-            value = Description;
-            return Description is not null;
+            value = DescriptionElement;
+            return DescriptionElement is not null;
           case "file":
             value = File;
             return File?.Any() == true;
@@ -526,7 +544,7 @@ namespace Hl7.Fhir.Model
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (Technique is not null) yield return new KeyValuePair<string,object>("technique",Technique);
         if (Form is not null) yield return new KeyValuePair<string,object>("form",Form);
-        if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+        if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
         if (File?.Any() == true) yield return new KeyValuePair<string,object>("file",File);
       }
 
@@ -2654,13 +2672,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=150)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Textual description of the substance
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Supporting literature
@@ -2924,7 +2960,7 @@ namespace Hl7.Fhir.Model
       if(Classification != null) dest.Classification = new List<Hl7.Fhir.Model.CodeableConcept>(Classification.DeepCopy());
       if(Domain != null) dest.Domain = (Hl7.Fhir.Model.CodeableConcept)Domain.DeepCopy();
       if(Grade != null) dest.Grade = new List<Hl7.Fhir.Model.CodeableConcept>(Grade.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(InformationSource != null) dest.InformationSource = new List<Hl7.Fhir.Model.ResourceReference>(InformationSource.DeepCopy());
       if(Note != null) dest.Note = new List<Hl7.Fhir.Model.Annotation>(Note.DeepCopy());
       if(Manufacturer != null) dest.Manufacturer = new List<Hl7.Fhir.Model.ResourceReference>(Manufacturer.DeepCopy());
@@ -2963,7 +2999,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Classification, otherT.Classification)) return false;
       if( !DeepComparable.Matches(Domain, otherT.Domain)) return false;
       if( !DeepComparable.Matches(Grade, otherT.Grade)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(InformationSource, otherT.InformationSource)) return false;
       if( !DeepComparable.Matches(Note, otherT.Note)) return false;
       if( !DeepComparable.Matches(Manufacturer, otherT.Manufacturer)) return false;
@@ -2997,7 +3033,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Classification, otherT.Classification)) return false;
       if( !DeepComparable.IsExactly(Domain, otherT.Domain)) return false;
       if( !DeepComparable.IsExactly(Grade, otherT.Grade)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(InformationSource, otherT.InformationSource)) return false;
       if( !DeepComparable.IsExactly(Note, otherT.Note)) return false;
       if( !DeepComparable.IsExactly(Manufacturer, otherT.Manufacturer)) return false;
@@ -3031,7 +3067,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Classification) { if (elem != null) yield return elem; }
         if (Domain != null) yield return Domain;
         foreach (var elem in Grade) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in InformationSource) { if (elem != null) yield return elem; }
         foreach (var elem in Note) { if (elem != null) yield return elem; }
         foreach (var elem in Manufacturer) { if (elem != null) yield return elem; }
@@ -3064,7 +3100,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Classification) { if (elem != null) yield return new ElementValue("classification", elem); }
         if (Domain != null) yield return new ElementValue("domain", Domain);
         foreach (var elem in Grade) { if (elem != null) yield return new ElementValue("grade", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in InformationSource) { if (elem != null) yield return new ElementValue("informationSource", elem); }
         foreach (var elem in Note) { if (elem != null) yield return new ElementValue("note", elem); }
         foreach (var elem in Manufacturer) { if (elem != null) yield return new ElementValue("manufacturer", elem); }
@@ -3108,8 +3144,8 @@ namespace Hl7.Fhir.Model
           value = Grade;
           return Grade?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "informationSource":
           value = InformationSource;
           return InformationSource?.Any() == true;
@@ -3176,7 +3212,7 @@ namespace Hl7.Fhir.Model
       if (Classification?.Any() == true) yield return new KeyValuePair<string,object>("classification",Classification);
       if (Domain is not null) yield return new KeyValuePair<string,object>("domain",Domain);
       if (Grade?.Any() == true) yield return new KeyValuePair<string,object>("grade",Grade);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (InformationSource?.Any() == true) yield return new KeyValuePair<string,object>("informationSource",InformationSource);
       if (Note?.Any() == true) yield return new KeyValuePair<string,object>("note",Note);
       if (Manufacturer?.Any() == true) yield return new KeyValuePair<string,object>("manufacturer",Manufacturer);

--- a/src/Hl7.Fhir.R5/Model/Generated/TerminologyCapabilities.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/TerminologyCapabilities.cs
@@ -1257,13 +1257,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("textFilter", Order=80)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown TextFilter
+      public Hl7.Fhir.Model.Markdown TextFilterElement
       {
-        get { return _TextFilter; }
-        set { _TextFilter = value; OnPropertyChanged("TextFilter"); }
+        get { return _TextFilterElement; }
+        set { _TextFilterElement = value; OnPropertyChanged("TextFilterElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _TextFilter;
+      private Hl7.Fhir.Model.Markdown _TextFilterElement;
+
+      /// <summary>
+      /// Documentation about text searching works
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string TextFilter
+      {
+        get { return TextFilterElement != null ? TextFilterElement.Value : null; }
+        set
+        {
+          if (value == null)
+            TextFilterElement = null;
+          else
+            TextFilterElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("TextFilter");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -1279,7 +1297,7 @@ namespace Hl7.Fhir.Model
         if(PagingElement != null) dest.PagingElement = (Hl7.Fhir.Model.FhirBoolean)PagingElement.DeepCopy();
         if(IncompleteElement != null) dest.IncompleteElement = (Hl7.Fhir.Model.FhirBoolean)IncompleteElement.DeepCopy();
         if(Parameter != null) dest.Parameter = new List<Hl7.Fhir.Model.TerminologyCapabilities.ParameterComponent>(Parameter.DeepCopy());
-        if(TextFilter != null) dest.TextFilter = (Hl7.Fhir.Model.Markdown)TextFilter.DeepCopy();
+        if(TextFilterElement != null) dest.TextFilterElement = (Hl7.Fhir.Model.Markdown)TextFilterElement.DeepCopy();
         return dest;
       }
 
@@ -1299,7 +1317,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.Matches(PagingElement, otherT.PagingElement)) return false;
         if( !DeepComparable.Matches(IncompleteElement, otherT.IncompleteElement)) return false;
         if( !DeepComparable.Matches(Parameter, otherT.Parameter)) return false;
-        if( !DeepComparable.Matches(TextFilter, otherT.TextFilter)) return false;
+        if( !DeepComparable.Matches(TextFilterElement, otherT.TextFilterElement)) return false;
 
         return true;
       }
@@ -1314,7 +1332,7 @@ namespace Hl7.Fhir.Model
         if( !DeepComparable.IsExactly(PagingElement, otherT.PagingElement)) return false;
         if( !DeepComparable.IsExactly(IncompleteElement, otherT.IncompleteElement)) return false;
         if( !DeepComparable.IsExactly(Parameter, otherT.Parameter)) return false;
-        if( !DeepComparable.IsExactly(TextFilter, otherT.TextFilter)) return false;
+        if( !DeepComparable.IsExactly(TextFilterElement, otherT.TextFilterElement)) return false;
 
         return true;
       }
@@ -1329,7 +1347,7 @@ namespace Hl7.Fhir.Model
           if (PagingElement != null) yield return PagingElement;
           if (IncompleteElement != null) yield return IncompleteElement;
           foreach (var elem in Parameter) { if (elem != null) yield return elem; }
-          if (TextFilter != null) yield return TextFilter;
+          if (TextFilterElement != null) yield return TextFilterElement;
         }
       }
 
@@ -1343,7 +1361,7 @@ namespace Hl7.Fhir.Model
           if (PagingElement != null) yield return new ElementValue("paging", PagingElement);
           if (IncompleteElement != null) yield return new ElementValue("incomplete", IncompleteElement);
           foreach (var elem in Parameter) { if (elem != null) yield return new ElementValue("parameter", elem); }
-          if (TextFilter != null) yield return new ElementValue("textFilter", TextFilter);
+          if (TextFilterElement != null) yield return new ElementValue("textFilter", TextFilterElement);
         }
       }
 
@@ -1364,8 +1382,8 @@ namespace Hl7.Fhir.Model
             value = Parameter;
             return Parameter?.Any() == true;
           case "textFilter":
-            value = TextFilter;
-            return TextFilter is not null;
+            value = TextFilterElement;
+            return TextFilterElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -1379,7 +1397,7 @@ namespace Hl7.Fhir.Model
         if (PagingElement is not null) yield return new KeyValuePair<string,object>("paging",PagingElement);
         if (IncompleteElement is not null) yield return new KeyValuePair<string,object>("incomplete",IncompleteElement);
         if (Parameter?.Any() == true) yield return new KeyValuePair<string,object>("parameter",Parameter);
-        if (TextFilter is not null) yield return new KeyValuePair<string,object>("textFilter",TextFilter);
+        if (TextFilterElement is not null) yield return new KeyValuePair<string,object>("textFilter",TextFilterElement);
       }
 
     }
@@ -2219,13 +2237,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the terminology capabilities
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -2260,26 +2296,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this terminology capabilities is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", InSummary=true, Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// instance | capability | requirements
@@ -2489,11 +2561,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(KindElement != null) dest.KindElement = (Code<Hl7.Fhir.Model.CapabilityStatementKind>)KindElement.DeepCopy();
       if(Software != null) dest.Software = (Hl7.Fhir.Model.TerminologyCapabilities.SoftwareComponent)Software.DeepCopy();
       if(Implementation != null) dest.Implementation = (Hl7.Fhir.Model.TerminologyCapabilities.ImplementationComponent)Implementation.DeepCopy();
@@ -2529,11 +2601,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(KindElement, otherT.KindElement)) return false;
       if( !DeepComparable.Matches(Software, otherT.Software)) return false;
       if( !DeepComparable.Matches(Implementation, otherT.Implementation)) return false;
@@ -2564,11 +2636,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(KindElement, otherT.KindElement)) return false;
       if( !DeepComparable.IsExactly(Software, otherT.Software)) return false;
       if( !DeepComparable.IsExactly(Implementation, otherT.Implementation)) return false;
@@ -2599,11 +2671,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (KindElement != null) yield return KindElement;
         if (Software != null) yield return Software;
         if (Implementation != null) yield return Implementation;
@@ -2633,11 +2705,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (KindElement != null) yield return new ElementValue("kind", KindElement);
         if (Software != null) yield return new ElementValue("software", Software);
         if (Implementation != null) yield return new ElementValue("implementation", Implementation);
@@ -2686,8 +2758,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2695,11 +2767,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "kind":
           value = KindElement;
           return KindElement is not null;
@@ -2749,11 +2821,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (KindElement is not null) yield return new KeyValuePair<string,object>("kind",KindElement);
       if (Software is not null) yield return new KeyValuePair<string,object>("software",Software);
       if (Implementation is not null) yield return new KeyValuePair<string,object>("implementation",Implementation);

--- a/src/Hl7.Fhir.R5/Model/Generated/TestReport.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/TestReport.cs
@@ -693,13 +693,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("message", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Message
+      public Hl7.Fhir.Model.Markdown MessageElement
       {
-        get { return _Message; }
-        set { _Message = value; OnPropertyChanged("Message"); }
+        get { return _MessageElement; }
+        set { _MessageElement = value; OnPropertyChanged("MessageElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Message;
+      private Hl7.Fhir.Model.Markdown _MessageElement;
+
+      /// <summary>
+      /// A message associated with the result
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Message
+      {
+        get { return MessageElement != null ? MessageElement.Value : null; }
+        set
+        {
+          if (value == null)
+            MessageElement = null;
+          else
+            MessageElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Message");
+        }
+      }
 
       /// <summary>
       /// A link to further details on the result
@@ -743,7 +761,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(ResultElement != null) dest.ResultElement = (Code<Hl7.Fhir.Model.TestReport.TestReportActionResult>)ResultElement.DeepCopy();
-        if(Message != null) dest.Message = (Hl7.Fhir.Model.Markdown)Message.DeepCopy();
+        if(MessageElement != null) dest.MessageElement = (Hl7.Fhir.Model.Markdown)MessageElement.DeepCopy();
         if(DetailElement != null) dest.DetailElement = (Hl7.Fhir.Model.FhirUri)DetailElement.DeepCopy();
         return dest;
       }
@@ -761,7 +779,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(ResultElement, otherT.ResultElement)) return false;
-        if( !DeepComparable.Matches(Message, otherT.Message)) return false;
+        if( !DeepComparable.Matches(MessageElement, otherT.MessageElement)) return false;
         if( !DeepComparable.Matches(DetailElement, otherT.DetailElement)) return false;
 
         return true;
@@ -774,7 +792,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(ResultElement, otherT.ResultElement)) return false;
-        if( !DeepComparable.IsExactly(Message, otherT.Message)) return false;
+        if( !DeepComparable.IsExactly(MessageElement, otherT.MessageElement)) return false;
         if( !DeepComparable.IsExactly(DetailElement, otherT.DetailElement)) return false;
 
         return true;
@@ -787,7 +805,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (ResultElement != null) yield return ResultElement;
-          if (Message != null) yield return Message;
+          if (MessageElement != null) yield return MessageElement;
           if (DetailElement != null) yield return DetailElement;
         }
       }
@@ -799,7 +817,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (ResultElement != null) yield return new ElementValue("result", ResultElement);
-          if (Message != null) yield return new ElementValue("message", Message);
+          if (MessageElement != null) yield return new ElementValue("message", MessageElement);
           if (DetailElement != null) yield return new ElementValue("detail", DetailElement);
         }
       }
@@ -812,8 +830,8 @@ namespace Hl7.Fhir.Model
             value = ResultElement;
             return ResultElement is not null;
           case "message":
-            value = Message;
-            return Message is not null;
+            value = MessageElement;
+            return MessageElement is not null;
           case "detail":
             value = DetailElement;
             return DetailElement is not null;
@@ -827,7 +845,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (ResultElement is not null) yield return new KeyValuePair<string,object>("result",ResultElement);
-        if (Message is not null) yield return new KeyValuePair<string,object>("message",Message);
+        if (MessageElement is not null) yield return new KeyValuePair<string,object>("message",MessageElement);
         if (DetailElement is not null) yield return new KeyValuePair<string,object>("detail",DetailElement);
       }
 
@@ -884,13 +902,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("message", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Message
+      public Hl7.Fhir.Model.Markdown MessageElement
       {
-        get { return _Message; }
-        set { _Message = value; OnPropertyChanged("Message"); }
+        get { return _MessageElement; }
+        set { _MessageElement = value; OnPropertyChanged("MessageElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Message;
+      private Hl7.Fhir.Model.Markdown _MessageElement;
+
+      /// <summary>
+      /// A message associated with the result
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Message
+      {
+        get { return MessageElement != null ? MessageElement.Value : null; }
+        set
+        {
+          if (value == null)
+            MessageElement = null;
+          else
+            MessageElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Message");
+        }
+      }
 
       /// <summary>
       /// A link to further details on the result
@@ -934,7 +970,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(ResultElement != null) dest.ResultElement = (Code<Hl7.Fhir.Model.TestReport.TestReportActionResult>)ResultElement.DeepCopy();
-        if(Message != null) dest.Message = (Hl7.Fhir.Model.Markdown)Message.DeepCopy();
+        if(MessageElement != null) dest.MessageElement = (Hl7.Fhir.Model.Markdown)MessageElement.DeepCopy();
         if(DetailElement != null) dest.DetailElement = (Hl7.Fhir.Model.FhirString)DetailElement.DeepCopy();
         return dest;
       }
@@ -952,7 +988,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(ResultElement, otherT.ResultElement)) return false;
-        if( !DeepComparable.Matches(Message, otherT.Message)) return false;
+        if( !DeepComparable.Matches(MessageElement, otherT.MessageElement)) return false;
         if( !DeepComparable.Matches(DetailElement, otherT.DetailElement)) return false;
 
         return true;
@@ -965,7 +1001,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(ResultElement, otherT.ResultElement)) return false;
-        if( !DeepComparable.IsExactly(Message, otherT.Message)) return false;
+        if( !DeepComparable.IsExactly(MessageElement, otherT.MessageElement)) return false;
         if( !DeepComparable.IsExactly(DetailElement, otherT.DetailElement)) return false;
 
         return true;
@@ -978,7 +1014,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (ResultElement != null) yield return ResultElement;
-          if (Message != null) yield return Message;
+          if (MessageElement != null) yield return MessageElement;
           if (DetailElement != null) yield return DetailElement;
         }
       }
@@ -990,7 +1026,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (ResultElement != null) yield return new ElementValue("result", ResultElement);
-          if (Message != null) yield return new ElementValue("message", Message);
+          if (MessageElement != null) yield return new ElementValue("message", MessageElement);
           if (DetailElement != null) yield return new ElementValue("detail", DetailElement);
         }
       }
@@ -1003,8 +1039,8 @@ namespace Hl7.Fhir.Model
             value = ResultElement;
             return ResultElement is not null;
           case "message":
-            value = Message;
-            return Message is not null;
+            value = MessageElement;
+            return MessageElement is not null;
           case "detail":
             value = DetailElement;
             return DetailElement is not null;
@@ -1018,7 +1054,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (ResultElement is not null) yield return new KeyValuePair<string,object>("result",ResultElement);
-        if (Message is not null) yield return new KeyValuePair<string,object>("message",Message);
+        if (MessageElement is not null) yield return new KeyValuePair<string,object>("message",MessageElement);
         if (DetailElement is not null) yield return new KeyValuePair<string,object>("detail",DetailElement);
       }
 

--- a/src/Hl7.Fhir.R5/Model/Generated/TestScript.cs
+++ b/src/Hl7.Fhir.R5/Model/Generated/TestScript.cs
@@ -5112,13 +5112,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the test script
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// The context that the content is intended to support
@@ -5153,26 +5171,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=230, FiveWs="FiveWs.why[x]")]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this test script is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=240)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Copyright holder and year(s)
@@ -5381,11 +5435,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(CopyrightLabelElement != null) dest.CopyrightLabelElement = (Hl7.Fhir.Model.FhirString)CopyrightLabelElement.DeepCopy();
       if(Origin != null) dest.Origin = new List<Hl7.Fhir.Model.TestScript.OriginComponent>(Origin.DeepCopy());
       if(Destination != null) dest.Destination = new List<Hl7.Fhir.Model.TestScript.DestinationComponent>(Destination.DeepCopy());
@@ -5423,11 +5477,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.Matches(Origin, otherT.Origin)) return false;
       if( !DeepComparable.Matches(Destination, otherT.Destination)) return false;
@@ -5460,11 +5514,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(CopyrightLabelElement, otherT.CopyrightLabelElement)) return false;
       if( !DeepComparable.IsExactly(Origin, otherT.Origin)) return false;
       if( !DeepComparable.IsExactly(Destination, otherT.Destination)) return false;
@@ -5497,11 +5551,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (CopyrightLabelElement != null) yield return CopyrightLabelElement;
         foreach (var elem in Origin) { if (elem != null) yield return elem; }
         foreach (var elem in Destination) { if (elem != null) yield return elem; }
@@ -5533,11 +5587,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (CopyrightLabelElement != null) yield return new ElementValue("copyrightLabel", CopyrightLabelElement);
         foreach (var elem in Origin) { if (elem != null) yield return new ElementValue("origin", elem); }
         foreach (var elem in Destination) { if (elem != null) yield return new ElementValue("destination", elem); }
@@ -5590,8 +5644,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -5599,11 +5653,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "copyrightLabel":
           value = CopyrightLabelElement;
           return CopyrightLabelElement is not null;
@@ -5657,11 +5711,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (CopyrightLabelElement is not null) yield return new KeyValuePair<string,object>("copyrightLabel",CopyrightLabelElement);
       if (Origin?.Any() == true) yield return new KeyValuePair<string,object>("origin",Origin);
       if (Destination?.Any() == true) yield return new KeyValuePair<string,object>("destination",Destination);

--- a/src/Hl7.Fhir.R5/Model/IConformanceResource.cs
+++ b/src/Hl7.Fhir.R5/Model/IConformanceResource.cs
@@ -50,11 +50,13 @@ namespace Hl7.Fhir.Model
     {
         //I think ImplementationGuide should have a purpose element.
         [Obsolete("This property is not a part of the official FHIR specification", true)]
-        public Markdown Purpose
+        public Markdown PurposeElement
         {
             get { return null; }
             set { throw new NotImplementedException(); }
         }
+
+        public string Purpose { get => null; set => throw new NotImplementedException(); }
     }
 
     public partial class CompartmentDefinition : IVersionableConformanceResource

--- a/src/Hl7.Fhir.STU3/Model/Generated/ActivityDefinition.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/ActivityDefinition.cs
@@ -722,26 +722,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the activity definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Why this activity definition is defined
     /// </summary>
     [FhirElement("purpose", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this activity definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the asset
@@ -924,13 +960,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=290)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Additional documentation, citations, etc
@@ -1156,8 +1210,8 @@ namespace Hl7.Fhir.Model
       if(ExperimentalElement != null) dest.ExperimentalElement = (Hl7.Fhir.Model.FhirBoolean)ExperimentalElement.DeepCopy();
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
@@ -1167,7 +1221,7 @@ namespace Hl7.Fhir.Model
       if(Topic != null) dest.Topic = new List<Hl7.Fhir.Model.CodeableConcept>(Topic.DeepCopy());
       if(Contributor != null) dest.Contributor = new List<Hl7.Fhir.Model.Contributor>(Contributor.DeepCopy());
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
       if(Library != null) dest.Library = new List<Hl7.Fhir.Model.ResourceReference>(Library.DeepCopy());
       if(KindElement != null) dest.KindElement = (Code<Hl7.Fhir.Model.ResourceType>)KindElement.DeepCopy();
@@ -1205,8 +1259,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(ExperimentalElement, otherT.ExperimentalElement)) return false;
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
@@ -1216,7 +1270,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Topic, otherT.Topic)) return false;
       if( !DeepComparable.Matches(Contributor, otherT.Contributor)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.Matches(Library, otherT.Library)) return false;
       if( !DeepComparable.Matches(KindElement, otherT.KindElement)) return false;
@@ -1249,8 +1303,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(ExperimentalElement, otherT.ExperimentalElement)) return false;
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
@@ -1260,7 +1314,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Topic, otherT.Topic)) return false;
       if( !DeepComparable.IsExactly(Contributor, otherT.Contributor)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.IsExactly(Library, otherT.Library)) return false;
       if( !DeepComparable.IsExactly(KindElement, otherT.KindElement)) return false;
@@ -1293,8 +1347,8 @@ namespace Hl7.Fhir.Model
         if (ExperimentalElement != null) yield return ExperimentalElement;
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
-        if (Description != null) yield return Description;
-        if (Purpose != null) yield return Purpose;
+        if (DescriptionElement != null) yield return DescriptionElement;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
@@ -1304,7 +1358,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Topic) { if (elem != null) yield return elem; }
         foreach (var elem in Contributor) { if (elem != null) yield return elem; }
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return elem; }
         foreach (var elem in Library) { if (elem != null) yield return elem; }
         if (KindElement != null) yield return KindElement;
@@ -1336,8 +1390,8 @@ namespace Hl7.Fhir.Model
         if (ExperimentalElement != null) yield return new ElementValue("experimental", ExperimentalElement);
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
-        if (Description != null) yield return new ElementValue("description", Description);
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
@@ -1347,7 +1401,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Topic) { if (elem != null) yield return new ElementValue("topic", elem); }
         foreach (var elem in Contributor) { if (elem != null) yield return new ElementValue("contributor", elem); }
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return new ElementValue("relatedArtifact", elem); }
         foreach (var elem in Library) { if (elem != null) yield return new ElementValue("library", elem); }
         if (KindElement != null) yield return new ElementValue("kind", KindElement);
@@ -1396,11 +1450,11 @@ namespace Hl7.Fhir.Model
           value = PublisherElement;
           return PublisherElement is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
@@ -1429,8 +1483,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "relatedArtifact":
           value = RelatedArtifact;
           return RelatedArtifact?.Any() == true;
@@ -1488,8 +1542,8 @@ namespace Hl7.Fhir.Model
       if (ExperimentalElement is not null) yield return new KeyValuePair<string,object>("experimental",ExperimentalElement);
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
@@ -1499,7 +1553,7 @@ namespace Hl7.Fhir.Model
       if (Topic?.Any() == true) yield return new KeyValuePair<string,object>("topic",Topic);
       if (Contributor?.Any() == true) yield return new KeyValuePair<string,object>("contributor",Contributor);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (RelatedArtifact?.Any() == true) yield return new KeyValuePair<string,object>("relatedArtifact",RelatedArtifact);
       if (Library?.Any() == true) yield return new KeyValuePair<string,object>("library",Library);
       if (KindElement is not null) yield return new KeyValuePair<string,object>("kind",KindElement);

--- a/src/Hl7.Fhir.STU3/Model/Generated/CapabilityStatement.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/CapabilityStatement.cs
@@ -1557,13 +1557,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("documentation", Order=60)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Documentation
+      public Hl7.Fhir.Model.Markdown DocumentationElement
       {
-        get { return _Documentation; }
-        set { _Documentation = value; OnPropertyChanged("Documentation"); }
+        get { return _DocumentationElement; }
+        set { _DocumentationElement = value; OnPropertyChanged("DocumentationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Documentation;
+      private Hl7.Fhir.Model.Markdown _DocumentationElement;
+
+      /// <summary>
+      /// Additional information about the use of the resource type
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Documentation
+      {
+        get { return DocumentationElement != null ? DocumentationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            DocumentationElement = null;
+          else
+            DocumentationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Documentation");
+        }
+      }
 
       /// <summary>
       /// What operations are supported?
@@ -1922,7 +1940,7 @@ namespace Hl7.Fhir.Model
         base.CopyTo(dest);
         if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.ResourceType>)TypeElement.DeepCopy();
         if(Profile != null) dest.Profile = (Hl7.Fhir.Model.ResourceReference)Profile.DeepCopy();
-        if(Documentation != null) dest.Documentation = (Hl7.Fhir.Model.Markdown)Documentation.DeepCopy();
+        if(DocumentationElement != null) dest.DocumentationElement = (Hl7.Fhir.Model.Markdown)DocumentationElement.DeepCopy();
         if(Interaction != null) dest.Interaction = new List<Hl7.Fhir.Model.CapabilityStatement.ResourceInteractionComponent>(Interaction.DeepCopy());
         if(VersioningElement != null) dest.VersioningElement = (Code<Hl7.Fhir.Model.CapabilityStatement.ResourceVersionPolicy>)VersioningElement.DeepCopy();
         if(ReadHistoryElement != null) dest.ReadHistoryElement = (Hl7.Fhir.Model.FhirBoolean)ReadHistoryElement.DeepCopy();
@@ -1952,7 +1970,7 @@ namespace Hl7.Fhir.Model
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(TypeElement, otherT.TypeElement)) return false;
         if( !DeepComparable.Matches(Profile, otherT.Profile)) return false;
-        if( !DeepComparable.Matches(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.Matches(DocumentationElement, otherT.DocumentationElement)) return false;
         if( !DeepComparable.Matches(Interaction, otherT.Interaction)) return false;
         if( !DeepComparable.Matches(VersioningElement, otherT.VersioningElement)) return false;
         if( !DeepComparable.Matches(ReadHistoryElement, otherT.ReadHistoryElement)) return false;
@@ -1977,7 +1995,7 @@ namespace Hl7.Fhir.Model
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(TypeElement, otherT.TypeElement)) return false;
         if( !DeepComparable.IsExactly(Profile, otherT.Profile)) return false;
-        if( !DeepComparable.IsExactly(Documentation, otherT.Documentation)) return false;
+        if( !DeepComparable.IsExactly(DocumentationElement, otherT.DocumentationElement)) return false;
         if( !DeepComparable.IsExactly(Interaction, otherT.Interaction)) return false;
         if( !DeepComparable.IsExactly(VersioningElement, otherT.VersioningElement)) return false;
         if( !DeepComparable.IsExactly(ReadHistoryElement, otherT.ReadHistoryElement)) return false;
@@ -2002,7 +2020,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.Children) yield return item;
           if (TypeElement != null) yield return TypeElement;
           if (Profile != null) yield return Profile;
-          if (Documentation != null) yield return Documentation;
+          if (DocumentationElement != null) yield return DocumentationElement;
           foreach (var elem in Interaction) { if (elem != null) yield return elem; }
           if (VersioningElement != null) yield return VersioningElement;
           if (ReadHistoryElement != null) yield return ReadHistoryElement;
@@ -2026,7 +2044,7 @@ namespace Hl7.Fhir.Model
           foreach (var item in base.NamedChildren) yield return item;
           if (TypeElement != null) yield return new ElementValue("type", TypeElement);
           if (Profile != null) yield return new ElementValue("profile", Profile);
-          if (Documentation != null) yield return new ElementValue("documentation", Documentation);
+          if (DocumentationElement != null) yield return new ElementValue("documentation", DocumentationElement);
           foreach (var elem in Interaction) { if (elem != null) yield return new ElementValue("interaction", elem); }
           if (VersioningElement != null) yield return new ElementValue("versioning", VersioningElement);
           if (ReadHistoryElement != null) yield return new ElementValue("readHistory", ReadHistoryElement);
@@ -2053,8 +2071,8 @@ namespace Hl7.Fhir.Model
             value = Profile;
             return Profile is not null;
           case "documentation":
-            value = Documentation;
-            return Documentation is not null;
+            value = DocumentationElement;
+            return DocumentationElement is not null;
           case "interaction":
             value = Interaction;
             return Interaction?.Any() == true;
@@ -2102,7 +2120,7 @@ namespace Hl7.Fhir.Model
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (TypeElement is not null) yield return new KeyValuePair<string,object>("type",TypeElement);
         if (Profile is not null) yield return new KeyValuePair<string,object>("profile",Profile);
-        if (Documentation is not null) yield return new KeyValuePair<string,object>("documentation",Documentation);
+        if (DocumentationElement is not null) yield return new KeyValuePair<string,object>("documentation",DocumentationElement);
         if (Interaction?.Any() == true) yield return new KeyValuePair<string,object>("interaction",Interaction);
         if (VersioningElement is not null) yield return new KeyValuePair<string,object>("versioning",VersioningElement);
         if (ReadHistoryElement is not null) yield return new KeyValuePair<string,object>("readHistory",ReadHistoryElement);
@@ -4190,13 +4208,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the capability statement
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Context the content is intended to support
@@ -4231,26 +4267,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this capability statement is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// instance | capability | requirements
@@ -4581,11 +4653,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(KindElement != null) dest.KindElement = (Code<Hl7.Fhir.Model.CapabilityStatement.CapabilityStatementKind>)KindElement.DeepCopy();
       if(InstantiatesElement != null) dest.InstantiatesElement = new List<Hl7.Fhir.Model.FhirUri>(InstantiatesElement.DeepCopy());
       if(Software != null) dest.Software = (Hl7.Fhir.Model.CapabilityStatement.SoftwareComponent)Software.DeepCopy();
@@ -4623,11 +4695,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(KindElement, otherT.KindElement)) return false;
       if( !DeepComparable.Matches(InstantiatesElement, otherT.InstantiatesElement)) return false;
       if( !DeepComparable.Matches(Software, otherT.Software)) return false;
@@ -4660,11 +4732,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(KindElement, otherT.KindElement)) return false;
       if( !DeepComparable.IsExactly(InstantiatesElement, otherT.InstantiatesElement)) return false;
       if( !DeepComparable.IsExactly(Software, otherT.Software)) return false;
@@ -4697,11 +4769,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (KindElement != null) yield return KindElement;
         foreach (var elem in InstantiatesElement) { if (elem != null) yield return elem; }
         if (Software != null) yield return Software;
@@ -4733,11 +4805,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (KindElement != null) yield return new ElementValue("kind", KindElement);
         foreach (var elem in InstantiatesElement) { if (elem != null) yield return new ElementValue("instantiates", elem); }
         if (Software != null) yield return new ElementValue("software", Software);
@@ -4786,8 +4858,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -4795,11 +4867,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "kind":
           value = KindElement;
           return KindElement is not null;
@@ -4857,11 +4929,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (KindElement is not null) yield return new KeyValuePair<string,object>("kind",KindElement);
       if (InstantiatesElement?.Any() == true) yield return new KeyValuePair<string,object>("instantiates",InstantiatesElement);
       if (Software is not null) yield return new KeyValuePair<string,object>("software",Software);

--- a/src/Hl7.Fhir.STU3/Model/Generated/CodeSystem.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/CodeSystem.cs
@@ -1572,13 +1572,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the code system
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Context the content is intended to support
@@ -1613,26 +1631,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this code system is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// If code comparison is case sensitive
@@ -1916,11 +1970,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(CaseSensitiveElement != null) dest.CaseSensitiveElement = (Hl7.Fhir.Model.FhirBoolean)CaseSensitiveElement.DeepCopy();
       if(ValueSetElement != null) dest.ValueSetElement = (Hl7.Fhir.Model.FhirUri)ValueSetElement.DeepCopy();
       if(HierarchyMeaningElement != null) dest.HierarchyMeaningElement = (Code<Hl7.Fhir.Model.CodeSystem.CodeSystemHierarchyMeaning>)HierarchyMeaningElement.DeepCopy();
@@ -1956,11 +2010,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(CaseSensitiveElement, otherT.CaseSensitiveElement)) return false;
       if( !DeepComparable.Matches(ValueSetElement, otherT.ValueSetElement)) return false;
       if( !DeepComparable.Matches(HierarchyMeaningElement, otherT.HierarchyMeaningElement)) return false;
@@ -1991,11 +2045,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(CaseSensitiveElement, otherT.CaseSensitiveElement)) return false;
       if( !DeepComparable.IsExactly(ValueSetElement, otherT.ValueSetElement)) return false;
       if( !DeepComparable.IsExactly(HierarchyMeaningElement, otherT.HierarchyMeaningElement)) return false;
@@ -2026,11 +2080,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (CaseSensitiveElement != null) yield return CaseSensitiveElement;
         if (ValueSetElement != null) yield return ValueSetElement;
         if (HierarchyMeaningElement != null) yield return HierarchyMeaningElement;
@@ -2060,11 +2114,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (CaseSensitiveElement != null) yield return new ElementValue("caseSensitive", CaseSensitiveElement);
         if (ValueSetElement != null) yield return new ElementValue("valueSet", ValueSetElement);
         if (HierarchyMeaningElement != null) yield return new ElementValue("hierarchyMeaning", HierarchyMeaningElement);
@@ -2113,8 +2167,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2122,11 +2176,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "caseSensitive":
           value = CaseSensitiveElement;
           return CaseSensitiveElement is not null;
@@ -2176,11 +2230,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (CaseSensitiveElement is not null) yield return new KeyValuePair<string,object>("caseSensitive",CaseSensitiveElement);
       if (ValueSetElement is not null) yield return new KeyValuePair<string,object>("valueSet",ValueSetElement);
       if (HierarchyMeaningElement is not null) yield return new KeyValuePair<string,object>("hierarchyMeaning",HierarchyMeaningElement);

--- a/src/Hl7.Fhir.STU3/Model/Generated/CompartmentDefinition.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/CompartmentDefinition.cs
@@ -505,26 +505,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=170)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the compartment definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Why this compartment definition is defined
     /// </summary>
     [FhirElement("purpose", Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this compartment definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Context the content is intended to support
@@ -651,8 +687,8 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
       if(CodeElement != null) dest.CodeElement = (Code<Hl7.Fhir.Model.CompartmentType>)CodeElement.DeepCopy();
@@ -681,8 +717,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.Matches(CodeElement, otherT.CodeElement)) return false;
@@ -706,8 +742,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.IsExactly(CodeElement, otherT.CodeElement)) return false;
@@ -731,8 +767,8 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
-        if (Purpose != null) yield return Purpose;
+        if (DescriptionElement != null) yield return DescriptionElement;
+        if (PurposeElement != null) yield return PurposeElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
         if (CodeElement != null) yield return CodeElement;
@@ -755,8 +791,8 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
         if (CodeElement != null) yield return new ElementValue("code", CodeElement);
@@ -794,11 +830,11 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -831,8 +867,8 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
       if (CodeElement is not null) yield return new KeyValuePair<string,object>("code",CodeElement);

--- a/src/Hl7.Fhir.STU3/Model/Generated/ConceptMap.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/ConceptMap.cs
@@ -1709,13 +1709,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the concept map
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Context the content is intended to support
@@ -1750,26 +1768,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this concept map is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Identifies the source of the concepts which are being mapped
@@ -1837,11 +1891,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(Source != null) dest.Source = (Hl7.Fhir.Model.DataType)Source.DeepCopy();
       if(Target != null) dest.Target = (Hl7.Fhir.Model.DataType)Target.DeepCopy();
       if(Group != null) dest.Group = new List<Hl7.Fhir.Model.ConceptMap.GroupComponent>(Group.DeepCopy());
@@ -1870,11 +1924,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(Source, otherT.Source)) return false;
       if( !DeepComparable.Matches(Target, otherT.Target)) return false;
       if( !DeepComparable.Matches(Group, otherT.Group)) return false;
@@ -1898,11 +1952,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(Source, otherT.Source)) return false;
       if( !DeepComparable.IsExactly(Target, otherT.Target)) return false;
       if( !DeepComparable.IsExactly(Group, otherT.Group)) return false;
@@ -1926,11 +1980,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (Source != null) yield return Source;
         if (Target != null) yield return Target;
         foreach (var elem in Group) { if (elem != null) yield return elem; }
@@ -1953,11 +2007,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (Source != null) yield return new ElementValue("source", Source);
         if (Target != null) yield return new ElementValue("target", Target);
         foreach (var elem in Group) { if (elem != null) yield return new ElementValue("group", elem); }
@@ -1999,8 +2053,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2008,11 +2062,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "source":
           value = Source;
           return Source is not null;
@@ -2041,11 +2095,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (Source is not null) yield return new KeyValuePair<string,object>("source",Source);
       if (Target is not null) yield return new KeyValuePair<string,object>("target",Target);
       if (Group?.Any() == true) yield return new KeyValuePair<string,object>("group",Group);

--- a/src/Hl7.Fhir.STU3/Model/Generated/DataElement.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/DataElement.cs
@@ -660,13 +660,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// comparable | fully-specified | equivalent | convertable | scaleable | flexible
@@ -750,7 +768,7 @@ namespace Hl7.Fhir.Model
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(StringencyElement != null) dest.StringencyElement = (Code<Hl7.Fhir.Model.DataElement.DataElementStringency>)StringencyElement.DeepCopy();
       if(Mapping != null) dest.Mapping = new List<Hl7.Fhir.Model.DataElement.MappingComponent>(Mapping.DeepCopy());
       if(Element != null) dest.Element = new List<Hl7.Fhir.Model.ElementDefinition>(Element.DeepCopy());
@@ -781,7 +799,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(StringencyElement, otherT.StringencyElement)) return false;
       if( !DeepComparable.Matches(Mapping, otherT.Mapping)) return false;
       if( !DeepComparable.Matches(Element, otherT.Element)) return false;
@@ -807,7 +825,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(StringencyElement, otherT.StringencyElement)) return false;
       if( !DeepComparable.IsExactly(Mapping, otherT.Mapping)) return false;
       if( !DeepComparable.IsExactly(Element, otherT.Element)) return false;
@@ -833,7 +851,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (StringencyElement != null) yield return StringencyElement;
         foreach (var elem in Mapping) { if (elem != null) yield return elem; }
         foreach (var elem in Element) { if (elem != null) yield return elem; }
@@ -858,7 +876,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (StringencyElement != null) yield return new ElementValue("stringency", StringencyElement);
         foreach (var elem in Mapping) { if (elem != null) yield return new ElementValue("mapping", elem); }
         foreach (var elem in Element) { if (elem != null) yield return new ElementValue("element", elem); }
@@ -906,8 +924,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "stringency":
           value = StringencyElement;
           return StringencyElement is not null;
@@ -938,7 +956,7 @@ namespace Hl7.Fhir.Model
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (StringencyElement is not null) yield return new KeyValuePair<string,object>("stringency",StringencyElement);
       if (Mapping?.Any() == true) yield return new KeyValuePair<string,object>("mapping",Mapping);
       if (Element?.Any() == true) yield return new KeyValuePair<string,object>("element",Element);

--- a/src/Hl7.Fhir.STU3/Model/Generated/ExpansionProfile.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/ExpansionProfile.cs
@@ -1362,13 +1362,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the expansion profile
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Context the content is intended to support
@@ -1705,7 +1723,7 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
       if(FixedVersion != null) dest.FixedVersion = new List<Hl7.Fhir.Model.ExpansionProfile.FixedVersionComponent>(FixedVersion.DeepCopy());
@@ -1743,7 +1761,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.Matches(FixedVersion, otherT.FixedVersion)) return false;
@@ -1776,7 +1794,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.IsExactly(FixedVersion, otherT.FixedVersion)) return false;
@@ -1809,7 +1827,7 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
         foreach (var elem in FixedVersion) { if (elem != null) yield return elem; }
@@ -1841,7 +1859,7 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
         foreach (var elem in FixedVersion) { if (elem != null) yield return new ElementValue("fixedVersion", elem); }
@@ -1890,8 +1908,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1949,7 +1967,7 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
       if (FixedVersion?.Any() == true) yield return new KeyValuePair<string,object>("fixedVersion",FixedVersion);

--- a/src/Hl7.Fhir.STU3/Model/Generated/GraphDefinition.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/GraphDefinition.cs
@@ -1105,13 +1105,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=170)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the graph definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Context the content is intended to support
@@ -1146,13 +1164,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this graph definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Type of resource at which the graph starts
@@ -1250,10 +1286,10 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(StartElement != null) dest.StartElement = (Code<Hl7.Fhir.Model.ResourceType>)StartElement.DeepCopy();
       if(ProfileElement != null) dest.ProfileElement = (Hl7.Fhir.Model.FhirUri)ProfileElement.DeepCopy();
       if(Link != null) dest.Link = new List<Hl7.Fhir.Model.GraphDefinition.LinkComponent>(Link.DeepCopy());
@@ -1280,10 +1316,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(StartElement, otherT.StartElement)) return false;
       if( !DeepComparable.Matches(ProfileElement, otherT.ProfileElement)) return false;
       if( !DeepComparable.Matches(Link, otherT.Link)) return false;
@@ -1305,10 +1341,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(StartElement, otherT.StartElement)) return false;
       if( !DeepComparable.IsExactly(ProfileElement, otherT.ProfileElement)) return false;
       if( !DeepComparable.IsExactly(Link, otherT.Link)) return false;
@@ -1330,10 +1366,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (StartElement != null) yield return StartElement;
         if (ProfileElement != null) yield return ProfileElement;
         foreach (var elem in Link) { if (elem != null) yield return elem; }
@@ -1354,10 +1390,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (StartElement != null) yield return new ElementValue("start", StartElement);
         if (ProfileElement != null) yield return new ElementValue("profile", ProfileElement);
         foreach (var elem in Link) { if (elem != null) yield return new ElementValue("link", elem); }
@@ -1393,8 +1429,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1402,8 +1438,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "start":
           value = StartElement;
           return StartElement is not null;
@@ -1430,10 +1466,10 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (StartElement is not null) yield return new KeyValuePair<string,object>("start",StartElement);
       if (ProfileElement is not null) yield return new KeyValuePair<string,object>("profile",ProfileElement);
       if (Link?.Any() == true) yield return new KeyValuePair<string,object>("link",Link);

--- a/src/Hl7.Fhir.STU3/Model/Generated/ImplementationGuide.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/ImplementationGuide.cs
@@ -1545,13 +1545,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=170)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the implementation guide
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Context the content is intended to support
@@ -1586,13 +1604,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// FHIR Version this Implementation Guide targets
@@ -1730,10 +1766,10 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(FhirVersionElement != null) dest.FhirVersionElement = (Hl7.Fhir.Model.Id)FhirVersionElement.DeepCopy();
       if(Dependency != null) dest.Dependency = new List<Hl7.Fhir.Model.ImplementationGuide.DependencyComponent>(Dependency.DeepCopy());
       if(Package != null) dest.Package = new List<Hl7.Fhir.Model.ImplementationGuide.PackageComponent>(Package.DeepCopy());
@@ -1763,10 +1799,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(FhirVersionElement, otherT.FhirVersionElement)) return false;
       if( !DeepComparable.Matches(Dependency, otherT.Dependency)) return false;
       if( !DeepComparable.Matches(Package, otherT.Package)) return false;
@@ -1791,10 +1827,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(FhirVersionElement, otherT.FhirVersionElement)) return false;
       if( !DeepComparable.IsExactly(Dependency, otherT.Dependency)) return false;
       if( !DeepComparable.IsExactly(Package, otherT.Package)) return false;
@@ -1819,10 +1855,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (FhirVersionElement != null) yield return FhirVersionElement;
         foreach (var elem in Dependency) { if (elem != null) yield return elem; }
         foreach (var elem in Package) { if (elem != null) yield return elem; }
@@ -1846,10 +1882,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (FhirVersionElement != null) yield return new ElementValue("fhirVersion", FhirVersionElement);
         foreach (var elem in Dependency) { if (elem != null) yield return new ElementValue("dependency", elem); }
         foreach (var elem in Package) { if (elem != null) yield return new ElementValue("package", elem); }
@@ -1888,8 +1924,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1897,8 +1933,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "fhirVersion":
           value = FhirVersionElement;
           return FhirVersionElement is not null;
@@ -1934,10 +1970,10 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (FhirVersionElement is not null) yield return new KeyValuePair<string,object>("fhirVersion",FhirVersionElement);
       if (Dependency?.Any() == true) yield return new KeyValuePair<string,object>("dependency",Dependency);
       if (Package?.Any() == true) yield return new KeyValuePair<string,object>("package",Package);

--- a/src/Hl7.Fhir.STU3/Model/Generated/Library.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/Library.cs
@@ -338,26 +338,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the library
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Why this library is defined
     /// </summary>
     [FhirElement("purpose", Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this library is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the library
@@ -540,13 +576,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=300)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Additional documentation, citations, etc.
@@ -624,8 +678,8 @@ namespace Hl7.Fhir.Model
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
@@ -635,7 +689,7 @@ namespace Hl7.Fhir.Model
       if(Topic != null) dest.Topic = new List<Hl7.Fhir.Model.CodeableConcept>(Topic.DeepCopy());
       if(Contributor != null) dest.Contributor = new List<Hl7.Fhir.Model.Contributor>(Contributor.DeepCopy());
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
       if(Parameter != null) dest.Parameter = new List<Hl7.Fhir.Model.ParameterDefinition>(Parameter.DeepCopy());
       if(DataRequirement != null) dest.DataRequirement = new List<Hl7.Fhir.Model.DataRequirement>(DataRequirement.DeepCopy());
@@ -665,8 +719,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Type, otherT.Type)) return false;
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
@@ -676,7 +730,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Topic, otherT.Topic)) return false;
       if( !DeepComparable.Matches(Contributor, otherT.Contributor)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.Matches(Parameter, otherT.Parameter)) return false;
       if( !DeepComparable.Matches(DataRequirement, otherT.DataRequirement)) return false;
@@ -701,8 +755,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
@@ -712,7 +766,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Topic, otherT.Topic)) return false;
       if( !DeepComparable.IsExactly(Contributor, otherT.Contributor)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.IsExactly(Parameter, otherT.Parameter)) return false;
       if( !DeepComparable.IsExactly(DataRequirement, otherT.DataRequirement)) return false;
@@ -737,8 +791,8 @@ namespace Hl7.Fhir.Model
         if (Type != null) yield return Type;
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
-        if (Description != null) yield return Description;
-        if (Purpose != null) yield return Purpose;
+        if (DescriptionElement != null) yield return DescriptionElement;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
@@ -748,7 +802,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Topic) { if (elem != null) yield return elem; }
         foreach (var elem in Contributor) { if (elem != null) yield return elem; }
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return elem; }
         foreach (var elem in Parameter) { if (elem != null) yield return elem; }
         foreach (var elem in DataRequirement) { if (elem != null) yield return elem; }
@@ -772,8 +826,8 @@ namespace Hl7.Fhir.Model
         if (Type != null) yield return new ElementValue("type", Type);
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
-        if (Description != null) yield return new ElementValue("description", Description);
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
@@ -783,7 +837,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Topic) { if (elem != null) yield return new ElementValue("topic", elem); }
         foreach (var elem in Contributor) { if (elem != null) yield return new ElementValue("contributor", elem); }
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return new ElementValue("relatedArtifact", elem); }
         foreach (var elem in Parameter) { if (elem != null) yield return new ElementValue("parameter", elem); }
         foreach (var elem in DataRequirement) { if (elem != null) yield return new ElementValue("dataRequirement", elem); }
@@ -826,11 +880,11 @@ namespace Hl7.Fhir.Model
           value = PublisherElement;
           return PublisherElement is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
@@ -859,8 +913,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "relatedArtifact":
           value = RelatedArtifact;
           return RelatedArtifact?.Any() == true;
@@ -892,8 +946,8 @@ namespace Hl7.Fhir.Model
       if (Type is not null) yield return new KeyValuePair<string,object>("type",Type);
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
@@ -903,7 +957,7 @@ namespace Hl7.Fhir.Model
       if (Topic?.Any() == true) yield return new KeyValuePair<string,object>("topic",Topic);
       if (Contributor?.Any() == true) yield return new KeyValuePair<string,object>("contributor",Contributor);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (RelatedArtifact?.Any() == true) yield return new KeyValuePair<string,object>("relatedArtifact",RelatedArtifact);
       if (Parameter?.Any() == true) yield return new KeyValuePair<string,object>("parameter",Parameter);
       if (DataRequirement?.Any() == true) yield return new KeyValuePair<string,object>("dataRequirement",DataRequirement);

--- a/src/Hl7.Fhir.STU3/Model/Generated/Measure.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/Measure.cs
@@ -1213,26 +1213,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the measure
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Why this measure is defined
     /// </summary>
     [FhirElement("purpose", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this measure is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the measure
@@ -1415,13 +1451,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=290)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Additional documentation, citations, etc
@@ -1458,13 +1512,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("disclaimer", InSummary=true, Order=320)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Disclaimer
+    public Hl7.Fhir.Model.Markdown DisclaimerElement
     {
-      get { return _Disclaimer; }
-      set { _Disclaimer = value; OnPropertyChanged("Disclaimer"); }
+      get { return _DisclaimerElement; }
+      set { _DisclaimerElement = value; OnPropertyChanged("DisclaimerElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Disclaimer;
+    private Hl7.Fhir.Model.Markdown _DisclaimerElement;
+
+    /// <summary>
+    /// Disclaimer for use of the measure or its referenced content
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Disclaimer
+    {
+      get { return DisclaimerElement != null ? DisclaimerElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DisclaimerElement = null;
+        else
+          DisclaimerElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Disclaimer");
+      }
+    }
 
     /// <summary>
     /// proportion | ratio | continuous-variable | cohort
@@ -1573,26 +1645,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("rationale", InSummary=true, Order=380)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Rationale
+    public Hl7.Fhir.Model.Markdown RationaleElement
     {
-      get { return _Rationale; }
-      set { _Rationale = value; OnPropertyChanged("Rationale"); }
+      get { return _RationaleElement; }
+      set { _RationaleElement = value; OnPropertyChanged("RationaleElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Rationale;
+    private Hl7.Fhir.Model.Markdown _RationaleElement;
+
+    /// <summary>
+    /// Why does this measure exist
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Rationale
+    {
+      get { return RationaleElement != null ? RationaleElement.Value : null; }
+      set
+      {
+        if (value == null)
+          RationaleElement = null;
+        else
+          RationaleElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Rationale");
+      }
+    }
 
     /// <summary>
     /// Summary of clinical guidelines
     /// </summary>
     [FhirElement("clinicalRecommendationStatement", InSummary=true, Order=390)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown ClinicalRecommendationStatement
+    public Hl7.Fhir.Model.Markdown ClinicalRecommendationStatementElement
     {
-      get { return _ClinicalRecommendationStatement; }
-      set { _ClinicalRecommendationStatement = value; OnPropertyChanged("ClinicalRecommendationStatement"); }
+      get { return _ClinicalRecommendationStatementElement; }
+      set { _ClinicalRecommendationStatementElement = value; OnPropertyChanged("ClinicalRecommendationStatementElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _ClinicalRecommendationStatement;
+    private Hl7.Fhir.Model.Markdown _ClinicalRecommendationStatementElement;
+
+    /// <summary>
+    /// Summary of clinical guidelines
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string ClinicalRecommendationStatement
+    {
+      get { return ClinicalRecommendationStatementElement != null ? ClinicalRecommendationStatementElement.Value : null; }
+      set
+      {
+        if (value == null)
+          ClinicalRecommendationStatementElement = null;
+        else
+          ClinicalRecommendationStatementElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("ClinicalRecommendationStatement");
+      }
+    }
 
     /// <summary>
     /// Improvement notation for the measure, e.g. higher score indicates better quality
@@ -1631,26 +1739,62 @@ namespace Hl7.Fhir.Model
     [FhirElement("definition", InSummary=true, Order=410)]
     [Cardinality(Min=0,Max=-1)]
     [DataMember]
-    public List<Hl7.Fhir.Model.Markdown> Definition
+    public List<Hl7.Fhir.Model.Markdown> DefinitionElement
     {
-      get { if(_Definition==null) _Definition = new List<Hl7.Fhir.Model.Markdown>(); return _Definition; }
-      set { _Definition = value; OnPropertyChanged("Definition"); }
+      get { if(_DefinitionElement==null) _DefinitionElement = new List<Hl7.Fhir.Model.Markdown>(); return _DefinitionElement; }
+      set { _DefinitionElement = value; OnPropertyChanged("DefinitionElement"); }
     }
 
-    private List<Hl7.Fhir.Model.Markdown> _Definition;
+    private List<Hl7.Fhir.Model.Markdown> _DefinitionElement;
+
+    /// <summary>
+    /// Defined terms used in the measure documentation
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public IEnumerable<string> Definition
+    {
+      get { return DefinitionElement != null ? DefinitionElement.Select(elem => elem.Value) : null; }
+      set
+      {
+        if (value == null)
+          DefinitionElement = null;
+        else
+          DefinitionElement = new List<Hl7.Fhir.Model.Markdown>(value.Select(elem=>new Hl7.Fhir.Model.Markdown(elem)));
+        OnPropertyChanged("Definition");
+      }
+    }
 
     /// <summary>
     /// Additional guidance for implementers
     /// </summary>
     [FhirElement("guidance", InSummary=true, Order=420)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Guidance
+    public Hl7.Fhir.Model.Markdown GuidanceElement
     {
-      get { return _Guidance; }
-      set { _Guidance = value; OnPropertyChanged("Guidance"); }
+      get { return _GuidanceElement; }
+      set { _GuidanceElement = value; OnPropertyChanged("GuidanceElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Guidance;
+    private Hl7.Fhir.Model.Markdown _GuidanceElement;
+
+    /// <summary>
+    /// Additional guidance for implementers
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Guidance
+    {
+      get { return GuidanceElement != null ? GuidanceElement.Value : null; }
+      set
+      {
+        if (value == null)
+          GuidanceElement = null;
+        else
+          GuidanceElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Guidance");
+      }
+    }
 
     /// <summary>
     /// The measure set, e.g. Preventive Care and Screening
@@ -1730,8 +1874,8 @@ namespace Hl7.Fhir.Model
       if(ExperimentalElement != null) dest.ExperimentalElement = (Hl7.Fhir.Model.FhirBoolean)ExperimentalElement.DeepCopy();
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
@@ -1741,20 +1885,20 @@ namespace Hl7.Fhir.Model
       if(Topic != null) dest.Topic = new List<Hl7.Fhir.Model.CodeableConcept>(Topic.DeepCopy());
       if(Contributor != null) dest.Contributor = new List<Hl7.Fhir.Model.Contributor>(Contributor.DeepCopy());
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
       if(Library != null) dest.Library = new List<Hl7.Fhir.Model.ResourceReference>(Library.DeepCopy());
-      if(Disclaimer != null) dest.Disclaimer = (Hl7.Fhir.Model.Markdown)Disclaimer.DeepCopy();
+      if(DisclaimerElement != null) dest.DisclaimerElement = (Hl7.Fhir.Model.Markdown)DisclaimerElement.DeepCopy();
       if(Scoring != null) dest.Scoring = (Hl7.Fhir.Model.CodeableConcept)Scoring.DeepCopy();
       if(CompositeScoring != null) dest.CompositeScoring = (Hl7.Fhir.Model.CodeableConcept)CompositeScoring.DeepCopy();
       if(Type != null) dest.Type = new List<Hl7.Fhir.Model.CodeableConcept>(Type.DeepCopy());
       if(RiskAdjustmentElement != null) dest.RiskAdjustmentElement = (Hl7.Fhir.Model.FhirString)RiskAdjustmentElement.DeepCopy();
       if(RateAggregationElement != null) dest.RateAggregationElement = (Hl7.Fhir.Model.FhirString)RateAggregationElement.DeepCopy();
-      if(Rationale != null) dest.Rationale = (Hl7.Fhir.Model.Markdown)Rationale.DeepCopy();
-      if(ClinicalRecommendationStatement != null) dest.ClinicalRecommendationStatement = (Hl7.Fhir.Model.Markdown)ClinicalRecommendationStatement.DeepCopy();
+      if(RationaleElement != null) dest.RationaleElement = (Hl7.Fhir.Model.Markdown)RationaleElement.DeepCopy();
+      if(ClinicalRecommendationStatementElement != null) dest.ClinicalRecommendationStatementElement = (Hl7.Fhir.Model.Markdown)ClinicalRecommendationStatementElement.DeepCopy();
       if(ImprovementNotationElement != null) dest.ImprovementNotationElement = (Hl7.Fhir.Model.FhirString)ImprovementNotationElement.DeepCopy();
-      if(Definition != null) dest.Definition = new List<Hl7.Fhir.Model.Markdown>(Definition.DeepCopy());
-      if(Guidance != null) dest.Guidance = (Hl7.Fhir.Model.Markdown)Guidance.DeepCopy();
+      if(DefinitionElement != null) dest.DefinitionElement = new List<Hl7.Fhir.Model.Markdown>(DefinitionElement.DeepCopy());
+      if(GuidanceElement != null) dest.GuidanceElement = (Hl7.Fhir.Model.Markdown)GuidanceElement.DeepCopy();
       if(SetElement != null) dest.SetElement = (Hl7.Fhir.Model.FhirString)SetElement.DeepCopy();
       if(Group != null) dest.Group = new List<Hl7.Fhir.Model.Measure.GroupComponent>(Group.DeepCopy());
       if(SupplementalData != null) dest.SupplementalData = new List<Hl7.Fhir.Model.Measure.SupplementalDataComponent>(SupplementalData.DeepCopy());
@@ -1782,8 +1926,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(ExperimentalElement, otherT.ExperimentalElement)) return false;
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
@@ -1793,20 +1937,20 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Topic, otherT.Topic)) return false;
       if( !DeepComparable.Matches(Contributor, otherT.Contributor)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.Matches(Library, otherT.Library)) return false;
-      if( !DeepComparable.Matches(Disclaimer, otherT.Disclaimer)) return false;
+      if( !DeepComparable.Matches(DisclaimerElement, otherT.DisclaimerElement)) return false;
       if( !DeepComparable.Matches(Scoring, otherT.Scoring)) return false;
       if( !DeepComparable.Matches(CompositeScoring, otherT.CompositeScoring)) return false;
       if( !DeepComparable.Matches(Type, otherT.Type)) return false;
       if( !DeepComparable.Matches(RiskAdjustmentElement, otherT.RiskAdjustmentElement)) return false;
       if( !DeepComparable.Matches(RateAggregationElement, otherT.RateAggregationElement)) return false;
-      if( !DeepComparable.Matches(Rationale, otherT.Rationale)) return false;
-      if( !DeepComparable.Matches(ClinicalRecommendationStatement, otherT.ClinicalRecommendationStatement)) return false;
+      if( !DeepComparable.Matches(RationaleElement, otherT.RationaleElement)) return false;
+      if( !DeepComparable.Matches(ClinicalRecommendationStatementElement, otherT.ClinicalRecommendationStatementElement)) return false;
       if( !DeepComparable.Matches(ImprovementNotationElement, otherT.ImprovementNotationElement)) return false;
-      if( !DeepComparable.Matches(Definition, otherT.Definition)) return false;
-      if( !DeepComparable.Matches(Guidance, otherT.Guidance)) return false;
+      if( !DeepComparable.Matches(DefinitionElement, otherT.DefinitionElement)) return false;
+      if( !DeepComparable.Matches(GuidanceElement, otherT.GuidanceElement)) return false;
       if( !DeepComparable.Matches(SetElement, otherT.SetElement)) return false;
       if( !DeepComparable.Matches(Group, otherT.Group)) return false;
       if( !DeepComparable.Matches(SupplementalData, otherT.SupplementalData)) return false;
@@ -1829,8 +1973,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(ExperimentalElement, otherT.ExperimentalElement)) return false;
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
@@ -1840,20 +1984,20 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Topic, otherT.Topic)) return false;
       if( !DeepComparable.IsExactly(Contributor, otherT.Contributor)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.IsExactly(Library, otherT.Library)) return false;
-      if( !DeepComparable.IsExactly(Disclaimer, otherT.Disclaimer)) return false;
+      if( !DeepComparable.IsExactly(DisclaimerElement, otherT.DisclaimerElement)) return false;
       if( !DeepComparable.IsExactly(Scoring, otherT.Scoring)) return false;
       if( !DeepComparable.IsExactly(CompositeScoring, otherT.CompositeScoring)) return false;
       if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
       if( !DeepComparable.IsExactly(RiskAdjustmentElement, otherT.RiskAdjustmentElement)) return false;
       if( !DeepComparable.IsExactly(RateAggregationElement, otherT.RateAggregationElement)) return false;
-      if( !DeepComparable.IsExactly(Rationale, otherT.Rationale)) return false;
-      if( !DeepComparable.IsExactly(ClinicalRecommendationStatement, otherT.ClinicalRecommendationStatement)) return false;
+      if( !DeepComparable.IsExactly(RationaleElement, otherT.RationaleElement)) return false;
+      if( !DeepComparable.IsExactly(ClinicalRecommendationStatementElement, otherT.ClinicalRecommendationStatementElement)) return false;
       if( !DeepComparable.IsExactly(ImprovementNotationElement, otherT.ImprovementNotationElement)) return false;
-      if( !DeepComparable.IsExactly(Definition, otherT.Definition)) return false;
-      if( !DeepComparable.IsExactly(Guidance, otherT.Guidance)) return false;
+      if( !DeepComparable.IsExactly(DefinitionElement, otherT.DefinitionElement)) return false;
+      if( !DeepComparable.IsExactly(GuidanceElement, otherT.GuidanceElement)) return false;
       if( !DeepComparable.IsExactly(SetElement, otherT.SetElement)) return false;
       if( !DeepComparable.IsExactly(Group, otherT.Group)) return false;
       if( !DeepComparable.IsExactly(SupplementalData, otherT.SupplementalData)) return false;
@@ -1876,8 +2020,8 @@ namespace Hl7.Fhir.Model
         if (ExperimentalElement != null) yield return ExperimentalElement;
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
-        if (Description != null) yield return Description;
-        if (Purpose != null) yield return Purpose;
+        if (DescriptionElement != null) yield return DescriptionElement;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
@@ -1887,20 +2031,20 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Topic) { if (elem != null) yield return elem; }
         foreach (var elem in Contributor) { if (elem != null) yield return elem; }
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return elem; }
         foreach (var elem in Library) { if (elem != null) yield return elem; }
-        if (Disclaimer != null) yield return Disclaimer;
+        if (DisclaimerElement != null) yield return DisclaimerElement;
         if (Scoring != null) yield return Scoring;
         if (CompositeScoring != null) yield return CompositeScoring;
         foreach (var elem in Type) { if (elem != null) yield return elem; }
         if (RiskAdjustmentElement != null) yield return RiskAdjustmentElement;
         if (RateAggregationElement != null) yield return RateAggregationElement;
-        if (Rationale != null) yield return Rationale;
-        if (ClinicalRecommendationStatement != null) yield return ClinicalRecommendationStatement;
+        if (RationaleElement != null) yield return RationaleElement;
+        if (ClinicalRecommendationStatementElement != null) yield return ClinicalRecommendationStatementElement;
         if (ImprovementNotationElement != null) yield return ImprovementNotationElement;
-        foreach (var elem in Definition) { if (elem != null) yield return elem; }
-        if (Guidance != null) yield return Guidance;
+        foreach (var elem in DefinitionElement) { if (elem != null) yield return elem; }
+        if (GuidanceElement != null) yield return GuidanceElement;
         if (SetElement != null) yield return SetElement;
         foreach (var elem in Group) { if (elem != null) yield return elem; }
         foreach (var elem in SupplementalData) { if (elem != null) yield return elem; }
@@ -1922,8 +2066,8 @@ namespace Hl7.Fhir.Model
         if (ExperimentalElement != null) yield return new ElementValue("experimental", ExperimentalElement);
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
-        if (Description != null) yield return new ElementValue("description", Description);
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
@@ -1933,20 +2077,20 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Topic) { if (elem != null) yield return new ElementValue("topic", elem); }
         foreach (var elem in Contributor) { if (elem != null) yield return new ElementValue("contributor", elem); }
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return new ElementValue("relatedArtifact", elem); }
         foreach (var elem in Library) { if (elem != null) yield return new ElementValue("library", elem); }
-        if (Disclaimer != null) yield return new ElementValue("disclaimer", Disclaimer);
+        if (DisclaimerElement != null) yield return new ElementValue("disclaimer", DisclaimerElement);
         if (Scoring != null) yield return new ElementValue("scoring", Scoring);
         if (CompositeScoring != null) yield return new ElementValue("compositeScoring", CompositeScoring);
         foreach (var elem in Type) { if (elem != null) yield return new ElementValue("type", elem); }
         if (RiskAdjustmentElement != null) yield return new ElementValue("riskAdjustment", RiskAdjustmentElement);
         if (RateAggregationElement != null) yield return new ElementValue("rateAggregation", RateAggregationElement);
-        if (Rationale != null) yield return new ElementValue("rationale", Rationale);
-        if (ClinicalRecommendationStatement != null) yield return new ElementValue("clinicalRecommendationStatement", ClinicalRecommendationStatement);
+        if (RationaleElement != null) yield return new ElementValue("rationale", RationaleElement);
+        if (ClinicalRecommendationStatementElement != null) yield return new ElementValue("clinicalRecommendationStatement", ClinicalRecommendationStatementElement);
         if (ImprovementNotationElement != null) yield return new ElementValue("improvementNotation", ImprovementNotationElement);
-        foreach (var elem in Definition) { if (elem != null) yield return new ElementValue("definition", elem); }
-        if (Guidance != null) yield return new ElementValue("guidance", Guidance);
+        foreach (var elem in DefinitionElement) { if (elem != null) yield return new ElementValue("definition", elem); }
+        if (GuidanceElement != null) yield return new ElementValue("guidance", GuidanceElement);
         if (SetElement != null) yield return new ElementValue("set", SetElement);
         foreach (var elem in Group) { if (elem != null) yield return new ElementValue("group", elem); }
         foreach (var elem in SupplementalData) { if (elem != null) yield return new ElementValue("supplementalData", elem); }
@@ -1985,11 +2129,11 @@ namespace Hl7.Fhir.Model
           value = PublisherElement;
           return PublisherElement is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
@@ -2018,8 +2162,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "relatedArtifact":
           value = RelatedArtifact;
           return RelatedArtifact?.Any() == true;
@@ -2027,8 +2171,8 @@ namespace Hl7.Fhir.Model
           value = Library;
           return Library?.Any() == true;
         case "disclaimer":
-          value = Disclaimer;
-          return Disclaimer is not null;
+          value = DisclaimerElement;
+          return DisclaimerElement is not null;
         case "scoring":
           value = Scoring;
           return Scoring is not null;
@@ -2045,20 +2189,20 @@ namespace Hl7.Fhir.Model
           value = RateAggregationElement;
           return RateAggregationElement is not null;
         case "rationale":
-          value = Rationale;
-          return Rationale is not null;
+          value = RationaleElement;
+          return RationaleElement is not null;
         case "clinicalRecommendationStatement":
-          value = ClinicalRecommendationStatement;
-          return ClinicalRecommendationStatement is not null;
+          value = ClinicalRecommendationStatementElement;
+          return ClinicalRecommendationStatementElement is not null;
         case "improvementNotation":
           value = ImprovementNotationElement;
           return ImprovementNotationElement is not null;
         case "definition":
-          value = Definition;
-          return Definition?.Any() == true;
+          value = DefinitionElement;
+          return DefinitionElement?.Any() == true;
         case "guidance":
-          value = Guidance;
-          return Guidance is not null;
+          value = GuidanceElement;
+          return GuidanceElement is not null;
         case "set":
           value = SetElement;
           return SetElement is not null;
@@ -2086,8 +2230,8 @@ namespace Hl7.Fhir.Model
       if (ExperimentalElement is not null) yield return new KeyValuePair<string,object>("experimental",ExperimentalElement);
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
@@ -2097,20 +2241,20 @@ namespace Hl7.Fhir.Model
       if (Topic?.Any() == true) yield return new KeyValuePair<string,object>("topic",Topic);
       if (Contributor?.Any() == true) yield return new KeyValuePair<string,object>("contributor",Contributor);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (RelatedArtifact?.Any() == true) yield return new KeyValuePair<string,object>("relatedArtifact",RelatedArtifact);
       if (Library?.Any() == true) yield return new KeyValuePair<string,object>("library",Library);
-      if (Disclaimer is not null) yield return new KeyValuePair<string,object>("disclaimer",Disclaimer);
+      if (DisclaimerElement is not null) yield return new KeyValuePair<string,object>("disclaimer",DisclaimerElement);
       if (Scoring is not null) yield return new KeyValuePair<string,object>("scoring",Scoring);
       if (CompositeScoring is not null) yield return new KeyValuePair<string,object>("compositeScoring",CompositeScoring);
       if (Type?.Any() == true) yield return new KeyValuePair<string,object>("type",Type);
       if (RiskAdjustmentElement is not null) yield return new KeyValuePair<string,object>("riskAdjustment",RiskAdjustmentElement);
       if (RateAggregationElement is not null) yield return new KeyValuePair<string,object>("rateAggregation",RateAggregationElement);
-      if (Rationale is not null) yield return new KeyValuePair<string,object>("rationale",Rationale);
-      if (ClinicalRecommendationStatement is not null) yield return new KeyValuePair<string,object>("clinicalRecommendationStatement",ClinicalRecommendationStatement);
+      if (RationaleElement is not null) yield return new KeyValuePair<string,object>("rationale",RationaleElement);
+      if (ClinicalRecommendationStatementElement is not null) yield return new KeyValuePair<string,object>("clinicalRecommendationStatement",ClinicalRecommendationStatementElement);
       if (ImprovementNotationElement is not null) yield return new KeyValuePair<string,object>("improvementNotation",ImprovementNotationElement);
-      if (Definition?.Any() == true) yield return new KeyValuePair<string,object>("definition",Definition);
-      if (Guidance is not null) yield return new KeyValuePair<string,object>("guidance",Guidance);
+      if (DefinitionElement?.Any() == true) yield return new KeyValuePair<string,object>("definition",DefinitionElement);
+      if (GuidanceElement is not null) yield return new KeyValuePair<string,object>("guidance",GuidanceElement);
       if (SetElement is not null) yield return new KeyValuePair<string,object>("set",SetElement);
       if (Group?.Any() == true) yield return new KeyValuePair<string,object>("group",Group);
       if (SupplementalData?.Any() == true) yield return new KeyValuePair<string,object>("supplementalData",SupplementalData);

--- a/src/Hl7.Fhir.STU3/Model/Generated/MessageDefinition.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/MessageDefinition.cs
@@ -322,13 +322,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("situation", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Situation
+      public Hl7.Fhir.Model.Markdown SituationElement
       {
-        get { return _Situation; }
-        set { _Situation = value; OnPropertyChanged("Situation"); }
+        get { return _SituationElement; }
+        set { _SituationElement = value; OnPropertyChanged("SituationElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Situation;
+      private Hl7.Fhir.Model.Markdown _SituationElement;
+
+      /// <summary>
+      /// When should this response be used
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Situation
+      {
+        get { return SituationElement != null ? SituationElement.Value : null; }
+        set
+        {
+          if (value == null)
+            SituationElement = null;
+          else
+            SituationElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Situation");
+        }
+      }
 
       public override IDeepCopyable CopyTo(IDeepCopyable other)
       {
@@ -341,7 +359,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(Message != null) dest.Message = (Hl7.Fhir.Model.ResourceReference)Message.DeepCopy();
-        if(Situation != null) dest.Situation = (Hl7.Fhir.Model.Markdown)Situation.DeepCopy();
+        if(SituationElement != null) dest.SituationElement = (Hl7.Fhir.Model.Markdown)SituationElement.DeepCopy();
         return dest;
       }
 
@@ -358,7 +376,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(Message, otherT.Message)) return false;
-        if( !DeepComparable.Matches(Situation, otherT.Situation)) return false;
+        if( !DeepComparable.Matches(SituationElement, otherT.SituationElement)) return false;
 
         return true;
       }
@@ -370,7 +388,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(Message, otherT.Message)) return false;
-        if( !DeepComparable.IsExactly(Situation, otherT.Situation)) return false;
+        if( !DeepComparable.IsExactly(SituationElement, otherT.SituationElement)) return false;
 
         return true;
       }
@@ -382,7 +400,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (Message != null) yield return Message;
-          if (Situation != null) yield return Situation;
+          if (SituationElement != null) yield return SituationElement;
         }
       }
 
@@ -393,7 +411,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (Message != null) yield return new ElementValue("message", Message);
-          if (Situation != null) yield return new ElementValue("situation", Situation);
+          if (SituationElement != null) yield return new ElementValue("situation", SituationElement);
         }
       }
 
@@ -405,8 +423,8 @@ namespace Hl7.Fhir.Model
             value = Message;
             return Message is not null;
           case "situation":
-            value = Situation;
-            return Situation is not null;
+            value = SituationElement;
+            return SituationElement is not null;
           default:
             return base.TryGetValue(key, out value);
         }
@@ -417,7 +435,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (Message is not null) yield return new KeyValuePair<string,object>("message",Message);
-        if (Situation is not null) yield return new KeyValuePair<string,object>("situation",Situation);
+        if (SituationElement is not null) yield return new KeyValuePair<string,object>("situation",SituationElement);
       }
 
     }
@@ -705,13 +723,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the message definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Context the content is intended to support
@@ -746,26 +782,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", InSummary=true, Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this message definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Definition this one is based on
@@ -939,11 +1011,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(Base != null) dest.Base = (Hl7.Fhir.Model.ResourceReference)Base.DeepCopy();
       if(Parent != null) dest.Parent = new List<Hl7.Fhir.Model.ResourceReference>(Parent.DeepCopy());
       if(Replaces != null) dest.Replaces = new List<Hl7.Fhir.Model.ResourceReference>(Replaces.DeepCopy());
@@ -977,11 +1049,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(Base, otherT.Base)) return false;
       if( !DeepComparable.Matches(Parent, otherT.Parent)) return false;
       if( !DeepComparable.Matches(Replaces, otherT.Replaces)) return false;
@@ -1010,11 +1082,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(Base, otherT.Base)) return false;
       if( !DeepComparable.IsExactly(Parent, otherT.Parent)) return false;
       if( !DeepComparable.IsExactly(Replaces, otherT.Replaces)) return false;
@@ -1043,11 +1115,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (Base != null) yield return Base;
         foreach (var elem in Parent) { if (elem != null) yield return elem; }
         foreach (var elem in Replaces) { if (elem != null) yield return elem; }
@@ -1075,11 +1147,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (Base != null) yield return new ElementValue("base", Base);
         foreach (var elem in Parent) { if (elem != null) yield return new ElementValue("parent", elem); }
         foreach (var elem in Replaces) { if (elem != null) yield return new ElementValue("replaces", elem); }
@@ -1126,8 +1198,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1135,11 +1207,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "base":
           value = Base;
           return Base is not null;
@@ -1183,11 +1255,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (Base is not null) yield return new KeyValuePair<string,object>("base",Base);
       if (Parent?.Any() == true) yield return new KeyValuePair<string,object>("parent",Parent);
       if (Replaces?.Any() == true) yield return new KeyValuePair<string,object>("replaces",Replaces);

--- a/src/Hl7.Fhir.STU3/Model/Generated/NamingSystem.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/NamingSystem.cs
@@ -613,13 +613,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=170)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the naming system
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Context the content is intended to support
@@ -727,7 +745,7 @@ namespace Hl7.Fhir.Model
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
       if(ResponsibleElement != null) dest.ResponsibleElement = (Hl7.Fhir.Model.FhirString)ResponsibleElement.DeepCopy();
       if(Type != null) dest.Type = (Hl7.Fhir.Model.CodeableConcept)Type.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
@@ -756,7 +774,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
       if( !DeepComparable.Matches(ResponsibleElement, otherT.ResponsibleElement)) return false;
       if( !DeepComparable.Matches(Type, otherT.Type)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
@@ -780,7 +798,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
       if( !DeepComparable.IsExactly(ResponsibleElement, otherT.ResponsibleElement)) return false;
       if( !DeepComparable.IsExactly(Type, otherT.Type)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
@@ -804,7 +822,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
         if (ResponsibleElement != null) yield return ResponsibleElement;
         if (Type != null) yield return Type;
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
         if (UsageElement != null) yield return UsageElement;
@@ -827,7 +845,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
         if (ResponsibleElement != null) yield return new ElementValue("responsible", ResponsibleElement);
         if (Type != null) yield return new ElementValue("type", Type);
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
@@ -865,8 +883,8 @@ namespace Hl7.Fhir.Model
           value = Type;
           return Type is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -899,7 +917,7 @@ namespace Hl7.Fhir.Model
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
       if (ResponsibleElement is not null) yield return new KeyValuePair<string,object>("responsible",ResponsibleElement);
       if (Type is not null) yield return new KeyValuePair<string,object>("type",Type);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);

--- a/src/Hl7.Fhir.STU3/Model/Generated/OperationDefinition.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/OperationDefinition.cs
@@ -1115,13 +1115,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the operation definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Context the content is intended to support
@@ -1156,13 +1174,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=210)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this operation definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Whether content is unchanged by the operation
@@ -1449,10 +1485,10 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(IdempotentElement != null) dest.IdempotentElement = (Hl7.Fhir.Model.FhirBoolean)IdempotentElement.DeepCopy();
       if(CodeElement != null) dest.CodeElement = (Hl7.Fhir.Model.Code)CodeElement.DeepCopy();
       if(CommentElement != null) dest.CommentElement = (Hl7.Fhir.Model.FhirString)CommentElement.DeepCopy();
@@ -1487,10 +1523,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(IdempotentElement, otherT.IdempotentElement)) return false;
       if( !DeepComparable.Matches(CodeElement, otherT.CodeElement)) return false;
       if( !DeepComparable.Matches(CommentElement, otherT.CommentElement)) return false;
@@ -1520,10 +1556,10 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(IdempotentElement, otherT.IdempotentElement)) return false;
       if( !DeepComparable.IsExactly(CodeElement, otherT.CodeElement)) return false;
       if( !DeepComparable.IsExactly(CommentElement, otherT.CommentElement)) return false;
@@ -1553,10 +1589,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (IdempotentElement != null) yield return IdempotentElement;
         if (CodeElement != null) yield return CodeElement;
         if (CommentElement != null) yield return CommentElement;
@@ -1585,10 +1621,10 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (IdempotentElement != null) yield return new ElementValue("idempotent", IdempotentElement);
         if (CodeElement != null) yield return new ElementValue("code", CodeElement);
         if (CommentElement != null) yield return new ElementValue("comment", CommentElement);
@@ -1634,8 +1670,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1643,8 +1679,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "idempotent":
           value = IdempotentElement;
           return IdempotentElement is not null;
@@ -1693,10 +1729,10 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (IdempotentElement is not null) yield return new KeyValuePair<string,object>("idempotent",IdempotentElement);
       if (CodeElement is not null) yield return new KeyValuePair<string,object>("code",CodeElement);
       if (CommentElement is not null) yield return new KeyValuePair<string,object>("comment",CommentElement);

--- a/src/Hl7.Fhir.STU3/Model/Generated/PlanDefinition.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/PlanDefinition.cs
@@ -2418,26 +2418,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", InSummary=true, Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the plan definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Why this plan definition is defined
     /// </summary>
     [FhirElement("purpose", Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this plan definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the asset
@@ -2620,13 +2656,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=300)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Related artifacts for the asset
@@ -2706,8 +2760,8 @@ namespace Hl7.Fhir.Model
       if(ExperimentalElement != null) dest.ExperimentalElement = (Hl7.Fhir.Model.FhirBoolean)ExperimentalElement.DeepCopy();
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
@@ -2717,7 +2771,7 @@ namespace Hl7.Fhir.Model
       if(Topic != null) dest.Topic = new List<Hl7.Fhir.Model.CodeableConcept>(Topic.DeepCopy());
       if(Contributor != null) dest.Contributor = new List<Hl7.Fhir.Model.Contributor>(Contributor.DeepCopy());
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
       if(Library != null) dest.Library = new List<Hl7.Fhir.Model.ResourceReference>(Library.DeepCopy());
       if(Goal != null) dest.Goal = new List<Hl7.Fhir.Model.PlanDefinition.GoalComponent>(Goal.DeepCopy());
@@ -2747,8 +2801,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(ExperimentalElement, otherT.ExperimentalElement)) return false;
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
@@ -2758,7 +2812,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Topic, otherT.Topic)) return false;
       if( !DeepComparable.Matches(Contributor, otherT.Contributor)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.Matches(Library, otherT.Library)) return false;
       if( !DeepComparable.Matches(Goal, otherT.Goal)) return false;
@@ -2783,8 +2837,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(ExperimentalElement, otherT.ExperimentalElement)) return false;
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
@@ -2794,7 +2848,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Topic, otherT.Topic)) return false;
       if( !DeepComparable.IsExactly(Contributor, otherT.Contributor)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.IsExactly(Library, otherT.Library)) return false;
       if( !DeepComparable.IsExactly(Goal, otherT.Goal)) return false;
@@ -2819,8 +2873,8 @@ namespace Hl7.Fhir.Model
         if (ExperimentalElement != null) yield return ExperimentalElement;
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
-        if (Description != null) yield return Description;
-        if (Purpose != null) yield return Purpose;
+        if (DescriptionElement != null) yield return DescriptionElement;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
@@ -2830,7 +2884,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Topic) { if (elem != null) yield return elem; }
         foreach (var elem in Contributor) { if (elem != null) yield return elem; }
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return elem; }
         foreach (var elem in Library) { if (elem != null) yield return elem; }
         foreach (var elem in Goal) { if (elem != null) yield return elem; }
@@ -2854,8 +2908,8 @@ namespace Hl7.Fhir.Model
         if (ExperimentalElement != null) yield return new ElementValue("experimental", ExperimentalElement);
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
-        if (Description != null) yield return new ElementValue("description", Description);
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
@@ -2865,7 +2919,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Topic) { if (elem != null) yield return new ElementValue("topic", elem); }
         foreach (var elem in Contributor) { if (elem != null) yield return new ElementValue("contributor", elem); }
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return new ElementValue("relatedArtifact", elem); }
         foreach (var elem in Library) { if (elem != null) yield return new ElementValue("library", elem); }
         foreach (var elem in Goal) { if (elem != null) yield return new ElementValue("goal", elem); }
@@ -2908,11 +2962,11 @@ namespace Hl7.Fhir.Model
           value = PublisherElement;
           return PublisherElement is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
@@ -2941,8 +2995,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "relatedArtifact":
           value = RelatedArtifact;
           return RelatedArtifact?.Any() == true;
@@ -2974,8 +3028,8 @@ namespace Hl7.Fhir.Model
       if (ExperimentalElement is not null) yield return new KeyValuePair<string,object>("experimental",ExperimentalElement);
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
@@ -2985,7 +3039,7 @@ namespace Hl7.Fhir.Model
       if (Topic?.Any() == true) yield return new KeyValuePair<string,object>("topic",Topic);
       if (Contributor?.Any() == true) yield return new KeyValuePair<string,object>("contributor",Contributor);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (RelatedArtifact?.Any() == true) yield return new KeyValuePair<string,object>("relatedArtifact",RelatedArtifact);
       if (Library?.Any() == true) yield return new KeyValuePair<string,object>("library",Library);
       if (Goal?.Any() == true) yield return new KeyValuePair<string,object>("goal",Goal);

--- a/src/Hl7.Fhir.STU3/Model/Generated/Questionnaire.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/Questionnaire.cs
@@ -1334,26 +1334,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the questionnaire
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Why this questionnaire is defined
     /// </summary>
     [FhirElement("purpose", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this questionnaire is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// When the questionnaire was approved by publisher
@@ -1477,13 +1513,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=260)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Concept that represents the overall questionnaire
@@ -1565,15 +1619,15 @@ namespace Hl7.Fhir.Model
       if(ExperimentalElement != null) dest.ExperimentalElement = (Hl7.Fhir.Model.FhirBoolean)ExperimentalElement.DeepCopy();
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
       if(EffectivePeriod != null) dest.EffectivePeriod = (Hl7.Fhir.Model.Period)EffectivePeriod.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(Code != null) dest.Code = new List<Hl7.Fhir.Model.Coding>(Code.DeepCopy());
       if(SubjectTypeElement != null) dest.SubjectTypeElement = new List<Code<Hl7.Fhir.Model.ResourceType>>(SubjectTypeElement.DeepCopy());
       if(Item != null) dest.Item = new List<Hl7.Fhir.Model.Questionnaire.ItemComponent>(Item.DeepCopy());
@@ -1601,15 +1655,15 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(ExperimentalElement, otherT.ExperimentalElement)) return false;
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.Matches(EffectivePeriod, otherT.EffectivePeriod)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(Code, otherT.Code)) return false;
       if( !DeepComparable.Matches(SubjectTypeElement, otherT.SubjectTypeElement)) return false;
       if( !DeepComparable.Matches(Item, otherT.Item)) return false;
@@ -1632,15 +1686,15 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(ExperimentalElement, otherT.ExperimentalElement)) return false;
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
       if( !DeepComparable.IsExactly(EffectivePeriod, otherT.EffectivePeriod)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(Code, otherT.Code)) return false;
       if( !DeepComparable.IsExactly(SubjectTypeElement, otherT.SubjectTypeElement)) return false;
       if( !DeepComparable.IsExactly(Item, otherT.Item)) return false;
@@ -1663,15 +1717,15 @@ namespace Hl7.Fhir.Model
         if (ExperimentalElement != null) yield return ExperimentalElement;
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
-        if (Description != null) yield return Description;
-        if (Purpose != null) yield return Purpose;
+        if (DescriptionElement != null) yield return DescriptionElement;
+        if (PurposeElement != null) yield return PurposeElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
         if (EffectivePeriod != null) yield return EffectivePeriod;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         foreach (var elem in Code) { if (elem != null) yield return elem; }
         foreach (var elem in SubjectTypeElement) { if (elem != null) yield return elem; }
         foreach (var elem in Item) { if (elem != null) yield return elem; }
@@ -1693,15 +1747,15 @@ namespace Hl7.Fhir.Model
         if (ExperimentalElement != null) yield return new ElementValue("experimental", ExperimentalElement);
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
-        if (Description != null) yield return new ElementValue("description", Description);
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
         if (EffectivePeriod != null) yield return new ElementValue("effectivePeriod", EffectivePeriod);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         foreach (var elem in Code) { if (elem != null) yield return new ElementValue("code", elem); }
         foreach (var elem in SubjectTypeElement) { if (elem != null) yield return new ElementValue("subjectType", elem); }
         foreach (var elem in Item) { if (elem != null) yield return new ElementValue("item", elem); }
@@ -1740,11 +1794,11 @@ namespace Hl7.Fhir.Model
           value = PublisherElement;
           return PublisherElement is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "approvalDate":
           value = ApprovalDateElement;
           return ApprovalDateElement is not null;
@@ -1764,8 +1818,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "code":
           value = Code;
           return Code?.Any() == true;
@@ -1793,15 +1847,15 @@ namespace Hl7.Fhir.Model
       if (ExperimentalElement is not null) yield return new KeyValuePair<string,object>("experimental",ExperimentalElement);
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
       if (EffectivePeriod is not null) yield return new KeyValuePair<string,object>("effectivePeriod",EffectivePeriod);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (Code?.Any() == true) yield return new KeyValuePair<string,object>("code",Code);
       if (SubjectTypeElement?.Any() == true) yield return new KeyValuePair<string,object>("subjectType",SubjectTypeElement);
       if (Item?.Any() == true) yield return new KeyValuePair<string,object>("item",Item);

--- a/src/Hl7.Fhir.STU3/Model/Generated/ResearchStudy.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/ResearchStudy.cs
@@ -490,13 +490,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=200)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// What this is study doing
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Inclusion &amp; exclusion criteria
@@ -635,7 +653,7 @@ namespace Hl7.Fhir.Model
       if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
       if(Keyword != null) dest.Keyword = new List<Hl7.Fhir.Model.CodeableConcept>(Keyword.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(Enrollment != null) dest.Enrollment = new List<Hl7.Fhir.Model.ResourceReference>(Enrollment.DeepCopy());
       if(Period != null) dest.Period = (Hl7.Fhir.Model.Period)Period.DeepCopy();
       if(Sponsor != null) dest.Sponsor = (Hl7.Fhir.Model.ResourceReference)Sponsor.DeepCopy();
@@ -670,7 +688,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.Matches(Keyword, otherT.Keyword)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(Enrollment, otherT.Enrollment)) return false;
       if( !DeepComparable.Matches(Period, otherT.Period)) return false;
       if( !DeepComparable.Matches(Sponsor, otherT.Sponsor)) return false;
@@ -700,7 +718,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.IsExactly(Keyword, otherT.Keyword)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(Enrollment, otherT.Enrollment)) return false;
       if( !DeepComparable.IsExactly(Period, otherT.Period)) return false;
       if( !DeepComparable.IsExactly(Sponsor, otherT.Sponsor)) return false;
@@ -730,7 +748,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return elem; }
         foreach (var elem in Keyword) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in Enrollment) { if (elem != null) yield return elem; }
         if (Period != null) yield return Period;
         if (Sponsor != null) yield return Sponsor;
@@ -759,7 +777,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return new ElementValue("relatedArtifact", elem); }
         foreach (var elem in Keyword) { if (elem != null) yield return new ElementValue("keyword", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in Enrollment) { if (elem != null) yield return new ElementValue("enrollment", elem); }
         if (Period != null) yield return new ElementValue("period", Period);
         if (Sponsor != null) yield return new ElementValue("sponsor", Sponsor);
@@ -809,8 +827,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "enrollment":
           value = Enrollment;
           return Enrollment?.Any() == true;
@@ -855,7 +873,7 @@ namespace Hl7.Fhir.Model
       if (RelatedArtifact?.Any() == true) yield return new KeyValuePair<string,object>("relatedArtifact",RelatedArtifact);
       if (Keyword?.Any() == true) yield return new KeyValuePair<string,object>("keyword",Keyword);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (Enrollment?.Any() == true) yield return new KeyValuePair<string,object>("enrollment",Enrollment);
       if (Period is not null) yield return new KeyValuePair<string,object>("period",Period);
       if (Sponsor is not null) yield return new KeyValuePair<string,object>("sponsor",Sponsor);

--- a/src/Hl7.Fhir.STU3/Model/Generated/SearchParameter.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/SearchParameter.cs
@@ -650,13 +650,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this search parameter is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Code used in URL
@@ -793,13 +811,31 @@ namespace Hl7.Fhir.Model
     [FhirElement("description", InSummary=true, Order=240)]
     [Cardinality(Min=1,Max=1)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the search parameter
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// FHIRPath expression that extracts the values
@@ -1060,12 +1096,12 @@ namespace Hl7.Fhir.Model
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(CodeElement != null) dest.CodeElement = (Hl7.Fhir.Model.Code)CodeElement.DeepCopy();
       if(BaseElement != null) dest.BaseElement = new List<Code<Hl7.Fhir.Model.ResourceType>>(BaseElement.DeepCopy());
       if(TypeElement != null) dest.TypeElement = (Code<Hl7.Fhir.Model.SearchParamType>)TypeElement.DeepCopy();
       if(DerivedFromElement != null) dest.DerivedFromElement = (Hl7.Fhir.Model.FhirUri)DerivedFromElement.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(ExpressionElement != null) dest.ExpressionElement = (Hl7.Fhir.Model.FhirString)ExpressionElement.DeepCopy();
       if(XpathElement != null) dest.XpathElement = (Hl7.Fhir.Model.FhirString)XpathElement.DeepCopy();
       if(XpathUsageElement != null) dest.XpathUsageElement = (Code<Hl7.Fhir.Model.SearchParameter.XPathUsageType>)XpathUsageElement.DeepCopy();
@@ -1099,12 +1135,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(CodeElement, otherT.CodeElement)) return false;
       if( !DeepComparable.Matches(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.Matches(TypeElement, otherT.TypeElement)) return false;
       if( !DeepComparable.Matches(DerivedFromElement, otherT.DerivedFromElement)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(ExpressionElement, otherT.ExpressionElement)) return false;
       if( !DeepComparable.Matches(XpathElement, otherT.XpathElement)) return false;
       if( !DeepComparable.Matches(XpathUsageElement, otherT.XpathUsageElement)) return false;
@@ -1133,12 +1169,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(CodeElement, otherT.CodeElement)) return false;
       if( !DeepComparable.IsExactly(BaseElement, otherT.BaseElement)) return false;
       if( !DeepComparable.IsExactly(TypeElement, otherT.TypeElement)) return false;
       if( !DeepComparable.IsExactly(DerivedFromElement, otherT.DerivedFromElement)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(ExpressionElement, otherT.ExpressionElement)) return false;
       if( !DeepComparable.IsExactly(XpathElement, otherT.XpathElement)) return false;
       if( !DeepComparable.IsExactly(XpathUsageElement, otherT.XpathUsageElement)) return false;
@@ -1167,12 +1203,12 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
+        if (PurposeElement != null) yield return PurposeElement;
         if (CodeElement != null) yield return CodeElement;
         foreach (var elem in BaseElement) { if (elem != null) yield return elem; }
         if (TypeElement != null) yield return TypeElement;
         if (DerivedFromElement != null) yield return DerivedFromElement;
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         if (ExpressionElement != null) yield return ExpressionElement;
         if (XpathElement != null) yield return XpathElement;
         if (XpathUsageElement != null) yield return XpathUsageElement;
@@ -1200,12 +1236,12 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (CodeElement != null) yield return new ElementValue("code", CodeElement);
         foreach (var elem in BaseElement) { if (elem != null) yield return new ElementValue("base", elem); }
         if (TypeElement != null) yield return new ElementValue("type", TypeElement);
         if (DerivedFromElement != null) yield return new ElementValue("derivedFrom", DerivedFromElement);
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         if (ExpressionElement != null) yield return new ElementValue("expression", ExpressionElement);
         if (XpathElement != null) yield return new ElementValue("xpath", XpathElement);
         if (XpathUsageElement != null) yield return new ElementValue("xpathUsage", XpathUsageElement);
@@ -1252,8 +1288,8 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "code":
           value = CodeElement;
           return CodeElement is not null;
@@ -1267,8 +1303,8 @@ namespace Hl7.Fhir.Model
           value = DerivedFromElement;
           return DerivedFromElement is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "expression":
           value = ExpressionElement;
           return ExpressionElement is not null;
@@ -1312,12 +1348,12 @@ namespace Hl7.Fhir.Model
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (CodeElement is not null) yield return new KeyValuePair<string,object>("code",CodeElement);
       if (BaseElement?.Any() == true) yield return new KeyValuePair<string,object>("base",BaseElement);
       if (TypeElement is not null) yield return new KeyValuePair<string,object>("type",TypeElement);
       if (DerivedFromElement is not null) yield return new KeyValuePair<string,object>("derivedFrom",DerivedFromElement);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (ExpressionElement is not null) yield return new KeyValuePair<string,object>("expression",ExpressionElement);
       if (XpathElement is not null) yield return new KeyValuePair<string,object>("xpath",XpathElement);
       if (XpathUsageElement is not null) yield return new KeyValuePair<string,object>("xpathUsage",XpathUsageElement);

--- a/src/Hl7.Fhir.STU3/Model/Generated/ServiceDefinition.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/ServiceDefinition.cs
@@ -324,26 +324,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=180)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the service definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Why this service definition is defined
     /// </summary>
     [FhirElement("purpose", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this service definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Describes the clinical usage of the module
@@ -526,13 +562,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("copyright", Order=290)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Additional documentation, citations, etc
@@ -610,8 +664,8 @@ namespace Hl7.Fhir.Model
       if(ExperimentalElement != null) dest.ExperimentalElement = (Hl7.Fhir.Model.FhirBoolean)ExperimentalElement.DeepCopy();
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
       if(UsageElement != null) dest.UsageElement = (Hl7.Fhir.Model.FhirString)UsageElement.DeepCopy();
       if(ApprovalDateElement != null) dest.ApprovalDateElement = (Hl7.Fhir.Model.Date)ApprovalDateElement.DeepCopy();
       if(LastReviewDateElement != null) dest.LastReviewDateElement = (Hl7.Fhir.Model.Date)LastReviewDateElement.DeepCopy();
@@ -621,7 +675,7 @@ namespace Hl7.Fhir.Model
       if(Topic != null) dest.Topic = new List<Hl7.Fhir.Model.CodeableConcept>(Topic.DeepCopy());
       if(Contributor != null) dest.Contributor = new List<Hl7.Fhir.Model.Contributor>(Contributor.DeepCopy());
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(RelatedArtifact != null) dest.RelatedArtifact = new List<Hl7.Fhir.Model.RelatedArtifact>(RelatedArtifact.DeepCopy());
       if(Trigger != null) dest.Trigger = new List<Hl7.Fhir.Model.TriggerDefinition>(Trigger.DeepCopy());
       if(DataRequirement != null) dest.DataRequirement = new List<Hl7.Fhir.Model.DataRequirement>(DataRequirement.DeepCopy());
@@ -650,8 +704,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(ExperimentalElement, otherT.ExperimentalElement)) return false;
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.Matches(UsageElement, otherT.UsageElement)) return false;
       if( !DeepComparable.Matches(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.Matches(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
@@ -661,7 +715,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(Topic, otherT.Topic)) return false;
       if( !DeepComparable.Matches(Contributor, otherT.Contributor)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.Matches(Trigger, otherT.Trigger)) return false;
       if( !DeepComparable.Matches(DataRequirement, otherT.DataRequirement)) return false;
@@ -685,8 +739,8 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(ExperimentalElement, otherT.ExperimentalElement)) return false;
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
       if( !DeepComparable.IsExactly(UsageElement, otherT.UsageElement)) return false;
       if( !DeepComparable.IsExactly(ApprovalDateElement, otherT.ApprovalDateElement)) return false;
       if( !DeepComparable.IsExactly(LastReviewDateElement, otherT.LastReviewDateElement)) return false;
@@ -696,7 +750,7 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(Topic, otherT.Topic)) return false;
       if( !DeepComparable.IsExactly(Contributor, otherT.Contributor)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(RelatedArtifact, otherT.RelatedArtifact)) return false;
       if( !DeepComparable.IsExactly(Trigger, otherT.Trigger)) return false;
       if( !DeepComparable.IsExactly(DataRequirement, otherT.DataRequirement)) return false;
@@ -720,8 +774,8 @@ namespace Hl7.Fhir.Model
         if (ExperimentalElement != null) yield return ExperimentalElement;
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
-        if (Description != null) yield return Description;
-        if (Purpose != null) yield return Purpose;
+        if (DescriptionElement != null) yield return DescriptionElement;
+        if (PurposeElement != null) yield return PurposeElement;
         if (UsageElement != null) yield return UsageElement;
         if (ApprovalDateElement != null) yield return ApprovalDateElement;
         if (LastReviewDateElement != null) yield return LastReviewDateElement;
@@ -731,7 +785,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Topic) { if (elem != null) yield return elem; }
         foreach (var elem in Contributor) { if (elem != null) yield return elem; }
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Copyright != null) yield return Copyright;
+        if (CopyrightElement != null) yield return CopyrightElement;
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return elem; }
         foreach (var elem in Trigger) { if (elem != null) yield return elem; }
         foreach (var elem in DataRequirement) { if (elem != null) yield return elem; }
@@ -754,8 +808,8 @@ namespace Hl7.Fhir.Model
         if (ExperimentalElement != null) yield return new ElementValue("experimental", ExperimentalElement);
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
-        if (Description != null) yield return new ElementValue("description", Description);
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
         if (UsageElement != null) yield return new ElementValue("usage", UsageElement);
         if (ApprovalDateElement != null) yield return new ElementValue("approvalDate", ApprovalDateElement);
         if (LastReviewDateElement != null) yield return new ElementValue("lastReviewDate", LastReviewDateElement);
@@ -765,7 +819,7 @@ namespace Hl7.Fhir.Model
         foreach (var elem in Topic) { if (elem != null) yield return new ElementValue("topic", elem); }
         foreach (var elem in Contributor) { if (elem != null) yield return new ElementValue("contributor", elem); }
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         foreach (var elem in RelatedArtifact) { if (elem != null) yield return new ElementValue("relatedArtifact", elem); }
         foreach (var elem in Trigger) { if (elem != null) yield return new ElementValue("trigger", elem); }
         foreach (var elem in DataRequirement) { if (elem != null) yield return new ElementValue("dataRequirement", elem); }
@@ -805,11 +859,11 @@ namespace Hl7.Fhir.Model
           value = PublisherElement;
           return PublisherElement is not null;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "usage":
           value = UsageElement;
           return UsageElement is not null;
@@ -838,8 +892,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "relatedArtifact":
           value = RelatedArtifact;
           return RelatedArtifact?.Any() == true;
@@ -870,8 +924,8 @@ namespace Hl7.Fhir.Model
       if (ExperimentalElement is not null) yield return new KeyValuePair<string,object>("experimental",ExperimentalElement);
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
       if (UsageElement is not null) yield return new KeyValuePair<string,object>("usage",UsageElement);
       if (ApprovalDateElement is not null) yield return new KeyValuePair<string,object>("approvalDate",ApprovalDateElement);
       if (LastReviewDateElement is not null) yield return new KeyValuePair<string,object>("lastReviewDate",LastReviewDateElement);
@@ -881,7 +935,7 @@ namespace Hl7.Fhir.Model
       if (Topic?.Any() == true) yield return new KeyValuePair<string,object>("topic",Topic);
       if (Contributor?.Any() == true) yield return new KeyValuePair<string,object>("contributor",Contributor);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (RelatedArtifact?.Any() == true) yield return new KeyValuePair<string,object>("relatedArtifact",RelatedArtifact);
       if (Trigger?.Any() == true) yield return new KeyValuePair<string,object>("trigger",Trigger);
       if (DataRequirement?.Any() == true) yield return new KeyValuePair<string,object>("dataRequirement",DataRequirement);

--- a/src/Hl7.Fhir.STU3/Model/Generated/StructureDefinition.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/StructureDefinition.cs
@@ -892,13 +892,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the structure definition
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Context the content is intended to support
@@ -933,26 +951,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this structure definition is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Assist with indexing and finding
@@ -1315,11 +1369,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(Keyword != null) dest.Keyword = new List<Hl7.Fhir.Model.Coding>(Keyword.DeepCopy());
       if(FhirVersionElement != null) dest.FhirVersionElement = (Hl7.Fhir.Model.Id)FhirVersionElement.DeepCopy();
       if(Mapping != null) dest.Mapping = new List<Hl7.Fhir.Model.StructureDefinition.MappingComponent>(Mapping.DeepCopy());
@@ -1358,11 +1412,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(Keyword, otherT.Keyword)) return false;
       if( !DeepComparable.Matches(FhirVersionElement, otherT.FhirVersionElement)) return false;
       if( !DeepComparable.Matches(Mapping, otherT.Mapping)) return false;
@@ -1396,11 +1450,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(Keyword, otherT.Keyword)) return false;
       if( !DeepComparable.IsExactly(FhirVersionElement, otherT.FhirVersionElement)) return false;
       if( !DeepComparable.IsExactly(Mapping, otherT.Mapping)) return false;
@@ -1434,11 +1488,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         foreach (var elem in Keyword) { if (elem != null) yield return elem; }
         if (FhirVersionElement != null) yield return FhirVersionElement;
         foreach (var elem in Mapping) { if (elem != null) yield return elem; }
@@ -1471,11 +1525,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         foreach (var elem in Keyword) { if (elem != null) yield return new ElementValue("keyword", elem); }
         if (FhirVersionElement != null) yield return new ElementValue("fhirVersion", FhirVersionElement);
         foreach (var elem in Mapping) { if (elem != null) yield return new ElementValue("mapping", elem); }
@@ -1527,8 +1581,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -1536,11 +1590,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "keyword":
           value = Keyword;
           return Keyword?.Any() == true;
@@ -1599,11 +1653,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (Keyword?.Any() == true) yield return new KeyValuePair<string,object>("keyword",Keyword);
       if (FhirVersionElement is not null) yield return new KeyValuePair<string,object>("fhirVersion",FhirVersionElement);
       if (Mapping?.Any() == true) yield return new KeyValuePair<string,object>("mapping",Mapping);

--- a/src/Hl7.Fhir.STU3/Model/Generated/StructureMap.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/StructureMap.cs
@@ -2836,13 +2836,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the structure map
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Context the content is intended to support
@@ -2877,26 +2895,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this structure map is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Structure Definition used by this map
@@ -2978,11 +3032,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(Structure != null) dest.Structure = new List<Hl7.Fhir.Model.StructureMap.StructureComponent>(Structure.DeepCopy());
       if(ImportElement != null) dest.ImportElement = new List<Hl7.Fhir.Model.FhirUri>(ImportElement.DeepCopy());
       if(Group != null) dest.Group = new List<Hl7.Fhir.Model.StructureMap.GroupComponent>(Group.DeepCopy());
@@ -3011,11 +3065,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(Structure, otherT.Structure)) return false;
       if( !DeepComparable.Matches(ImportElement, otherT.ImportElement)) return false;
       if( !DeepComparable.Matches(Group, otherT.Group)) return false;
@@ -3039,11 +3093,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(Structure, otherT.Structure)) return false;
       if( !DeepComparable.IsExactly(ImportElement, otherT.ImportElement)) return false;
       if( !DeepComparable.IsExactly(Group, otherT.Group)) return false;
@@ -3067,11 +3121,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         foreach (var elem in Structure) { if (elem != null) yield return elem; }
         foreach (var elem in ImportElement) { if (elem != null) yield return elem; }
         foreach (var elem in Group) { if (elem != null) yield return elem; }
@@ -3094,11 +3148,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         foreach (var elem in Structure) { if (elem != null) yield return new ElementValue("structure", elem); }
         foreach (var elem in ImportElement) { if (elem != null) yield return new ElementValue("import", elem); }
         foreach (var elem in Group) { if (elem != null) yield return new ElementValue("group", elem); }
@@ -3140,8 +3194,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -3149,11 +3203,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "structure":
           value = Structure;
           return Structure?.Any() == true;
@@ -3182,11 +3236,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (Structure?.Any() == true) yield return new KeyValuePair<string,object>("structure",Structure);
       if (ImportElement?.Any() == true) yield return new KeyValuePair<string,object>("import",ImportElement);
       if (Group?.Any() == true) yield return new KeyValuePair<string,object>("group",Group);

--- a/src/Hl7.Fhir.STU3/Model/Generated/TestReport.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/TestReport.cs
@@ -693,13 +693,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("message", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Message
+      public Hl7.Fhir.Model.Markdown MessageElement
       {
-        get { return _Message; }
-        set { _Message = value; OnPropertyChanged("Message"); }
+        get { return _MessageElement; }
+        set { _MessageElement = value; OnPropertyChanged("MessageElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Message;
+      private Hl7.Fhir.Model.Markdown _MessageElement;
+
+      /// <summary>
+      /// A message associated with the result
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Message
+      {
+        get { return MessageElement != null ? MessageElement.Value : null; }
+        set
+        {
+          if (value == null)
+            MessageElement = null;
+          else
+            MessageElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Message");
+        }
+      }
 
       /// <summary>
       /// A link to further details on the result
@@ -743,7 +761,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(ResultElement != null) dest.ResultElement = (Code<Hl7.Fhir.Model.TestReport.TestReportActionResult>)ResultElement.DeepCopy();
-        if(Message != null) dest.Message = (Hl7.Fhir.Model.Markdown)Message.DeepCopy();
+        if(MessageElement != null) dest.MessageElement = (Hl7.Fhir.Model.Markdown)MessageElement.DeepCopy();
         if(DetailElement != null) dest.DetailElement = (Hl7.Fhir.Model.FhirUri)DetailElement.DeepCopy();
         return dest;
       }
@@ -761,7 +779,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(ResultElement, otherT.ResultElement)) return false;
-        if( !DeepComparable.Matches(Message, otherT.Message)) return false;
+        if( !DeepComparable.Matches(MessageElement, otherT.MessageElement)) return false;
         if( !DeepComparable.Matches(DetailElement, otherT.DetailElement)) return false;
 
         return true;
@@ -774,7 +792,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(ResultElement, otherT.ResultElement)) return false;
-        if( !DeepComparable.IsExactly(Message, otherT.Message)) return false;
+        if( !DeepComparable.IsExactly(MessageElement, otherT.MessageElement)) return false;
         if( !DeepComparable.IsExactly(DetailElement, otherT.DetailElement)) return false;
 
         return true;
@@ -787,7 +805,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (ResultElement != null) yield return ResultElement;
-          if (Message != null) yield return Message;
+          if (MessageElement != null) yield return MessageElement;
           if (DetailElement != null) yield return DetailElement;
         }
       }
@@ -799,7 +817,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (ResultElement != null) yield return new ElementValue("result", ResultElement);
-          if (Message != null) yield return new ElementValue("message", Message);
+          if (MessageElement != null) yield return new ElementValue("message", MessageElement);
           if (DetailElement != null) yield return new ElementValue("detail", DetailElement);
         }
       }
@@ -812,8 +830,8 @@ namespace Hl7.Fhir.Model
             value = ResultElement;
             return ResultElement is not null;
           case "message":
-            value = Message;
-            return Message is not null;
+            value = MessageElement;
+            return MessageElement is not null;
           case "detail":
             value = DetailElement;
             return DetailElement is not null;
@@ -827,7 +845,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (ResultElement is not null) yield return new KeyValuePair<string,object>("result",ResultElement);
-        if (Message is not null) yield return new KeyValuePair<string,object>("message",Message);
+        if (MessageElement is not null) yield return new KeyValuePair<string,object>("message",MessageElement);
         if (DetailElement is not null) yield return new KeyValuePair<string,object>("detail",DetailElement);
       }
 
@@ -884,13 +902,31 @@ namespace Hl7.Fhir.Model
       /// </summary>
       [FhirElement("message", Order=50)]
       [DataMember]
-      public Hl7.Fhir.Model.Markdown Message
+      public Hl7.Fhir.Model.Markdown MessageElement
       {
-        get { return _Message; }
-        set { _Message = value; OnPropertyChanged("Message"); }
+        get { return _MessageElement; }
+        set { _MessageElement = value; OnPropertyChanged("MessageElement"); }
       }
 
-      private Hl7.Fhir.Model.Markdown _Message;
+      private Hl7.Fhir.Model.Markdown _MessageElement;
+
+      /// <summary>
+      /// A message associated with the result
+      /// </summary>
+      /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+      [IgnoreDataMember]
+      public string Message
+      {
+        get { return MessageElement != null ? MessageElement.Value : null; }
+        set
+        {
+          if (value == null)
+            MessageElement = null;
+          else
+            MessageElement = new Hl7.Fhir.Model.Markdown(value);
+          OnPropertyChanged("Message");
+        }
+      }
 
       /// <summary>
       /// A link to further details on the result
@@ -934,7 +970,7 @@ namespace Hl7.Fhir.Model
 
         base.CopyTo(dest);
         if(ResultElement != null) dest.ResultElement = (Code<Hl7.Fhir.Model.TestReport.TestReportActionResult>)ResultElement.DeepCopy();
-        if(Message != null) dest.Message = (Hl7.Fhir.Model.Markdown)Message.DeepCopy();
+        if(MessageElement != null) dest.MessageElement = (Hl7.Fhir.Model.Markdown)MessageElement.DeepCopy();
         if(DetailElement != null) dest.DetailElement = (Hl7.Fhir.Model.FhirString)DetailElement.DeepCopy();
         return dest;
       }
@@ -952,7 +988,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.Matches(otherT)) return false;
         if( !DeepComparable.Matches(ResultElement, otherT.ResultElement)) return false;
-        if( !DeepComparable.Matches(Message, otherT.Message)) return false;
+        if( !DeepComparable.Matches(MessageElement, otherT.MessageElement)) return false;
         if( !DeepComparable.Matches(DetailElement, otherT.DetailElement)) return false;
 
         return true;
@@ -965,7 +1001,7 @@ namespace Hl7.Fhir.Model
 
         if(!base.IsExactly(otherT)) return false;
         if( !DeepComparable.IsExactly(ResultElement, otherT.ResultElement)) return false;
-        if( !DeepComparable.IsExactly(Message, otherT.Message)) return false;
+        if( !DeepComparable.IsExactly(MessageElement, otherT.MessageElement)) return false;
         if( !DeepComparable.IsExactly(DetailElement, otherT.DetailElement)) return false;
 
         return true;
@@ -978,7 +1014,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.Children) yield return item;
           if (ResultElement != null) yield return ResultElement;
-          if (Message != null) yield return Message;
+          if (MessageElement != null) yield return MessageElement;
           if (DetailElement != null) yield return DetailElement;
         }
       }
@@ -990,7 +1026,7 @@ namespace Hl7.Fhir.Model
         {
           foreach (var item in base.NamedChildren) yield return item;
           if (ResultElement != null) yield return new ElementValue("result", ResultElement);
-          if (Message != null) yield return new ElementValue("message", Message);
+          if (MessageElement != null) yield return new ElementValue("message", MessageElement);
           if (DetailElement != null) yield return new ElementValue("detail", DetailElement);
         }
       }
@@ -1003,8 +1039,8 @@ namespace Hl7.Fhir.Model
             value = ResultElement;
             return ResultElement is not null;
           case "message":
-            value = Message;
-            return Message is not null;
+            value = MessageElement;
+            return MessageElement is not null;
           case "detail":
             value = DetailElement;
             return DetailElement is not null;
@@ -1018,7 +1054,7 @@ namespace Hl7.Fhir.Model
       {
         foreach (var kvp in base.GetElementPairs()) yield return kvp;
         if (ResultElement is not null) yield return new KeyValuePair<string,object>("result",ResultElement);
-        if (Message is not null) yield return new KeyValuePair<string,object>("message",Message);
+        if (MessageElement is not null) yield return new KeyValuePair<string,object>("message",MessageElement);
         if (DetailElement is not null) yield return new KeyValuePair<string,object>("detail",DetailElement);
       }
 

--- a/src/Hl7.Fhir.STU3/Model/Generated/TestScript.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/TestScript.cs
@@ -6366,13 +6366,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the test script
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Context the content is intended to support
@@ -6407,26 +6425,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=220)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this test script is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// An abstract server representing a client or sender in a message exchange
@@ -6601,11 +6655,11 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(Origin != null) dest.Origin = new List<Hl7.Fhir.Model.TestScript.OriginComponent>(Origin.DeepCopy());
       if(Destination != null) dest.Destination = new List<Hl7.Fhir.Model.TestScript.DestinationComponent>(Destination.DeepCopy());
       if(Metadata != null) dest.Metadata = (Hl7.Fhir.Model.TestScript.MetadataComponent)Metadata.DeepCopy();
@@ -6642,11 +6696,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(Origin, otherT.Origin)) return false;
       if( !DeepComparable.Matches(Destination, otherT.Destination)) return false;
       if( !DeepComparable.Matches(Metadata, otherT.Metadata)) return false;
@@ -6678,11 +6732,11 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(Origin, otherT.Origin)) return false;
       if( !DeepComparable.IsExactly(Destination, otherT.Destination)) return false;
       if( !DeepComparable.IsExactly(Metadata, otherT.Metadata)) return false;
@@ -6714,11 +6768,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         foreach (var elem in Origin) { if (elem != null) yield return elem; }
         foreach (var elem in Destination) { if (elem != null) yield return elem; }
         if (Metadata != null) yield return Metadata;
@@ -6749,11 +6803,11 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         foreach (var elem in Origin) { if (elem != null) yield return new ElementValue("origin", elem); }
         foreach (var elem in Destination) { if (elem != null) yield return new ElementValue("destination", elem); }
         if (Metadata != null) yield return new ElementValue("metadata", Metadata);
@@ -6803,8 +6857,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -6812,11 +6866,11 @@ namespace Hl7.Fhir.Model
           value = Jurisdiction;
           return Jurisdiction?.Any() == true;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "origin":
           value = Origin;
           return Origin?.Any() == true;
@@ -6869,11 +6923,11 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (Origin?.Any() == true) yield return new KeyValuePair<string,object>("origin",Origin);
       if (Destination?.Any() == true) yield return new KeyValuePair<string,object>("destination",Destination);
       if (Metadata is not null) yield return new KeyValuePair<string,object>("metadata",Metadata);

--- a/src/Hl7.Fhir.STU3/Model/Generated/ValueSet.cs
+++ b/src/Hl7.Fhir.STU3/Model/Generated/ValueSet.cs
@@ -2217,13 +2217,31 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("description", Order=190)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Description
+    public Hl7.Fhir.Model.Markdown DescriptionElement
     {
-      get { return _Description; }
-      set { _Description = value; OnPropertyChanged("Description"); }
+      get { return _DescriptionElement; }
+      set { _DescriptionElement = value; OnPropertyChanged("DescriptionElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Description;
+    private Hl7.Fhir.Model.Markdown _DescriptionElement;
+
+    /// <summary>
+    /// Natural language description of the value set
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Description
+    {
+      get { return DescriptionElement != null ? DescriptionElement.Value : null; }
+      set
+      {
+        if (value == null)
+          DescriptionElement = null;
+        else
+          DescriptionElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Description");
+      }
+    }
 
     /// <summary>
     /// Context the content is intended to support
@@ -2289,26 +2307,62 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [FhirElement("purpose", Order=230)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Purpose
+    public Hl7.Fhir.Model.Markdown PurposeElement
     {
-      get { return _Purpose; }
-      set { _Purpose = value; OnPropertyChanged("Purpose"); }
+      get { return _PurposeElement; }
+      set { _PurposeElement = value; OnPropertyChanged("PurposeElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Purpose;
+    private Hl7.Fhir.Model.Markdown _PurposeElement;
+
+    /// <summary>
+    /// Why this value set is defined
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Purpose
+    {
+      get { return PurposeElement != null ? PurposeElement.Value : null; }
+      set
+      {
+        if (value == null)
+          PurposeElement = null;
+        else
+          PurposeElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Purpose");
+      }
+    }
 
     /// <summary>
     /// Use and/or publishing restrictions
     /// </summary>
     [FhirElement("copyright", Order=240)]
     [DataMember]
-    public Hl7.Fhir.Model.Markdown Copyright
+    public Hl7.Fhir.Model.Markdown CopyrightElement
     {
-      get { return _Copyright; }
-      set { _Copyright = value; OnPropertyChanged("Copyright"); }
+      get { return _CopyrightElement; }
+      set { _CopyrightElement = value; OnPropertyChanged("CopyrightElement"); }
     }
 
-    private Hl7.Fhir.Model.Markdown _Copyright;
+    private Hl7.Fhir.Model.Markdown _CopyrightElement;
+
+    /// <summary>
+    /// Use and/or publishing restrictions
+    /// </summary>
+    /// <remarks>This uses the native .NET datatype, rather than the FHIR equivalent</remarks>
+    [IgnoreDataMember]
+    public string Copyright
+    {
+      get { return CopyrightElement != null ? CopyrightElement.Value : null; }
+      set
+      {
+        if (value == null)
+          CopyrightElement = null;
+        else
+          CopyrightElement = new Hl7.Fhir.Model.Markdown(value);
+        OnPropertyChanged("Copyright");
+      }
+    }
 
     /// <summary>
     /// Whether this is intended to be used with an extensible binding
@@ -2387,12 +2441,12 @@ namespace Hl7.Fhir.Model
       if(DateElement != null) dest.DateElement = (Hl7.Fhir.Model.FhirDateTime)DateElement.DeepCopy();
       if(PublisherElement != null) dest.PublisherElement = (Hl7.Fhir.Model.FhirString)PublisherElement.DeepCopy();
       if(Contact != null) dest.Contact = new List<Hl7.Fhir.Model.ContactDetail>(Contact.DeepCopy());
-      if(Description != null) dest.Description = (Hl7.Fhir.Model.Markdown)Description.DeepCopy();
+      if(DescriptionElement != null) dest.DescriptionElement = (Hl7.Fhir.Model.Markdown)DescriptionElement.DeepCopy();
       if(UseContext != null) dest.UseContext = new List<Hl7.Fhir.Model.UsageContext>(UseContext.DeepCopy());
       if(Jurisdiction != null) dest.Jurisdiction = new List<Hl7.Fhir.Model.CodeableConcept>(Jurisdiction.DeepCopy());
       if(ImmutableElement != null) dest.ImmutableElement = (Hl7.Fhir.Model.FhirBoolean)ImmutableElement.DeepCopy();
-      if(Purpose != null) dest.Purpose = (Hl7.Fhir.Model.Markdown)Purpose.DeepCopy();
-      if(Copyright != null) dest.Copyright = (Hl7.Fhir.Model.Markdown)Copyright.DeepCopy();
+      if(PurposeElement != null) dest.PurposeElement = (Hl7.Fhir.Model.Markdown)PurposeElement.DeepCopy();
+      if(CopyrightElement != null) dest.CopyrightElement = (Hl7.Fhir.Model.Markdown)CopyrightElement.DeepCopy();
       if(ExtensibleElement != null) dest.ExtensibleElement = (Hl7.Fhir.Model.FhirBoolean)ExtensibleElement.DeepCopy();
       if(Compose != null) dest.Compose = (Hl7.Fhir.Model.ValueSet.ComposeComponent)Compose.DeepCopy();
       if(Expansion != null) dest.Expansion = (Hl7.Fhir.Model.ValueSet.ExpansionComponent)Expansion.DeepCopy();
@@ -2421,12 +2475,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.Matches(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.Matches(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.Matches(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.Matches(Description, otherT.Description)) return false;
+      if( !DeepComparable.Matches(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.Matches(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.Matches(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.Matches(ImmutableElement, otherT.ImmutableElement)) return false;
-      if( !DeepComparable.Matches(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.Matches(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.Matches(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.Matches(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.Matches(ExtensibleElement, otherT.ExtensibleElement)) return false;
       if( !DeepComparable.Matches(Compose, otherT.Compose)) return false;
       if( !DeepComparable.Matches(Expansion, otherT.Expansion)) return false;
@@ -2450,12 +2504,12 @@ namespace Hl7.Fhir.Model
       if( !DeepComparable.IsExactly(DateElement, otherT.DateElement)) return false;
       if( !DeepComparable.IsExactly(PublisherElement, otherT.PublisherElement)) return false;
       if( !DeepComparable.IsExactly(Contact, otherT.Contact)) return false;
-      if( !DeepComparable.IsExactly(Description, otherT.Description)) return false;
+      if( !DeepComparable.IsExactly(DescriptionElement, otherT.DescriptionElement)) return false;
       if( !DeepComparable.IsExactly(UseContext, otherT.UseContext)) return false;
       if( !DeepComparable.IsExactly(Jurisdiction, otherT.Jurisdiction)) return false;
       if( !DeepComparable.IsExactly(ImmutableElement, otherT.ImmutableElement)) return false;
-      if( !DeepComparable.IsExactly(Purpose, otherT.Purpose)) return false;
-      if( !DeepComparable.IsExactly(Copyright, otherT.Copyright)) return false;
+      if( !DeepComparable.IsExactly(PurposeElement, otherT.PurposeElement)) return false;
+      if( !DeepComparable.IsExactly(CopyrightElement, otherT.CopyrightElement)) return false;
       if( !DeepComparable.IsExactly(ExtensibleElement, otherT.ExtensibleElement)) return false;
       if( !DeepComparable.IsExactly(Compose, otherT.Compose)) return false;
       if( !DeepComparable.IsExactly(Expansion, otherT.Expansion)) return false;
@@ -2479,12 +2533,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return DateElement;
         if (PublisherElement != null) yield return PublisherElement;
         foreach (var elem in Contact) { if (elem != null) yield return elem; }
-        if (Description != null) yield return Description;
+        if (DescriptionElement != null) yield return DescriptionElement;
         foreach (var elem in UseContext) { if (elem != null) yield return elem; }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return elem; }
         if (ImmutableElement != null) yield return ImmutableElement;
-        if (Purpose != null) yield return Purpose;
-        if (Copyright != null) yield return Copyright;
+        if (PurposeElement != null) yield return PurposeElement;
+        if (CopyrightElement != null) yield return CopyrightElement;
         if (ExtensibleElement != null) yield return ExtensibleElement;
         if (Compose != null) yield return Compose;
         if (Expansion != null) yield return Expansion;
@@ -2507,12 +2561,12 @@ namespace Hl7.Fhir.Model
         if (DateElement != null) yield return new ElementValue("date", DateElement);
         if (PublisherElement != null) yield return new ElementValue("publisher", PublisherElement);
         foreach (var elem in Contact) { if (elem != null) yield return new ElementValue("contact", elem); }
-        if (Description != null) yield return new ElementValue("description", Description);
+        if (DescriptionElement != null) yield return new ElementValue("description", DescriptionElement);
         foreach (var elem in UseContext) { if (elem != null) yield return new ElementValue("useContext", elem); }
         foreach (var elem in Jurisdiction) { if (elem != null) yield return new ElementValue("jurisdiction", elem); }
         if (ImmutableElement != null) yield return new ElementValue("immutable", ImmutableElement);
-        if (Purpose != null) yield return new ElementValue("purpose", Purpose);
-        if (Copyright != null) yield return new ElementValue("copyright", Copyright);
+        if (PurposeElement != null) yield return new ElementValue("purpose", PurposeElement);
+        if (CopyrightElement != null) yield return new ElementValue("copyright", CopyrightElement);
         if (ExtensibleElement != null) yield return new ElementValue("extensible", ExtensibleElement);
         if (Compose != null) yield return new ElementValue("compose", Compose);
         if (Expansion != null) yield return new ElementValue("expansion", Expansion);
@@ -2554,8 +2608,8 @@ namespace Hl7.Fhir.Model
           value = Contact;
           return Contact?.Any() == true;
         case "description":
-          value = Description;
-          return Description is not null;
+          value = DescriptionElement;
+          return DescriptionElement is not null;
         case "useContext":
           value = UseContext;
           return UseContext?.Any() == true;
@@ -2566,11 +2620,11 @@ namespace Hl7.Fhir.Model
           value = ImmutableElement;
           return ImmutableElement is not null;
         case "purpose":
-          value = Purpose;
-          return Purpose is not null;
+          value = PurposeElement;
+          return PurposeElement is not null;
         case "copyright":
-          value = Copyright;
-          return Copyright is not null;
+          value = CopyrightElement;
+          return CopyrightElement is not null;
         case "extensible":
           value = ExtensibleElement;
           return ExtensibleElement is not null;
@@ -2599,12 +2653,12 @@ namespace Hl7.Fhir.Model
       if (DateElement is not null) yield return new KeyValuePair<string,object>("date",DateElement);
       if (PublisherElement is not null) yield return new KeyValuePair<string,object>("publisher",PublisherElement);
       if (Contact?.Any() == true) yield return new KeyValuePair<string,object>("contact",Contact);
-      if (Description is not null) yield return new KeyValuePair<string,object>("description",Description);
+      if (DescriptionElement is not null) yield return new KeyValuePair<string,object>("description",DescriptionElement);
       if (UseContext?.Any() == true) yield return new KeyValuePair<string,object>("useContext",UseContext);
       if (Jurisdiction?.Any() == true) yield return new KeyValuePair<string,object>("jurisdiction",Jurisdiction);
       if (ImmutableElement is not null) yield return new KeyValuePair<string,object>("immutable",ImmutableElement);
-      if (Purpose is not null) yield return new KeyValuePair<string,object>("purpose",Purpose);
-      if (Copyright is not null) yield return new KeyValuePair<string,object>("copyright",Copyright);
+      if (PurposeElement is not null) yield return new KeyValuePair<string,object>("purpose",PurposeElement);
+      if (CopyrightElement is not null) yield return new KeyValuePair<string,object>("copyright",CopyrightElement);
       if (ExtensibleElement is not null) yield return new KeyValuePair<string,object>("extensible",ExtensibleElement);
       if (Compose is not null) yield return new KeyValuePair<string,object>("compose",Compose);
       if (Expansion is not null) yield return new KeyValuePair<string,object>("expansion",Expansion);

--- a/src/Hl7.Fhir.STU3/Model/IConformanceResource.cs
+++ b/src/Hl7.Fhir.STU3/Model/IConformanceResource.cs
@@ -67,11 +67,13 @@ namespace Hl7.Fhir.Model
     {
         //I think ImplementationGuide should have a purpose element.
         [NotMapped]
-        public Markdown Purpose
+        public Markdown PurposeElement
         {
             get { return null; }
             set { throw new NotImplementedException(); }
         }
+
+        public string Purpose { get => null; set => throw new NotImplementedException(); }
     }
 
     public partial class CompartmentDefinition : IConformanceResource
@@ -104,11 +106,13 @@ namespace Hl7.Fhir.Model
 
     public partial class ExpansionProfile : IVersionableConformanceResource
     {
-        public Markdown Purpose
+        public Markdown PurposeElement
         {
             get { return null; }
             set { throw new NotImplementedException(); }
         }
+
+        public string Purpose { get => null; set => throw new NotImplementedException(); }
     }
 
     public partial class Questionnaire : IVersionableConformanceResource
@@ -120,18 +124,21 @@ namespace Hl7.Fhir.Model
     {
         // I think DataElement should have Description too
         [NotMapped]
-        public Markdown Description
+        public Markdown DescriptionElement
         {
             get { return null; }
             set { throw new NotImplementedException(); }
         }
 
         [NotMapped]
-        public Markdown Purpose
+        public Markdown PurposeElement
         {
             get { return null; }
             set { throw new NotImplementedException(); }
         }
+
+        public string Description { get => null; set => throw new NotImplementedException(); }
+        public string Purpose { get => null; set => throw new NotImplementedException(); }
     }
 
 
@@ -139,7 +146,7 @@ namespace Hl7.Fhir.Model
     {
         // I think NamingSystem should have Experimental too
         [NotMapped]
-        public Markdown Purpose
+        public Markdown PurposeElement
         {
             get { return null; }
             set { throw new NotImplementedException(); }
@@ -185,5 +192,7 @@ namespace Hl7.Fhir.Model
             }
             set { throw new NotImplementedException(); }
         }
+
+        public string Purpose { get => null; set => throw new NotImplementedException(); }
     }
 }

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/DebugExtensions.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/DebugExtensions.cs
@@ -99,9 +99,9 @@ namespace Hl7.Fhir.Specification.Tests
             if (!DeepComparable.IsExactly(elem.Code, other.Code)) { l.Add(nameof(ElementDefinition.Code)); }
             if (!DeepComparable.IsExactly(elem.Slicing, other.Slicing)) { l.Add(nameof(ElementDefinition.Slicing)); }
             if (!DeepComparable.IsExactly(elem.ShortElement, other.ShortElement)) { l.Add(nameof(ElementDefinition.Short)); }
-            if (!DeepComparable.IsExactly(elem.Definition, other.Definition)) { l.Add(nameof(ElementDefinition.Definition)); }
-            if (!DeepComparable.IsExactly(elem.Comment, other.Comment)) { l.Add(nameof(ElementDefinition.Comment)); }
-            if (!DeepComparable.IsExactly(elem.Requirements, other.Requirements)) { l.Add(nameof(ElementDefinition.Requirements)); }
+            if (!DeepComparable.IsExactly(elem.DefinitionElement, other.DefinitionElement)) { l.Add(nameof(ElementDefinition.Definition)); }
+            if (!DeepComparable.IsExactly(elem.CommentElement, other.CommentElement)) { l.Add(nameof(ElementDefinition.Comment)); }
+            if (!DeepComparable.IsExactly(elem.RequirementsElement, other.RequirementsElement)) { l.Add(nameof(ElementDefinition.Requirements)); }
             if (!DeepComparable.IsExactly(elem.AliasElement, other.AliasElement)) { l.Add(nameof(ElementDefinition.Alias)); }
             if (!DeepComparable.IsExactly(elem.MinElement, other.MinElement)) { l.Add(nameof(ElementDefinition.Min)); }
             if (!DeepComparable.IsExactly(elem.MaxElement, other.MaxElement)) { l.Add(nameof(ElementDefinition.Max)); }
@@ -109,7 +109,7 @@ namespace Hl7.Fhir.Specification.Tests
             if (!DeepComparable.IsExactly(elem.ContentReferenceElement, other.ContentReferenceElement)) { l.Add(nameof(ElementDefinition.ContentReference)); }
             if (!DeepComparable.IsExactly(elem.Type, other.Type)) { l.Add(nameof(ElementDefinition.Type)); }
             if (!DeepComparable.IsExactly(elem.DefaultValue, other.DefaultValue)) { l.Add(nameof(ElementDefinition.DefaultValue)); }
-            if (!DeepComparable.IsExactly(elem.MeaningWhenMissing, other.MeaningWhenMissing)) { l.Add(nameof(ElementDefinition.MeaningWhenMissing)); }
+            if (!DeepComparable.IsExactly(elem.MeaningWhenMissingElement, other.MeaningWhenMissingElement)) { l.Add(nameof(ElementDefinition.MeaningWhenMissing)); }
             if (!DeepComparable.IsExactly(elem.OrderMeaningElement, other.OrderMeaningElement)) { l.Add(nameof(ElementDefinition.OrderMeaning)); }
             if (!DeepComparable.IsExactly(elem.Fixed, other.Fixed)) { l.Add(nameof(ElementDefinition.Fixed)); }
             if (!DeepComparable.IsExactly(elem.Pattern, other.Pattern)) { l.Add(nameof(ElementDefinition.Pattern)); }
@@ -121,7 +121,7 @@ namespace Hl7.Fhir.Specification.Tests
             if (!DeepComparable.IsExactly(elem.Constraint, other.Constraint)) { l.Add(nameof(ElementDefinition.Constraint)); }
             if (!DeepComparable.IsExactly(elem.MustSupportElement, other.MustSupportElement)) { l.Add(nameof(ElementDefinition.MustSupport)); }
             if (!DeepComparable.IsExactly(elem.IsModifierElement, other.IsModifierElement)) { l.Add(nameof(ElementDefinition.IsModifier)); }
-            if (!DeepComparable.IsExactly(elem.IsModifierReasonElement, other.IsModifierReasonElement)) { l.Add(nameof(ElementDefinition.IsModifier)); }
+            if (!DeepComparable.IsExactly(elem.IsModifierReasonElement, other.IsModifierReasonElement)) { l.Add(nameof(ElementDefinition.IsModifierReason)); }
             if (!DeepComparable.IsExactly(elem.IsSummaryElement, other.IsSummaryElement)) { l.Add(nameof(ElementDefinition.IsSummary)); }
             if (!DeepComparable.IsExactly(elem.Binding, other.Binding)) { l.Add(nameof(ElementDefinition.Binding)); }
             if (!DeepComparable.IsExactly(elem.Mapping, other.Mapping)) { l.Add(nameof(ElementDefinition.Mapping)); }

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -2120,7 +2120,7 @@ namespace Hl7.Fhir.Specification.Tests
                 Assert.IsFalse(elem.ShortElement.IsConstrainedByDiff());
                 // Profile overrides the definition property of the extension definition root element 
                 Assert.AreNotEqual(baseElem.Definition, elem.Definition);
-                Assert.IsTrue(elem.Definition.IsConstrainedByDiff());
+                Assert.IsTrue(elem.DefinitionElement.IsConstrainedByDiff());
 
                 Assert.IsTrue(nav.MoveToFirstChild());
 
@@ -2149,8 +2149,8 @@ namespace Hl7.Fhir.Specification.Tests
                 Assert.IsFalse(elem.ShortElement.IsConstrainedByDiff());
                 // Verify that definition property is inherited
                 // [WMR 20181212] R4 - Definition type changed from string to markdown
-                Assert.IsTrue(elem.Definition.IsExactly(baseElem.Definition));
-                Assert.IsFalse(elem.Definition.IsConstrainedByDiff());
+                Assert.IsTrue(elem.DefinitionElement.IsExactly(baseElem.DefinitionElement));
+                Assert.IsFalse(elem.DefinitionElement.IsConstrainedByDiff());
             }
             finally
             {
@@ -2497,11 +2497,11 @@ namespace Hl7.Fhir.Specification.Tests
                 || isChanged(elem.Base)
                 || isChanged(elem.Binding)
                 || hasChanges(elem.Code)
-                || isChanged(elem.Comment)
+                || isChanged(elem.CommentElement)
                 || hasChanges(elem.ConditionElement)
                 || hasChanges(elem.Constraint)
                 || isChanged(elem.DefaultValue)
-                || isChanged(elem.Definition)
+                || isChanged(elem.DefinitionElement)
                 || hasChanges(elem.Example)
                 || hasChanges(elem.Extension)
                 //   || hasChanges(elem.FhirCommentsElement)
@@ -2513,7 +2513,7 @@ namespace Hl7.Fhir.Specification.Tests
                 || isChanged(elem.MaxElement)
                 || isChanged(elem.MaxLengthElement)
                 || isChanged(elem.MaxValue)
-                || isChanged(elem.MeaningWhenMissing)
+                || isChanged(elem.MeaningWhenMissingElement)
                 || isChanged(elem.MinElement)
                 || isChanged(elem.MinValue)
                 || isChanged(elem.MustSupportElement)
@@ -2522,7 +2522,7 @@ namespace Hl7.Fhir.Specification.Tests
                 || isChanged(elem.PathElement)
                 || isChanged(elem.Pattern)
                 || hasChanges(elem.RepresentationElement)
-                || isChanged(elem.Requirements)
+                || isChanged(elem.RequirementsElement)
                 || isChanged(elem.ShortElement)
                 || isChanged(elem.Slicing)
                 || hasChanges(elem.Type);
@@ -2538,11 +2538,11 @@ namespace Hl7.Fhir.Specification.Tests
             if (isChanged(element.Base)) { return "Base"; }
             if (isChanged(element.Binding)) { return "Binding"; }
             if (hasChanges(element.Code)) { return "Code"; }
-            if (isChanged(element.Comment)) { return "Comment"; }
+            if (isChanged(element.CommentElement)) { return "Comment"; }
             if (hasChanges(element.ConditionElement)) { return "Condition"; }
             if (hasChanges(element.Constraint)) { return "Constraint"; }
             if (isChanged(element.DefaultValue)) { return "DefaultValue"; }
-            if (isChanged(element.Definition)) { return "Definition"; }
+            if (isChanged(element.DefinitionElement)) { return "Definition"; }
             if (hasChanges(element.Example)) { return "Example"; }
             if (hasChanges(element.Extension)) { return "Extension"; }
             //if (hasChanges(element.FhirCommentsElement)) { return "FhirComments"; }
@@ -2554,7 +2554,7 @@ namespace Hl7.Fhir.Specification.Tests
             if (isChanged(element.MaxElement)) { return "Max"; }
             if (isChanged(element.MaxLengthElement)) { return "MaxLength"; }
             if (isChanged(element.MaxValue)) { return "MaxValue"; }
-            if (isChanged(element.MeaningWhenMissing)) { return "MeaningWhenMissing"; }
+            if (isChanged(element.MeaningWhenMissingElement)) { return "MeaningWhenMissing"; }
             if (isChanged(element.MinElement)) { return "Min"; }
             if (isChanged(element.MinValue)) { return "MinValue"; }
             if (isChanged(element.MustSupportElement)) { return "MustSupport"; }
@@ -2563,7 +2563,7 @@ namespace Hl7.Fhir.Specification.Tests
             if (isChanged(element.PathElement)) { return "Path"; }
             if (isChanged(element.Pattern)) { return "Pattern"; }
             if (hasChanges(element.RepresentationElement)) { return "Representation"; }
-            if (isChanged(element.Requirements)) { return "Requirements"; }
+            if (isChanged(element.RequirementsElement)) { return "Requirements"; }
             //if (IsChanged(element.ShortElement)) { return "Short"; }
             //if (IsChanged(element.Slicing)) { return "Slicing"; }
             //if (HasChanges(element.Type)) { return "Type"; }
@@ -3900,18 +3900,18 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual(1, labelExtElem.Min);                                           // Explicit Observation profile constraint
             Assert.AreEqual(labelExtRootElem.Max, labelExtElem.Max);                        // Inherited from external ObservationLabelExtension root element
             // [WMR 20181212] R4 - Definition type changed from string to markdown
-            Assert.IsTrue(labelExtElem.Definition.IsExactly(coreExtensionRootElem.Definition)); // Inherited from Observation.extension base element
+            Assert.IsTrue(labelExtElem.DefinitionElement.IsExactly(coreExtensionRootElem.DefinitionElement)); // Inherited from Observation.extension base element
             // [WMR 20181212] R4 - Comment type changed from string to markdown
-            Assert.IsTrue(labelExtElem.Comment.IsExactly(labelExtRootElem.Comment));            // Inherited from external ObservationLabelExtension root element
+            Assert.IsTrue(labelExtElem.CommentElement.IsExactly(labelExtRootElem.CommentElement));            // Inherited from external ObservationLabelExtension root element
             verifyProfileExtensionBaseElement(labelExtElem);
 
             var locationExtRootElem = locationExt.Differential.Element[0];
             Assert.AreEqual(0, locationExtElem.Min);                                        // Inherited from external ObservationLabelExtension root element
             Assert.AreEqual("1", locationExtElem.Max);                                      // Explicit Observation profile constraint
             // [WMR 20181212] R4 - Definition type changed from string to markdown
-            Assert.IsTrue(locationExtElem.Definition.IsExactly(coreExtensionRootElem.Definition));  // Inherited from Observation.extension base element
+            Assert.IsTrue(locationExtElem.DefinitionElement.IsExactly(coreExtensionRootElem.DefinitionElement));  // Inherited from Observation.extension base element
             // [WMR 20181212] R4 - Comment type changed from string to markdown
-            Assert.IsTrue(locationExtElem.Comment.IsExactly(locationExtRootElem.Comment));          // Inherited from external ObservationLocationExtension root element
+            Assert.IsTrue(locationExtElem.CommentElement.IsExactly(locationExtRootElem.CommentElement));          // Inherited from external ObservationLocationExtension root element
             verifyProfileExtensionBaseElement(locationExtElem);
 
             // Last (unresolved) extension element should have been merged with Observation.extension
@@ -3923,9 +3923,9 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual(1, otherExtElem.Min);                                           // Explicit Observation profile constraint
             Assert.AreEqual(coreObsExtensionElem.Max, otherExtElem.Max);                    // Inherited from Observation.extension base element
             // [WMR 20181212] R4 - Definition type changed from string to markdown
-            Assert.IsTrue(otherExtElem.Definition.IsExactly(coreObsExtensionElem.Definition));  // Inherited from Observation.extension base element
+            Assert.IsTrue(otherExtElem.DefinitionElement.IsExactly(coreObsExtensionElem.DefinitionElement));  // Inherited from Observation.extension base element
             // [WMR 20181212] R4 - Comment type changed from string to markdown
-            Assert.IsTrue(otherExtElem.Comment.IsExactly(coreObsExtensionElem.Comment));    // Inherited from Observation.extension base element
+            Assert.IsTrue(otherExtElem.CommentElement.IsExactly(coreObsExtensionElem.CommentElement));    // Inherited from Observation.extension base element
             verifyProfileExtensionBaseElement(coreObsExtensionElem);
         }
 
@@ -3935,9 +3935,9 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsNotNull(baseElem);
             Assert.AreEqual(baseElem.Short, extElem.Short);
             // [WMR 20181212] R4 - Definition type changed from string to markdown
-            Assert.IsTrue(extElem.Definition.IsExactly(baseElem.Definition));
+            Assert.IsTrue(extElem.DefinitionElement.IsExactly(baseElem.DefinitionElement));
             // [WMR 20181212] R4 - Comment type changed from string to markdown
-            Assert.IsTrue(extElem.Comment.IsExactly(baseElem.Comment));
+            Assert.IsTrue(extElem.CommentElement.IsExactly(baseElem.CommentElement));
             Assert.IsTrue(baseElem.Alias.SequenceEqual(extElem.Alias));
         }
 
@@ -4437,7 +4437,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual("*", nav.Current.Max);
             // Slice entry should inherit Comments from base element, merged with diff constraints
             // [WMR 20181212] R4 - Comment type changed from string to markdown
-            Assert.AreEqual("NationalPatientProfile\r\nSlicedNationalPatientProfile", nav.Current.Comment?.Value);
+            Assert.AreEqual("NationalPatientProfile\r\nSlicedNationalPatientProfile", nav.Current.Comment);
             // Slice entry should also inherit constraints on child elements from base element
             var bm = nav.Bookmark();
             Assert.IsTrue(nav.MoveToChild("system"));
@@ -4457,7 +4457,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual("1", nav.Current.Max);
             // Named slices should inherit Comments from base element
             // [WMR 20181212] R4 - Comment type changed from string to markdown
-            Assert.AreEqual("NationalPatientProfile", nav.Current.Comment?.Value);
+            Assert.AreEqual("NationalPatientProfile", nav.Current.Comment);
             // Named slices should also inherit constraints on child elements from base element
             bm = nav.Bookmark();
             Assert.IsTrue(nav.MoveToChild("system"));
@@ -4479,7 +4479,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual("2", nav.Current.Max);
             // Named slices should inherit Comments from base element
             // [WMR 20181212] R4 - Comment type changed from string to markdown
-            Assert.AreEqual("NationalPatientProfile", nav.Current.Comment?.Value);
+            Assert.AreEqual("NationalPatientProfile", nav.Current.Comment);
             // Named slices should also inherit constraints on child elements from base element
             bm = nav.Bookmark();
             Assert.IsTrue(nav.MoveToChild("system"));
@@ -4633,7 +4633,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual("*", nav.Current.Max);
             // Slice entry should inherit Comments from base element, merged with diff constraints
             // [WMR 20181212] R4 - Comment type changed from string to markdown
-            Assert.AreEqual("NationalPatientProfile\r\nReslicedNationalPatientProfile", nav.Current.Comment?.Value);
+            Assert.AreEqual("NationalPatientProfile\r\nReslicedNationalPatientProfile", nav.Current.Comment);
             // Slice entry should also inherit constraints on child elements from base element
             var bm = nav.Bookmark();
             Assert.IsTrue(nav.MoveToChild("system"));
@@ -4653,7 +4653,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual("1", nav.Current.Max);
             // Named slices should inherit Comments from base element
             // [WMR 20181212] R4 - Comment type changed from string to markdown
-            Assert.AreEqual("NationalPatientProfile", nav.Current.Comment?.Value);
+            Assert.AreEqual("NationalPatientProfile", nav.Current.Comment);
             // Named slices should also inherit constraints on child elements from base element
             bm = nav.Bookmark();
             Assert.IsTrue(nav.MoveToChild("system"));
@@ -4675,7 +4675,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual("2", nav.Current.Max);
             // Named slices should inherit Comments from base element
             // [WMR 20181212] R4 - Comment type changed from string to markdown
-            Assert.AreEqual("NationalPatientProfile", nav.Current.Comment?.Value);
+            Assert.AreEqual("NationalPatientProfile", nav.Current.Comment);
             // Named slices should also inherit constraints on child elements from base element
             bm = nav.Bookmark();
             Assert.IsTrue(nav.MoveToChild("system"));
@@ -4695,7 +4695,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.AreEqual("1", nav.Current.Max);
             // Named slices should inherit Comments from base element
             // [WMR 20181212] R4 - Comment type changed from string to markdown
-            Assert.AreEqual("NationalPatientProfile", nav.Current.Comment?.Value);
+            Assert.AreEqual("NationalPatientProfile", nav.Current.Comment);
             // Named slices should also inherit constraints on child elements from base element
             bm = nav.Bookmark();
             Assert.IsTrue(nav.MoveToChild("system"));
@@ -6041,10 +6041,10 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsTrue(coreObs.HasSnapshot);
             var coreMethodElem = coreObs.Snapshot.Element.FirstOrDefault(e => e.Path == "Observation.method");
             Assert.IsNotNull(coreMethodElem);
-            Assert.IsNotNull(coreMethodElem.Comment);
+            Assert.IsNotNull(coreMethodElem.CommentElement);
             // [WMR 20181212] R4 - Comment type changed from string to markdown
-            Assert.IsTrue(coreMethodElem.Comment.IsExactly(baseElem.Comment));
-            Assert.IsTrue(baseElem.Comment.IsExactly(coreMethodElem.Comment));
+            Assert.IsTrue(coreMethodElem.CommentElement.IsExactly(baseElem.CommentElement));
+            Assert.IsTrue(baseElem.CommentElement.IsExactly(coreMethodElem.CommentElement));
         }
 
         // [WMR 20170718] Test for slicing issue
@@ -7340,7 +7340,7 @@ namespace Hl7.Fhir.Specification.Tests
 
             Assert.IsTrue(nav.JumpToFirst("Questionnaire.item.item.type"));
             // [WMR 20181212] R4 - Comment type changed from string to markdown
-            Assert.AreEqual("level 2", nav.Current.Comment?.Value);
+            Assert.AreEqual("level 2", nav.Current.Comment);
             // Level 2 should NOT inherit constraints from level 1
             Assert.AreNotEqual("level 1", nav.Current.Short);
         }
@@ -7389,11 +7389,11 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsTrue(nav.JumpToFirst("Questionnaire.item.type"));
             Assert.AreEqual("level 1", nav.Current.Short);
             // [WMR 20181212] R4 - Comment type changed from string to markdown
-            Assert.AreEqual("level 1 *", nav.Current.Comment?.Value);
+            Assert.AreEqual("level 1 *", nav.Current.Comment);
 
             Assert.IsTrue(nav.JumpToFirst("Questionnaire.item.item.type"));
             // [WMR 20181212] R4 - Comment type changed from string to markdown
-            Assert.AreEqual("level 2", nav.Current.Comment?.Value);
+            Assert.AreEqual("level 2", nav.Current.Comment);
             Assert.AreEqual("level 2 *", nav.Current.Short);
         }
 
@@ -7716,7 +7716,7 @@ namespace Hl7.Fhir.Specification.Tests
             Assert.IsNotNull(nav.Current);
             // Verify that snapshot generator merges constraints from external ReferenceProfile
             // [WMR 20181212] R4 Fixed markdown
-            Assert.AreEqual("CustomReference", nav.Current.Comment?.Value);
+            Assert.AreEqual("CustomReference", nav.Current.Comment);
             Assert.IsNotNull(nav.Current.Type);
             Assert.AreEqual(1, nav.Current.Type.Count);
             Assert.AreEqual(FHIRAllTypes.Reference.GetLiteral(), nav.Current.Type[0].Code);


### PR DESCRIPTION
Regenerated the POCO's to make all elements of type Markdown follow the "primitive property" pattern.