### PR TITLE
Improve performance of EnumUtility generic methods

### DIFF
--- a/src/Benchmarks/EnumUtilityBenchmarks.cs
+++ b/src/Benchmarks/EnumUtilityBenchmarks.cs
@@ -40,15 +40,15 @@ namespace Firely.Sdk.Benchmarks
             => EnumUtility.ParseLiteral<SearchParamType>("string").Value;
 
         [Benchmark]
+        public Enum EnumUtilityParseLiteralNonGeneric()
+            => EnumUtility.ParseLiteral("string", typeof(SearchParamType));
+
+        [Benchmark]
         public SearchParamType EnumUtilityParseLiteralIgnoreCase()
             => EnumUtility.ParseLiteral<SearchParamType>("string", true).Value;
 
         [Benchmark]
-        public Enum EnumUtilityNonGenericParseLiteral()
-            => EnumUtility.ParseLiteral("string", typeof(SearchParamType));
-
-        [Benchmark]
-        public Enum EnumUtilityNonGenericParseLiteralIgnoreCase()
+        public Enum EnumUtilityParseLiteralIgnoreCaseNonGeneric()
             => EnumUtility.ParseLiteral("string", typeof(SearchParamType), true);
 
         [Benchmark]
@@ -56,7 +56,7 @@ namespace Firely.Sdk.Benchmarks
             => EnumUtility.GetSystem(StringSearchParam);
 
         [Benchmark]
-        public string EnumUtilityNonGenericGetSystem()
+        public string EnumUtilityGetSystemNonGeneric()
             => EnumUtility.GetSystem(StringSearchParamEnum);
     }
 }

--- a/src/Benchmarks/EnumUtilityBenchmarks.cs
+++ b/src/Benchmarks/EnumUtilityBenchmarks.cs
@@ -1,0 +1,62 @@
+﻿using BenchmarkDotNet.Attributes;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Utility;
+using System;
+
+namespace Firely.Sdk.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class EnumUtilityBenchmarks
+    {
+        private static readonly SearchParamType StringSearchParam = SearchParamType.String;
+        private static readonly Enum StringSearchParamEnum = StringSearchParam;
+
+        [Benchmark]
+        public string EnumToString()
+            => SearchParamType.String.ToString();
+
+        [Benchmark]
+        public string EnumGetName()
+            => Enum.GetName(StringSearchParam);
+
+        [Benchmark]
+        public string EnumUtilityGetLiteral()
+            => EnumUtility.GetLiteral(StringSearchParam);
+
+        [Benchmark]
+        public string EnumUtilityGetLiteralNonGeneric()
+            => EnumUtility.GetLiteral(StringSearchParamEnum);
+
+        [Benchmark]
+        public SearchParamType EnumParse()
+            => Enum.Parse<SearchParamType>("String");
+
+        [Benchmark]
+        public SearchParamType EnumParseIgnoreCase()
+            => Enum.Parse<SearchParamType>("string", true);
+
+        [Benchmark]
+        public SearchParamType EnumUtilityParseLiteral()
+            => EnumUtility.ParseLiteral<SearchParamType>("string").Value;
+
+        [Benchmark]
+        public SearchParamType EnumUtilityParseLiteralIgnoreCase()
+            => EnumUtility.ParseLiteral<SearchParamType>("string", true).Value;
+
+        [Benchmark]
+        public Enum EnumUtilityNonGenericParseLiteral()
+            => EnumUtility.ParseLiteral("string", typeof(SearchParamType));
+
+        [Benchmark]
+        public Enum EnumUtilityNonGenericParseLiteralIgnoreCase()
+            => EnumUtility.ParseLiteral("string", typeof(SearchParamType), true);
+
+        [Benchmark]
+        public string? EnumUtilityGetSystem()
+            => EnumUtility.GetSystem(StringSearchParam);
+
+        [Benchmark]
+        public string EnumUtilityNonGenericGetSystem()
+            => EnumUtility.GetSystem(StringSearchParamEnum);
+    }
+}

