### PR TITLE
#2662 duplicate choice type entries

### DIFF
--- a/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirJsonDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirJsonDeserializationTests.cs
@@ -1001,6 +1001,34 @@ namespace Hl7.Fhir.Support.Poco.Tests
                 assertErrors(dfe.Exceptions, expectedErrs);
             }
         }
+
+        [TestMethod]
+        public void TestDuplicateChoiceTypeEntries()
+        {
+            var scenario = """
+                           {
+                             "resourceType": "Patient",
+                             "deceasedBoolean": true,
+                             "deceasedDateTime": "2022"
+                           }
+                           """;
+            
+            string expected = ERR.DUPLICATE_PROPERTY_CODE;
+
+            var jsonSerializerOptions = new JsonSerializerOptions().ForFhir(typeof(TestPatient).Assembly);
+
+            try
+            {
+                _ = JsonSerializer.Deserialize<TestPatient>(scenario, jsonSerializerOptions);
+                Assert.Fail("Should have encountered errors.");
+            }
+            catch (DeserializationFailedException dfe)
+            {
+                assertErrors(dfe.Exceptions, [expected]);
+            }
+            
+            
+        }
     }
 }
 #nullable restore


### PR DESCRIPTION
## Description
This bug was fixed by PR #2708, but added a test to consolidate this behaviour for future PRs

## Related issues
Closes #2662.

## Testing
Added test with both deceasedBoolean and deceasedDateTime set