### PR TITLE
#2411: Made the ArtifactSummaryGenerator.Default obsolete

### DIFF
--- a/src/Hl7.Fhir.Conformance/Specification/Source/Summary/ArtifactSummaryGenerator.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Source/Summary/ArtifactSummaryGenerator.cs
@@ -69,6 +69,8 @@ namespace Hl7.Fhir.Specification.Summary
         private readonly IModelInfo _modelInfo;
 
         /// <summary>Singleton. Returns a global default instance.</summary>
+        [Obsolete("This static property uses an incorrect ModelInspector. Use new ArtifactSummaryGenerator(ModelInspector) instead. " +
+            "Obsolete since 2023-05-03. Will be removed in the next major release.")]
         public static ArtifactSummaryGenerator Default { get; } = new ArtifactSummaryGenerator(ModelInspector.ForAssembly(typeof(IModelInfo).Assembly));
 
         /// <summary>Default constructor. Creates a new instance of the <see cref="ArtifactSummaryGenerator"/>.</summary>


### PR DESCRIPTION
## Description
In R4 and newer versions, the static property `ArtifactSummaryGenerator.Default` does not function correctly due to an incorrect `ModelInspector`. As this is a static property, it cannot be modified to incorporate a correct ModelInspector. To resolve this issue, end-users should use the constructor `new ArtifactSummaryGenerator(IModelInfo modelInfo)`.

## Related issues
Resolves issue #2411.

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes