### PR TITLE
#1442: Added Quantity arithmetic

### DIFF
--- a/src/Hl7.Fhir.Base/ElementModel/Types/Ucum.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/Types/Ucum.cs
@@ -47,6 +47,13 @@ namespace Hl7.Fhir.ElementModel.Types
             Metric metric = (unit != null) ? SYSTEM.Value.Metric(unit) : new Metric(new List<Metric.Axis>());
             return new M.Quantity(value, metric);
         }
+
+        internal static string PerformMetricOperation(string unit1, string unit2, Func<Metric, Metric, Metric> operation)
+        {
+            var a = SYSTEM.Value.Metric(unit1);
+            var b = SYSTEM.Value.Metric(unit2);
+            return operation(a, b).ToString();
+        }
     }
 }
 

--- a/src/Hl7.Fhir.Support.Tests/ElementModel/QuantityTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/ElementModel/QuantityTests.cs
@@ -8,10 +8,13 @@
 
 using FluentAssertions;
 using Hl7.Fhir.ElementModel.Types;
+using Hl7.Fhir.Utility;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using P = Hl7.Fhir.ElementModel.Types;
+
+#nullable enable
 
 namespace Hl7.Fhir.ElementModel.Tests
 {
@@ -149,50 +152,55 @@ namespace Hl7.Fhir.ElementModel.Tests
             }
         }
 
-        /*     [DataTestMethod]
-         [DataRow("25 'kg'", "5 'kg'", "30 'kg'",  (Quantity a, Quantity b) => a + b ]
-        [DataRow("1 'm'", "2 'm'", Comparison.LessThan)]
-            [DataRow("1 'cm'", "1 'm'", Comparison.LessThan)]
-            [DataRow("30.0 'g'", "0.03 'kg'", Comparison.Equals)]
-            [DataRow("1 '[in_i]'", "2 'cm'", Comparison.GreaterThan)] // 1 inch is greater than 2
-            [DataRow("1 '[stone_av]'", "6350.29318 'g'", Comparison.Equals)]
-            [DataRow("3 'hr'", "3 'h'", Comparison.Equals, true)]
-            [DataRow("3 'a'", "3 year", Comparison.Equals)]
-            [DataRow("3 'a'", "3 years", Comparison.Equals)]
-            [DataRow("3 'mo'", "3 months", Comparison.Equals)]
-            [DataRow("3 'd'", "3 days", Comparison.Equals)]
-            [DataRow("1 'd'", "3 days", Comparison.LessThan)]*/
-
-        public static IEnumerable<object[]> ArithmeticTestdata => new[]
+        public static IEnumerable<object?[]> ArithmeticTestdata => new[]
                 {
-                    new object[] { "25 'kg'", "5 'kg'", "30 'kg'", (Quantity a, Quantity b) => a + b },
-                    new object[] { "25 'kg'", "1000 'g'", "26000 'g'", (Quantity a, Quantity b) => a + b },
-                    new object[] { "3 '[in_i]'", "2 '[in_i]'", "5 '[in_i]'", (Quantity a, Quantity b) => a + b },
-                    new object[] { "4.0 'kg.m/s2'", "2000 'g.m.s-2'", "6000 'g.m.s-2'", (Quantity a, Quantity b) => a + b },
+                    new object[] { "25 'kg'", "5 'kg'", "30 'kg'" , (object)Quantity.Add },
+                    new object[] { "25 'kg'", "1000 'g'", "26000 'g'", (object)Quantity.Add },
+                    new object[] { "3 '[in_i]'", "2 '[in_i]'", "5 '[in_i]'", (object)Quantity.Add },
+                    new object[] { "4.0 'kg.m/s2'", "2000 'g.m.s-2'", "6000 'g.m.s-2'", (object)Quantity.Add } ,
+                    new object[] { "3 'm'", "3 'cm'", "303 'cm'", (object)Quantity.Add },
+                    new object[] { "3 'm'", "0 'cm'","300 'cm'", (object)Quantity.Add },
+                    new object[] { "3 'm'", "-80 'cm'", "220 'cm'", (object)Quantity.Add },
 
-                    new object[] { "25 'kg'", "500 'g'", "24500 'g'", (Quantity a, Quantity b) => a - b },
-                    new object[] { "25 'kg'", "25001 'g'", "-1 'g'", (Quantity a, Quantity b) => a - b },
-                    new object[] { "1 '[in_i]'", "2 'cm'", "0.005400 'm'", (Quantity a, Quantity b) => a - b },
+                    new object?[] { "3 'm'", "0 'kg'", null, (object)Quantity.Add },
 
-                    new object[] { "25 'km'", "20 'cm'", "5000 'm2'", (Quantity a, Quantity b) => a * b },
-                    new object[] { "2.0 'cm'", "2.0 'm'", "0.040 'm2'", (Quantity a, Quantity b) => a * b },
+                    new object[] { "25 'kg'", "500 'g'", "24500 'g'", (object)Quantity.Substract },
+                    new object[] { "25 'kg'", "25001 'g'", "-1 'g'", (object)Quantity.Substract},
+                    new object[] { "1 '[in_i]'", "2 'cm'", "0.005400 'm'", (object)Quantity.Substract },
 
-                    new object[] { "14.4 'km'", "2.0 'h'", "2 'm.s-1'", (Quantity a, Quantity b) => a / b },
-                    new object[] { "9 'm2'", "3 'm'", "3 'm'", (Quantity a, Quantity b) => a / b },
+                    new object?[] { "1 '[in_i]'", "2 'kg'", null, (object)Quantity.Substract },
+
+                    new object[] { "25 'km'", "20 'cm'", "5000 'm2'", (object)Quantity.Multiply },
+                    new object[] { "2.0 'cm'", "2.0 'm'", "0.040 'm2'", (object)Quantity.Multiply  },
+                    new object[] { "2.0 'cm'", "9 'kg'", "180 'g.m'", (object)Quantity.Multiply  },
+
+
+                    new object[] { "14.4 'km'", "2.0 'h'", "2 'm.s-1'", (object)Quantity.Divide },
+                    new object[] { "9 'm2'", "3 'm'", "3 'm'", (object)Quantity.Divide },
+                    new object[] { "6 'm'", "3 'm'", "2 '1'", (object)Quantity.Divide },
+                    new object?[] { "3 'm'", "0 'cm'", null, (object)Quantity.Divide },
                 };
 
 
         [TestMethod]
         [DynamicData(nameof(ArithmeticTestdata))]
-        public void ArithmeticOperationsTests(string left, string right, string result, Func<Quantity, Quantity, Quantity> operation)
+        public void ArithmeticOperationsTests(string left, string right, object result, Func<Quantity, Quantity, Result<Quantity>> operation)
         {
             _ = Quantity.TryParse(left, out var q1);
             _ = Quantity.TryParse(right, out var q2);
-            _ = Quantity.TryParse(result, out var r);
 
             var opResult = operation(q1, q2);
 
-            opResult.Should().Be(r);
+            if (result is string r && Quantity.TryParse(r, out var q3))
+            {
+                opResult.ValueOrDefault().Should().Be(q3);
+            }
+            else
+            {
+                opResult.Should().BeAssignableTo<IFailed>();
+            }
         }
     }
 }
+
+#nullable restore

--- a/src/Hl7.FhirPath.Tests/Functions/MathOperatorsTests.cs
+++ b/src/Hl7.FhirPath.Tests/Functions/MathOperatorsTests.cs
@@ -1,6 +1,13 @@
 ﻿using FluentAssertions;
+using Hl7.Fhir.ElementModel;
+using Hl7.FhirPath;
 using Hl7.FhirPath.FhirPath.Functions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+#nullable enable
 
 namespace HL7.FhirPath.Tests.Functions
 {
@@ -22,5 +29,72 @@ namespace HL7.FhirPath.Tests.Functions
 
             2m.Power(2m).Should().BeOfType(typeof(decimal));
         }
+
+        private static IEnumerable<object[]> QuantityAddOperations() =>
+           new (string expression, bool expected, bool invalid)[]
+                {
+                     ("25 'kg' + 5 'kg' = 30 'kg'", true, false),
+                     ("3 '[in_i]' + 2 '[in_i]' = 5 '[in_i]'", true, false),
+                     ("3 'm' + 0 'cm' = 300 'cm'", true, false),
+                     ("(3 'm' + 0 'kg').empty()", true, false),
+                }.Select(t => new object[] { t.expression, t.expected, t.invalid });
+
+        private static IEnumerable<object[]> QuantitySubstractOperations() =>
+          new (string expression, bool expected, bool invalid)[]
+               {
+                     ("25 'kg' - 500 'g' = 24500 'g'", true, false),
+                     ("25 'kg' - 25001 'g' = -1 'g'", true, false),
+                     ("1 '[in_i]' - 2 'cm' = 0.005400 'm'", true, false),
+                     ("(3 '[in_i]' - 0 'kg').empty()", true, false),
+               }.Select(t => new object[] { t.expression, t.expected, t.invalid });
+
+        private static IEnumerable<object[]> QuantityMultiplyOperations() =>
+          new (string expression, bool expected, bool invalid)[]
+               {
+                     ("25 'km' * 20 'cm' = 5000 'm2'", true, false),
+                     ("2 'cm' * 2 'm' = 0.040 'm2'", true, false),
+                     ("2 'cm' * 9 'kg' = 180 'g.m'", true, false),
+               }.Select(t => new object[] { t.expression, t.expected, t.invalid });
+
+        private static IEnumerable<object[]> QuantityDivideOperations() =>
+          new (string expression, bool expected, bool invalid)[]
+               {
+                     ("14.4 'km' / 2 'h' = 2 'm.s-1'", true, false),
+                     ("9 'm2' / 3 'm' = 3 'm'", true, false),
+                     ("6 'm' / 3 'm' = 2 '1'", true, false),
+                     ("(3 'm' / 0 'cm').empty()", true, false),
+               }.Select(t => new object[] { t.expression, t.expected, t.invalid });
+
+        public static IEnumerable<object[]> AllQuantityOperations()
+        {
+            return
+                Enumerable.Empty<object[]>()
+                .Union(QuantityAddOperations())
+                .Union(QuantitySubstractOperations())
+                .Union(QuantityMultiplyOperations())
+                .Union(QuantityDivideOperations())
+                ;
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(AllQuantityOperations), DynamicDataSourceType.Method)]
+        public void AssertTestcases(string expression, bool expected, bool invalid = false)
+        {
+            ITypedElement dummy = ElementNode.ForPrimitive(true);
+
+            if (invalid)
+            {
+                Action act = () => dummy.IsBoolean(expression, expected);
+                act.Should().Throw<Exception>();
+            }
+            else
+            {
+                dummy.IsBoolean(expression, expected)
+                    .Should().BeTrue(because: $"The expression was supposed to result in {expected}.");
+            }
+        }
     }
+
+
 }
+#nullable restore


### PR DESCRIPTION
## Description
Added the `Quantity` arithmetic operations, like Add, Substract, Multiply and Divide. These operations can now also be used in FhirPath.

I changed the signature of the not implemented static operators of `Quantity`. Technically is that a breaking change, but here we can get away with it or not?

## Related issues
Resolves #1442.

## Testing
- Hl7.Fhir.ElementModel.Tests.QuantityTests.ArithmeticOperationsTests
- HL7.FhirPath.Tests.OperationsTests.AssertTestcases

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] Mark the PR with the label **breaking change** when this PR introduces breaking changes