### PR TITLE
#2661 FhirClient Serialization engine modification

### DIFF
--- a/src/Hl7.Fhir.Support.Poco.Tests/Rest/FhirClientMockTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Rest/FhirClientMockTests.cs
@@ -5,6 +5,7 @@ using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
+using Hl7.Fhir.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Moq.Protected;
@@ -414,6 +415,24 @@ namespace Hl7.Fhir.Core.Tests.Rest
             var mock = new Mock<BaseFhirClient>(new object[] { new Uri("http://example.org"), TESTINSPECTOR, FhirClientSettings.CreateDefault() });
             var _ = await mock.Object.ReadAsync<TestPatient>("http://example.org/fhir");
             mock.Verify(c => c.ReadAsync<TestPatient>(It.IsAny<string>(), null, null, null), Times.Once);
+        }
+
+        [TestMethod]
+        public void TestFhirClientSettings()
+        {
+            var fhirClient1 = new BaseFhirClient(
+                new Uri("http://example.org"), TESTINSPECTOR, new FhirClientSettings { SerializationEngine = FhirSerializationEngineFactory.Strict(TESTINSPECTOR) }
+            );
+
+            (fhirClient1.Settings.SerializationEngine is PocoSerializationEngine).Should().BeTrue();
+
+            var fhirClient2 = new BaseFhirClient(
+                new Uri("http://example.org"), TESTINSPECTOR)
+            ;
+            fhirClient2.Settings.SerializationEngine = FhirSerializationEngineFactory.Strict(TESTINSPECTOR);
+
+            // Fail, serialization engine is ElementModelSerializationEngine here
+            (fhirClient2.Settings.SerializationEngine is PocoSerializationEngine).Should().BeTrue();
         }
 
 

--- a/src/Hl7.Fhir.Support.Poco.Tests/Rest/FhirClientMockTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Rest/FhirClientMockTests.cs
@@ -423,16 +423,21 @@ namespace Hl7.Fhir.Core.Tests.Rest
             var fhirClient1 = new BaseFhirClient(
                 new Uri("http://example.org"), TESTINSPECTOR, new FhirClientSettings { SerializationEngine = FhirSerializationEngineFactory.Strict(TESTINSPECTOR) }
             );
+            
+            MethodInfo? serializationEngineField = fhirClient1.GetType().GetMethod("getSerializationEngine", BindingFlags.NonPublic | BindingFlags.Instance);
+            serializationEngineField.Should().NotBeNull();
 
-            (fhirClient1.Settings.SerializationEngine is PocoSerializationEngine).Should().BeTrue();
+            (serializationEngineField!.Invoke(fhirClient1, []) is PocoSerializationEngine).Should().BeTrue();
 
             var fhirClient2 = new BaseFhirClient(
                 new Uri("http://example.org"), TESTINSPECTOR)
             ;
+            
+            (serializationEngineField!.Invoke(fhirClient2, []) is ElementModelSerializationEngine).Should().BeTrue();
+            
             fhirClient2.Settings.SerializationEngine = FhirSerializationEngineFactory.Strict(TESTINSPECTOR);
-
-            // Fail, serialization engine is ElementModelSerializationEngine here
-            (fhirClient2.Settings.SerializationEngine is PocoSerializationEngine).Should().BeTrue();
+            
+            (serializationEngineField!.Invoke(fhirClient2, []) is PocoSerializationEngine).Should().BeTrue();
         }
 
 


### PR DESCRIPTION
## Description
The serialization engine used by an instance of BaseFhirClient (or its derivations) can now be changed in the settings. The new value will decide the engine used by this client. This used to require a new client with the required serialization engine in the constructor.

## Related issues
Closes issue #2661.

## Testing
Added a unit test which tests whether the serialization engine used by BaseFhirClient matches an expected type