### PR TITLE
#2445 Correct split function to not remove empty strings

### DIFF
--- a/src/Hl7.Fhir.Base/FhirPath/Functions/StringOperators.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Functions/StringOperators.cs
@@ -49,7 +49,7 @@ namespace Hl7.FhirPath.Functions
 
         public static IEnumerable<ITypedElement> FpSplit(this string me, string seperator)
         {
-            var results = me.Split(new[] { seperator }, StringSplitOptions.RemoveEmptyEntries);
+            var results = me.Split(new[] { seperator }, StringSplitOptions.None);
             return results.Select(s => ElementNode.ForPrimitive(s));
         }
 

--- a/src/Hl7.FhirPath.Tests/Functions/StringFunctionsTests.cs
+++ b/src/Hl7.FhirPath.Tests/Functions/StringFunctionsTests.cs
@@ -11,6 +11,21 @@ namespace HL7.FhirPath.Tests.Functions
     public class StringFunctionsTests
     {
         [TestMethod]
+        public void StringSplit()
+        {
+            CollectionAssert.AreEqual(new[] { "A", "B", "C" }, StringOperators.FpSplit("A,B,C", ",").Select(r => r.Value.ToString()).ToArray());
+
+            // verify the empty string
+            CollectionAssert.AreEqual(new[] { "A", "", "C" }, StringOperators.FpSplit("A,,C", ",").Select(r => r.Value.ToString()).ToArray());
+
+            // Verify dups aren't removed
+            CollectionAssert.AreEqual(new[] { "A", "B", "C", "C" }, StringOperators.FpSplit("A,B,C,C", ",").Select(r => r.Value.ToString()).ToArray());
+
+            // The test from the spec
+            Assert.AreEqual(5, StringOperators.FpSplit("Peter,James,Jim,Peter,James", ",").Count());
+        }
+
+        [TestMethod]
         public void EncodeBase64()
         {
             StringOperators.EncodeBase64(null).Should().BeNull();

--- a/src/Hl7.FhirPath.Tests/Tests/BasicFunctionTests.cs
+++ b/src/Hl7.FhirPath.Tests/Tests/BasicFunctionTests.cs
@@ -248,7 +248,7 @@ namespace Hl7.FhirPath.Tests
             dummy = ElementNode.ForPrimitive("a,,b,c,d"); // Empty element should be removed
             result = dummy.Select("split(',')");
             Assert.IsNotNull(result);
-            CollectionAssert.AreEqual(new[] { "a", "b", "c", "d" }, result.Select(r => r.Value.ToString()).ToArray());
+            CollectionAssert.AreEqual(new[] { "a", "", "b", "c", "d" }, result.Select(r => r.Value.ToString()).ToArray());
 
             dummy = ElementNode.ForPrimitive("");
             result = dummy.Select("split(',')");
@@ -257,7 +257,7 @@ namespace Hl7.FhirPath.Tests
             dummy = ElementNode.ForPrimitive("[stop]ONE[stop][stop]TWO[stop][stop][stop]THREE[stop][stop]");
             result = dummy.Select("split('[stop]')");
             Assert.IsNotNull(result);
-            CollectionAssert.AreEqual(new[] { "ONE", "TWO", "THREE" }, result.Select(r => r.Value.ToString()).ToArray());
+            CollectionAssert.AreEqual(new[] { "", "ONE", "", "TWO", "", "", "THREE", "", "" }, result.Select(r => r.Value.ToString()).ToArray());
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
Describe the changes in this PR.

## Related issues
Resolves issue #2445

## Testing
Unit tests added/updated

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes