### PR TITLE
Add Process message operation

### DIFF
--- a/src/Hl7.Fhir.Base/Rest/BaseFhirClient.cs
+++ b/src/Hl7.Fhir.Base/Rest/BaseFhirClient.cs
@@ -938,6 +938,20 @@ namespace Hl7.Fhir.Rest
             return OperationAsync(operation, parameters, useGet).WaitResult();
         }
 
+        public virtual Task<Bundle?> ProcessMessageAsync(Bundle bundle, bool async = false, string? responseUrl = null, CancellationToken? ct = null)
+        {
+            if (bundle == null) throw new ArgumentNullException(nameof(bundle));
+
+            var tx = new TransactionBuilder(Endpoint).ProcessMessage(bundle, async, responseUrl).ToBundle();
+            return executeAsync<Bundle>(tx, new [] {HttpStatusCode.OK, HttpStatusCode.Accepted, HttpStatusCode.NoContent}, ct);
+        }
+
+        [Obsolete("Synchronous use of the FhirClient is strongly discouraged, use the asynchronous call instead.")]
+        public virtual Resource? ProcessMessage(Bundle messageBundle, bool async = false, string? responseUrl = null)
+        {
+            return ProcessMessageAsync(messageBundle, async, responseUrl).WaitResult();
+        }
+
         private Task<Resource?> internalOperationAsync(string operationName, string? type = null, string? id = null, string? vid = null,
             Parameters? parameters = null, bool useGet = false, CancellationToken? ct = null)
         {

--- a/src/Hl7.Fhir.Base/Rest/BaseFhirClient.cs
+++ b/src/Hl7.Fhir.Base/Rest/BaseFhirClient.cs
@@ -943,6 +943,7 @@ namespace Hl7.Fhir.Rest
             if (bundle == null) throw new ArgumentNullException(nameof(bundle));
 
             var tx = new TransactionBuilder(Endpoint).ProcessMessage(bundle, async, responseUrl).ToBundle();
+
             return executeAsync<Bundle>(tx, new [] {HttpStatusCode.OK, HttpStatusCode.Accepted, HttpStatusCode.NoContent}, ct);
         }
 

--- a/src/Hl7.Fhir.Base/Rest/TransactionBuilder.cs
+++ b/src/Hl7.Fhir.Base/Rest/TransactionBuilder.cs
@@ -498,6 +498,26 @@ namespace Hl7.Fhir.Rest
             return EndpointOperation(path, parameters, useGet, bundleEntryFullUrl);
         }
 
+        public TransactionBuilder ProcessMessage(Bundle messageBundle, bool async = false, string? responseUrl = null, string? bundleEntryFullUrl = null)
+        {
+            var path = newRestUrl().AddPath(OPERATIONPREFIX + "process-message");
+            if (async)
+            {
+                path.AddParam("async", "true");
+            }
+
+            if (!string.IsNullOrEmpty(responseUrl))
+            {
+                path.AddParam("response-url", responseUrl);
+            }
+
+
+            var entry = newEntry(Bundle.HTTPVerb.POST, InteractionType.Operation, bundleEntryFullUrl);
+            entry.Resource = messageBundle;
+            addEntry(entry, path);
+            return this;
+        }
+
         /// <summary>
         /// Add a "search" entry to the transaction/batch
         /// </summary>

--- a/src/Hl7.Fhir.Base/Rest/TransactionBuilder.cs
+++ b/src/Hl7.Fhir.Base/Rest/TransactionBuilder.cs
@@ -500,21 +500,13 @@ namespace Hl7.Fhir.Rest
 
         public TransactionBuilder ProcessMessage(Bundle messageBundle, bool async = false, string? responseUrl = null, string? bundleEntryFullUrl = null)
         {
-            var path = newRestUrl().AddPath(OPERATIONPREFIX + "process-message");
-            if (async)
-            {
-                path.AddParam("async", "true");
-            }
-
-            if (!string.IsNullOrEmpty(responseUrl))
-            {
-                path.AddParam("response-url", responseUrl);
-            }
-
-
             var entry = newEntry(Bundle.HTTPVerb.POST, InteractionType.Operation, bundleEntryFullUrl);
+            var path = newRestUrl().AddPath(OPERATIONPREFIX + "process-message");
+            if (async) path.AddParam("async", "true");
+            if (responseUrl != null) path.AddParam("response-url", responseUrl);
             entry.Resource = messageBundle;
             addEntry(entry, path);
+
             return this;
         }
 

--- a/src/Hl7.Fhir.Support.Poco.Tests/Rest/FhirClientMockTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Rest/FhirClientMockTests.cs
@@ -270,6 +270,27 @@ namespace Hl7.Fhir.Core.Tests.Rest
         }
 
         [TestMethod]
+        public async T.Task TestProcessMessageParameters()
+        {
+            var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(@"{""resourceType"": ""Bundle"" }", Encoding.UTF8, "application/json"),
+                RequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://example.com/$process-message")
+            };
+
+            using var client = new MoqBuilder()
+                .Send(response, h => h.RequestUri == new Uri("http://example.com/$process-message?async=true&response-url=http%3A%2F%2Fresponseurl.com"))
+                .AsClient();
+
+            var message = new TransactionBuilder("http://example.com/", Bundle.BundleType.Message).ToBundle();
+
+            var bundle = await client.ProcessMessageAsync(message, true, "http://responseurl.com");
+
+            bundle.Should().NotBeNull();
+        }
+
+        [TestMethod]
         public async Task WillFetchFullRepresentation()
         {
             var mock = new Mock<HttpMessageHandler>();

--- a/src/Hl7.Fhir.Support.Poco.Tests/Rest/FhirClientMockTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Rest/FhirClientMockTests.cs
@@ -249,6 +249,27 @@ namespace Hl7.Fhir.Core.Tests.Rest
         }
 
         [TestMethod]
+        public async T.Task TestProcessMessage()
+        {
+            var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(@"{""resourceType"": ""Bundle"" }", Encoding.UTF8, "application/json"),
+                RequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://example.com/$process-message")
+            };
+
+            using var client = new MoqBuilder()
+                .Send(response, h => h.RequestUri == new Uri("http://example.com/$process-message"))
+                .AsClient();
+
+            var message = new TransactionBuilder("http://example.com/", Bundle.BundleType.Message).ToBundle();
+
+            var bundle = await client.ProcessMessageAsync(message);
+
+            bundle.Should().NotBeNull();
+        }
+
+        [TestMethod]
         public async Task WillFetchFullRepresentation()
         {
             var mock = new Mock<HttpMessageHandler>();


### PR DESCRIPTION
## Description
Adds support for the ($process-message)[http://hl7.org/fhir/messageheader-operation-process-message.html] operation used in fhir (messaging)[http://hl7.org/fhir/messaging.html#process].

## Related issues
Resolves #2605

## Testing
Added unit test.

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes