### PR TITLE
Use ignoreOrder also in the recursion for method IsExactlyEqualTo

### DIFF
--- a/src/Hl7.Fhir.Base/ElementModel/TypedElementExtensions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/TypedElementExtensions.cs
@@ -58,7 +58,7 @@ namespace Hl7.Fhir.ElementModel
             }
 
             return childrenL.Zip(childrenR,
-                        (childL, childR) => childL.Name == childR.Name && childL.IsExactlyEqualTo(childR)).All(t => t);
+                        (childL, childR) => childL.Name == childR.Name && childL.IsExactlyEqualTo(childR, ignoreOrder)).All(t => t);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
`TypedElementExtensions.IsExactlyEqualTo()` is now corrected: the `ignoreOrder` was not passed in the recursion

Part of issue #2375 