--- a/src/Hl7.Fhir.Base/Utility/EnumUtility.cs
+++ b/src/Hl7.Fhir.Base/Utility/EnumUtility.cs
@@ -84,11 +84,6 @@ namespace Hl7.Fhir.Utility
         private static class EnumMappingCache<TEnum>
             where TEnum : struct, Enum
         {
-            private static readonly Dictionary<string, TEnum> _literalToEnum = new();
-            private static readonly Dictionary<string, TEnum> _caseInsensitiveLiteralToEnum = new(StringComparer.OrdinalIgnoreCase);
-            private static readonly Dictionary<TEnum, string> _enumToLiteral = new();
-            private static readonly Dictionary<TEnum, string> _enumToSystem = new();
-
             static EnumMappingCache()
             {
                 var t = typeof(TEnum);
@@ -115,6 +110,11 @@ namespace Hl7.Fhir.Utility
             public static string Name { get; }
 
             public static string? DefaultCodeSystem { get; }
+
+            private static readonly Dictionary<string, TEnum> _literalToEnum = new();
+            private static readonly Dictionary<string, TEnum> _caseInsensitiveLiteralToEnum = new(StringComparer.OrdinalIgnoreCase);
+            private static readonly Dictionary<TEnum, string> _enumToLiteral = new();
+            private static readonly Dictionary<TEnum, string> _enumToSystem = new();
 
             public static string? GetSystem(TEnum value) =>
                 !_enumToSystem.TryGetValue(value, out string? result)

--- a/src/Hl7.Fhir.Support.Tests/Utility/EnumMappingTest.cs
+++ b/src/Hl7.Fhir.Support.Tests/Utility/EnumMappingTest.cs
@@ -9,6 +9,7 @@
 using FluentAssertions;
 using Hl7.Fhir.Utility;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Diagnostics;
 
 namespace Hl7.Fhir.Support.Tests.Utils
@@ -33,6 +34,25 @@ namespace Hl7.Fhir.Support.Tests.Utils
             Assert.AreEqual("ItemThree", TestEnum.Item3.GetLiteral());
             Assert.AreEqual("Item3", TestEnum.Item3.GetDocumentation());
             Assert.IsNull(TestEnum.Item3.GetSystem());
+        }
+
+        [TestMethod]
+        public void TestCreationNonGeneric()
+        {
+            Assert.AreEqual("Testee", EnumUtility.GetName(typeof(TestEnum)));
+            Assert.AreEqual(TestEnum.Item1, EnumUtility.ParseLiteral("Item1", typeof(TestEnum)));
+            Assert.IsNull(EnumUtility.ParseLiteral("Item2", typeof(TestEnum)));
+            Assert.AreEqual(TestEnum.Item2, EnumUtility.ParseLiteral("ItemTwo", typeof(TestEnum)));
+            Assert.IsNull(EnumUtility.ParseLiteral("iTeM1", typeof(TestEnum)));
+            Assert.AreEqual(TestEnum.Item1, EnumUtility.ParseLiteral("iTeM1", typeof(TestEnum), ignoreCase: true));
+
+            Assert.AreEqual("Item1", ((Enum)TestEnum.Item1).GetLiteral());
+            Assert.AreEqual("ItemTwo", ((Enum)TestEnum.Item2).GetLiteral());
+            Assert.AreEqual("This is item two", TestEnum.Item2.GetDocumentation());
+            Assert.AreEqual("http://example.org/test-system", ((Enum)TestEnum.Item2).GetSystem());
+            Assert.AreEqual("ItemThree", ((Enum)TestEnum.Item3).GetLiteral());
+            Assert.AreEqual("Item3", ((Enum)TestEnum.Item3).GetDocumentation());
+            Assert.IsNull(((Enum)TestEnum.Item3).GetSystem());
         }
 
         [FhirEnumeration("Testee")]
@@ -108,6 +128,21 @@ namespace Hl7.Fhir.Support.Tests.Utils
         }
 
         [TestMethod]
+        public void EnumParsingPerformanceNonGeneric()
+        {
+            var sw = new Stopwatch();
+            sw.Start();
+
+            for (var i = 0; i < 10000; i++)
+                EnumUtility.ParseLiteral("male", typeof(TestAdministrativeGender));
+
+            sw.Stop();
+
+            Debug.WriteLine(sw.ElapsedMilliseconds);
+            Assert.IsTrue(sw.ElapsedMilliseconds < 100);
+        }
+
+        [TestMethod]
         public void TestEnumMapping()
         {
             Assert.AreEqual(TestAdministrativeGender.Male, EnumUtility.ParseLiteral<TestAdministrativeGender>("male"));
@@ -119,13 +154,41 @@ namespace Hl7.Fhir.Support.Tests.Utils
         }
 
         [TestMethod]
+        public void TestEnumMappingNonGeneric()
+        {
+            Assert.AreEqual(TestAdministrativeGender.Male, EnumUtility.ParseLiteral("male", typeof(TestAdministrativeGender)));
+            Assert.IsNull(EnumUtility.ParseLiteral("maleX", typeof(TestAdministrativeGender)));
+            Assert.AreEqual(X.a, EnumUtility.ParseLiteral("a", typeof(X)));
+
+            Assert.AreEqual("Male", TestAdministrativeGender.Male.GetDocumentation());
+            Assert.AreEqual("a", X.a.GetDocumentation()); // default documentation = name of item
+        }
+
+        [TestMethod]
         public void EnumLiteralPerformance()
         {
             var result = string.Empty;
+            var value = TestAdministrativeGender.Male;
 
             var sw = Stopwatch.StartNew();
             for (var i = 0; i < 50_000; i++)
-                result = TestAdministrativeGender.Male.GetLiteral();
+                result = value.GetLiteral();
+            sw.Stop();
+
+            Assert.AreEqual("male", result);
+            Debug.WriteLine(sw.ElapsedMilliseconds);
+            Assert.IsTrue(sw.ElapsedMilliseconds < 500);
+        }
+
+        [TestMethod]
+        public void EnumLiteralPerformanceNonGeneric()
+        {
+            var result = string.Empty;
+            Enum value = TestAdministrativeGender.Male;
+
+            var sw = Stopwatch.StartNew();
+            for (var i = 0; i < 50_000; i++)
+                result = value.GetLiteral();
             sw.Stop();
 
             Assert.AreEqual("male", result);


### PR DESCRIPTION
## Description
- Improve performance of generic methods in EnumUtility
- Remove usage of ToLowerInvariant for case insensitive parsing in EnumUtility
- Added generic version of GetLiteral and GetSystem methods in EnumUtility
- Added EnumUtility benchmarks
- `ParseLiteral<T>` and `GetName<T>` have an added Enum generic type constraint which is technically a breaking change, but these methods are unlikely to be called with non-Enum generic type parameters.

## Related issues
Resolves #2575.

## Testing
- Hl7.Fhir.Support.Tests.Utils.EnumMappingTest
- Firely.Sdk.Benchmarks.EnumUtilityBenchmarks

```
BenchmarkDotNet v0.13.8, Windows 11 (10.0.22621.2283/22H2/2022Update/SunValley2)
AMD Ryzen 7 7840U w/ Radeon 780M Graphics, 1 CPU, 16 logical and 8 physical cores
.NET SDK 7.0.401
  [Host]     : .NET 6.0.22 (6.0.2223.42425), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.22 (6.0.2223.42425), X64 RyuJIT AVX2
```
| Method                                      | Mean         | Error      | StdDev     | Gen0   | Allocated |
|-------------------------------------------- |-------------:|-----------:|-----------:|-------:|----------:|
| EnumUtilityGetLiteral                       |     7.557 ns |  0.0530 ns |  0.0470 ns |      - |         - |
| EnumUtilityGetLiteralNonGeneric             |    46.648 ns |  0.4639 ns |  0.4340 ns |      - |         - |
| EnumUtilityParseLiteral                     |    19.346 ns |  0.1596 ns |  0.1493 ns |      - |         - |
| EnumUtilityParseLiteralNonGeneric           |    29.049 ns |  0.1169 ns |  0.0976 ns |      - |         - |
| EnumUtilityParseLiteralIgnoreCase           |    21.979 ns |  0.2612 ns |  0.2316 ns |      - |         - |
| EnumUtilityParseLiteralIgnoreCaseNonGeneric |    32.509 ns |  0.1329 ns |  0.1244 ns |      - |         - |
| EnumUtilityGetSystem                        |     2.728 ns |  0.1049 ns |  0.0981 ns |      - |         - |
| EnumUtilityGetSystemNonGeneric              | 2,882.727 ns | 28.1981 ns | 24.9969 ns | 0.1030 |     864 B |

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes