### PR TITLE
Change error message when the ValueSetExpander can't find a specific CodeSystem

### DIFF
--- a/src/Hl7.Fhir.Conformance/Specification/Terminology/ValueSetExpander.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Terminology/ValueSetExpander.cs
@@ -12,14 +12,14 @@ using Hl7.Fhir.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using T=System.Threading.Tasks;
+using T = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Specification.Terminology
 {
     public class ValueSetExpander
     {
 
-//ValueSetExpander keeps throwing TerminologyService Exceptions to not change the public interface.
+        //ValueSetExpander keeps throwing TerminologyService Exceptions to not change the public interface.
 #pragma warning disable 0618
 
         public ValueSetExpanderSettings Settings { get; }
@@ -55,19 +55,19 @@ namespace Hl7.Fhir.Specification.Terminology
                 source.Expansion = null;
                 throw;
             }
-            
+
         }
 
         private void setExpansionParameters(ValueSet vs)
         {
             vs.Expansion.Parameter = new List<ValueSet.ParameterComponent>();
-            if(Settings.IncludeDesignations)
+            if (Settings.IncludeDesignations)
             {
                 vs.Expansion.Parameter.Add(new ValueSet.ParameterComponent
                 {
                     Name = "includeDesignations",
                     Value = new FhirBoolean(true)
-                }); 
+                });
             }
             //TODO add more parameters to the valuset here when we implement them.
         }
@@ -122,7 +122,7 @@ namespace Hl7.Fhir.Specification.Terminology
                     {
                         // We'd probably really have to look this code up in the original ValueSet (by system) to know something about 'abstract'
                         // and what would we do with a hierarchy if we encountered that in the include?
-                        if(Settings.IncludeDesignations)
+                        if (Settings.IncludeDesignations)
                         {
                             result.Add(conceptSet.System, conceptSet.Version, concept.Code, concept.Display, concept.Designation);
                         }
@@ -130,7 +130,7 @@ namespace Hl7.Fhir.Specification.Terminology
                         {
                             result.Add(conceptSet.System, conceptSet.Version, concept.Code, concept.Display);
                         }
-                       
+
                     }
                 }
                 else
@@ -152,7 +152,7 @@ namespace Hl7.Fhir.Specification.Terminology
                 var concepts = await getExpansionForValueSet(importedVs).ConfigureAwait(false);
                 import(result, concepts, importedVs);
             }
-            
+
             return result;
 
             void import(List<ValueSet.ContainsComponent> dest, List<ValueSet.ContainsComponent> source, string importeeUrl)
@@ -209,7 +209,7 @@ namespace Hl7.Fhir.Specification.Terminology
                         "set ValueSetExpander.Settings.ValueSetSource to fix.");
 
             var importedVs = await Settings.ValueSetSource.AsAsync().FindValueSetAsync(uri).ConfigureAwait(false);
-            if (importedVs == null) throw new ValueSetUnknownException($"Cannot resolve canonical reference '{uri}' to ValueSet");
+            if (importedVs == null) throw new ValueSetUnknownException($"The ValueSet expander cannot find system '{uri}', so the expansion cannot be completed.");
 
             if (!importedVs.HasExpansion) await ExpandAsync(importedVs).ConfigureAwait(false);
 
@@ -226,7 +226,7 @@ namespace Hl7.Fhir.Specification.Terminology
                         "set ValueSetExpander.Settings.ValueSetSource to fix.");
 
             var importedCs = await Settings.ValueSetSource.AsAsync().FindCodeSystemAsync(uri).ConfigureAwait(false);
-            if (importedCs == null) throw new ValueSetUnknownException($"Cannot resolve canonical reference '{uri}' to CodeSystem");
+            if (importedCs == null) throw new ValueSetUnknownException($"The ValueSet expander cannot find system '{uri}', so the expansion cannot be completed.");
 
             var result = new List<ValueSet.ContainsComponent>();
             result.AddRange(importedCs.Concept.Select(c => c.ToContainsComponent(importedCs, Settings)));
@@ -294,9 +294,9 @@ namespace Hl7.Fhir.Specification.Terminology
             newContains.System = system.Url;
             newContains.Version = system.Version;
             newContains.Code = source.Code;
-            newContains.Display = source.Display;            
-            if(settings.IncludeDesignations)            
-                newContains.Designation = source.Designation.ToValueSetDesignations();                    
+            newContains.Display = source.Display;
+            if (settings.IncludeDesignations)
+                newContains.Designation = source.Designation.ToValueSetDesignations();
 
             var abstractProperty = source.ListConceptProperties(system, CodeSystem.CONCEPTPROPERTY_NOT_SELECTABLE).SingleOrDefault();
             if (abstractProperty?.Value is FhirBoolean isAbstract)
