### PR TITLE
JSON POCO Deserializer type mapping fix.

### DIFF
--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonPocoDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonPocoDeserializer.cs
@@ -351,7 +351,10 @@ namespace Hl7.Fhir.Serialization
 
             if (propertyValueMapping.IsFhirPrimitive)
             {
-                var fhirType = propertyMapping.FhirType.FirstOrDefault();
+                // fix for https://github.com/FirelyTeam/firely-net-sdk/issues/2701 - use the known native type if it is in the list
+                Type? fhirType = propertyMapping.FhirType.Contains(propertyValueMapping.NativeType)
+                    ? propertyValueMapping.NativeType
+                    : propertyMapping.FhirType.FirstOrDefault();
 
                 // Note that the POCO model will always allocate a new list if the property had not been set before,
                 // so there is always an existingValue for IList


### PR DESCRIPTION
Fix: JSON deserializer should use the known native type when possible when targeting choice types with primitives.

## Description
Modifies the Base JSON POCO deserializer to use a known native type as the destination type when there is a choice type with primitives and the target type is in the list.

## Related issues
Fixes #2701 .

## Testing
Additional unit test locally, @mmsmits pass on full repo.

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes