### PR TITLE
#2463 improved ostrich parsing

### DIFF
--- a/src/Hl7.Fhir.Base/Serialization/engine/FhirSerializationEngineFactory.cs
+++ b/src/Hl7.Fhir.Base/Serialization/engine/FhirSerializationEngineFactory.cs
@@ -141,7 +141,7 @@ namespace Hl7.Fhir.Serialization
         /// and just continue parsing. Note that this may mean data loss.
         /// </summary>
         public static IFhirSerializationEngine Ostrich(ModelInspector inspector) =>
-            new PocoSerializationEngine(inspector, _ => true);
+            new PocoSerializationEngine(inspector, _ => true, new FhirJsonPocoDeserializerSettings(){Validator = null}, new FhirXmlPocoDeserializerSettings(){Validator = null});
 
 
         private static bool isRecoverableIssue(CodedException ce) =>

--- a/src/Hl7.Fhir.Base/Serialization/engine/PocoSerializationEngine.cs
+++ b/src/Hl7.Fhir.Base/Serialization/engine/PocoSerializationEngine.cs
@@ -13,6 +13,7 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Utility;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
 namespace Hl7.Fhir.Serialization
@@ -27,39 +28,35 @@ namespace Hl7.Fhir.Serialization
 
         private readonly ModelInspector _inspector;
         private readonly Predicate<CodedException> _ignoreFilter;
-      
-        /// <summary>
-        /// Creates an implementation of <see cref="IFhirSerializationEngine"/> that uses the newer POCO (de)serializers.
-        /// </summary>
-        /// <param name="inspector">Reflection data of the POCO model to use.</param>
-        /// <param name="ignoreFilter">A predicate that returns true for issues that should not be reported.</param>
-        public PocoSerializationEngine(ModelInspector inspector, Predicate<CodedException> ignoreFilter)
-        {
-            _inspector = inspector;
-            _ignoreFilter = ignoreFilter;
-        }
+        private readonly FhirJsonPocoDeserializerSettings _jsonSettings;
+        private readonly FhirXmlPocoDeserializerSettings _xmlSettings;
 
         /// <summary>
         /// Creates an implementation of <see cref="IFhirSerializationEngine"/> that uses the newer POCO (de)serializers.
         /// </summary>
         /// <param name="inspector">Reflection data of the POCO model to use.</param>
-        public PocoSerializationEngine(ModelInspector inspector)
+        /// <param name="ignoreFilter">Predicate specifying which exceptions to ignore</param>
+        /// <param name="jsonSettings">Settings for json deserializing</param>
+        /// <param name="xmlSettings">Settings for xml deserializing</param>
+        public PocoSerializationEngine(ModelInspector inspector, Predicate<CodedException>? ignoreFilter=null, FhirJsonPocoDeserializerSettings? jsonSettings=null, FhirXmlPocoDeserializerSettings? xmlSettings=null)
         {
             _inspector = inspector;
-            _ignoreFilter = _ => false;
+            _ignoreFilter = ignoreFilter ?? (_ => false);
+            _jsonSettings = jsonSettings ?? new FhirJsonPocoDeserializerSettings();
+            _xmlSettings = xmlSettings ?? new FhirXmlPocoDeserializerSettings();
         }
 
         /// <inheritdoc />
         public Resource DeserializeFromXml(string data)
         {
-            var deserializer = new BaseFhirXmlPocoDeserializer(_inspector);
+            var deserializer = new BaseFhirXmlPocoDeserializer(_inspector, _xmlSettings);
             return deserializeAndIgnoreErrors(deserializer.TryDeserializeResource, data);
         }
 
         /// <inheritdoc />
         public Resource DeserializeFromJson(string data)
         {
-            var deserializer = new BaseFhirJsonPocoDeserializer(_inspector);
+            var deserializer = new BaseFhirJsonPocoDeserializer(_inspector, _jsonSettings);
             return deserializeAndIgnoreErrors(deserializer.TryDeserializeResource, data);
         }
 


### PR DESCRIPTION
## Description
Redid PocoSerializationEngine.cs constructor to now accept settings objects. Improved ostrich parsing by setting validators to null when creating an ostrich mode parser.

## Related issues
Closes #2463.

## Testing
Tested using existing round trip tests