### PR TITLE
#2404: Implementation of FhirPath function memberOf()

### DIFF
--- a/src/Hl7.Fhir.Base/FhirPath/FhirEvaluationContext.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/FhirEvaluationContext.cs
@@ -7,6 +7,7 @@
  */
 
 using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Specification.Terminology;
 using Hl7.FhirPath;
 using System;
 
@@ -15,7 +16,7 @@ namespace Hl7.Fhir.FhirPath
     public class FhirEvaluationContext : EvaluationContext
     {
         /// <summary>Creates a new <see cref="FhirEvaluationContext"/> instance with default property values.</summary>
-        public static new FhirEvaluationContext CreateDefault() => new FhirEvaluationContext();
+        public static new FhirEvaluationContext CreateDefault() => new();
 
         /// <summary>Default constructor. Creates a new <see cref="FhirEvaluationContext"/> instance with default property values.</summary>
         public FhirEvaluationContext() : base()
@@ -41,6 +42,8 @@ namespace Hl7.Fhir.FhirPath
         {
             RootResource = Resource is ScopedNode sn ? sn.ResourceContext : node;
         }
+
+        public ITerminologyService TerminologyService { get; set; }
 
         private static ITypedElement toNearestResource(ScopedNode node)
         {

--- a/src/Hl7.Fhir.Shims.STU3AndUp/FhirPath/FhirPathExtensions.cs
+++ b/src/Hl7.Fhir.Shims.STU3AndUp/FhirPath/FhirPathExtensions.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.FhirPath
         internal static SymbolTable GetSymbols() => COMPILER.Symbols;
 
         /// <inheritdoc cref="FhirPathCompilerCache.Select(ITypedElement, string, EvaluationContext?)"/>
-        public static IEnumerable<Base> Select(this Base input, string expression, FhirEvaluationContext? ctx = null)
+        public static IEnumerable<Base?> Select(this Base input, string expression, FhirEvaluationContext? ctx = null)
             => CACHE.Select(input.ToTypedElement(), expression, ctx ?? FhirEvaluationContext.CreateDefault()).ToFhirValues();
 
         /// <inheritdoc cref="FhirPathCompilerCache.Scalar(ITypedElement, string, EvaluationContext?)"/>

--- a/src/Hl7.Fhir.Support.Tests/FhirPath/FhirPathTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/FhirPath/FhirPathTests.cs
@@ -161,5 +161,8 @@ namespace Hl7.Fhir.Support.Tests
                 expected.Should().BeFalse();
             }
         }
+
+
+
     }
 }

--- a/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
+++ b/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
@@ -348,7 +348,7 @@ namespace Hl7.FhirPath.R4.Tests
 
         [DataTestMethod]
         [DynamicData(nameof(MemberOfTestData), DynamicDataSourceType.Method)]
-        public void MemberOfTests(Base poco, string expression, bool expectedResult)
+        public void MemberOfTests(Base poco, string expression, bool? expectedResult)
         {
             var context = FhirEvaluationContext.CreateDefault();
             context.TerminologyService = new LocalTerminologyService(resolver: ZipSource.CreateValidationSource());
@@ -360,18 +360,78 @@ namespace Hl7.FhirPath.R4.Tests
 
         public static IEnumerable<object[]> MemberOfTestData()
         {
-            // memberOf with single Coding objects
-            yield return new object[] { new Code("85353-1"), "Code.memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", true };
+            // memberOf with single Code objects
+            yield return new object[] { new Code("85353-1"), "memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", true };
+            yield return new object[] { new Code("unknown"), "memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", false };
+            yield return new object[] { new Code("male"), "memberOf('http://hl7.org/fhir/ValueSet/administrative-gender')", true };
+            yield return new object[] { new Code("female"), "memberOf('http://hl7.org/fhir/ValueSet/administrative-gender')", true };
+            yield return new object[] { new Code("no-idea"), "memberOf('http://hl7.org/fhir/ValueSet/administrative-gender')", false };
 
-            /*
             // memberOf with single Coding objects
-            yield return new object[] { new Coding("http://loinc.org", "85353-1"), "Coding.memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", true };
-            yield return new object[] { new Coding("http://unknown.system", "85353-1"), "Coding.memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", false };
-            yield return new object[] { new Coding("http://loinc.org", "unknown"), "Coding.memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", false };
+            yield return new object[] { new Coding("http://loinc.org", "85353-1"), "memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", true };
+            yield return new object[] { new Coding("http://unknown.system", "85353-1"), "memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", false };
+            yield return new object[] { new Coding("http://loinc.org", "unknown"), "memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", false };
+
+            // memberOf with single CodeableConcept objects
+            yield return new object[] { new CodeableConcept("http://loinc.org", "85353-1"), "memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", true };
+            yield return new object[] { new CodeableConcept()
+                                            {
+                                                Coding = new List<Coding>() {
+                                                    new Coding("http://loinc.org", "85353-1"),
+                                                    new Coding("http://unknown.system", "a-code")
+                                                }
+                                            }, "memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", true };
 
             // memberOf with string objects
             yield return new object[] { new FhirBoolean(), "'85353-1'.memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", true };
-            */
+            yield return new object[] { new FhirBoolean(), "'male'.memberOf('http://hl7.org/fhir/ValueSet/administrative-gender')", true };
+            yield return new object[] { new FhirBoolean(), "'female'.memberOf('http://hl7.org/fhir/ValueSet/administrative-gender')", true };
+            yield return new object[] { new FhirBoolean(), "'no-idea'.memberOf('http://hl7.org/fhir/ValueSet/administrative-gender')", false };
+
+            // memberOf with illegal input datatype
+            yield return new object[] { new FhirDecimal(45.1m), "memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", null };
+            yield return new object[] { FhirDateTime.Now(), "memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", null };
+
+            // memberOf with unknown valueset
+            yield return new object[] { new Code("85353-1"), "memberOf('http://example.com/ValueSet/unknown')", null };
+        }
+
+        [TestMethod]
+        public void MemberOfTestsWithoutTerminologyService()
+        {
+            var context = FhirEvaluationContext.CreateDefault();
+
+            Action action = () => new Code("male").Scalar("memberOf('http://hl7.org/fhir/ValueSet/administrative-gender')", context);
+
+            action.Should().Throw<InvalidOperationException>();
+        }
+
+        [TestMethod]
+        public void MemberOfTestWithExampleFromSpecification()
+        {
+            var context = FhirEvaluationContext.CreateDefault();
+            context.TerminologyService = new LocalTerminologyService(resolver: ZipSource.CreateValidationSource());
+
+            Observation observation = new()
+            {
+                Component = new()
+                {
+                    new()
+                    {
+                        Code = new CodeableConcept("http://loinc.org", "2708-6")
+                    },
+                    new ()
+                    {
+                        Code = new CodeableConcept("http://example.com/other-system", "a-code")
+                    }
+                }
+            };
+
+            var result = observation.Select("component.where(code.memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult'))", context);
+
+            result.Should().ContainSingle().Subject
+                .Should().BeOfType<Observation.ComponentComponent>()
+                .Subject.Code.Should().BeEquivalentTo(new CodeableConcept("http://loinc.org", "2708-6"));
         }
     }
 }

--- a/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
+++ b/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
@@ -9,9 +9,12 @@
 // To introduce the DSTU2 FHIR specification
 // extern alias dstu2;
 
+using FluentAssertions;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.FhirPath;
 using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Source;
+using Hl7.Fhir.Specification.Terminology;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -341,6 +344,34 @@ namespace Hl7.FhirPath.R4.Tests
 
             var result = bundle.Select("Bundle.entry.where(fullUrl = 'urn:uuid:555').resource.managingOrganization.resolve()");
             Assert.IsTrue(result.Any());
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(MemberOfTestData), DynamicDataSourceType.Method)]
+        public void MemberOfTests(Base poco, string expression, bool expectedResult)
+        {
+            var context = FhirEvaluationContext.CreateDefault();
+            context.TerminologyService = new LocalTerminologyService(resolver: ZipSource.CreateValidationSource());
+
+            var result = poco.Scalar(expression, context);
+
+            result.Should().Be(expectedResult);
+        }
+
+        public static IEnumerable<object[]> MemberOfTestData()
+        {
+            // memberOf with single Coding objects
+            yield return new object[] { new Code("85353-1"), "Code.memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", true };
+
+            /*
+            // memberOf with single Coding objects
+            yield return new object[] { new Coding("http://loinc.org", "85353-1"), "Coding.memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", true };
+            yield return new object[] { new Coding("http://unknown.system", "85353-1"), "Coding.memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", false };
+            yield return new object[] { new Coding("http://loinc.org", "unknown"), "Coding.memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", false };
+
+            // memberOf with string objects
+            yield return new object[] { new FhirBoolean(), "'85353-1'.memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", true };
+            */
         }
     }
 }


### PR DESCRIPTION
## Description
Implemented the FhirPath function `memberOf(valueset)`. See also the definition of the function [here](https://hl7.org/fhir/fhirpath.html#functions).

## Related issues
Resolves issue #2404.

## Testing
The following unittest are made:
- `Hl7.FhirPath.R4.Tests.FhirPathTest.MemberOfTests`
- `Hl7.FhirPath.R4.Tests.FhirPathTest.MemberOfTestsWithoutTerminologyService`
- `Hl7.FhirPath.R4.Tests.FhirPathTest.MemberOfTestWithExampleFromSpecification`

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes