### PR TITLE
Support parsing CodeableReference

### DIFF
--- a/src/Hl7.Fhir.Base/ElementModel/TypedElementParseExtensions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/TypedElementParseExtensions.cs
@@ -1,4 +1,6 @@
-﻿/* 
+﻿#nullable enable
+
+/* 
  * Copyright (c) 2018, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
  * 
@@ -33,26 +35,33 @@ namespace Hl7.Fhir.ElementModel
         ///   'string' => code
         ///   'uri' => code
         /// </remarks>
-        public static Element ParseBindable(this ITypedElement instance)
+        public static Element? ParseBindable(this ITypedElement instance)
 #pragma warning disable CS0618 // Type or member is obsolete
             => instance.ParseBindableInternal();
 #pragma warning restore CS0618 // Type or member is obsolete
 
         [Obsolete("WARNING! Intended for internal API usage exclusively, interface IBaseElementNavigator can be changed in " +
             "the near future.")]
-        public static Element ParseBindableInternal<T>(this IBaseElementNavigator<T> instance) where T : IBaseElementNavigator<T>
+        internal static Element? ParseBindableInternal<T>(this IBaseElementNavigator<T> instance) where T : IBaseElementNavigator<T>
         {
             return instance.InstanceType switch
             {
                 FhirTypeConstants.CODE => instance.ParsePrimitiveInternal<Code, T>(),
-                FhirTypeConstants.STRING => new Code(instance.ParsePrimitiveInternal<FhirString, T>()?.Value),
-                FhirTypeConstants.URI => new Code(instance.ParsePrimitiveInternal<FhirUri, T>()?.Value),
+                FhirTypeConstants.STRING => new Code(instance.ParsePrimitiveInternal<FhirString, T>().Value),
+                FhirTypeConstants.URI => new Code(instance.ParsePrimitiveInternal<FhirUri, T>().Value),
                 FhirTypeConstants.CODING => instance.ParseCodingInternal(),
                 FhirTypeConstants.CODEABLE_CONCEPT => instance.ParseCodeableConceptInternal(),
                 FhirTypeConstants.QUANTITY => parseQuantity(),
                 FhirTypeConstants.EXTENSION => parseExtension(),
+                FhirTypeConstants.CODEABLEREFERENCE => parseCodeableReference(), 
                 _ => null,
             };
+
+            CodeableConcept? parseCodeableReference()
+            {
+                var valueChild = instance.Children("concept").FirstOrDefault();
+                return valueChild?.ParseCodeableConceptInternal();
+            }
 
             Coding parseQuantity()
             {
@@ -62,7 +71,8 @@ namespace Hl7.Fhir.ElementModel
                 newCoding.System = q.System ?? "http://unitsofmeasure.org";
                 return newCoding;
             }
-            Element parseExtension()
+            
+            Element? parseExtension()
             {
                 var valueChild = instance.Children("value").FirstOrDefault();
                 return valueChild?.ParseBindableInternal();
@@ -71,7 +81,7 @@ namespace Hl7.Fhir.ElementModel
         #endregion
 
         #region ParseQuantity
-        public static Model.Quantity ParseQuantity(this ITypedElement instance)
+        public static Quantity ParseQuantity(this ITypedElement instance)
 #pragma warning disable CS0618 // Type or member is obsolete
             => ParseQuantityInternal(instance);
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -169,8 +179,10 @@ namespace Hl7.Fhir.ElementModel
         #endregion
 
 #pragma warning disable CS0618 // Type or member is obsolete
-        public static string GetString<T>(this IEnumerable<T> instance) where T : IBaseElementNavigator<T>
+        public static string? GetString<T>(this IEnumerable<T> instance) where T : IBaseElementNavigator<T>
 #pragma warning restore CS0618 // Type or member is obsolete
             => instance.SingleOrDefault()?.Value as string;
     }
 }
+
+#nullable restore

--- a/src/Hl7.Fhir.Base/Model/FhirTypeConstants.cs
+++ b/src/Hl7.Fhir.Base/Model/FhirTypeConstants.cs
@@ -43,6 +43,7 @@ namespace Hl7.Fhir.Support.Poco
         // Special Purpose Data types
         public const string EXTENSION = "Extension";
         public const string REFERENCE = "Reference";
+        public const string CODEABLEREFERENCE = "CodeableReference";
         public const string XHTML = "xhtml";
 
         // Resource type

--- a/src/Hl7.Fhir.Base/Rest/FhirClientSearch.cs
+++ b/src/Hl7.Fhir.Base/Rest/FhirClientSearch.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
 
 namespace Hl7.Fhir.Rest
 {

--- a/src/Hl7.Fhir.Base/Serialization/DataAnnotationDeserialzationValidator.cs
+++ b/src/Hl7.Fhir.Base/Serialization/DataAnnotationDeserialzationValidator.cs
@@ -15,6 +15,8 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+#pragma warning disable CS1580 // Invalid type for parameter in XML comment cref attribute
+#pragma warning disable CS1584 // XML comment has syntactically incorrect cref attribute
 
 namespace Hl7.Fhir.Serialization
 {

--- a/src/Hl7.Fhir.ElementModel.R4B.Tests/ParseExtensionsTests.cs
+++ b/src/Hl7.Fhir.ElementModel.R4B.Tests/ParseExtensionsTests.cs
@@ -1,0 +1,27 @@
+﻿using FluentAssertions;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Terminology;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Hl7.Fhir.Validation
+{
+    public partial class ParseExtensionsTests
+    {
+        [Fact]
+        public void TestParseCodeableReference()
+        {
+            var i = new CodeableReference
+            {
+                Reference = new ResourceReference("http://example.org/fhir/Patient/1"),
+                Concept = new CodeableConcept("http://nu.nl", "bla")
+            };
+            
+            var node = i.ToTypedElement();
+            var p = node.ParseBindable();
+
+            p.Should().BeEquivalentTo(new { Coding = new List<Coding> { new Coding("http://nu.nl", "bla") }  });
+        }
+    }
+}

--- a/src/Hl7.Fhir.ElementModel.R5.Tests/ParseExtensionsTests.cs
+++ b/src/Hl7.Fhir.ElementModel.R5.Tests/ParseExtensionsTests.cs
@@ -1,0 +1,26 @@
+﻿using FluentAssertions;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Hl7.Fhir.Validation
+{
+    public partial class ParseExtensionsTests
+    {
+        [Fact]
+        public void TestParseCodeableReference()
+        {
+            var i = new CodeableReference
+            {
+                Reference = new ResourceReference("http://example.org/fhir/Patient/1"),
+                Concept = new CodeableConcept("http://nu.nl", "bla")
+            };
+            
+            var node = i.ToTypedElement();
+            var p = node.ParseBindable();
+
+            p.Should().BeEquivalentTo(new { Coding = new List<Coding> { new Coding("http://nu.nl", "bla") }  });
+        }
+    }
+}

--- a/src/Hl7.Fhir.ElementModel.Shared.Tests/ParseExtensionsTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Shared.Tests/ParseExtensionsTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Hl7.Fhir.Validation
 {
-    public class ParseExtensionsTests
+    public partial class ParseExtensionsTests
     {
         [Fact]
         public void TestParseQuantity()

--- a/src/Hl7.Fhir.R4B/Model/CodeableReference.cs
+++ b/src/Hl7.Fhir.R4B/Model/CodeableReference.cs
@@ -1,0 +1,18 @@
+/* 
+ * Copyright (c) 2024, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+#nullable enable
+using Hl7.Fhir.Introspection;
+
+namespace Hl7.Fhir.Model
+{
+    [Bindable(true)]
+    public partial class CodeableReference
+    {
+    }
+}

--- a/src/Hl7.Fhir.R5/Model/CodeableReference.cs
+++ b/src/Hl7.Fhir.R5/Model/CodeableReference.cs
@@ -1,0 +1,18 @@
+/* 
+ * Copyright (c) 2024, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+#nullable enable
+using Hl7.Fhir.Introspection;
+
+namespace Hl7.Fhir.Model
+{
+    [Bindable(true)]
+    public partial class CodeableReference
+    {
+    }
+}


### PR DESCRIPTION
Added code that can extract a CodeableConcept from a CodeableReference, thus extending our capabilities to support CodeableReference as input to the validator.