### PR TITLE
2413 Add support for `resourceType` elements present in R4 and R5

### DIFF
--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonPocoDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonPocoDeserializer.cs
@@ -247,10 +247,11 @@ namespace Hl7.Fhir.Serialization
             {
                 var currentPropertyName = reader.GetString()!;
 
-                if (currentPropertyName == "resourceType")
+                // The resourceType property on the level of a resource is used to determine
+                // the type and should otherwise be skipped when processing a resource.
+                if (currentPropertyName == "resourceType" && kind is DeserializedObjectKind.Resource)
                 {
-                    if (kind != DeserializedObjectKind.Resource) state.Errors.Add(ERR.RESOURCETYPE_UNEXPECTED.With(ref reader));
-                    reader.SkipTo(JsonTokenType.PropertyName);  // skip to next property
+                    reader.SkipTo(JsonTokenType.PropertyName);
                     continue;
                 }
 

--- a/src/Hl7.Fhir.Base/Serialization/DataAnnotationDeserialzationValidator.cs
+++ b/src/Hl7.Fhir.Base/Serialization/DataAnnotationDeserialzationValidator.cs
@@ -83,7 +83,13 @@ namespace Hl7.Fhir.Serialization
                     var propValue = propMapping.GetValue(instance);
 
                     if (propValue is null || ReflectionHelper.IsRepeatingElement(propValue, out var list) && list.Count == 0)
-                        errors = add(errors, runAttributeValidation(propValue, new[] { cardinality }, validationContext));
+                    {
+                        // Add the name of the property to the path, so we can display the correct name of the element,
+                        // even if it does not really contain any values.
+                        var nestedContext = validationContext.IntoPath(validationContext.ObjectInstance, propMapping.Name);
+
+                        errors = add(errors, runAttributeValidation(propValue, new[] { cardinality }, nestedContext));
+                    }
                 }
             }
 
@@ -105,7 +111,7 @@ namespace Hl7.Fhir.Serialization
             }
 
             reportedErrors = errors?.ToArray();
-            return;           
+            return;
         }
 
         private IEnumerable<CodedValidationException>? add(IEnumerable<CodedValidationException>? errors, IEnumerable<CodedValidationException>? moreErrors)
@@ -131,7 +137,7 @@ namespace Hl7.Fhir.Serialization
                     if (vr is CodedValidationResult cvr)
                         errors = add(errors, new[] { cvr.ValidationException });
                     else
-                        throw new InvalidOperationException($"Validation attributes should return a {nameof(CodedValidationResult)}.");                  
+                        throw new InvalidOperationException($"Validation attributes should return a {nameof(CodedValidationResult)}.");
                 }
             }
 

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
@@ -43,6 +43,8 @@ namespace Hl7.Fhir.Serialization
         public const string UNKNOWN_RESOURCE_TYPE_CODE = "JSON116";
         public const string RESOURCE_TYPE_NOT_A_RESOURCE_CODE = "JSON117";
         public const string UNKNOWN_PROPERTY_FOUND_CODE = "JSON118";
+
+        [Obsolete("This issue is no longer raised as it is now allowed to use `resourceType` as the name of an element.")]
         public const string RESOURCETYPE_UNEXPECTED_CODE = "JSON119";
         public const string OBJECTS_CANNOT_BE_EMPTY_CODE = "JSON120";
         public const string ARRAYS_CANNOT_BE_EMPTY_CODE = "JSON121";
@@ -98,6 +100,8 @@ namespace Hl7.Fhir.Serialization
         internal static readonly FhirJsonException USE_OF_UNDERSCORE_ILLEGAL = new(USE_OF_UNDERSCORE_ILLEGAL_CODE, "Element '{0}' is not a FHIR primitive, so it should not use an underscore in the '{1}' property.");
 
         // The serialization contained a superfluous 'resourceType' property, but we have read all data anyway.
+        // Note, this is no longer considered an error, since there are Resources using an element named "resourceType" (Subscription.filterBy for example).
+        [Obsolete("This issue is no longer raised as it is now allowed to use `resourceType` as the name of an element.")]
         internal static readonly FhirJsonException RESOURCETYPE_UNEXPECTED = new(RESOURCETYPE_UNEXPECTED_CODE, "The 'resourceType' property should only be used in resources.");
 
         // Empty objects and arrays can be ignored without discarding data
@@ -106,7 +110,8 @@ namespace Hl7.Fhir.Serialization
 
         // Shortest array will be filled out with nulls
         // [EK 20221027] The new R5 spec clarifies that this is actually correct behaviour, so this error is not used anymore.
-        //internal static readonly FhirJsonException PRIMITIVE_ARRAYS_INCOMPAT_SIZE = new(PRIMITIVE_ARRAYS_INCOMPAT_SIZE_CODE, "Primitive arrays split in two properties should have the same size.");
+        [Obsolete("According to the latest updates of the Json format, primitive arrays of different sizes are no longer considered an error.")]
+        internal static readonly FhirJsonException PRIMITIVE_ARRAYS_INCOMPAT_SIZE = new(PRIMITIVE_ARRAYS_INCOMPAT_SIZE_CODE, "Primitive arrays split in two properties should have the same size.");
 
         // This leaves the incorrect nulls in place, no change in data.
         internal static readonly FhirJsonException PRIMITIVE_ARRAYS_ONLY_NULL = new(PRIMITIVE_ARRAYS_ONLY_NULL_CODE, "Arrays need to have at least one non-null element.");
@@ -115,6 +120,7 @@ namespace Hl7.Fhir.Serialization
         /// Whether this issue leads to dataloss or not. Recoverable issues mean that all data present in the parsed data could be retrieved and
         /// captured in the POCO model, even if the syntax or the data was not fully FHIR compliant.
         /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete
         internal static bool IsRecoverableIssue(FhirJsonException e) =>
             e.ErrorCode is EXPECTED_PRIMITIVE_NOT_NULL_CODE or
             INCORRECT_BASE64_DATA_CODE or
@@ -128,8 +134,10 @@ namespace Hl7.Fhir.Serialization
             RESOURCETYPE_UNEXPECTED_CODE or
             OBJECTS_CANNOT_BE_EMPTY_CODE or
             ARRAYS_CANNOT_BE_EMPTY_CODE or
+            PRIMITIVE_ARRAYS_INCOMPAT_SIZE_CODE or
             PRIMITIVE_ARRAYS_ONLY_NULL_CODE or
             PROPERTY_MAY_NOT_BE_EMPTY_CODE;
+#pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// An issue is allowable for backwards compatibility if it could be caused because an older parser encounters data coming from a newer 

--- a/src/Hl7.Fhir.Base/Serialization/JTokenExtensions.cs
+++ b/src/Hl7.Fhir.Base/Serialization/JTokenExtensions.cs
@@ -13,11 +13,17 @@ namespace Hl7.Fhir.Serialization
 {
     internal static class JTokenExtensions
     {
-        public static JProperty GetResourceTypePropertyFromObject(this JObject o, string myName) =>
-            !(o.Property(JsonSerializationDetails.RESOURCETYPE_MEMBER_NAME) is JProperty type) ?
-                null
-                : type.Value.Type == JTokenType.String && myName != "instance" ? type : null;
-        // Hack to support R4 ExampleScenario.instance.resourceType element
+        public static JProperty GetResourceTypePropertyFromObject(this JObject o, string myName)
+        {
+            return o.Property(JsonSerializationDetails.RESOURCETYPE_MEMBER_NAME) switch
+            {
+                JProperty { Value.Type: JTokenType.String } stringProp when !isException(myName) => stringProp,
+                _ => null
+            };
+
+            // Hack to support R4 ExampleScenario.instance.resourceType and R5 Subscription.filterBy.resourceType element
+            static bool isException(string myName) => myName is "filterBy" or "instance";
+        }
     }
 }
 

