### PR TITLE
path stack edge case for non-resource root

### DIFF
--- a/src/Hl7.Fhir.Base/Serialization/PathStack.cs
+++ b/src/Hl7.Fhir.Base/Serialization/PathStack.cs
@@ -34,7 +34,8 @@ namespace Hl7.Fhir.Serialization
             _tops.Push(_path.Length);
             _path += RESOURCEPREFIX + name;
 
-            if (!_paths.Any())
+            // or rhs is edge case for EG a split bundle with a backbone element as its root (see issue #2627)
+            if (!_paths.Any() || (_paths.Count == 1 && !_paths.First().StartsWith(RESOURCEPREFIX.ToString())))
                 _paths.Push(name);
         }
 
@@ -55,7 +56,7 @@ namespace Hl7.Fhir.Serialization
                 _path = _path.Substring(0, top);
             }
 
-            if (_paths.Count() == 1)
+            if (_paths.Count == 1)
                 _paths.Pop();
         }
 


### PR DESCRIPTION
## Description
Added edge case check to the resource entering path check for backbone element roots (for use cases such as split bundles)

## Related issues
Resolves #2627.

## Testing
Tested using the unit test suggested in the issue report. (Create parameter component backbone element, add patient to it, parse the object)