### PR TITLE
Renamed CodeSystemTerminologyService for clarity

### DIFF
--- a/src/Hl7.Fhir.Base/Specification/Terminology/CustomValueSetTerminologyService.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/CustomValueSetTerminologyService.cs
@@ -18,19 +18,19 @@ namespace Hl7.Fhir.Specification.Terminology
     public abstract class CustomValueSetTerminologyService : ITerminologyService
     {
         private readonly string _terminologyType;
-        private readonly string _valueSetName;
+        private readonly string _codeSystem;
         private readonly string[] _codeValueSets;
 
         /// <summary>
         /// Base class for checking terminology of codes that are part of a value set.
         /// </summary>
         /// <param name="terminologyType">String representation of the code type which is being checked. Exclusively used for error messages</param>
-        /// <param name="valueSetName">Name of the specification defining the members of the value set</param>
+        /// <param name="codeSystem">Name of the specification defining the members of the value set</param>
         /// <param name="codeValueSets">uri's of the definitions of the code system. This can be multiple, if a FHIR version has changed this at some point.</param>
-        protected CustomValueSetTerminologyService(string terminologyType, string valueSetName, string[] codeValueSets)
+        protected CustomValueSetTerminologyService(string terminologyType, string codeSystem, string[] codeValueSets)
         {
             _terminologyType = terminologyType;
-            _valueSetName = valueSetName;
+            _codeSystem = codeSystem;
             _codeValueSets = codeValueSets;
         }
         
@@ -148,7 +148,7 @@ namespace Hl7.Fhir.Specification.Terminology
             var systemUri = system != null ? new Canonical(system).Uri : null;
 
 
-            if (systemUri == _valueSetName || systemUri == null)
+            if (systemUri == _codeSystem || systemUri == null)
             {
                 if (code is null)
                 {

--- a/src/Hl7.Fhir.Base/Specification/Terminology/CustomValueSetTerminologyService.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/CustomValueSetTerminologyService.cs
@@ -15,7 +15,7 @@ namespace Hl7.Fhir.Specification.Terminology
     /// <summary>
     /// Base class for checking Code terminology
     /// </summary>
-    public abstract class ValueSetTerminologyService : ITerminologyService
+    public abstract class CustomValueSetTerminologyService : ITerminologyService
     {
         private readonly string _terminologyType;
         private readonly string _valueSetName;
@@ -27,7 +27,7 @@ namespace Hl7.Fhir.Specification.Terminology
         /// <param name="terminologyType">String representation of the code type which is being checked. Exclusively used for error messages</param>
         /// <param name="valueSetName">Name of the specification defining the members of the value set</param>
         /// <param name="codeValueSets">uri's of the definitions of the code system. This can be multiple, if a FHIR version has changed this at some point.</param>
-        protected ValueSetTerminologyService(string terminologyType, string valueSetName, string[] codeValueSets)
+        protected CustomValueSetTerminologyService(string terminologyType, string valueSetName, string[] codeValueSets)
         {
             _terminologyType = terminologyType;
             _valueSetName = valueSetName;

--- a/src/Hl7.Fhir.Base/Specification/Terminology/LanguageTerminologyService.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/LanguageTerminologyService.cs
@@ -7,7 +7,7 @@ namespace Hl7.Fhir.Specification.Terminology
     /// <summary>
     /// Checks if codes are valid language types
     /// </summary>
-    public class LanguageTerminologyService : CodeSystemTerminologyService
+    public class LanguageTerminologyService : ValueSetTerminologyService
     {
         private const string LANGUAGE_SYSTEM = "urn:ietf:bcp:47";
         public const string LANGUAGE_VALUESET = "http://hl7.org/fhir/ValueSet/all-languages";

--- a/src/Hl7.Fhir.Base/Specification/Terminology/LanguageTerminologyService.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/LanguageTerminologyService.cs
@@ -7,7 +7,7 @@ namespace Hl7.Fhir.Specification.Terminology
     /// <summary>
     /// Checks if codes are valid language types
     /// </summary>
-    public class LanguageTerminologyService : ValueSetTerminologyService
+    public class LanguageTerminologyService : CustomValueSetTerminologyService
     {
         private const string LANGUAGE_SYSTEM = "urn:ietf:bcp:47";
         public const string LANGUAGE_VALUESET = "http://hl7.org/fhir/ValueSet/all-languages";

--- a/src/Hl7.Fhir.Base/Specification/Terminology/MimeTypeTerminologyService.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/MimeTypeTerminologyService.cs
@@ -7,7 +7,7 @@ namespace Hl7.Fhir.Specification.Terminology
     /// <summary>
     /// Checks if codes are valid Mime-Types (urn:ietf:bcp:13)
     /// </summary>
-    public sealed class MimeTypeTerminologyService : ValueSetTerminologyService
+    public sealed class MimeTypeTerminologyService : CustomValueSetTerminologyService
     {
         private const string MIMETYPE_SYSTEM = "urn:ietf:bcp:13";
         public const string MIMETYPE_VALUESET_R4_AND_UP = "http://hl7.org/fhir/ValueSet/mimetypes";

--- a/src/Hl7.Fhir.Base/Specification/Terminology/MimeTypeTerminologyService.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/MimeTypeTerminologyService.cs
@@ -7,7 +7,7 @@ namespace Hl7.Fhir.Specification.Terminology
     /// <summary>
     /// Checks if codes are valid Mime-Types (urn:ietf:bcp:13)
     /// </summary>
-    public sealed class MimeTypeTerminologyService : CodeSystemTerminologyService
+    public sealed class MimeTypeTerminologyService : ValueSetTerminologyService
     {
         private const string MIMETYPE_SYSTEM = "urn:ietf:bcp:13";
         public const string MIMETYPE_VALUESET_R4_AND_UP = "http://hl7.org/fhir/ValueSet/mimetypes";

--- a/src/Hl7.Fhir.Base/Specification/Terminology/ValueSetTerminologyService.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/ValueSetTerminologyService.cs
@@ -15,22 +15,22 @@ namespace Hl7.Fhir.Specification.Terminology
     /// <summary>
     /// Base class for checking Code terminology
     /// </summary>
-    public abstract class CodeSystemTerminologyService : ITerminologyService
+    public abstract class ValueSetTerminologyService : ITerminologyService
     {
         private readonly string _terminologyType;
-        private readonly string _codeSystem;
+        private readonly string _valueSetName;
         private readonly string[] _codeValueSets;
 
         /// <summary>
-        /// Base class for checking Code terminology.
+        /// Base class for checking terminology of codes that are part of a value set.
         /// </summary>
         /// <param name="terminologyType">String representation of the code type which is being checked. Exclusively used for error messages</param>
-        /// <param name="codeSystem">Name of the specification defining the members of the value set</param>
+        /// <param name="valueSetName">Name of the specification defining the members of the value set</param>
         /// <param name="codeValueSets">uri's of the definitions of the code system. This can be multiple, if a FHIR version has changed this at some point.</param>
-        protected CodeSystemTerminologyService(string terminologyType, string codeSystem, string[] codeValueSets)
+        protected ValueSetTerminologyService(string terminologyType, string valueSetName, string[] codeValueSets)
         {
             _terminologyType = terminologyType;
-            _codeSystem = codeSystem;
+            _valueSetName = valueSetName;
             _codeValueSets = codeValueSets;
         }
         
@@ -148,7 +148,7 @@ namespace Hl7.Fhir.Specification.Terminology
             var systemUri = system != null ? new Canonical(system).Uri : null;
 
 
-            if (systemUri == _codeSystem || systemUri == null)
+            if (systemUri == _valueSetName || systemUri == null)
             {
                 if (code is null)
                 {


### PR DESCRIPTION
## Description
Renamed CodeSystemTerminologyService to be called CustomValueSetTerminologyService to avoid confusion (it only implements validateValueSet, not validateCodeSystem)

## Related issues
none