--- a/src/Hl7.Fhir.Serialization.R5.Tests/RoundtripTest.cs
+++ b/src/Hl7.Fhir.Serialization.R5.Tests/RoundtripTest.cs
@@ -6,17 +6,51 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+using FluentAssertions;
+using Hl7.Fhir.Introspection;
+using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification;
 using Hl7.Fhir.Specification.Source;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using Tasks = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Serialization.Tests
 {
+
     [TestClass]
     public partial class RoundtripTest
     {
         private readonly string _attachmentJson = "{\"size\":\"12\"}";
+
+
+        private static IEnumerable<object[]> getEngines()
+        {
+            yield return new[] { FhirSerializationEngineFactory.Strict(ModelInspector.ForType(typeof(Subscription))) };
+            yield return new[] { FhirSerializationEngineFactory.Legacy.Strict(ModelInspector.ForType(typeof(Subscription))) };
+        }
+
+        [TestMethod]
+        [DynamicData(nameof(getEngines), DynamicDataSourceType.Method)]
+        public void TestAcceptsResourceTypeElementInDatatype(IFhirSerializationEngine engine)
+        {
+            var sub = new Subscription { ChannelType = new("http://nu.nl", "test'"), Status = SubscriptionStatusCodes.Active, Topic = "Test" };
+            sub.FilterBy.Add(new() { ResourceType = "TestResource", FilterParameter = "test", Value = "test" });
+
+            var json = engine.SerializeToJson(sub);
+            json.Should().Contain("\"resourceType\":\"TestResource\"");
+
+            var xml = engine.SerializeToXml(sub);
+            xml.Should().Contain("resourceType");
+
+            check(engine.DeserializeFromJson(json));
+            check(engine.DeserializeFromXml(xml));
+
+            static void check(Resource r)
+            {
+                r.Should().BeOfType<Subscription>().Which.FilterBy[0].ResourceType.Should().Be("TestResource");
+            }
+        }
 
         [TestMethod]
         [TestCategory("LongRunner")]

--- a/src/Hl7.Fhir.Serialization.STU3.Tests/RoundtripTest.cs
+++ b/src/Hl7.Fhir.Serialization.STU3.Tests/RoundtripTest.cs
@@ -255,7 +255,7 @@ namespace Hl7.Fhir.Serialization.Tests
             Assert.AreEqual(0, errors.Count, "Errors were encountered comparing converted content");
         }
 
-        static bool SkipFile(string file)
+        private static bool SkipFile(string file)
         {
             if (file.Contains(".profile"))
                 return true;
@@ -263,8 +263,6 @@ namespace Hl7.Fhir.Serialization.Tests
                 return true;
             if (file.Contains(".diff"))
                 return true;
-            if (file.Contains("examplescenario-example"))
-                return true; // this resource has a property name resourceType (which is reserved in the .net json serializer)
             if (file.Contains("backbone-elements"))
                 return true; // its not really a resource!
             if (file.Contains("json-edge-cases"))

--- a/src/Hl7.Fhir.Serialization.Shared.Tests/RoundtripTest.cs
+++ b/src/Hl7.Fhir.Serialization.Shared.Tests/RoundtripTest.cs
@@ -163,7 +163,7 @@ namespace Hl7.Fhir.Serialization.Tests
             Assert.AreEqual(0, errors.Count, "Errors were encountered comparing converted content");
         }
 
-        static bool SkipFile(string file)
+        private static bool SkipFile(string file)
         {
             if (file.Contains(".profile"))
                 return true;
@@ -177,8 +177,6 @@ namespace Hl7.Fhir.Serialization.Tests
                 return true; // not a resource
             if (file.Contains("uml.json"))
                 return true; // not a resource
-            if (file.Contains("examplescenario-example"))
-                return true; // this resource has a property name resourceType (which is reserved in the .net json serializer)
             if (file.Contains("backbone-elements"))
                 return true; // its not really a resource!
             if (file.Contains("json-edge-cases"))
@@ -194,8 +192,6 @@ namespace Hl7.Fhir.Serialization.Tests
                 return true; // this file is known to have a single dud valueset - have reported on Zulip
                              // https://chat.fhir.org/#narrow/stream/48-terminology/subject/v2.20Table.200550
 
-            if (file.Contains("subscriptiontopic-example-admission"))  // version 4.6.0: resourceType is not accepted in resourceTrigger
-                return true;
             if (file.Contains("conceptmaps."))  // version 4.6.0: identifier is not an array
                 return true;
             if (file.EndsWith("-questionnaire.json") && !file.EndsWith("operation-structuredefinition-questionnaire.json"))  // version 4.6.0: 'choice' is not a valid Questionnaire.Item.Type anymore
@@ -204,10 +200,6 @@ namespace Hl7.Fhir.Serialization.Tests
             if (file.EndsWith("notification-empty(9601c07a-e34f-4945-93ca-6efb5394c995).xml"))
                 return true;
 
-#if R5
-            // This example contains resourceType which cannot be handled by our old serializers
-            if (file.Contains("subscription-example")) return true;
-#endif 
             return false;
         }
 

--- a/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirJsonDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirJsonDeserializationTests.cs
@@ -382,14 +382,12 @@ namespace Hl7.Fhir.Support.Poco.Tests
             yield return data<Extension>(5, JsonTokenType.Number, ERR.EXPECTED_START_OF_OBJECT);
             yield return data<Extension>(new[] { 2, 3 }, JsonTokenType.EndArray, ERR.EXPECTED_START_OF_OBJECT);
             yield return data<Extension>(new { }, ERR.OBJECTS_CANNOT_BE_EMPTY);
-            yield return data<Extension>(new { resourceType = "Whatever" },
-                ERR.RESOURCETYPE_UNEXPECTED, ERR.OBJECTS_CANNOT_BE_EMPTY);
             yield return data<Extension>(new { }, ERR.OBJECTS_CANNOT_BE_EMPTY);
             yield return data<Extension>(new { unknown = "test" }, ERR.UNKNOWN_PROPERTY_FOUND);
             yield return data<Extension>(new { url = "test" });
             yield return data<Extension>(new { _url = "test" }, ERR.USE_OF_UNDERSCORE_ILLEGAL);
-            yield return data<Extension>(new { resourceType = "whatever", unknown = "test", url = "test" },
-                    ERR.RESOURCETYPE_UNEXPECTED, ERR.UNKNOWN_PROPERTY_FOUND);
+            yield return data<Extension>(new { unknown = "test", url = "test" },
+                    ERR.UNKNOWN_PROPERTY_FOUND);
             yield return data<Extension>(new { value = "no type suffix" }, ERR.CHOICE_ELEMENT_HAS_NO_TYPE);
             yield return data<Extension>(new { valueUnknown = "incorrect type suffix" }, ERR.CHOICE_ELEMENT_HAS_UNKOWN_TYPE);
             yield return data<Extension>(new { valueBoolean = true, url = "http://something.nl" }, JsonTokenType.EndObject);
@@ -583,7 +581,7 @@ namespace Hl7.Fhir.Support.Poco.Tests
                 assertErrors(dfe.Exceptions, new string[]
                 {
                     ERR.STRING_ISNOTAN_INSTANT_CODE,
-                    ERR.RESOURCETYPE_UNEXPECTED_CODE,
+                    ERR.UNKNOWN_PROPERTY_FOUND_CODE, // resourceType at the non-root level                   
                     ERR.UNKNOWN_RESOURCE_TYPE_CODE,
                     ERR.RESOURCE_TYPE_NOT_A_RESOURCE_CODE,
                     ERR.RESOURCETYPE_SHOULD_BE_STRING_CODE,
@@ -592,7 +590,6 @@ namespace Hl7.Fhir.Support.Poco.Tests
                     ERR.EXPECTED_START_OF_ARRAY_CODE,
                     ERR.UNKNOWN_PROPERTY_FOUND_CODE, // mother is not a property of HumanName
                     ERR.EXPECTED_PRIMITIVE_NOT_ARRAY_CODE, // family is not an array,
-                    //ERR.PRIMITIVE_ARRAYS_INCOMPAT_SIZE_CODE, // given and _given not the same length
                     ERR.EXPECTED_PRIMITIVE_NOT_NULL_CODE, // telecom use cannot be null
                     ERR.EXPECTED_PRIMITIVE_NOT_OBJECT_CODE, // address.use is not an object
                     COVE.REPEATING_ELEMENT_CANNOT_CONTAIN_NULL_CODE, // address.line should not have a null at the same position in both arrays


### PR DESCRIPTION
* For Legacy parsers, I built in another exception.
* For the new parsers, I just removed the explicit raising of an error when resourceType appears in a non-resource root path.
* Improved the error message for missing elements (indicental finding while writing unit tests)
* Added unit test to R5 to make sure Subscription.filterBy.resourceType is supported.