@@ -316,7 +316,7 @@ namespace Hl7.Fhir.Specification.Terminology
         private static List<ValueSet.DesignationComponent> ToValueSetDesignations(this List<CodeSystem.DesignationComponent> csDesignations)
         {
             var vsDesignations = new List<ValueSet.DesignationComponent>();
-            csDesignations.ForEach(d => vsDesignations.Add(d.ToValueSetDesignation()));           
+            csDesignations.ForEach(d => vsDesignations.Add(d.ToValueSetDesignation()));
             return vsDesignations;
         }
 
@@ -331,5 +331,5 @@ namespace Hl7.Fhir.Specification.Terminology
         }
 
     }
-    #pragma warning restore
+#pragma warning restore
 }

--- a/src/Hl7.Fhir.STU3/Specification/Terminology/ValueSetExpander.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Terminology/ValueSetExpander.cs
@@ -12,14 +12,14 @@ using Hl7.Fhir.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using T=System.Threading.Tasks;
+using T = System.Threading.Tasks;
 
 namespace Hl7.Fhir.Specification.Terminology
 {
     public class ValueSetExpander
     {
 
-//ValueSetExpander keeps throwing TerminologyService Exceptions to not change the public interface.
+        //ValueSetExpander keeps throwing TerminologyService Exceptions to not change the public interface.
 #pragma warning disable 0618
 
         public ValueSetExpanderSettings Settings { get; }
@@ -55,19 +55,19 @@ namespace Hl7.Fhir.Specification.Terminology
                 source.Expansion = null;
                 throw;
             }
-            
+
         }
 
         private void setExpansionParameters(ValueSet vs)
         {
             vs.Expansion.Parameter = new List<ValueSet.ParameterComponent>();
-            if(Settings.IncludeDesignations)
+            if (Settings.IncludeDesignations)
             {
                 vs.Expansion.Parameter.Add(new ValueSet.ParameterComponent
                 {
                     Name = "includeDesignations",
                     Value = new FhirBoolean(true)
-                }); 
+                });
             }
             //TODO add more parameters to the valuset here when we implement them.
         }
@@ -122,7 +122,7 @@ namespace Hl7.Fhir.Specification.Terminology
                     {
                         // We'd probably really have to look this code up in the original ValueSet (by system) to know something about 'abstract'
                         // and what would we do with a hierarchy if we encountered that in the include?
-                        if(Settings.IncludeDesignations)
+                        if (Settings.IncludeDesignations)
                         {
                             result.Add(conceptSet.System, conceptSet.Version, concept.Code, concept.Display, concept.Designation);
                         }
@@ -130,7 +130,7 @@ namespace Hl7.Fhir.Specification.Terminology
                         {
                             result.Add(conceptSet.System, conceptSet.Version, concept.Code, concept.Display);
                         }
-                       
+
                     }
                 }
                 else
@@ -152,7 +152,7 @@ namespace Hl7.Fhir.Specification.Terminology
                 var concepts = await getExpansionForValueSet(importedVs).ConfigureAwait(false);
                 import(result, concepts, importedVs);
             }
-            
+
             return result;
 
             void import(List<ValueSet.ContainsComponent> dest, List<ValueSet.ContainsComponent> source, string importeeUrl)
@@ -226,7 +226,7 @@ namespace Hl7.Fhir.Specification.Terminology
                         "set ValueSetExpander.Settings.ValueSetSource to fix.");
 
             var importedCs = await Settings.ValueSetSource.AsAsync().FindCodeSystemAsync(uri).ConfigureAwait(false);
-            if (importedCs == null) throw new ValueSetUnknownException($"Cannot resolve canonical reference '{uri}' to CodeSystem");
+            if (importedCs == null) throw new ValueSetUnknownException($"The ValueSet expander cannot find system '{uri}', so the expansion cannot be completed.");
 
             var result = new List<ValueSet.ContainsComponent>();
             result.AddRange(importedCs.Concept.Select(c => c.ToContainsComponent(importedCs, Settings)));
@@ -294,9 +294,9 @@ namespace Hl7.Fhir.Specification.Terminology
             newContains.System = system.Url;
             newContains.Version = system.Version;
             newContains.Code = source.Code;
-            newContains.Display = source.Display;            
-            if(settings.IncludeDesignations)            
-                newContains.Designation = source.Designation.ToValueSetDesignations();                    
+            newContains.Display = source.Display;
+            if (settings.IncludeDesignations)
+                newContains.Designation = source.Designation.ToValueSetDesignations();
 
             var abstractProperty = source.ListConceptProperties(system, CodeSystem.CONCEPTPROPERTY_NOT_SELECTABLE).SingleOrDefault();
             if (abstractProperty?.Value is FhirBoolean isAbstract)
@@ -316,7 +316,7 @@ namespace Hl7.Fhir.Specification.Terminology
         private static List<ValueSet.DesignationComponent> ToValueSetDesignations(this List<CodeSystem.DesignationComponent> csDesignations)
         {
             var vsDesignations = new List<ValueSet.DesignationComponent>();
-            csDesignations.ForEach(d => vsDesignations.Add(d.ToValueSetDesignation()));           
+            csDesignations.ForEach(d => vsDesignations.Add(d.ToValueSetDesignation()));
             return vsDesignations;
         }
 
@@ -331,5 +331,5 @@ namespace Hl7.Fhir.Specification.Terminology
         }
 
     }
-    #pragma warning restore
+#pragma warning restore
 }

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Source/TerminologyTests.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Source/TerminologyTests.cs
@@ -60,6 +60,29 @@ namespace Hl7.Fhir.Specification.Tests
             //Assert.Equal("http://hl7.org/fhir/ValueSet/issue-type?version=3.14", ((FhirUri)versionParam.Value).Value);
         }
 
+        [Fact]
+        public async T.Task TestExpandingVsWithUnknownSystem()
+        {
+
+            var expander = new ValueSetExpander(new ValueSetExpanderSettings { ValueSetSource = _resolverWithoutExpansions });
+            var vs = new ValueSet
+            {
+                Compose = new()
+                {
+                    Include = new List<ValueSet.ConceptSetComponent>
+                    {
+                        new()
+                        {
+                            System = "http://www.unknown.org/"
+                        }
+                    }
+                }
+            };
+
+            var job = async () => await expander.ExpandAsync(vs);
+            await job.Should().ThrowAsync<ValueSetUnknownException>().WithMessage("The ValueSet expander cannot find system 'http://www.unknown.org/', so the expansion cannot be completed.");
+        }
+
 
         [Fact]
         public async T.Task ExpansionOfComposeInclude()

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Source/TerminologyTests.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Source/TerminologyTests.cs
@@ -64,7 +64,7 @@ namespace Hl7.Fhir.Specification.Tests
         public async T.Task TestExpandingVsWithUnknownSystem()
         {
 
-            var expander = new ValueSetExpander(new ValueSetExpanderSettings { ValueSetSource = _resolverWithoutExpansions });
+            var expander = new ValueSetExpander(new ValueSetExpanderSettings { ValueSetSource = new InMemoryResourceResolver() });
             var vs = new ValueSet
             {
                 Compose = new()

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Source/TerminologyTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Source/TerminologyTests.cs
@@ -70,6 +70,29 @@ namespace Hl7.Fhir.Specification.Tests
             //Assert.Equal("http://hl7.org/fhir/ValueSet/issue-type?version=3.14", ((FhirUri)versionParam.Value).Value);
         }
 
+        [Fact]
+        public async T.Task TestExpandingVsWithUnknownSystem()
+        {
+
+            var expander = new ValueSetExpander(new ValueSetExpanderSettings { ValueSetSource = _resolverWithoutExpansions });
+            var vs = new ValueSet
+            {
+                Compose = new()
+                {
+                    Include = new List<ValueSet.ConceptSetComponent>
+                    {
+                        new()
+                        {
+                            System = "http://www.unknown.org/"
+                        }
+                    }
+                }
+            };
+
+            var job = async () => await expander.ExpandAsync(vs);
+            await job.Should().ThrowAsync<ValueSetUnknownException>().WithMessage("The ValueSet expander cannot find system 'http://www.unknown.org/', so the expansion cannot be completed.");
+        }
+
 
         [Fact]
         public async T.Task ExpansionOfComposeInclude()

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Source/TerminologyTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Source/TerminologyTests.cs
@@ -74,7 +74,7 @@ namespace Hl7.Fhir.Specification.Tests
         public async T.Task TestExpandingVsWithUnknownSystem()
         {
 
-            var expander = new ValueSetExpander(new ValueSetExpanderSettings { ValueSetSource = _resolverWithoutExpansions });
+            var expander = new ValueSetExpander(new ValueSetExpanderSettings { ValueSetSource = new InMemoryResourceResolver() });
             var vs = new ValueSet
             {
                 Compose = new()


### PR DESCRIPTION
fixes https://github.com/FirelyTeam/firely-validator-api/issues/142