### PR TITLE
Make it easy to configure serialization in the FhirClient

### DIFF
--- a/build/templates/test-job-template.yml
+++ b/build/templates/test-job-template.yml
@@ -9,7 +9,8 @@ steps:
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk $(NET_CORE_SDK)'
   inputs:
-    version: $(NET_CORE_SDK)
+    packageType: runtime
+    version: 6.0.
 - task: DownloadPipelineArtifact@2
   inputs:
     displayName: Download Build artifacts

--- a/src/Hl7.Fhir.Base/Rest/BaseFhirClient.cs
+++ b/src/Hl7.Fhir.Base/Rest/BaseFhirClient.cs
@@ -25,14 +25,6 @@ using static Hl7.Fhir.Rest.HttpContentParsers;
 
 namespace Hl7.Fhir.Rest
 {
-    public static class FhirClientConfigExtensions
-    {
-        public static BaseFhirClient WithPocoDeserializers(this BaseFhirClient client)
-        {
-            client.Settings.SerializationEngine = FhirSerializationEngine.Poco(client.Inspector);
-            return client;
-        }
-    }
 
     public partial class BaseFhirClient : IDisposable
     {
@@ -58,7 +50,8 @@ namespace Hl7.Fhir.Rest
             Inspector = inspector;
             Settings = settings ?? new FhirClientSettings();
             Endpoint = getValidatedEndpoint(endpoint);
-            _serializationEngine = settings?.SerializationEngine ?? FhirSerializationEngine.ElementModel(Inspector, Settings.ParserSettings);
+            _serializationEngine = settings?.SerializationEngine ?? 
+                new ElementModelSerializationEngine(Inspector, Settings.ParserSettings);
 
             HttpClientRequester requester = new(Endpoint, Settings.Timeout, messageHandler ?? makeDefaultHandler(), messageHandler == null);
             Requester = requester;
@@ -86,7 +79,8 @@ namespace Hl7.Fhir.Rest
             Inspector = inspector;
             Settings = (settings ?? new FhirClientSettings());
             Endpoint = getValidatedEndpoint(endpoint);
-            _serializationEngine = settings?.SerializationEngine ?? FhirSerializationEngine.ElementModel(Inspector, Settings.ParserSettings);
+            _serializationEngine = settings?.SerializationEngine ?? 
+                new ElementModelSerializationEngine(Inspector, Settings.ParserSettings);
 
             HttpClientRequester requester = new(Endpoint, httpClient);
             Requester = requester;

--- a/src/Hl7.Fhir.Base/Rest/FhirClientSearch.cs
+++ b/src/Hl7.Fhir.Base/Rest/FhirClientSearch.cs
@@ -90,7 +90,7 @@ namespace Hl7.Fhir.Rest
         {
             // [WMR 20160421] GetResourceNameForType is obsolete
             // return Search(q, ModelInfo.GetResourceNameForType(typeof(TResource)));
-            return SearchAsync(q, _inspector.GetFhirTypeNameForType(typeof(TResource)), ct);
+            return SearchAsync(q, Inspector.GetFhirTypeNameForType(typeof(TResource)), ct);
         }
 
         /// <summary>
@@ -107,13 +107,13 @@ namespace Hl7.Fhir.Rest
 
         public virtual Task<Bundle?> SearchUsingPostAsync<TResource>(SearchParams q, CancellationToken? ct = null) where TResource : Resource
         {
-            return SearchUsingPostAsync(q, _inspector.GetFhirTypeNameForType(typeof(TResource)), ct);
+            return SearchUsingPostAsync(q, Inspector.GetFhirTypeNameForType(typeof(TResource)), ct);
         }
 
         [Obsolete("Synchronous use of the FhirClient is strongly discouraged, use the asynchronous call instead.")]
         public virtual Bundle? SearchUsingPost<TResource>(SearchParams q) where TResource : Resource
         {
-            return SearchUsingPostAsync(q, _inspector.GetFhirTypeNameForType(typeof(TResource))).WaitResult();
+            return SearchUsingPostAsync(q, Inspector.GetFhirTypeNameForType(typeof(TResource))).WaitResult();
         }
 
         #endregion

--- a/src/Hl7.Fhir.Base/Rest/FhirClientSerializationEngineExtensions.cs
+++ b/src/Hl7.Fhir.Base/Rest/FhirClientSerializationEngineExtensions.cs
@@ -1,0 +1,89 @@
+﻿#nullable enable
+
+/* 
+ * Copyright (c) 2023, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+using Hl7.Fhir.Serialization;
+
+namespace Hl7.Fhir.Rest
+{
+    /// <summary>
+    /// A set of extension methods to configure the serialization/deserialization engine used by the client to some common defaults.
+    /// </summary>
+    public static class FhirClientSerializationEngineExtensions
+    {
+        /// <summary>
+        /// Configures the FhirClient to use the original serialization behaviour, using the <see cref="FhirClientSettings.ParserSettings"/>.
+        /// </summary>
+        public static BaseFhirClient WithOriginalDeserializer(this BaseFhirClient client)
+        {
+            client.Settings.SerializationEngine = new ElementModelSerializationEngine(client.Inspector, client.Settings.ParserSettings);
+            return client;
+        }
+
+        /// <summary>
+        /// Configures the FhirClient to use the newer POCO-based serializer, configured to parse the incoming data strictly.
+        /// </summary>
+        public static BaseFhirClient WithStrictPocoDeserializer(this BaseFhirClient client)
+        {
+            client.Settings.SerializationEngine = FhirSerializationEngineFactory.Poco.Strict(client.Inspector);
+            return client;
+        }
+
+        /// <summary>
+        /// Configures the FhirClient to use the original serializer, configured to parse the incoming data strictly.
+        /// </summary>
+        public static BaseFhirClient WithStrictOriginalDeserializer(this BaseFhirClient client)
+        {
+            client.Settings.SerializationEngine = FhirSerializationEngineFactory.ElementModel.Strict(client.Inspector);
+            return client;
+        }
+
+        /// <summary>
+        /// Configures the FhirClient to use the newer POCO-based serializer, configured to ignore recoverable errors in the
+        /// the incoming data.
+        /// </summary>
+        public static BaseFhirClient WithLenientPocoDeserializer(this BaseFhirClient client)
+        {
+            client.Settings.SerializationEngine = FhirSerializationEngineFactory.Poco.Recoverable(client.Inspector);
+            return client;
+        }
+
+        /// <summary>
+        /// Configures the FhirClient to use the original serializer, configured to be permissive.
+        /// </summary>
+        public static BaseFhirClient WithPermissiveOriginalDeserializer(this BaseFhirClient client)
+        {
+            client.Settings.SerializationEngine = FhirSerializationEngineFactory.ElementModel.Permissive(client.Inspector);
+            return client;
+        }
+
+        /// <summary>
+        /// Configures the FhirClient to use the newer POCO-based serializer, configured to ignore errors that can
+        /// be caused when encountering data from a newer version of FHIR. NB: This may cause data loss.
+        /// </summary>
+        public static BaseFhirClient WithBackwardsCompatiblePocoDeserializer(this BaseFhirClient client)
+        {
+            client.Settings.SerializationEngine = FhirSerializationEngineFactory.Poco.BackwardsCompatible(client.Inspector);
+            return client;
+        }
+
+        /// <summary>
+        /// Configures the FhirClient to use the original serializer, configured to ignore errors that can
+        /// be caused when encountering data from a newer version of FHIR. NB: This may cause data loss.
+        /// </summary>
+        public static BaseFhirClient WithBackwardsCompatibleOriginalDeserializer(this BaseFhirClient client)
+        {
+            client.Settings.SerializationEngine = FhirSerializationEngineFactory.ElementModel.BackwardsCompatible(client.Inspector);
+            return client;
+        }
+    }
+}
+
+#nullable restore
+

--- a/src/Hl7.Fhir.Base/Rest/FhirClientSettings.cs
+++ b/src/Hl7.Fhir.Base/Rest/FhirClientSettings.cs
@@ -123,6 +123,9 @@ namespace Hl7.Fhir.Rest
         /// </summary>
         public IFhirSerializationEngine? SerializationEngine = null;
 
+        /// <summary>
+        /// ParserSettings for the pre-5.0 SDK parsers. Are only used when <see cref="SerializationEngine"/> is not set.
+        /// </summary>
         public ParserSettings? ParserSettings = ParserSettings.CreateDefault();
 
         public FhirClientSettings() { }

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlPocoDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlPocoDeserializer.cs
@@ -113,7 +113,7 @@ namespace Hl7.Fhir.Serialization
         internal Resource? DeserializeResourceInternal(XmlReader reader, FhirXmlPocoDeserializerState state)
         {
             //check if we are actually on an opening element. 
-            VerifyOpeningElement(reader, state);
+            verifyOpeningElement(reader, state);
 
             (ClassMapping? resourceMapping, FhirXmlException? error) = DetermineClassMappingFromInstance(reader, _inspector);
 
@@ -150,7 +150,7 @@ namespace Hl7.Fhir.Serialization
             }
         }
 
-        private static void VerifyOpeningElement(XmlReader reader, FhirXmlPocoDeserializerState state)
+        private static void verifyOpeningElement(XmlReader reader, FhirXmlPocoDeserializerState state)
         {
             //If not skip all non-content and check again.
             reader.MoveToContent();
@@ -192,7 +192,7 @@ namespace Hl7.Fhir.Serialization
                   $"therefore not be used for deserialization. " + reader.GenerateLocationMessage(), nameof(targetType));
 
             //check if we are at an opening element.
-            VerifyOpeningElement(reader, state);
+            verifyOpeningElement(reader, state);
 
             // If we have at least a mapping, let's try to continue               
             var newDatatype = (Base)mapping.Factory();

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
@@ -107,16 +107,36 @@ namespace Hl7.Fhir.Serialization
         // This leaves the incorrect nulls in place, no change in data.
         internal static readonly FhirJsonException PRIMITIVE_ARRAYS_ONLY_NULL = new(PRIMITIVE_ARRAYS_ONLY_NULL_CODE, "Arrays need to have at least one non-null element.");
 
-        internal static readonly FhirJsonException[] RECOVERABLE_ERRORS = new[] { EXPECTED_PRIMITIVE_NOT_NULL, INCORRECT_BASE64_DATA, STRING_ISNOTAN_INSTANT,
-            NUMBER_CANNOT_BE_PARSED, UNEXPECTED_JSON_TOKEN, LONG_CANNOT_BE_PARSED, LONG_INCORRECT_FORMAT, EXPECTED_START_OF_ARRAY, USE_OF_UNDERSCORE_ILLEGAL,
-            RESOURCETYPE_UNEXPECTED, OBJECTS_CANNOT_BE_EMPTY, ARRAYS_CANNOT_BE_EMPTY, PRIMITIVE_ARRAYS_ONLY_NULL};
+        /// <summary>
+        /// Whether this issue leads to dataloss or not. Recoverable issues mean that all data present in the parsed data could be retrieved and
+        /// captured in the POCO model, even if the syntax or the data was not fully FHIR compliant.
+        /// </summary>
+        internal static bool IsRecoverableIssue(FhirJsonException e) => 
+            e.ErrorCode is EXPECTED_PRIMITIVE_NOT_NULL_CODE or
+            INCORRECT_BASE64_DATA_CODE or
+            STRING_ISNOTAN_INSTANT_CODE or
+            NUMBER_CANNOT_BE_PARSED_CODE or
+            UNEXPECTED_JSON_TOKEN_CODE or
+            LONG_CANNOT_BE_PARSED_CODE or
+            LONG_INCORRECT_FORMAT_CODE or
+            EXPECTED_START_OF_ARRAY_CODE or
+            USE_OF_UNDERSCORE_ILLEGAL_CODE or
+            RESOURCETYPE_UNEXPECTED_CODE or
+            OBJECTS_CANNOT_BE_EMPTY_CODE or
+            ARRAYS_CANNOT_BE_EMPTY_CODE or
+            PRIMITIVE_ARRAYS_ONLY_NULL_CODE;
 
-        internal static readonly CodedException[] BACKWARDS_COMPAT_ERRORS = new CodedException[] { 
-            CodedValidationException.INVALID_CODED_VALUE, EXPECTED_PRIMITIVE_NOT_OBJECT, EXPECTED_PRIMITIVE_NOT_ARRAY, CHOICE_ELEMENT_HAS_UNKOWN_TYPE,
-            UNKNOWN_PROPERTY_FOUND, 
-        };
-
-
+        /// <summary>
+        /// An issue is allowable for backwards compatibility if it could be caused because an older parser encounters data coming from a newer 
+        /// FHIR release. This means allowing unknown elements, codes and types in a choice element. Note that the POCO model cannot capture
+        /// these newer elements and data, so this means data loss may occur.
+        /// </summary>
+        internal static bool AllowedForBackwardsCompatibility(CodedException e) =>
+            e.ErrorCode is CodedValidationException.INVALID_CODED_VALUE_CODE or
+            //EXPECTED_PRIMITIVE_NOT_OBJECT_CODE or  
+            //EXPECTED_PRIMITIVE_NOT_ARRAY_CODE or
+            CHOICE_ELEMENT_HAS_UNKOWN_TYPE_CODE or
+            UNKNOWN_PROPERTY_FOUND_CODE;
 
         public FhirJsonException(string code, string message) : base(code, message)
         {

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
@@ -9,6 +9,7 @@
 
 #if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
 using Hl7.Fhir.Utility;
+using Hl7.Fhir.Validation;
 using System;
 using System.Globalization;
 using System.Text.Json;
@@ -105,6 +106,17 @@ namespace Hl7.Fhir.Serialization
 
         // This leaves the incorrect nulls in place, no change in data.
         internal static readonly FhirJsonException PRIMITIVE_ARRAYS_ONLY_NULL = new(PRIMITIVE_ARRAYS_ONLY_NULL_CODE, "Arrays need to have at least one non-null element.");
+
+        internal static readonly FhirJsonException[] RECOVERABLE_ERRORS = new[] { EXPECTED_PRIMITIVE_NOT_NULL, INCORRECT_BASE64_DATA, STRING_ISNOTAN_INSTANT,
+            NUMBER_CANNOT_BE_PARSED, UNEXPECTED_JSON_TOKEN, LONG_CANNOT_BE_PARSED, LONG_INCORRECT_FORMAT, EXPECTED_START_OF_ARRAY, USE_OF_UNDERSCORE_ILLEGAL,
+            RESOURCETYPE_UNEXPECTED, OBJECTS_CANNOT_BE_EMPTY, ARRAYS_CANNOT_BE_EMPTY, PRIMITIVE_ARRAYS_ONLY_NULL};
+
+        internal static readonly CodedException[] BACKWARDS_COMPAT_ERRORS = new CodedException[] { 
+            CodedValidationException.INVALID_CODED_VALUE, EXPECTED_PRIMITIVE_NOT_OBJECT, EXPECTED_PRIMITIVE_NOT_ARRAY, CHOICE_ELEMENT_HAS_UNKOWN_TYPE,
+            UNKNOWN_PROPERTY_FOUND, 
+        };
+
+
 
         public FhirJsonException(string code, string message) : base(code, message)
         {

--- a/src/Hl7.Fhir.Base/Serialization/FhirXmlException.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirXmlException.cs
@@ -28,7 +28,9 @@ namespace Hl7.Fhir.Serialization
         public const string ELEMENT_NOT_IN_SEQUENCE_CODE = "XML116";
         public const string SCHEMALOCATION_DISALLOWED_CODE = "XML117";
         public const string EXPECTED_OPENING_ELEMENT_CODE = "XML118";
+        [Obsolete("This name contains a spelling mistake, use ENCOUNTERED_DTD_REFERENCES_CODE instead.")]
         public const string ENCOUNTERED_DTP_REFERENCES_CODE = "XML119";
+        public const string ENCOUNTERED_DTD_REFERENCES_CODE = "XML119";
         public const string ELEMENT_HAS_NO_VALUE_OR_CHILDREN_CODE = "XML120";
 
         public const string INCORRECT_BASE64_DATA_CODE = "XML202";
@@ -71,14 +73,36 @@ namespace Hl7.Fhir.Serialization
 
         // Xml paraphernalia that do not contain data so they can be safely skipped.
         internal static readonly FhirXmlException SCHEMALOCATION_DISALLOWED = new(SCHEMALOCATION_DISALLOWED_CODE, "The 'schemaLocation' attribute is disallowed.");
-        internal static readonly FhirXmlException ENCOUNTERED_DTD_REFERENCES = new(ENCOUNTERED_DTP_REFERENCES_CODE, "There SHALL be no DTD references in FHIR resources (because of the XXE security exploit)");
+        internal static readonly FhirXmlException ENCOUNTERED_DTD_REFERENCES = new(ENCOUNTERED_DTD_REFERENCES_CODE, "There SHALL be no DTD references in FHIR resources (because of the XXE security exploit)");
 
-        internal static readonly FhirXmlException[] RECOVERABLE_ERRORS = new[] { EMPTY_ELEMENT_NAMESPACE, INCORRECT_ELEMENT_NAMESPACE, INCORRECT_XHTML_NAMESPACE,
-            INCORRECT_ATTRIBUTE_NAMESPACE, INCORRECT_BASE64_DATA, VALUE_IS_NOT_OF_EXPECTED_TYPE, ELEMENT_OUT_OF_ORDER, ELEMENT_NOT_IN_SEQUENCE,
-            ATTRIBUTE_HAS_EMPTY_VALUE, ELEMENT_HAS_NO_VALUE_OR_CHILDREN, SCHEMALOCATION_DISALLOWED, ENCOUNTERED_DTD_REFERENCES };
-        internal static readonly CodedException[] BACKWARDS_COMPAT_ERRORS = new CodedException[] { CodedValidationException.INVALID_CODED_VALUE, UNKNOWN_ELEMENT,
-            CHOICE_ELEMENT_HAS_UNKNOWN_TYPE, UNKNOWN_ATTRIBUTE};
+        /// <summary>
+        /// Whether this issue leads to dataloss or not. Recoverable issues mean that all data present in the parsed data could be retrieved and
+        /// captured in the POCO model, even if the syntax or the data was not fully FHIR compliant.
+        /// </summary>
+        internal static bool IsRecoverableIssue(FhirXmlException e) =>
+            e.ErrorCode is EMPTY_ELEMENT_NAMESPACE_CODE or
+            INCORRECT_ELEMENT_NAMESPACE_CODE or
+            INCORRECT_XHTML_NAMESPACE_CODE or
+            INCORRECT_ATTRIBUTE_NAMESPACE_CODE or
+            INCORRECT_BASE64_DATA_CODE or
+            VALUE_IS_NOT_OF_EXPECTED_TYPE_CODE or
+            ELEMENT_OUT_OF_ORDER_CODE or
+            ELEMENT_NOT_IN_SEQUENCE_CODE or
+            ATTRIBUTE_HAS_EMPTY_VALUE_CODE or
+            ELEMENT_HAS_NO_VALUE_OR_CHILDREN_CODE or
+            SCHEMALOCATION_DISALLOWED_CODE or
+            ENCOUNTERED_DTD_REFERENCES_CODE;
 
+        /// <summary>
+        /// An issue is allowable for backwards compatibility if it could be caused because an older parser encounters data coming from a newer 
+        /// FHIR release. This means allowing unknown elements, attributes, codes and types in a choice element. Note that the POCO model cannot capture
+        /// these newer elements and data, so this means data loss may occur.
+        /// </summary>
+        internal static bool AllowedForBackwardsCompatibility(CodedException e) =>
+            e.ErrorCode is CodedValidationException.INVALID_CODED_VALUE_CODE or
+            UNKNOWN_ELEMENT_CODE or
+            CHOICE_ELEMENT_HAS_UNKNOWN_TYPE_CODE or
+            UNKNOWN_ATTRIBUTE_CODE;
 
         public FhirXmlException(string errorCode, string message) : base(errorCode, message)
         {

--- a/src/Hl7.Fhir.Base/Serialization/ParserSettings.cs
+++ b/src/Hl7.Fhir.Base/Serialization/ParserSettings.cs
@@ -95,7 +95,7 @@ namespace Hl7.Fhir.Serialization
         }
 
         /// <summary>Creates a new <see cref="ParserSettings"/> object that is a copy of the current instance.</summary>
-        public ParserSettings Clone() => new ParserSettings(this);
+        public ParserSettings Clone() => new(this);
 
         /// <summary>Creates a new <see cref="ParserSettings"/> instance with default property values.</summary>
         public static ParserSettings CreateDefault() => new ParserSettings();

--- a/src/Hl7.Fhir.Base/Serialization/engine/ElementModelSerializationEngine.cs
+++ b/src/Hl7.Fhir.Base/Serialization/engine/ElementModelSerializationEngine.cs
@@ -26,12 +26,12 @@ namespace Hl7.Fhir.Serialization
     internal class ElementModelSerializationEngine : IFhirSerializationEngine
     {
         private readonly ModelInspector _inspector;
-        private readonly ParserSettings? _settings;
+        private readonly ParserSettings _settings;
 
         public ElementModelSerializationEngine(ModelInspector inspector, ParserSettings? settings)
         {
             _inspector = inspector;
-            _settings = settings;
+            _settings = settings ?? new ParserSettings();
         }
 
         public static bool TryUnpackElementModelException(DeserializationFailedException dfe, out FormatException? fe)
@@ -54,7 +54,7 @@ namespace Hl7.Fhir.Serialization
 
         private Resource deserialize(Func<ISourceNode> deserializer)
         {
-            var settings = BaseFhirParser.BuildPocoBuilderSettings(_settings ?? ParserSettings.CreateDefault());
+            var settings = BaseFhirParser.BuildPocoBuilderSettings(_settings);
 
             try
             {

--- a/src/Hl7.Fhir.Base/Serialization/engine/IFhirSerializationEngine.cs
+++ b/src/Hl7.Fhir.Base/Serialization/engine/IFhirSerializationEngine.cs
@@ -12,33 +12,9 @@
 using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Utility;
-using System.Collections;
-using System.Collections.Generic;
 
 namespace Hl7.Fhir.Serialization
 {
-    /// <summary>
-    /// Factory methods for creating the default implementation of <see cref="IFhirSerializationEngine"/>, as used by the
-    /// FhirClient.
-    /// </summary>
-    public static class FhirSerializationEngine
-    {
-        /// <summary>
-        /// Create an implementation of <see cref="IFhirSerializationEngine"/> configured whith defaults,
-        /// which uses the "old" TypedElement-based parser and serializer.
-        /// </summary>
-        public static IFhirSerializationEngine ElementModel(ModelInspector inspector, ParserSettings? settings = null) =>
-            new ElementModelSerializationEngine(inspector, settings);
-
-        /// <summary>
-        /// Create an implementation of <see cref="IFhirSerializationEngine"/> configured with defaults 
-        /// which uses the new Poco-based parser and serializer.
-        /// </summary>
-        /// <param name="inspector"></param>
-        /// <returns></returns>
-        public static IFhirSerializationEngine Poco(ModelInspector inspector) =>  new PocoSerializationEngine(inspector);
-    }
-
     /// <summary>
     /// Represents an object that can serialize/deserialize FHIR data from the supported
     /// serialization formats.
@@ -50,13 +26,13 @@ namespace Hl7.Fhir.Serialization
         /// </summary>
         /// <exception cref="DeserializationFailedException">Thrown when the deserializer encountered one or more errors in the FHIR Xml format.</exception>
         /// <returns>Null if the data did not contain a resource, but another FHIR datatype.</returns>
-        public bool TryDeserializeFromXml(string data, out Resource? instance, out IEnumerable<CodedException> issues);
+        public Resource DeserializeFromXml(string data);
 
         /// <summary>
         /// Deserialize a Json string to a FHIR Resource POCO.
         /// </summary>
         /// <exception cref="DeserializationFailedException">Thrown when the deserializer encountered one or more errors in the FHIR Json format.</exception>
-        public bool TryDeserializeFromJson(string data, out Resource? instance, out IEnumerable<CodedException> issues);
+        public Resource DeserializeFromJson(string data);
 
         /// <summary>
         /// Serialize a FHIR Resource POCO into a string of Xml.
@@ -67,6 +43,84 @@ namespace Hl7.Fhir.Serialization
         /// Serialize a FHIR Resource POCO into a string of Json.
         /// </summary>
         public string SerializeToJson(Resource instance);
+    }
+
+
+    /// <summary>
+    /// Factory methods for creating the default implementation of <see cref="IFhirSerializationEngine"/>, as used by the
+    /// FhirClient.
+    /// </summary>
+    public static class FhirSerializationEngineFactory
+    {
+        /// <summary>
+        /// A named scope for the factory methods that use the ElementModel deserializers.
+        /// </summary>
+        public static class ElementModel
+        {
+            /// <summary>
+            /// Create an implementation of <see cref="IFhirSerializationEngine"/> which uses the "old" TypedElement-based parser and serializer
+            /// using <see cref="ParserSettings.PermissiveParsing"/> set to <c>true</c>.
+            /// </summary>
+            public static IFhirSerializationEngine Permissive(ModelInspector inspector) =>
+                new ElementModelSerializationEngine(inspector, ParserSettings.CreateDefault());
+
+            /// <summary>
+            /// Create an implementation of <see cref="IFhirSerializationEngine"/> which uses the "old" TypedElement-based parser and serializer
+            /// with <see cref="ParserSettings.PermissiveParsing"/> set to <c>false</c>.
+            /// </summary>
+            public static IFhirSerializationEngine Strict(ModelInspector inspector) =>
+                new ElementModelSerializationEngine(inspector, new ParserSettings { PermissiveParsing = false });
+
+            /// <summary>
+            /// Create an implementation of <see cref="IFhirSerializationEngine"/> configured to allow errors that 
+            /// could occur when reading data from newer releases of FHIR. Note that this parser may drop data
+            /// that cannot be captured in the POCO model, such as new elements in future FHIR releases.
+            /// </summary>
+            public static IFhirSerializationEngine BackwardsCompatible(ModelInspector inspector) =>
+                new ElementModelSerializationEngine(inspector, new ParserSettings {  AcceptUnknownMembers = true, AllowUnrecognizedEnums = true });
+        }
+
+        /// <summary>
+        /// A named scope for the factory methods that use the Poco deserializers.
+        /// </summary>
+        public static class Poco
+        {           
+            /// <summary>
+            /// Create an implementation of <see cref="IFhirSerializationEngine"/> configured to flag all parsing errors, 
+            /// which uses the new Poco-based parser and serializer.
+            /// </summary>
+            /// <param name="inspector"></param>
+            /// <returns></returns>
+            public static IFhirSerializationEngine Strict(ModelInspector inspector) => new PocoSerializationEngine(inspector);
+
+            /// <summary>
+            /// Create an implementation of <see cref="IFhirSerializationEngine"/> configured to ignore recoverable errors, 
+            /// which uses the new Poco-based parser and serializer.
+            /// </summary>
+            /// <param name="inspector"></param>
+            /// <returns></returns>
+            public static IFhirSerializationEngine Recoverable(ModelInspector inspector) => 
+                new PocoSerializationEngine(inspector, isRecoverableIssue);
+
+            /// <summary>
+            /// Create an implementation of <see cref="IFhirSerializationEngine"/> configured to allow errors that 
+            /// could occur when reading data from newer releases of FHIR. Note that this parser may drop data
+            /// that cannot be captured in the POCO model, such as new elements in future FHIR releases.
+            /// </summary>
+            public static IFhirSerializationEngine BackwardsCompatible(ModelInspector inspector) => 
+                new PocoSerializationEngine(inspector, isAllowedForBackwardsCompatibility);
+
+            private static bool isRecoverableIssue(CodedException ce) =>
+              ce switch
+              {
+                  FhirXmlException xmle => FhirXmlException.IsRecoverableIssue(xmle),
+                  FhirJsonException jsone => FhirJsonException.IsRecoverableIssue(jsone),
+                  _ => false
+              };
+
+            private static bool isAllowedForBackwardsCompatibility(CodedException ce) =>
+               FhirXmlException.AllowedForBackwardsCompatibility(ce) || FhirJsonException.AllowedForBackwardsCompatibility(ce);
+        }
     }
 }
 

--- a/src/Hl7.Fhir.Base/Serialization/engine/IFhirSerializationEngine.cs
+++ b/src/Hl7.Fhir.Base/Serialization/engine/IFhirSerializationEngine.cs
@@ -11,6 +11,9 @@
 
 using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
+using Hl7.Fhir.Utility;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace Hl7.Fhir.Serialization
 {
@@ -24,7 +27,7 @@ namespace Hl7.Fhir.Serialization
         /// Create an implementation of <see cref="IFhirSerializationEngine"/> configured whith defaults,
         /// which uses the "old" TypedElement-based parser and serializer.
         /// </summary>
-        public static IFhirSerializationEngine ElementModel(ModelInspector inspector, ParserSettings? settings) =>
+        public static IFhirSerializationEngine ElementModel(ModelInspector inspector, ParserSettings? settings = null) =>
             new ElementModelSerializationEngine(inspector, settings);
 
         /// <summary>
@@ -47,13 +50,13 @@ namespace Hl7.Fhir.Serialization
         /// </summary>
         /// <exception cref="DeserializationFailedException">Thrown when the deserializer encountered one or more errors in the FHIR Xml format.</exception>
         /// <returns>Null if the data did not contain a resource, but another FHIR datatype.</returns>
-        public Resource DeserializeFromXml(string data);
+        public bool TryDeserializeFromXml(string data, out Resource? instance, out IEnumerable<CodedException> issues);
 
         /// <summary>
         /// Deserialize a Json string to a FHIR Resource POCO.
         /// </summary>
         /// <exception cref="DeserializationFailedException">Thrown when the deserializer encountered one or more errors in the FHIR Json format.</exception>
-        public Resource DeserializeFromJson(string data);
+        public bool TryDeserializeFromJson(string data, out Resource? instance, out IEnumerable<CodedException> issues);
 
         /// <summary>
         /// Serialize a FHIR Resource POCO into a string of Xml.

--- a/src/Hl7.Fhir.Base/Serialization/engine/PocoDeserializationExtensions.cs
+++ b/src/Hl7.Fhir.Base/Serialization/engine/PocoDeserializationExtensions.cs
@@ -1,0 +1,151 @@
+﻿/*
+ * Copyright (c) 2023, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+#nullable enable
+
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Utility;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Xml;
+
+namespace Hl7.Fhir.Serialization
+{
+    /// <summary>
+    /// Extension methods that provide additional utility methods for deserialization on top of
+    /// the TryDeserialize() functions of the json and xml deserializers.
+    /// </summary>
+    public static class PocoDeserializationExtensions
+    {
+        /// <summary>
+        /// Deserialize the FHIR xml from the reader and create a new POCO resource containing the data from the reader.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="reader">An xml reader positioned on the first element, or the beginning of the stream.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns>
+        public static Resource DeserializeResource(this BaseFhirXmlPocoDeserializer deserializer, XmlReader reader) =>
+                deserializer.TryDeserializeResource(reader, out var instance, out var issues) ?
+                instance! : throw new DeserializationFailedException(instance, issues);
+
+        /// <summary>
+        /// Deserialize the FHIR xml from a string and create a new POCO resource containing the data from the reader.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="data">A string containing the XML from which to deserialize the resource.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns>
+        public static Resource DeserializeResource(this BaseFhirXmlPocoDeserializer deserializer, string data)
+        {
+            var xmlReader = SerializationUtil.XmlReaderFromXmlText(data);
+            return deserializer.DeserializeResource(xmlReader);
+        }
+
+        /// <summary>
+        /// Deserialize the FHIR xml from a string and create a new POCO resource containing the data from the reader.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="data">A string containing the XML from which to deserialize the resource.</param>
+        /// <param name="instance">The result of deserialization. May be incomplete when there are issues.</param>
+        /// <param name="issues">Issues encountered while deserializing. Will be empty when the function returns true.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns>
+        public static bool TryDeserializeResource(
+            this BaseFhirXmlPocoDeserializer deserializer, 
+            string data, 
+            out Resource? instance, 
+            out IEnumerable<CodedException> issues)
+        {
+            var xmlReader = SerializationUtil.XmlReaderFromXmlText(data);
+            return deserializer.TryDeserializeResource(xmlReader, out instance, out issues);
+        }
+
+        /// <summary>
+        /// Reads a (subtree) of serialized FHIR Xml data into a POCO object.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="targetType">The type of POCO to construct and deserialize</param>
+        /// <param name="reader">An xml reader positioned on the first element, or the beginning of the stream.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns>
+        public static Base DeserializeElement(this BaseFhirXmlPocoDeserializer deserializer, Type targetType, XmlReader reader) =>
+            deserializer.TryDeserializeElement(targetType, reader, out var instance, out var issues) ?
+            instance! : throw new DeserializationFailedException(instance, issues);
+
+        /// <summary>
+        /// Reads a (subtree) of serialized FHIR Xml data into a POCO object.
+        /// </summary>
+        /// <typeparam name="T">The type of POCO to construct and deserialize</typeparam>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="reader">An xml reader positioned on the first element, or the beginning of the stream.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns>
+        public static T DeserializeElement<T>(this BaseFhirXmlPocoDeserializer deserializer, XmlReader reader) where T : Base => 
+            (T)deserializer.DeserializeElement(typeof(T), reader);
+
+        /// <summary>
+        /// Deserialize the FHIR Json from the reader and create a new POCO object containing the data from the reader.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="reader">A json reader positioned on the first token of the object, or the beginning of the stream.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns>
+        public static Resource DeserializeResource(this BaseFhirJsonPocoDeserializer deserializer, ref Utf8JsonReader reader) =>
+            deserializer.TryDeserializeResource(ref reader, out var instance, out var issues)
+                ? instance! : throw new DeserializationFailedException(instance, issues);
+
+        /// <summary>
+        /// Deserialize the FHIR Json from the reader and create a new POCO object containing the data from the reader.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="json">A string of json.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns>
+        public static Resource DeserializeResource(this BaseFhirJsonPocoDeserializer deserializer, string json)
+        {
+            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json), new() { CommentHandling = JsonCommentHandling.Skip });
+            return deserializer.DeserializeResource(ref reader);
+        }
+
+        /// <summary>
+        /// Deserialize the FHIR Json from the reader and create a new POCO object containing the data from the reader.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="json">A string of json.</param>
+        /// <param name="instance">The result of deserialization. May be incomplete when there are issues.</param>
+        /// <param name="issues">Issues encountered while deserializing. Will be empty when the function returns true.</param>
+        /// <returns><c>false</c> if there are issues, <c>true</c> otherwise.</returns>
+        public static bool TryDeserializeResource(
+            this BaseFhirJsonPocoDeserializer deserializer, 
+            string json, 
+            out Resource? instance, 
+            out IEnumerable<CodedException> issues)
+        {
+            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json), new() { CommentHandling = JsonCommentHandling.Skip });
+            return deserializer.TryDeserializeResource(ref reader, out instance, out issues);
+        }
+
+        /// <summary>
+        /// Reads a (subtree) of serialized FHIR Json data into a POCO object.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="targetType">The type of POCO to construct and deserialize</param>
+        /// <param name="reader">A json reader positioned on the first token of the object, or the beginning of the stream.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns> 
+        public static Base DeserializeObject(this BaseFhirJsonPocoDeserializer deserializer, Type targetType, ref Utf8JsonReader reader) =>
+            deserializer.TryDeserializeObject(targetType, ref reader, out var instance, out var issues) ?
+                instance! : throw new DeserializationFailedException(instance, issues);
+
+        /// <summary>
+        /// Reads a (subtree) of serialzed FHIR Json data into a POCO object.
+        /// </summary>
+        /// <typeparam name="T">The type of POCO to construct and deserialize</typeparam>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="reader">A json reader positioned on the first token of the object, or the beginning of the stream.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns>
+        public static T DeserializeObject<T>(this BaseFhirJsonPocoDeserializer deserializer, ref Utf8JsonReader reader) where T : Base => 
+            (T)deserializer.DeserializeObject(typeof(T), ref reader);
+    }
+}
+
+#nullable restore

--- a/src/Hl7.Fhir.Base/Serialization/engine/PocoSerializationEngine.cs
+++ b/src/Hl7.Fhir.Base/Serialization/engine/PocoSerializationEngine.cs
@@ -15,6 +15,7 @@ using Hl7.Fhir.Validation;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Xml;
@@ -23,15 +24,16 @@ namespace Hl7.Fhir.Serialization
 {
     /// <summary>
     /// This is an implementation of <see cref="IFhirSerializationEngine"/> which uses the
-    /// new Poco-based parser and serializer. It is used as a switchable serialization
-    /// in the <c>BaseFhirClient</c>.
+    /// new Poco-based parser and serializer, initialized with the default settings.
     /// </summary>
     internal class PocoSerializationEngine : IFhirSerializationEngine
     {
+        private delegate bool TryDeserializer(string data, out Resource? instance, out IEnumerable<CodedException> issues);
+
         private readonly JsonSerializerOptions _options;
         private readonly ModelInspector _inspector;
         private readonly Predicate<CodedException> _ignoreFilter;
-
+      
         /// <summary>
         /// Creates an implementation of <see cref="IFhirSerializationEngine"/> that uses the newer POCO (de)serializers.
         /// </summary>
@@ -55,149 +57,31 @@ namespace Hl7.Fhir.Serialization
             _ignoreFilter = _ => false;
         }
 
+        /// <inheritdoc />
+        public Resource DeserializeFromXml(string data)
+        {
+            var deserializer = new BaseFhirXmlPocoDeserializer(_inspector);
+            return deserializeAndIgnoreErrors(deserializer.TryDeserializeResource, data);
+        }
 
-        public bool TryDeserializeFromXml(string data, out Resource? instance, IEnumerable<CodedException> issues) => 
-            new BaseFhirXmlPocoDeserializer(_inspector).TryDeserializeResource(data, out instance, out issues);
+        /// <inheritdoc />
+        public Resource DeserializeFromJson(string data)
+        {
+            var deserializer = new BaseFhirJsonPocoDeserializer(_inspector);
+            return deserializeAndIgnoreErrors(deserializer.TryDeserializeResource, data);
+        }
 
-        public Resource DeserializeFromJson(string data) => JsonSerializer.Deserialize<Resource>(data, _options)!;
+        private Resource deserializeAndIgnoreErrors(TryDeserializer deserializer, string data)
+        {
+            bool success = deserializer(data, out var instance, out var issues);
+            var relevantIssues = issues.Where(i => !_ignoreFilter(i)).ToList();
+
+            return relevantIssues.Any() ? throw new DeserializationFailedException(instance, relevantIssues) : instance!;
+        }
 
         public string SerializeToXml(Resource instance) => new BaseFhirXmlPocoSerializer(_inspector.FhirRelease).SerializeToString(instance);
 
         public string SerializeToJson(Resource instance) => JsonSerializer.Serialize(instance, _options);
-    }
-
-    /// <summary>
-    /// Extension methods that provide additional utility methods for deserialization on top of
-    /// the TryDeserialize() functions of the json and xml deserializers.
-    /// </summary>
-    public static class PocoDeserializationExtensions
-    {
-        /// <summary>
-        /// Deserialize the FHIR xml from the reader and create a new POCO resource containing the data from the reader.
-        /// </summary>
-        /// <param name="deserializer">The deserializer to use.</param>
-        /// <param name="reader">An xml reader positioned on the first element, or the beginning of the stream.</param>
-        /// <returns>A fully initialized POCO with the data from the reader.</returns>
-        public static Resource DeserializeResource(this BaseFhirXmlPocoDeserializer deserializer, XmlReader reader) =>
-                deserializer.TryDeserializeResource(reader, out var instance, out var issues) ?
-                instance! : throw new DeserializationFailedException(instance, issues);
-
-        /// <summary>
-        /// Deserialize the FHIR xml from a string and create a new POCO resource containing the data from the reader.
-        /// </summary>
-        /// <param name="deserializer">The deserializer to use.</param>
-        /// <param name="data">A string containing the XML from which to deserialize the resource.</param>
-        /// <returns>A fully initialized POCO with the data from the reader.</returns>
-        public static Resource DeserializeResource(this BaseFhirXmlPocoDeserializer deserializer, string data)
-        {
-            var xmlReader = SerializationUtil.XmlReaderFromXmlText(data);
-            return deserializer.DeserializeResource(xmlReader);
-        }
-
-        /// <summary>
-        /// Deserialize the FHIR xml from a string and create a new POCO resource containing the data from the reader.
-        /// </summary>
-        /// <param name="deserializer">The deserializer to use.</param>
-        /// <param name="data">A string containing the XML from which to deserialize the resource.</param>
-        /// <param name="instance">The result of deserialization. May be incomplete when there are issues.</param>
-        /// <param name="issues">Issues encountered while deserializing. Will be empty when the function returns true.</param>
-        /// <returns>A fully initialized POCO with the data from the reader.</returns>
-        public static bool TryDeserializeResource(
-            this BaseFhirXmlPocoDeserializer deserializer, 
-            string data, 
-            out Resource? instance, 
-            out IEnumerable<CodedException> issues)
-        {
-            var xmlReader = SerializationUtil.XmlReaderFromXmlText(data);
-            return deserializer.TryDeserializeResource(xmlReader, out instance, out issues);
-        }
-
-        /// <summary>
-        /// Reads a (subtree) of serialized FHIR Xml data into a POCO object.
-        /// </summary>
-        /// <param name="deserializer">The deserializer to use.</param>
-        /// <param name="targetType">The type of POCO to construct and deserialize</param>
-        /// <param name="reader">An xml reader positioned on the first element, or the beginning of the stream.</param>
-        /// <returns>A fully initialized POCO with the data from the reader.</returns>
-        public static Base DeserializeElement(this BaseFhirXmlPocoDeserializer deserializer, Type targetType, XmlReader reader) =>
-            deserializer.TryDeserializeElement(targetType, reader, out var instance, out var issues) ?
-            instance! : throw new DeserializationFailedException(instance, issues);
-
-        /// <summary>
-        /// Reads a (subtree) of serialized FHIR Xml data into a POCO object.
-        /// </summary>
-        /// <typeparam name="T">The type of POCO to construct and deserialize</typeparam>
-        /// <param name="deserializer">The deserializer to use.</param>
-        /// <param name="reader">An xml reader positioned on the first element, or the beginning of the stream.</param>
-        /// <returns>A fully initialized POCO with the data from the reader.</returns>
-        public static T DeserializeElement<T>(this BaseFhirXmlPocoDeserializer deserializer, XmlReader reader) where T : Base => 
-            (T)deserializer.DeserializeElement(typeof(T), reader);
-
-        /// <summary>
-        /// Deserialize the FHIR Json from the reader and create a new POCO object containing the data from the reader.
-        /// </summary>
-        /// <param name="deserializer">The deserializer to use.</param>
-        /// <param name="reader">A json reader positioned on the first token of the object, or the beginning of the stream.</param>
-        /// <returns>A fully initialized POCO with the data from the reader.</returns>
-        public static Resource DeserializeResource(this BaseFhirJsonPocoDeserializer deserializer, ref Utf8JsonReader reader) =>
-            deserializer.TryDeserializeResource(ref reader, out var instance, out var issues)
-                ? instance! : throw new DeserializationFailedException(instance, issues);
-
-        /// <summary>
-        /// Deserialize the FHIR Json from the reader and create a new POCO object containing the data from the reader.
-        /// </summary>
-        /// <param name="deserializer">The deserializer to use.</param>
-        /// <param name="json">A string of json.</param>
-        /// <returns>A fully initialized POCO with the data from the reader.</returns>
-        public static Resource DeserializeResource(this BaseFhirJsonPocoDeserializer deserializer, string json)
-        {
-            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json), new() { CommentHandling = JsonCommentHandling.Skip });
-            return deserializer.DeserializeResource(ref reader);
-        }
-
-        /// <summary>
-        /// Deserialize the FHIR Json from the reader and create a new POCO object containing the data from the reader.
-        /// </summary>
-        /// <param name="deserializer">The deserializer to use.</param>
-        /// <param name="json">A string of json.</param>
-        /// <param name="instance">The result of deserialization. May be incomplete when there are issues.</param>
-        /// <param name="issues">Issues encountered while deserializing. Will be empty when the function returns true.</param>
-        /// <returns><c>false</c> if there are issues, <c>true</c> otherwise.</returns>
-        public static bool TryDeserializeResource(
-            this BaseFhirJsonPocoDeserializer deserializer, 
-            string json, 
-            out Resource? instance, 
-            out IEnumerable<CodedException> issues)
-        {
-            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json), new() { CommentHandling = JsonCommentHandling.Skip });
-            return deserializer.TryDeserializeResource(ref reader, out instance, out issues);
-        }
-
-        /// <summary>
-        /// Reads a (subtree) of serialized FHIR Json data into a POCO object.
-        /// </summary>
-        /// <param name="deserializer">The deserializer to use.</param>
-        /// <param name="targetType">The type of POCO to construct and deserialize</param>
-        /// <param name="reader">A json reader positioned on the first token of the object, or the beginning of the stream.</param>
-        /// <returns>A fully initialized POCO with the data from the reader.</returns> 
-        public static Base DeserializeObject(this BaseFhirJsonPocoDeserializer deserializer, Type targetType, ref Utf8JsonReader reader) =>
-            deserializer.TryDeserializeObject(targetType, ref reader, out var instance, out var issues) ?
-                instance! : throw new DeserializationFailedException(instance, issues);
-
-        /// <summary>
-        /// Reads a (subtree) of serialzed FHIR Json data into a POCO object.
-        /// </summary>
-        /// <typeparam name="T">The type of POCO to construct and deserialize</typeparam>
-        /// <param name="deserializer">The deserializer to use.</param>
-        /// <param name="reader">A json reader positioned on the first token of the object, or the beginning of the stream.</param>
-        /// <returns>A fully initialized POCO with the data from the reader.</returns>
-        public static T DeserializeObject<T>(this BaseFhirJsonPocoDeserializer deserializer, ref Utf8JsonReader reader) where T : Base => 
-            (T)deserializer.DeserializeObject(typeof(T), ref reader);
-
-        internal static void Throw(this IEnumerable<CodedException> issues, Base instance)
-        {
-            throw new DeserializationFailedException(instance, issues);
-        }
     }
 }
 

--- a/src/Hl7.Fhir.Base/Serialization/engine/PocoSerializationEngine.cs
+++ b/src/Hl7.Fhir.Base/Serialization/engine/PocoSerializationEngine.cs
@@ -10,7 +10,14 @@
 
 using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
+using Hl7.Fhir.Utility;
+using Hl7.Fhir.Validation;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
 using System.Text.Json;
+using System.Xml;
 
 namespace Hl7.Fhir.Serialization
 {
@@ -23,20 +30,174 @@ namespace Hl7.Fhir.Serialization
     {
         private readonly JsonSerializerOptions _options;
         private readonly ModelInspector _inspector;
+        private readonly Predicate<CodedException> _ignoreFilter;
 
+        /// <summary>
+        /// Creates an implementation of <see cref="IFhirSerializationEngine"/> that uses the newer POCO (de)serializers.
+        /// </summary>
+        /// <param name="inspector">Reflection data of the POCO model to use.</param>
+        /// <param name="ignoreFilter">A predicate that returns true for issues that should not be reported.</param>
+        public PocoSerializationEngine(ModelInspector inspector, Predicate<CodedException> ignoreFilter)
+        {
+            _options = new JsonSerializerOptions().ForFhir(inspector);
+            _inspector = inspector;
+            _ignoreFilter = ignoreFilter;
+        }
+
+        /// <summary>
+        /// Creates an implementation of <see cref="IFhirSerializationEngine"/> that uses the newer POCO (de)serializers.
+        /// </summary>
+        /// <param name="inspector">Reflection data of the POCO model to use.</param>
         public PocoSerializationEngine(ModelInspector inspector)
         {
             _options = new JsonSerializerOptions().ForFhir(inspector);
             _inspector = inspector;
+            _ignoreFilter = _ => false;
         }
 
-        public Resource DeserializeFromXml(string data) => new BaseFhirXmlPocoDeserializer(_inspector).DeserializeResource(data);
+
+        public bool TryDeserializeFromXml(string data, out Resource? instance, IEnumerable<CodedException> issues) => 
+            new BaseFhirXmlPocoDeserializer(_inspector).TryDeserializeResource(data, out instance, out issues);
 
         public Resource DeserializeFromJson(string data) => JsonSerializer.Deserialize<Resource>(data, _options)!;
 
         public string SerializeToXml(Resource instance) => new BaseFhirXmlPocoSerializer(_inspector.FhirRelease).SerializeToString(instance);
 
         public string SerializeToJson(Resource instance) => JsonSerializer.Serialize(instance, _options);
+    }
+
+    /// <summary>
+    /// Extension methods that provide additional utility methods for deserialization on top of
+    /// the TryDeserialize() functions of the json and xml deserializers.
+    /// </summary>
+    public static class PocoDeserializationExtensions
+    {
+        /// <summary>
+        /// Deserialize the FHIR xml from the reader and create a new POCO resource containing the data from the reader.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="reader">An xml reader positioned on the first element, or the beginning of the stream.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns>
+        public static Resource DeserializeResource(this BaseFhirXmlPocoDeserializer deserializer, XmlReader reader) =>
+                deserializer.TryDeserializeResource(reader, out var instance, out var issues) ?
+                instance! : throw new DeserializationFailedException(instance, issues);
+
+        /// <summary>
+        /// Deserialize the FHIR xml from a string and create a new POCO resource containing the data from the reader.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="data">A string containing the XML from which to deserialize the resource.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns>
+        public static Resource DeserializeResource(this BaseFhirXmlPocoDeserializer deserializer, string data)
+        {
+            var xmlReader = SerializationUtil.XmlReaderFromXmlText(data);
+            return deserializer.DeserializeResource(xmlReader);
+        }
+
+        /// <summary>
+        /// Deserialize the FHIR xml from a string and create a new POCO resource containing the data from the reader.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="data">A string containing the XML from which to deserialize the resource.</param>
+        /// <param name="instance">The result of deserialization. May be incomplete when there are issues.</param>
+        /// <param name="issues">Issues encountered while deserializing. Will be empty when the function returns true.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns>
+        public static bool TryDeserializeResource(
+            this BaseFhirXmlPocoDeserializer deserializer, 
+            string data, 
+            out Resource? instance, 
+            out IEnumerable<CodedException> issues)
+        {
+            var xmlReader = SerializationUtil.XmlReaderFromXmlText(data);
+            return deserializer.TryDeserializeResource(xmlReader, out instance, out issues);
+        }
+
+        /// <summary>
+        /// Reads a (subtree) of serialized FHIR Xml data into a POCO object.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="targetType">The type of POCO to construct and deserialize</param>
+        /// <param name="reader">An xml reader positioned on the first element, or the beginning of the stream.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns>
+        public static Base DeserializeElement(this BaseFhirXmlPocoDeserializer deserializer, Type targetType, XmlReader reader) =>
+            deserializer.TryDeserializeElement(targetType, reader, out var instance, out var issues) ?
+            instance! : throw new DeserializationFailedException(instance, issues);
+
+        /// <summary>
+        /// Reads a (subtree) of serialized FHIR Xml data into a POCO object.
+        /// </summary>
+        /// <typeparam name="T">The type of POCO to construct and deserialize</typeparam>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="reader">An xml reader positioned on the first element, or the beginning of the stream.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns>
+        public static T DeserializeElement<T>(this BaseFhirXmlPocoDeserializer deserializer, XmlReader reader) where T : Base => 
+            (T)deserializer.DeserializeElement(typeof(T), reader);
+
+        /// <summary>
+        /// Deserialize the FHIR Json from the reader and create a new POCO object containing the data from the reader.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="reader">A json reader positioned on the first token of the object, or the beginning of the stream.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns>
+        public static Resource DeserializeResource(this BaseFhirJsonPocoDeserializer deserializer, ref Utf8JsonReader reader) =>
+            deserializer.TryDeserializeResource(ref reader, out var instance, out var issues)
+                ? instance! : throw new DeserializationFailedException(instance, issues);
+
+        /// <summary>
+        /// Deserialize the FHIR Json from the reader and create a new POCO object containing the data from the reader.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="json">A string of json.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns>
+        public static Resource DeserializeResource(this BaseFhirJsonPocoDeserializer deserializer, string json)
+        {
+            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json), new() { CommentHandling = JsonCommentHandling.Skip });
+            return deserializer.DeserializeResource(ref reader);
+        }
+
+        /// <summary>
+        /// Deserialize the FHIR Json from the reader and create a new POCO object containing the data from the reader.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="json">A string of json.</param>
+        /// <param name="instance">The result of deserialization. May be incomplete when there are issues.</param>
+        /// <param name="issues">Issues encountered while deserializing. Will be empty when the function returns true.</param>
+        /// <returns><c>false</c> if there are issues, <c>true</c> otherwise.</returns>
+        public static bool TryDeserializeResource(
+            this BaseFhirJsonPocoDeserializer deserializer, 
+            string json, 
+            out Resource? instance, 
+            out IEnumerable<CodedException> issues)
+        {
+            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json), new() { CommentHandling = JsonCommentHandling.Skip });
+            return deserializer.TryDeserializeResource(ref reader, out instance, out issues);
+        }
+
+        /// <summary>
+        /// Reads a (subtree) of serialized FHIR Json data into a POCO object.
+        /// </summary>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="targetType">The type of POCO to construct and deserialize</param>
+        /// <param name="reader">A json reader positioned on the first token of the object, or the beginning of the stream.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns> 
+        public static Base DeserializeObject(this BaseFhirJsonPocoDeserializer deserializer, Type targetType, ref Utf8JsonReader reader) =>
+            deserializer.TryDeserializeObject(targetType, ref reader, out var instance, out var issues) ?
+                instance! : throw new DeserializationFailedException(instance, issues);
+
+        /// <summary>
+        /// Reads a (subtree) of serialzed FHIR Json data into a POCO object.
+        /// </summary>
+        /// <typeparam name="T">The type of POCO to construct and deserialize</typeparam>
+        /// <param name="deserializer">The deserializer to use.</param>
+        /// <param name="reader">A json reader positioned on the first token of the object, or the beginning of the stream.</param>
+        /// <returns>A fully initialized POCO with the data from the reader.</returns>
+        public static T DeserializeObject<T>(this BaseFhirJsonPocoDeserializer deserializer, ref Utf8JsonReader reader) where T : Base => 
+            (T)deserializer.DeserializeObject(typeof(T), ref reader);
+
+        internal static void Throw(this IEnumerable<CodedException> issues, Base instance)
+        {
+            throw new DeserializationFailedException(instance, issues);
+        }
     }
 }
 

--- a/src/Hl7.Fhir.Base/Validation/ValidateEnumCodeAttribute.cs
+++ b/src/Hl7.Fhir.Base/Validation/ValidateEnumCodeAttribute.cs
@@ -19,6 +19,7 @@ namespace Hl7.Fhir.Validation
     /// Validates a code value against the FHIR rules for code.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+    [Obsolete("This is a duplicate of CodePatternAttribute and should not be used anymore.")]
     public class ValidateEnumCodeAttribute : ValidationAttribute
     {
         /// <inheritdoc/>

--- a/src/Hl7.Fhir.Shared.Tests/Rest/OperationsTests.cs
+++ b/src/Hl7.Fhir.Shared.Tests/Rest/OperationsTests.cs
@@ -144,7 +144,7 @@ namespace Hl7.Fhir.Tests.Rest
         }
 
 #if R5
-    [Ignore("No R5 version of FS yet - this operation fails when run on R4.")]
+    [Ignore("No R5 version of FS yet - this operation fails when run on R5.")]
 #endif
         [TestMethod]
         [TestCategory("IntegrationTest"), TestCategory("FhirClient")]

--- a/src/Hl7.Fhir.Support.Poco.Tests/Rest/FhirClientMockTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Rest/FhirClientMockTests.cs
@@ -28,8 +28,6 @@ namespace Hl7.Fhir.Core.Tests.Rest
     {
         private static readonly ModelInspector TESTINSPECTOR = ModelInspector.ForType(typeof(TestPatient));
         private static readonly string TESTVERSION = "3.0.1";
-        private static readonly IFhirSerializationEngine ELEMENTENGINE = FhirSerializationEngine.ElementModel(TESTINSPECTOR, new());
-        private static readonly IFhirSerializationEngine POCOENGINE = FhirSerializationEngine.Poco(TESTINSPECTOR);
 
         private static async T.Task mockVersionResponse(string capabilityStatementResponseJson, string patientResponseJson, bool verifyFhirVersion = true)
         {

--- a/src/Hl7.Fhir.Support.Poco.Tests/Rest/RequestMessageTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Rest/RequestMessageTests.cs
@@ -55,7 +55,7 @@ namespace Hl7.Fhir.Test
 
             return entryToConvert.ToHttpRequestMessage(
                 ENDPOINT,
-                FhirSerializationEngine.Poco(TESTINSPECTOR),
+                FhirSerializationEngineFactory.Poco.Strict(TESTINSPECTOR),
                 TESTVERSION,
                 settings);
         }

--- a/src/Hl7.Fhir.Support.Poco.Tests/Rest/ResponseMessageTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Rest/ResponseMessageTests.cs
@@ -32,8 +32,8 @@ namespace Hl7.Fhir.Test
     {
         private static readonly Uri ENDPOINT = new("http://myserver.org/fhir/");
         private static readonly ModelInspector TESTINSPECTOR = ModelInspector.ForType(typeof(TestPatient));
-        private static readonly IFhirSerializationEngine ELEMENTENGINE = FhirSerializationEngine.ElementModel(TESTINSPECTOR, new());
-        private static readonly IFhirSerializationEngine POCOENGINE = FhirSerializationEngine.Poco(TESTINSPECTOR);
+        private static readonly IFhirSerializationEngine ELEMENTENGINE = FhirSerializationEngineFactory.ElementModel.Permissive(TESTINSPECTOR);
+        private static readonly IFhirSerializationEngine POCOENGINE = FhirSerializationEngineFactory.Poco.Strict(TESTINSPECTOR);
 
         [TestMethod]
         public void CanRoundtripHeaders()
@@ -87,7 +87,7 @@ namespace Hl7.Fhir.Test
         [TestMethod]
         public async Tasks.Task SetAndExtractRelevantHeaders()
         {           
-            var engine = FhirSerializationEngine.Poco(TESTINSPECTOR);
+            var engine = FhirSerializationEngineFactory.Poco.Strict(TESTINSPECTOR);
             var xmlContent = makeXmlContent();
             xmlContent.Headers.LastModified = new DateTimeOffset(new DateTime(2012, 01, 01), new TimeSpan());
 


### PR DESCRIPTION
* Defined "recoverable" and "backwards compatible" issues for xml and json parser.
* Added a factory for constructing a few standard implementations of IFhirSerializationEngine
(lenient, strict, backwards compatible, etc)
* Added extension methods on FhirClient for easy configuring of the serialization engine.