### PR TITLE
Devops: Correction for the NuGet Metapackages version

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -102,10 +102,21 @@ stages:
         nobuild: true
         verbosityPack: Normal
     - powershell: |
-        nuget pack ./src/hl7.fhir.specification.nuspec -properties sdkversion=$Env:CurrentVersion-$Env:CurrentSuffix`;fhirrelease=STU3 -OutputDirectory $(Build.ArtifactStagingDirectory)
-        nuget pack ./src/hl7.fhir.specification.nuspec -properties sdkversion=$Env:CurrentVersion-$Env:CurrentSuffix`;fhirrelease=R4 -OutputDirectory $(Build.ArtifactStagingDirectory)
-        nuget pack ./src/hl7.fhir.specification.nuspec -properties sdkversion=$Env:CurrentVersion-$Env:CurrentSuffix`;fhirrelease=R4B -OutputDirectory $(Build.ArtifactStagingDirectory)
-        nuget pack ./src/hl7.fhir.specification.nuspec -properties sdkversion=$Env:CurrentVersion-$Env:CurrentSuffix`;fhirrelease=R5 -OutputDirectory $(Build.ArtifactStagingDirectory)
+        if ([string]::IsNullOrEmpty($Env:CurrentSuffix))
+        {
+          $version = $Env:CurrentVersion
+        }
+        else
+        {
+          $version = $Env:CurrentVersion-$Env:CurrentSuffix
+        }
+
+        Write-Host "Pack Hl7.Fhir.Specification.* with version $version" 
+
+        nuget pack ./src/hl7.fhir.specification.nuspec -properties sdkversion=$version`;fhirrelease=STU3 -OutputDirectory $(Build.ArtifactStagingDirectory)
+        nuget pack ./src/hl7.fhir.specification.nuspec -properties sdkversion=$version`;fhirrelease=R4 -OutputDirectory $(Build.ArtifactStagingDirectory)
+        nuget pack ./src/hl7.fhir.specification.nuspec -properties sdkversion=$version`;fhirrelease=R4B -OutputDirectory $(Build.ArtifactStagingDirectory)
+        nuget pack ./src/hl7.fhir.specification.nuspec -properties sdkversion=$version`;fhirrelease=R5 -OutputDirectory $(Build.ArtifactStagingDirectory)
       name: packMetapackages
       displayName: 'Pack NuGet Metapackages'    
     - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -108,7 +108,7 @@ stages:
         }
         else
         {
-          $version = $Env:CurrentVersion-$Env:CurrentSuffix
+          $version = "$Env:CurrentVersion-$Env:CurrentSuffix"
         }
 
         Write-Host "Pack Hl7.Fhir.Specification.* with version $version" 


### PR DESCRIPTION
## Description
When there is no suffix we would get an error. That is solved now.
