### PR TITLE
2410 - Enable roundtrip for empty attribute values.

### DIFF
--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonPocoDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonPocoDeserializer.cs
@@ -16,7 +16,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Text.Json;
 using ERR = Hl7.Fhir.Serialization.FhirJsonException;
 
@@ -78,7 +77,7 @@ namespace Hl7.Fhir.Serialization
         private const string INSTANCE_VALIDATION_KEY_SUFFIX = ":instance";
         private const string PROPERTY_VALIDATION_KEY_SUFFIX = ":property";
         private readonly ModelInspector _inspector;
-     
+
         /// <summary>
         /// Deserialize the FHIR Json from the reader and create a new POCO object containing the data from the reader.
         /// </summary>
@@ -101,7 +100,7 @@ namespace Hl7.Fhir.Serialization
 
             return !state.Errors.HasExceptions;
         }
-     
+
         /// <summary>
         /// Reads a (subtree) of serialized FHIR Json data into a POCO object.
         /// </summary>
@@ -135,7 +134,7 @@ namespace Hl7.Fhir.Serialization
             else
                 throw new ArgumentException($"Can only deserialize into subclasses of class {nameof(Base)}. " + reader.GenerateLocationMessage(), nameof(targetType));
         }
-     
+
         internal Resource? DeserializeResourceInternal(ref Utf8JsonReader reader, FhirJsonPocoDeserializerState state, bool stayOnLastToken)
         {
             if (reader.TokenType != JsonTokenType.StartObject)
@@ -674,7 +673,7 @@ namespace Hl7.Fhir.Serialization
             (object? partial, FhirJsonException? error) result = reader.TokenType switch
             {
                 JsonTokenType.Null => new(null, ERR.EXPECTED_PRIMITIVE_NOT_NULL.With(ref reader)),
-                JsonTokenType.String when string.IsNullOrEmpty(reader.GetString()) => new(null, ERR.PROPERTY_MAY_NOT_BE_EMPTY.With(ref reader)),
+                JsonTokenType.String when string.IsNullOrEmpty(reader.GetString()) => new(reader.GetString(), ERR.PROPERTY_MAY_NOT_BE_EMPTY.With(ref reader)),
                 JsonTokenType.String when implementingType == typeof(string) => new(reader.GetString(), null),
                 JsonTokenType.String when implementingType == typeof(byte[]) =>
                                 !Settings.DisableBase64Decoding ? readBase64(ref reader) : new(reader.GetString(), null),

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
@@ -77,6 +77,8 @@ namespace Hl7.Fhir.Serialization
 
         // The serialization contained a json null where it is not allowed, but a null does not contain data anyway.
         internal static readonly FhirJsonException EXPECTED_PRIMITIVE_NOT_NULL = new(EXPECTED_PRIMITIVE_NOT_NULL_CODE, "Expected a primitive value, not a json null.");
+
+        // Encountered an empty property, which is illegal, but the empty text is maintained.
         internal static readonly FhirJsonException PROPERTY_MAY_NOT_BE_EMPTY = new(PROPERTY_MAY_NOT_BE_EMPTY_CODE, "Properties cannot be empty strings. Either they are absent, or they are present with at least one character of non-whitespace content.");
 
         // These errors signal parsing errors, but the original raw data is retained in the POCO so no data is lost.
@@ -113,7 +115,7 @@ namespace Hl7.Fhir.Serialization
         /// Whether this issue leads to dataloss or not. Recoverable issues mean that all data present in the parsed data could be retrieved and
         /// captured in the POCO model, even if the syntax or the data was not fully FHIR compliant.
         /// </summary>
-        internal static bool IsRecoverableIssue(FhirJsonException e) => 
+        internal static bool IsRecoverableIssue(FhirJsonException e) =>
             e.ErrorCode is EXPECTED_PRIMITIVE_NOT_NULL_CODE or
             INCORRECT_BASE64_DATA_CODE or
             STRING_ISNOTAN_INSTANT_CODE or


### PR DESCRIPTION
When an attribute with an empty value is encountered, return an empty value, not null.