### PR TITLE
LocalTerminologyService returns original FhirOperationException from getExpandedValueSet

### DIFF
--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/LocalTerminologyService.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/LocalTerminologyService.cs
@@ -132,7 +132,6 @@ namespace Hl7.Fhir.Specification.Terminology
                 }
             }
             catch (TerminologyServiceException e)
-#pragma warning restore CS0618
             {
                 // Unprocessable entity
                 throw new FhirOperationException(
@@ -176,7 +175,7 @@ namespace Hl7.Fhir.Specification.Terminology
                 else
                     return await validateCodeVS(valueSet, validateCodeParams.Code?.Value, validateCodeParams.System?.Value, validateCodeParams.Display?.Value, validateCodeParams.Abstract?.Value).ConfigureAwait(false);
             }
-            catch (Exception e)
+            catch (Exception e) when (e is not FhirOperationException)
             {
                 //500 internal server error
                 throw new FhirOperationException(e.Message, (HttpStatusCode)500);

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Source/TerminologyTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Source/TerminologyTests.cs
@@ -312,8 +312,8 @@ namespace Hl7.Fhir.Specification.Tests
             inParams = new ValidateCodeParameters()
                 .WithValueSet(url: "http://hl7.org/fhir/ValueSet/substance-code")
                 .WithCode(code: "1166006", system: "http://snomed.info/sct");
-            await Assert.ThrowsAsync<FhirOperationException>(async () => await svc.ValueSetValidateCode(inParams));
-
+            var exception = await Assert.ThrowsAsync<FhirOperationException>(async () => await svc.ValueSetValidateCode(inParams));
+            Assert.Equal(System.Net.HttpStatusCode.UnprocessableEntity, exception.Status);
         }
 
         [Fact]
@@ -332,8 +332,8 @@ namespace Hl7.Fhir.Specification.Tests
                 }
             };
 
-            await Assert.ThrowsAsync<FhirOperationException>(async () => await svc.ValueSetValidateCode(inParams));
-
+            var exception = await Assert.ThrowsAsync<FhirOperationException>(async () => await svc.ValueSetValidateCode(inParams));
+            Assert.Equal(System.Net.HttpStatusCode.UnprocessableEntity, exception.Status);
         }
 
 
@@ -363,7 +363,8 @@ namespace Hl7.Fhir.Specification.Tests
                 }
             };
 
-            await Assert.ThrowsAsync<FhirOperationException>(async () => await svc.ValueSetValidateCode(inParams));
+            var exception = await Assert.ThrowsAsync<FhirOperationException>(async () => await svc.ValueSetValidateCode(inParams));
+            Assert.Equal(System.Net.HttpStatusCode.UnprocessableEntity, exception.Status);
         }
 
         [Fact]


### PR DESCRIPTION
fixes #2631