### PR TITLE
#2446 Join seperator parameter is optional in the spec

### DIFF
--- a/src/Hl7.Fhir.Base/FhirPath/Expressions/SymbolTableInit.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Expressions/SymbolTableInit.cs
@@ -163,6 +163,7 @@ namespace Hl7.FhirPath.Expressions
             t.Add("length", (string f) => f.Length, doNullProp: true);
             t.Add("split", (string f, string seperator) => f.FpSplit(seperator), doNullProp: true);
             t.Add("join", (IEnumerable<ITypedElement> f, string separator) => f.FpJoin(separator), doNullProp: true);
+            t.Add("join", (IEnumerable<ITypedElement> f) => f.FpJoin(), doNullProp: true);
 
             // Math functions
             t.Add("abs", (decimal f) => Math.Abs(f), doNullProp: true);

--- a/src/Hl7.Fhir.Base/FhirPath/Functions/CollectionOperators.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Functions/CollectionOperators.cs
@@ -85,7 +85,7 @@ namespace Hl7.FhirPath.Functions
             return element.Children(name);
         }
 
-        public static string FpJoin(this IEnumerable<ITypedElement> collection, string separator)
+        public static string FpJoin(this IEnumerable<ITypedElement> collection, string separator = null)
         {
             //if the collection is empty return the empty result
             if (!collection.Any())

--- a/src/Hl7.FhirPath.Tests/Tests/BasicFunctionTests.cs
+++ b/src/Hl7.FhirPath.Tests/Tests/BasicFunctionTests.cs
@@ -279,6 +279,11 @@ namespace Hl7.FhirPath.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual("This is one sentence.", result);
 
+            dummy = ElementNode.CreateList("a", "b", "c");
+            result = dummy.FpJoin();
+            Assert.IsNotNull(result);
+            Assert.AreEqual("abc", result);
+
             dummy = ElementNode.CreateList();
             result = dummy.FpJoin(string.Empty);
             Assert.AreEqual(string.Empty, result);


### PR DESCRIPTION
## Description
Make the seperater parameter optional in the join fhirpath operation as per the spec.

## Related issues
Fixes issue #2446 

## Testing
Unit test for split updated to include this case.

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes