### PR TITLE
#2439: FhirPath comparable() uses UCUMnow

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -53,13 +53,12 @@ stages:
     - task: NuGetToolInstaller@1
       inputs:
         versionSpec: '6.4.0' 
-    - task: DotNetCoreCLI@2
-      displayName: Restore
-      inputs:
-        command: restore
-        projects: ./Hl7.Fhir.sln
-        verbosityRestore: Minimal
-        arguments: --configuration $(buildConfiguration)
+
+    - template: restore.yml@templates
+      parameters:
+        nuGetServiceConnections: GitHubPackageGetFeed
+        nuGetSources: --source https://www.myget.org/F/vonk/api/v3/index.json 
+
     - task: DotNetCoreCLI@2
       displayName: Build
       inputs:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -17,6 +17,7 @@ name: $(date:yyyyMMdd)$(rev:.r)
 
 variables:
 - group: CodeSigning
+- group: APIKeys
 - template: build-variables.yml
 - template: pipeline-variables.yml
   

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -57,8 +57,8 @@ stages:
     - template: restore.yml@templates
       parameters:
         nuGetServiceConnections: GitHubPackageGetFeed
-        nuGetSources: --source https://www.myget.org/F/vonk/api/v3/index.json 
-
+        nuGetSources: --source https://nuget.pkg.github.com/FirelyTeam/index.json
+        
     - task: DotNetCoreCLI@2
       displayName: Build
       inputs:

--- a/build/pipeline-variables.yml
+++ b/build/pipeline-variables.yml
@@ -4,5 +4,5 @@
 
 variables:
   isTagBranch: $[startswith(variables['Build.SourceBranch'], 'refs/tags/v')]
-  GITHUB_PACKAGES_APIKEY: $(GitHubPushPackagesAPIKey)  # key is set in UI of Azure Devops
-  NUGET_APIKEY: $(NuGetAPIKey) # key is set in UI of Azure Devops
+  GITHUB_PACKAGES_APIKEY: $(GitHubPushPackagesAPIKey)  # key is set in variable group APIKeys
+  NUGET_APIKEY: $(NuGetSDKAPIKey) # key is set in variable group APIKeys

--- a/src/Hl7.Fhir.Base/ElementModel/Types/Ucum.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/Types/Ucum.cs
@@ -1,0 +1,29 @@
+﻿/* 
+ * Copyright (c) 2019, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+#nullable enable
+
+
+using Fhir.Metrics;
+using Hl7.Fhir.Utility;
+using P = Hl7.Fhir.ElementModel.Types;
+
+namespace Hl7.Fhir.Base.ElementModel
+{
+    internal static class Ucum
+    {
+        private static readonly SystemOfUnits SYSTEM = UCUM.Load();
+
+        public static Result<int> Compare(P.Quantity quantity, P.Quantity other)
+        {
+            return 0;
+        }
+    }
+}
+
+#nullable restore

--- a/src/Hl7.Fhir.Base/Hl7.Fhir.Base.csproj
+++ b/src/Hl7.Fhir.Base/Hl7.Fhir.Base.csproj
@@ -16,7 +16,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Fhir.Metrics" Version="1.2.1" />
+		<PackageReference Include="Fhir.Metrics" Version="1.2.2-build-20230511.10" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/src/Hl7.Fhir.Base/Hl7.Fhir.Base.csproj
+++ b/src/Hl7.Fhir.Base/Hl7.Fhir.Base.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<Import Project="..\firely-net-sdk.props" />
 
@@ -16,6 +16,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Fhir.Metrics" Version="1.2.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/src/Hl7.Fhir.Base/Hl7.Fhir.Base.csproj
+++ b/src/Hl7.Fhir.Base/Hl7.Fhir.Base.csproj
@@ -16,7 +16,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Fhir.Metrics" Version="1.2.2-build-20230511.10" />
+		<PackageReference Include="Fhir.Metrics" Version="1.2.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/src/Hl7.Fhir.Support.Tests/ElementModel/EquivalenceTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/ElementModel/EquivalenceTests.cs
@@ -139,13 +139,14 @@ namespace Hl7.Fhir.ElementModel.Tests
                 (Quantity.Parse("24 'kg'"), Quantity.Parse("24.0 'kg'"), true),
                 (Quantity.Parse("24 'kg'"), Quantity.Parse("24.0 'kg'"), true),
                 (Quantity.Parse("24.0 'kg'"), Quantity.Parse("25.0 'kg'"), false),
-                //Until we actually implement UCUM, these tests cannot yet be run correctly
-                //(Quantity.Parse("1 year"), Quantity.Parse("1 'a'"), false),
-                //(Quantity.Parse("1 month"), Quantity.Parse("1 'mo'"), false),
-                //(Quantity.Parse("1 hour"), Quantity.Parse("1 'h'"), false),
-                //(Quantity.Parse("1 second"), Quantity.Parse("1 's'"), true),
-                //(Quantity.Parse("1 millisecond"), Quantity.Parse("1 'ms'"), true),
                 (Quantity.Parse("24.0 'kg'"), null, null),
+
+                (Quantity.Parse("1 year"), Quantity.Parse("1 'a'"), null),
+                (Quantity.Parse("1 month"), Quantity.Parse("1 'mo'"), null),
+                (Quantity.Parse("1 hour"), Quantity.Parse("1 'h'"), true),
+                (Quantity.Parse("1 second"), Quantity.Parse("1 's'"), true),
+                (Quantity.Parse("1 millisecond"), Quantity.Parse("1 'ms'"), true),
+
             }.Select(t => new[] { t.Item1, t.Item2, t.Item3 });
 
 
@@ -233,6 +234,7 @@ namespace Hl7.Fhir.ElementModel.Tests
                 (Quantity.Parse("24 'kg'"), Quantity.Parse("24.0 'kg'"), true),
                 (Quantity.Parse("24 'kg'"), Quantity.Parse("24.0 'kg'"), true),
                 (Quantity.Parse("24.0 'kg'"), Quantity.Parse("25.0 'kg'"), false),
+
                 (Quantity.Parse("1 year"), Quantity.Parse("1 'a'"), true),
                 (Quantity.Parse("1 month"), Quantity.Parse("1 'mo'"), true),
                 (Quantity.Parse("1 hour"), Quantity.Parse("1 'h'"), true),

--- a/src/Hl7.Fhir.Support.Tests/ElementModel/UcumTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/ElementModel/UcumTests.cs
@@ -1,44 +1,34 @@
-﻿using FluentAssertions;
-using Hl7.Fhir.Base.ElementModel;
+﻿#nullable enable 
+
+using FluentAssertions;
+using Hl7.Fhir.ElementModel.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using P = Hl7.Fhir.ElementModel.Types;
+using System;
+
 namespace Hl7.Fhir.Support.Tests.ElementModel
 {
     [TestClass]
     public class UcumTests
     {
-        public enum MyEnum
-        {
-            smallerThan,
-            Equals,
-            greaterThan
-        }
-
         [DataTestMethod]
-        [DataRow(1.0f, "m", 1.0f, "m", MyEnum.Equals)]
-        //[DataRow(1.0f, "m", 1.0f, "in", MyEnum.greaterThan)]
-        //[DataRow(1.0f, "m", 1.0f, "in", MyEnum.greaterThan)]
-        //[DataRow(1.0f, "m", 1.0f, "in", MyEnum.greaterThan)]
-        public void MyTestMethod(decimal dLeft, string unitLeft, decimal dRight, string unitRight, MyEnum expectedResult)
+        [DataRow(1.0, "m", true, "m")]
+        [DataRow(1.0, "cm", true, "m")]
+        [DataRow(1.0, "mm", true, "m")]
+        [DataRow(1.0, "[in_i]", true, "m")]
+        [DataRow(1.0, "[stone_av]", true, "g")] //britisch stone
+        [DataRow(1.0, "m[H2O]", true, "g.m-1.s-2")] // meter of water column
+        [DataRow(1.0, "unknown", false, null)]
+        public void TryCanonicalizeTests(double val, string unit, bool exptectedResult, string? expectedUnit)
         {
+            var input = new Quantity(Convert.ToDecimal(val), unit);
 
-            var result = Ucum.Compare(new P.Quantity(dLeft, unitLeft), new P.Quantity(dRight, unitRight));
+            var result = input.TryCanonicalize(out var convertedQuantity);
 
-            result.Success.Should().BeTrue();
-            switch (expectedResult)
-            {
-                case MyEnum.smallerThan:
-                    result.ValueOrDefault().Should().BeNegative();
-                    break;
-                case MyEnum.Equals:
-                    result.ValueOrDefault().Should().Be(0);
-                    break;
-                case MyEnum.greaterThan:
-                    result.ValueOrDefault().Should().BePositive();
-                    break;
-            }
-
+            result.Should().Be(exptectedResult);
+            var u = convertedQuantity?.Unit;
+            u.Should().Be(expectedUnit);
         }
-
     }
 }
+
+#nullable restore

--- a/src/Hl7.Fhir.Support.Tests/ElementModel/UcumTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/ElementModel/UcumTests.cs
@@ -1,0 +1,44 @@
+﻿using FluentAssertions;
+using Hl7.Fhir.Base.ElementModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using P = Hl7.Fhir.ElementModel.Types;
+namespace Hl7.Fhir.Support.Tests.ElementModel
+{
+    [TestClass]
+    public class UcumTests
+    {
+        public enum MyEnum
+        {
+            smallerThan,
+            Equals,
+            greaterThan
+        }
+
+        [DataTestMethod]
+        [DataRow(1.0f, "m", 1.0f, "m", MyEnum.Equals)]
+        //[DataRow(1.0f, "m", 1.0f, "in", MyEnum.greaterThan)]
+        //[DataRow(1.0f, "m", 1.0f, "in", MyEnum.greaterThan)]
+        //[DataRow(1.0f, "m", 1.0f, "in", MyEnum.greaterThan)]
+        public void MyTestMethod(decimal dLeft, string unitLeft, decimal dRight, string unitRight, MyEnum expectedResult)
+        {
+
+            var result = Ucum.Compare(new P.Quantity(dLeft, unitLeft), new P.Quantity(dRight, unitRight));
+
+            result.Success.Should().BeTrue();
+            switch (expectedResult)
+            {
+                case MyEnum.smallerThan:
+                    result.ValueOrDefault().Should().BeNegative();
+                    break;
+                case MyEnum.Equals:
+                    result.ValueOrDefault().Should().Be(0);
+                    break;
+                case MyEnum.greaterThan:
+                    result.ValueOrDefault().Should().BePositive();
+                    break;
+            }
+
+        }
+
+    }
+}

--- a/src/Hl7.Fhir.Support.Tests/FhirPath/FhirPathTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/FhirPath/FhirPathTests.cs
@@ -134,8 +134,8 @@ namespace Hl7.Fhir.Support.Tests
         public static IEnumerable<object[]> ComparableTestCases() =>
            new (string expression, bool expected)[]
                {
-                //    ("1 'cm'.comparable(1 '[in_i]')", true),   for version 5.1
-                //    ("1 'week'.comparable(1 'wk')", true),
+                    ("1 'cm'.comparable(1 '[in_i]')", true),
+                    ("1 week.comparable(1 'wk')", true),
                     ("1 'cm'.comparable(1 's')", false),
                 }.Select(t => new object[] { t.expression, t.expected });
 

--- a/src/Hl7.FhirPath.Tests/Functions/OperationsTests.cs
+++ b/src/Hl7.FhirPath.Tests/Functions/OperationsTests.cs
@@ -80,7 +80,7 @@ namespace HL7.FhirPath.Tests
                     ("10 > 5.0", true, false),
                     ("'abc' > 'ABC'", true, false),
                     ("8 'm' > 4 'm'", true, false),
-                    ("(4 'm' > 4 'cm').empty()", true, false),   // we do not support unit conversion at the moment
+                    ("(4 'm' > 4 'cm')", true, false),
                     ("@2018-03-01 > @2018-01-01", true, false),
                     ("(@2018-03 > @2018-03-01).empty()", true, false),
                     ("@2018-03-01T10:30:00 > @2018-03-01T10:00:00", true, false),
@@ -98,7 +98,7 @@ namespace HL7.FhirPath.Tests
                     ("10 < 5.0", false, false),
                     ("'abc' < 'ABC'", false, false),
                     ("8 'm' < 4 'm'", false, false),
-                    ("(4 'm' < 4 'cm').empty()", true, false),   // we do not support unit conversion at the moment
+                    ("(4 'm' < 4 'cm')", false, false),
                     ("@2018-03-01 < @2018-01-01", false, false),
                     ("(@2018-03 < @2018-03-01).empty()", true, false),
                     ("@2018-03-01T10:30:00 < @2018-03-01T10:00:00", false, false),
@@ -116,7 +116,7 @@ namespace HL7.FhirPath.Tests
                     ("10 <= 5.0", false, false),
                     ("'abc' <= 'ABC'", false, false),
                     ("8 'm' <= 4 'm'", false, false),
-                    ("(4 'm' <= 4 'cm').empty()", true, false),   // we do not support unit conversion at the moment
+                    ("(4 'm' <= 4 'cm')", false, false),
                     ("@2018-03-01 <= @2018-01-01", false, false),
                     ("(@2018-03 <= @2018-03-01).empty()", true, false),
                     ("@2018-03-01T10:30:00 <= @2018-03-01T10:00:00", false, false),
@@ -134,7 +134,7 @@ namespace HL7.FhirPath.Tests
                     ("10 >= 5.0", true, false),
                     ("'abc' >= 'ABC'", true, false),
                     ("8 'm' >= 4 'm'", true, false),
-                    ("(4 'm' >= 4 'cm').empty()", true, false),   // we do not support unit conversion at the moment
+                    ("(4 'm' >= 4 'cm')", true, false),
                     ("@2018-03-01 >= @2018-01-01", true, false),
                     ("(@2018-03 >= @2018-03-01).empty()", true, false),
                     ("@2018-03-01T10:30:00 >= @2018-03-01T10:00:00", true, false),


### PR DESCRIPTION
## Description
The FhirPath function `comparable()` now utilizes the UCUM library, enabling the comparison of `Quantities` with different units, such as inches and meters.

Moreover, the system type `Quantity` now leverages the UCUM library for performing the comparable function, as well as handling Equality and Equivalence. This enhancement allows for expressions like `1 '[in_i]' > 1 'cm'` in FhirPath, yielding a result of `true`.

## Related issues
Resolves issue #2439.

## Testing
See the following unit tests:
- QuantityTests
- UcumTests
- EquivalenceTests
- FhirPathTests

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes