### PR TITLE
Use `string` also as a valid type for the input value of `memberOf()`

### DIFF
--- a/src/Hl7.Fhir.Base/FhirPath/ElementNavFhirExtensions.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/ElementNavFhirExtensions.cs
@@ -283,7 +283,7 @@ namespace Hl7.Fhir.FhirPath
                 "code" when input is ScopedNode sn => inParams.WithCode(code: sn.Value as string, context: sn.LocalLocation),
                 "Coding" => inParams.WithCoding(input.ParseCoding()),
                 "CodeableConcept" => inParams.WithCodeableConcept(input.ParseCodeableConcept()),
-                "System.String" => inParams.WithCode(code: input.Value as string, context: "No context available"),
+                "string" or "System.String" => inParams.WithCode(code: input.Value as string, context: "No context available"),
                 _ => null,
             };
 

--- a/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
+++ b/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
@@ -383,6 +383,12 @@ namespace Hl7.FhirPath.R4.Tests
                                             }, "memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", true };
 
             // memberOf with string objects
+            yield return new object[] { new FhirString("85353-1"), "memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", true };
+            yield return new object[] { new FhirString("male"), "memberOf('http://hl7.org/fhir/ValueSet/administrative-gender')", true };
+            yield return new object[] { new FhirString("female"), "memberOf('http://hl7.org/fhir/ValueSet/administrative-gender')", true };
+            yield return new object[] { new FhirString("no-idea"), "memberOf('http://hl7.org/fhir/ValueSet/administrative-gender')", false };
+
+            // memberOf with inline string objects
             yield return new object[] { new FhirBoolean(), "'85353-1'.memberOf('http://hl7.org/fhir/ValueSet/observation-vitalsignresult')", true };
             yield return new object[] { new FhirBoolean(), "'male'.memberOf('http://hl7.org/fhir/ValueSet/administrative-gender')", true };
             yield return new object[] { new FhirBoolean(), "'female'.memberOf('http://hl7.org/fhir/ValueSet/administrative-gender')", true };


### PR DESCRIPTION
## Description
Use `string` now as well for a valid input type for the FhirPath function `memberOf()`.

## Related issues
Resolves #2588 

## Testing
See unit test `TestFhirPathResolve.MemberOfTests`

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes