### PR TITLE
Vonk-4618: LocalTS ValidateCode reports an error for value set reference instead of a code system in coding.system

### DIFF
--- a/src/Hl7.Fhir.Conformance/Model/ValueSet.cs
+++ b/src/Hl7.Fhir.Conformance/Model/ValueSet.cs
@@ -6,24 +6,24 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+#nullable enable
+
 using Hl7.Fhir.Support;
+using Hl7.Fhir.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Hl7.Fhir.Introspection;
-using Hl7.Fhir.Utility;
 
 namespace Hl7.Fhir.Model
 {
     public partial class ValueSet : Hl7.Fhir.Model.DomainResource
     {
         [Obsolete("This property was renamed in DSTU2 to CodeSystem, and in DSTU3 out of the class entirely to the CodeSystem resource", true)]
-        public string Define { get; set; }
+        public string? Define { get; set; }
 
         public bool HasExpansion => Expansion != null;
 
-        public bool CodeInExpansion(String code, string system = null)
+        public bool CodeInExpansion(String code, string? system = null)
         {
             ensureExpansion();
 
@@ -41,7 +41,7 @@ namespace Hl7.Fhir.Model
                 return null;
         }
 
-        public ValueSet.ContainsComponent FindInExpansion(String code, string system = null)
+        public ValueSet.ContainsComponent FindInExpansion(String code, string? system = null)
         {
             ensureExpansion();
 
@@ -68,7 +68,7 @@ namespace Hl7.Fhir.Model
 
             combinedExpansion.Parameter.AddRange(other.Expansion.Parameter);
             combinedExpansion.Contains.AddRange(other.Expansion.Contains);
-            combinedExpansion.Total += other.Expansion?.Total ?? other.Expansion.Contains.CountConcepts();
+            combinedExpansion.Total += other.Expansion!.Total ?? other.Expansion.Contains.CountConcepts();
 
             Expansion = combinedExpansion;
         }
@@ -104,3 +104,4 @@ namespace Hl7.Fhir.Model
 
     }
 }
+#nullable restore

--- a/src/Hl7.Fhir.Conformance/Specification/Terminology/LocalTerminologyService.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Terminology/LocalTerminologyService.cs
@@ -288,7 +288,7 @@ namespace Hl7.Fhir.Specification.Terminology
             return result;
         }
 
-        private async Task messageForCodeNotFound(ValueSet vs, string? system, string codeLabel, StringBuilder messages)
+        private async T.Task messageForCodeNotFound(ValueSet vs, string? system, string codeLabel, StringBuilder messages)
         {
             if (system is not null && await isValueSet(system).ConfigureAwait(false))
             {

--- a/src/Hl7.Fhir.Conformance/Specification/Terminology/LocalTerminologyService.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Terminology/LocalTerminologyService.cs
@@ -6,6 +6,8 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+#nullable enable
+
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Specification.Source;
@@ -31,7 +33,7 @@ namespace Hl7.Fhir.Specification.Terminology
         private readonly string _systemAttribute = "system";
         private readonly string _contextAttribute = "context";
 
-        public LocalTerminologyService(IAsyncResourceResolver resolver, ValueSetExpanderSettings expanderSettings = null)
+        public LocalTerminologyService(IAsyncResourceResolver resolver, ValueSetExpanderSettings? expanderSettings = null)
         {
             _resolver = resolver ?? throw Error.ArgumentNull(nameof(resolver));
 
@@ -41,7 +43,7 @@ namespace Hl7.Fhir.Specification.Terminology
             _expander = new ValueSetExpander(settings);
         }
 
-        internal async T.Task<ValueSet> FindValueset(string canonical)
+        internal async T.Task<ValueSet?> FindValueset(string canonical)
         {
             var valueset = await _resolver.FindValueSetAsync(canonical).ConfigureAwait(false);
 
@@ -72,7 +74,7 @@ namespace Hl7.Fhir.Specification.Terminology
 
 
         ///<inheritdoc />
-        public async T.Task<Parameters> ValueSetValidateCode(Parameters parameters, string id = null, bool useGet = false)
+        public async T.Task<Parameters> ValueSetValidateCode(Parameters parameters, string? id = null, bool useGet = false)
         {
 
             //No duplicate parameters allowed (http://hl7.org/fhir/valueset-operation-validate-code.html)
@@ -137,13 +139,13 @@ namespace Hl7.Fhir.Specification.Terminology
         }
 
         #region Not implemented methods
-        public T.Task<Parameters> CodeSystemValidateCode(Parameters parameters, string id = null, bool useGet = false)
+        public T.Task<Parameters> CodeSystemValidateCode(Parameters parameters, string? id = null, bool useGet = false)
         {
             // make this method async, when implementing
             throw new NotImplementedException();
         }
 
-        public T.Task<Resource> Expand(Parameters parameters, string id = null, bool useGet = false)
+        public T.Task<Resource> Expand(Parameters parameters, string? id = null, bool useGet = false)
         {
             // make this method async, when implementing
             throw new NotImplementedException();
@@ -155,13 +157,13 @@ namespace Hl7.Fhir.Specification.Terminology
             throw new NotImplementedException();
         }
 
-        public T.Task<Parameters> Translate(Parameters parameters, string id = null, bool useGet = false)
+        public T.Task<Parameters> Translate(Parameters parameters, string? id = null, bool useGet = false)
         {
             // make this method async, when implementing
             throw new NotImplementedException();
         }
 
-        public T.Task<Parameters> Subsumes(Parameters parameters, string id = null, bool useGet = false)
+        public T.Task<Parameters> Subsumes(Parameters parameters, string? id = null, bool useGet = false)
         {
             // make this method async, when implementing
             throw new NotImplementedException();
@@ -221,7 +223,7 @@ namespace Hl7.Fhir.Specification.Terminology
             return await validateCodeVS(vs, coding.Code, coding.System, coding.Display, abstractAllowed).ConfigureAwait(false);
         }
 
-        private async T.Task<Parameters> validateCodeVS(ValueSet vs, string code, string system, string display, bool? abstractAllowed)
+        private async T.Task<Parameters> validateCodeVS(ValueSet vs, string? code, string? system, string? display, bool? abstractAllowed)
         {
 
             if (code is null)
@@ -288,3 +290,4 @@ namespace Hl7.Fhir.Specification.Terminology
     }
 }
 
+#nullable restore

--- a/src/Hl7.Fhir.STU3/Model/ValueSet.cs
+++ b/src/Hl7.Fhir.STU3/Model/ValueSet.cs
@@ -6,25 +6,26 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+#nullable enable
+
+using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Support;
+using Hl7.Fhir.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Hl7.Fhir.Introspection;
-using Hl7.Fhir.Utility;
 
 namespace Hl7.Fhir.Model
 {
     public partial class ValueSet : Hl7.Fhir.Model.DomainResource
     {
         [Obsolete("This property was renamed in DSTU2 to CodeSystem, and in DSTU3 out of the class entirely to the CodeSystem resource", true)]
-        public string Define { get; set; }
+        public string? Define { get; set; }
 
         [NotMapped]
         public bool HasExpansion => Expansion != null;
 
-        public bool CodeInExpansion(String code, string system = null)
+        public bool CodeInExpansion(String code, string? system = null)
         {
             ensureExpansion();
 
@@ -42,7 +43,7 @@ namespace Hl7.Fhir.Model
                 return null;
         }
 
-        public ValueSet.ContainsComponent FindInExpansion(String code, string system = null)
+        public ValueSet.ContainsComponent FindInExpansion(String code, string? system = null)
         {
             ensureExpansion();
 
@@ -69,7 +70,7 @@ namespace Hl7.Fhir.Model
 
             combinedExpansion.Parameter.AddRange(other.Expansion.Parameter);
             combinedExpansion.Contains.AddRange(other.Expansion.Contains);
-            combinedExpansion.Total += other.Expansion?.Total ?? other.Expansion.Contains.CountConcepts();
+            combinedExpansion.Total += other.Expansion!.Total ?? other.Expansion.Contains.CountConcepts();
 
             Expansion = combinedExpansion;
         }
@@ -105,3 +106,4 @@ namespace Hl7.Fhir.Model
 
     }
 }
+#nullable restore

--- a/src/Hl7.Fhir.STU3/Specification/Terminology/LocalTerminologyService.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Terminology/LocalTerminologyService.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using T = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Specification.Terminology
@@ -225,7 +226,6 @@ namespace Hl7.Fhir.Specification.Terminology
 
         private async T.Task<Parameters> validateCodeVS(ValueSet vs, string? code, string? system, string? display, bool? abstractAllowed)
         {
-
             if (code is null)
             {
                 var resultParam = new Parameters
@@ -260,7 +260,7 @@ namespace Hl7.Fhir.Specification.Terminology
 
             if (component is null)
             {
-                messages.AppendLine($"{codeLabel} does not exist in the value set '{vs.Title ?? vs.Name}' ({vs.Url})");
+                await messageForCodeNotFound(vs, system, codeLabel, messages).ConfigureAwait(false);
                 success = false;
             }
             else
@@ -286,6 +286,23 @@ namespace Hl7.Fhir.Specification.Terminology
             if (messages.Length > 0)
                 result.Add("message", new FhirString(messages.ToString().TrimEnd()));
             return result;
+        }
+        private async T.Task messageForCodeNotFound(ValueSet vs, string? system, string codeLabel, StringBuilder messages)
+        {
+            if (system is not null && await isValueSet(system).ConfigureAwait(false))
+            {
+                messages.AppendLine($"The Coding references a value set, not a code system ('{system}')");
+            }
+            else
+            {
+                messages.AppendLine($"{codeLabel} does not exist in the value set '{vs.Title ?? vs.Name}' ({vs.Url})");
+            }
+
+            async Task<bool> isValueSet(string system)
+            {
+                // First, conduct a quick initial check, and if that fails, proceed with a more comprehensive approach.
+                return (system.Contains(@"/ValueSet/") || await _resolver.FindValueSetAsync(system).ConfigureAwait(false) is not null);
+            }
         }
     }
 }

--- a/src/Hl7.Fhir.STU3/Specification/Terminology/LocalTerminologyService.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Terminology/LocalTerminologyService.cs
@@ -6,6 +6,8 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+#nullable enable
+
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Specification.Source;
@@ -31,7 +33,7 @@ namespace Hl7.Fhir.Specification.Terminology
         private readonly string _systemAttribute = "system";
         private readonly string _contextAttribute = "context";
 
-        public LocalTerminologyService(IAsyncResourceResolver resolver, ValueSetExpanderSettings expanderSettings = null)
+        public LocalTerminologyService(IAsyncResourceResolver resolver, ValueSetExpanderSettings? expanderSettings = null)
         {
             _resolver = resolver ?? throw Error.ArgumentNull(nameof(resolver));
 
@@ -41,7 +43,7 @@ namespace Hl7.Fhir.Specification.Terminology
             _expander = new ValueSetExpander(settings);
         }
 
-        internal async T.Task<ValueSet> FindValueset(string canonical)
+        internal async T.Task<ValueSet?> FindValueset(string canonical)
         {
             var valueset = await _resolver.FindValueSetAsync(canonical).ConfigureAwait(false);
 
@@ -72,7 +74,7 @@ namespace Hl7.Fhir.Specification.Terminology
 
 
         ///<inheritdoc />
-        public async T.Task<Parameters> ValueSetValidateCode(Parameters parameters, string id = null, bool useGet = false)
+        public async T.Task<Parameters> ValueSetValidateCode(Parameters parameters, string? id = null, bool useGet = false)
         {
 
             //No duplicate parameters allowed (http://hl7.org/fhir/valueset-operation-validate-code.html)
@@ -137,13 +139,13 @@ namespace Hl7.Fhir.Specification.Terminology
         }
 
         #region Not implemented methods
-        public T.Task<Parameters> CodeSystemValidateCode(Parameters parameters, string id = null, bool useGet = false)
+        public T.Task<Parameters> CodeSystemValidateCode(Parameters parameters, string? id = null, bool useGet = false)
         {
             // make this method async, when implementing
             throw new NotImplementedException();
         }
 
-        public T.Task<Resource> Expand(Parameters parameters, string id = null, bool useGet = false)
+        public T.Task<Resource> Expand(Parameters parameters, string? id = null, bool useGet = false)
         {
             // make this method async, when implementing
             throw new NotImplementedException();
@@ -155,13 +157,13 @@ namespace Hl7.Fhir.Specification.Terminology
             throw new NotImplementedException();
         }
 
-        public T.Task<Parameters> Translate(Parameters parameters, string id = null, bool useGet = false)
+        public T.Task<Parameters> Translate(Parameters parameters, string? id = null, bool useGet = false)
         {
             // make this method async, when implementing
             throw new NotImplementedException();
         }
 
-        public T.Task<Parameters> Subsumes(Parameters parameters, string id = null, bool useGet = false)
+        public T.Task<Parameters> Subsumes(Parameters parameters, string? id = null, bool useGet = false)
         {
             // make this method async, when implementing
             throw new NotImplementedException();
@@ -221,7 +223,7 @@ namespace Hl7.Fhir.Specification.Terminology
             return await validateCodeVS(vs, coding.Code, coding.System, coding.Display, abstractAllowed).ConfigureAwait(false);
         }
 
-        private async T.Task<Parameters> validateCodeVS(ValueSet vs, string code, string system, string display, bool? abstractAllowed)
+        private async T.Task<Parameters> validateCodeVS(ValueSet vs, string? code, string? system, string? display, bool? abstractAllowed)
         {
 
             if (code is null)
@@ -288,3 +290,4 @@ namespace Hl7.Fhir.Specification.Terminology
     }
 }
 
+#nullable restore

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Terminology/LocalTerminologyServiceTests.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Terminology/LocalTerminologyServiceTests.cs
@@ -40,8 +40,8 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [DataTestMethod]
-        [DataRow("http://hl7.org/fhir/ValueSet/basic-resource-type", "132037003", "http://hl7.org/fhir/ValueSet/account-type", "Pineywoods pig breed")]
-        [DataRow("http://hl7.org/fhir/ValueSet/basic-resource-type", "132037003", "http://example.com/an-exotic-valuset", "Pineywoods pig breed")]
+        [DataRow("http://hl7.org/fhir/ValueSet/administrative-gender", "not-human", "http://hl7.org/fhir/ValueSet/account-type", "Not existing code for gender")]
+        [DataRow("http://hl7.org/fhir/ValueSet/administrative-gender", "not-human", "http://example.com/an-exotic-valuset", "Not existing code for gender")]
         public async Task CodingWithValuesetAsSystem(string valueset, string code, string system, string display)
         {
             var parameters = new ValidateCodeParameters()

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Terminology/LocalTerminologyServiceTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Terminology/LocalTerminologyServiceTests.cs
@@ -40,8 +40,8 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [DataTestMethod]
-        [DataRow("http://hl7.org/fhir/ValueSet/basic-resource-type", "132037003", "http://hl7.org/fhir/ValueSet/account-type", "Pineywoods pig breed")]
-        [DataRow("http://hl7.org/fhir/ValueSet/basic-resource-type", "132037003", "http://example.com/an-exotic-valuset", "Pineywoods pig breed")]
+        [DataRow("http://hl7.org/fhir/ValueSet/administrative-gender", "not-human", "http://hl7.org/fhir/ValueSet/account-type", "Not existing code for gender")]
+        [DataRow("http://hl7.org/fhir/ValueSet/administrative-gender", "not-human", "http://example.com/an-exotic-valuset", "Not existing code for gender")]
         public async Task CodingWithValuesetAsSystem(string valueset, string code, string system, string display)
         {
             var parameters = new ValidateCodeParameters()


### PR DESCRIPTION
## Description
The `ValueSetValidateCode` method in the `LocalTerminologyService` now includes a check to determine if the `Coding.system` references a CodeSystem. If it does not, the method will generate a message to indicate the discrepancy.

## Related issues
Resolves VONK-4618

## Testing
See unit test `LocalTerminologyServiceTests.CodingWithValuesetAsSystem`

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes