### PR TITLE
#2164 reinforce zip cache validity check

### DIFF
--- a/src/Hl7.Fhir.Base/Specification/Source/ZipCacher.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/ZipCacher.cs
@@ -68,11 +68,9 @@ namespace Hl7.Fhir.Specification.Source
 
             if (!dir.Exists) return false;
 
-            // zip unpacking fails sometimes
-            // if this cache is supposed to contain the specification, it should have at least a bunch of files in there
-            // (notably, we test for profiles-types.xml)
+            // zip unpacking fails sometimes (issue #2164). if this cache is supposed to contain the specification, it should have at least a bunch of files in there (notably, we test for profiles-types.xml)
             var isSpecificationZip = ZipPath.EndsWith(Path.Combine("specification.zip"));
-            var doesNotHaveCriticalFiles = !File.Exists(Path.Combine(CachePath, "profiles-types.xml"));
+            var doesNotHaveCriticalFiles = !File.Exists(Path.Combine(CachePath, "specification", "profiles-types.xml"));
             if (isSpecificationZip && doesNotHaveCriticalFiles) return false;
             
             var currentZipFileTime = File.GetLastWriteTimeUtc(ZipPath);

--- a/src/Hl7.Fhir.Base/Specification/Source/ZipCacher.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/ZipCacher.cs
@@ -8,6 +8,7 @@
  * available at https://github.com/FirelyTeam/firely-net-sdk/blob/master/LICENSE
  */
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -70,7 +71,8 @@ namespace Hl7.Fhir.Specification.Source
             // Sometimes unzipping fails after creating the directory, try to fix that by
             // checking if there are any files at all.
             var dirIsEmpty = !dir.EnumerateFileSystemInfos().Any();
-            if (dirIsEmpty) return false;
+            var dirContents = dir.EnumerateFileSystemInfos();
+            Console.Error.WriteLine(dirIsEmpty);
 
             var currentZipFileTime = File.GetLastWriteTimeUtc(ZipPath);
 

--- a/src/Hl7.Fhir.Conformance/Specification/Source/CommonZipSource.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Source/CommonZipSource.cs
@@ -22,7 +22,7 @@ namespace Hl7.Fhir.Specification.Source
     /// <summary>Reads FHIR artifacts (Profiles, ValueSets, ...) from a ZIP archive. Thread-safe.</summary>
     /// <remarks>Extracts the ZIP archive to a temporary folder and delegates to the <see cref="CommonDirectorySource"/>.</remarks>
     [DebuggerDisplay(@"\{{DebuggerDisplay,nq}}")]
-    public class CommonZipSource : ISummarySource, ICommonConformanceSource, IArtifactSource, IResourceResolver, IAsyncResourceResolver
+    public class CommonZipSource : ISummarySource, ICommonConformanceSource, IArtifactSource, IAsyncResourceResolver
     {
 #pragma warning disable IDE1006 // Naming Styles - cannot fix this name because of bw-compatibility
         public const string SpecificationZipFileName = "specification.zip";

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Source/ZipSourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Source/ZipSourceTests.cs
@@ -63,7 +63,7 @@ namespace Hl7.Fhir.Specification.Tests.Source
         public void TestFilePrescence()
         {
             var zip = ZipSource.CreateValidationSource();
-            zip.ListSummaries(); // make sure it is unpacked, don't need the return value
+            zip.ListSummaries(); // make sure the zip is unpacked, we don't need the return value
             // if extractpath is null, something went seriously wrong
             File.Exists(Path.Combine(zip.ExtractPath!, "profiles-types.xml")).Should().BeTrue();
         }

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Source/ZipSourceTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Source/ZipSourceTests.cs
@@ -58,32 +58,14 @@ namespace Hl7.Fhir.Specification.Tests.Source
         }
 
         [TestMethod]
-        public void TestConcurrentUnpackAttempts()
+        // If this test fails, the specification might have changed. This filename is hardcoded into the validation of a successful ZIP unpack
+        // (firely-net-sdk/src/Hl7.Fhir.Base/Specification/Source/ZipCacher.cs:74)
+        public void TestFilePrescence()
         {
-            var zipFile = Path.Combine("TestData", "ResourcesInSubfolder.zip");
-            var extractDir  = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var startingSecond = (System.DateTime.UtcNow.Second) % 60;
-            Console.Error.WriteLine(extractDir);
-            
-            var tasks = Enumerable.Range(0, 10).Select(i => new Task(() => _doUnpackAttempt(startingSecond, zipFile, extractDir)));
-            
-            Assert.IsTrue(Task.WaitAll(tasks.ToArray(), 5000)); 
-        }
-
-        private static bool _canStart(int seconds)
-        {
-            return System.DateTime.UtcNow.Second >= seconds;
-        }
-
-        private static void _doUnpackAttempt(int seconds, string zipFile, string extractDir)
-        {
-            var zip = new ZipSource(zipFile, extractDir,
-                            new DirectorySourceSettings() { IncludeSubDirectories = false });
-            
-            while (!_canStart(seconds)) {}
-
-            var summaries = zip.ListSummaries();
-            Console.Error.WriteLine(summaries);
+            var zip = ZipSource.CreateValidationSource();
+            zip.ListSummaries(); // make sure it is unpacked, don't need the return value
+            // if extractpath is null, something went seriously wrong
+            File.Exists(Path.Combine(zip.ExtractPath!, "profiles-types.xml")).Should().BeTrue();
         }
     }
 }


### PR DESCRIPTION
## Description
Rewrote the check on zip file caches to verify the presence of critical files, instead of verifying the existence of the cache. This should hopefully fix issue #2164

## Related issues
Closes #2164

## Testing
Unable to reproduce the original issue in a unit test. 

note: added a test which verifies the existence of these critical files after a successful run, so that changing the specification will require the cache check to be rewritten with the proper critical files