### PR TITLE
#2457: Enhancing automatic generation of release notes

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -131,6 +131,12 @@ stages:
       inputs:
         pathToPublish: $(Build.ArtifactStagingDirectory)
         ArtifactName: NuGetPackages
+    
+  - job: generateReleaseNotes
+    dependsOn: restoreAndBuild
+    condition: and(succeeded(), eq(variables.isTagBranch, true)) 
+    steps:
+    - checkout: self
     - bash: |
         version=$(Build.SourceBranchName)
         title_release="${version:1}"
@@ -139,6 +145,22 @@ stages:
         echo "##vso[task.setvariable variable=release_title;isOutput=true]$title_release"
       name: tagnames
       displayName: Determine release title
+    - task: GitHubRelease@1
+      displayName: 'GitHub release notes (create)'  
+      inputs:
+        gitHubConnection: 'GitHub Firely-net-sdk'
+        repositoryName: '$(Build.Repository.Name)'
+        action: 'create'
+        target: '$(Build.SourceVersion)'
+        tagSource: gitTag
+        tagPattern: 'v.*'
+        releaseNotesSource: filePath
+        releaseNotesFilePath: $(Build.SourcesDirectory)\release-notes.md
+        title: '$(release_title)'
+        isDraft: true
+        changeLogCompareToRelease: lastNonDraftRelease
+        changeLogType: issueBased
+        changeLogLabels: '[{ "label" : "bug", "displayName" : "Bugfixes", "state" : "closed" },{ "label" : "enhancement", "displayName" : "New Functionality", "state" : "closed" }]'
 
 - stage: test
   displayName: Test
@@ -292,29 +314,3 @@ stages:
                 artifact: 'NuGetPackages'
                 source: https://api.nuget.org/v3/index.json
                 apiKey: $(NUGET_APIKEY)
-  - deployment: relNotes
-    displayName: Release Notes
-    environment: NuGet
-    variables:
-      - name: releaseTitle
-        value: $[ stageDependencies.build.restoreAndBuild.outputs['tagnames.release_title'] ]
-    strategy:
-      runOnce:
-        deploy:
-            steps:
-            - download: none
-            - task: GitHubRelease@1
-              displayName: 'GitHub release notes (create)'  
-              inputs:
-                gitHubConnection: 'GitHub Firely-net-sdk'
-                repositoryName: '$(Build.Repository.Name)'
-                action: 'create'
-                target: '$(Build.SourceVersion)'
-                tagSource: gitTag
-                tagPattern: 'v.*'
-                title: '$(releaseTitle)'
-                isDraft: true
-                changeLogCompareToRelease: lastNonDraftRelease
-                changeLogType: issueBased
-                changeLogLabels: '[{ "label" : "bug", "displayName" : "Bugfixes", "state" : "closed" },{ "label" : "enhancement", "displayName" : "New Functionality", "state" : "closed" }]'
-    

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,0 +1,4 @@
+## Intro:
+In this release we have two major changes:
+
+To be updated soon..


### PR DESCRIPTION
## Description
We have now the file `release-notes.md`. This file allows us to add extra text specifically intended for inclusion in the release notes. This file will serve as a valuable resource for providing further context and explanations about the release. 
This file will be merged during a release with the solved pull requests to a definite release note document.

## Related issues
Resolves #2457.

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes