### PR TITLE
Fixed location property on TypedElementOnSourceNode.cs

### DIFF
--- a/src/Hl7.Fhir.Base/ElementModel/SourceNodeExtensions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/SourceNodeExtensions.cs
@@ -170,6 +170,14 @@ namespace Hl7.Fhir.ElementModel
         /// <seealso cref="IAnnotated"/>
         public static IEnumerable<object> Annotations(this ISourceNode node, Type type) =>
             node is IAnnotated ann ? ann.Annotations(type) : Enumerable.Empty<object>();
+        
+        /// <summary>
+        /// Gets specific annotations from the list of annotations on the node.
+        /// </summary>
+        /// <returns>All of the annotations of the given type, or an empty list if none were found.</returns>
+        /// <seealso cref="IAnnotated"/>
+        public static IEnumerable<T> Annotations<T>(this ISourceNode node) =>
+            (node is IAnnotated ann ? ann.Annotations<T>() : []);
 
         /// <summary>
         /// Gets a specific annotation from the list of annotations on the node.

--- a/src/Hl7.Fhir.Base/ElementModel/TypedElementOnSourceNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/TypedElementOnSourceNode.cs
@@ -38,6 +38,7 @@ namespace Hl7.Fhir.ElementModel
             _source = source;
             (var typeOrNull, Definition) = buildRootPosition(type);
 
+            //TODO can secretly be null, but InstanceType cannot be nullable here since it's based in other classes.
             InstanceType = typeOrNull!;
         }
 

--- a/src/Hl7.Fhir.Base/ElementModel/TypedElementOnSourceNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/TypedElementOnSourceNode.cs
@@ -23,7 +23,7 @@ namespace Hl7.Fhir.ElementModel
         private const string XHTML_INSTANCETYPE = "xhtml";
         private const string XHTML_DIV_TAG_NAME = "div";
 
-        public TypedElementOnSourceNode(ISourceNode source, string type, IStructureDefinitionSummaryProvider provider, TypedElementSettings? settings = null)
+        public TypedElementOnSourceNode(ISourceNode source, string? type, IStructureDefinitionSummaryProvider provider, TypedElementSettings? settings = null)
         {
             if (source == null) throw Error.ArgumentNull(nameof(source));
 
@@ -36,10 +36,12 @@ namespace Hl7.Fhir.ElementModel
             Location = source.Name;
             ShortPath = source.Name;
             _source = source;
-            (InstanceType, Definition) = buildRootPosition(type);
+            (var typeOrNull, Definition) = buildRootPosition(type);
+
+            InstanceType = typeOrNull!;
         }
 
-        private (string instanceType, IElementDefinitionSummary? definition) buildRootPosition(string type)
+        private (string? instanceType, IElementDefinitionSummary? definition) buildRootPosition(string? type)
         {
             var rootType = type ?? _source.GetResourceTypeIndicator();
             if (rootType == null)
@@ -81,7 +83,7 @@ namespace Hl7.Fhir.ElementModel
             Location = location;
         }
 
-        public ExceptionNotificationHandler ExceptionHandler { get; set; } = null!;
+        public ExceptionNotificationHandler? ExceptionHandler { get; set; }
 
         private void raiseTypeError(string message, object source, bool warning = false, string? location = null)
         {
@@ -459,7 +461,7 @@ namespace Hl7.Fhir.ElementModel
                 else
                     // Ok, pass through the untyped members, but since there is no type information, 
                     // don't bother to run the additional rules
-                    return enumerateElements(childElementDefs, _source, name!);
+                    return enumerateElements(childElementDefs, _source, name);
             }
             else
                 return runAdditionalRules(enumerateElements(childElementDefs, _source, name));

--- a/src/Hl7.Fhir.Base/ElementModel/TypedElementOnSourceNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/TypedElementOnSourceNode.cs
@@ -14,6 +14,8 @@ using System.Linq;
 using System.Threading;
 using P = Hl7.Fhir.ElementModel.Types;
 
+#nullable enable
+
 namespace Hl7.Fhir.ElementModel
 {
     internal class TypedElementOnSourceNode : ITypedElement, IAnnotated, IExceptionSource, IShortPathGenerator
@@ -21,7 +23,7 @@ namespace Hl7.Fhir.ElementModel
         private const string XHTML_INSTANCETYPE = "xhtml";
         private const string XHTML_DIV_TAG_NAME = "div";
 
-        public TypedElementOnSourceNode(ISourceNode source, string type, IStructureDefinitionSummaryProvider provider, TypedElementSettings settings = null)
+        public TypedElementOnSourceNode(ISourceNode source, string type, IStructureDefinitionSummaryProvider provider, TypedElementSettings? settings = null)
         {
             if (source == null) throw Error.ArgumentNull(nameof(source));
 
@@ -37,7 +39,7 @@ namespace Hl7.Fhir.ElementModel
             (InstanceType, Definition) = buildRootPosition(type);
         }
 
-        private (string instanceType, IElementDefinitionSummary definition) buildRootPosition(string type)
+        private (string instanceType, IElementDefinitionSummary? definition) buildRootPosition(string type)
         {
             var rootType = type ?? _source.GetResourceTypeIndicator();
             if (rootType == null)
@@ -46,7 +48,7 @@ namespace Hl7.Fhir.ElementModel
                     throw Error.Format(nameof(type), $"Cannot determine the type of the root element at '{_source.Location}', " +
                         $"please supply a type argument.");
                 else
-                    return (rootType, null);
+                    return (rootType!, null);
             }
 
             var elementType = Provider.Provide(rootType);
@@ -67,7 +69,7 @@ namespace Hl7.Fhir.ElementModel
         }
 
 
-        private TypedElementOnSourceNode(TypedElementOnSourceNode parent, ISourceNode source, IElementDefinitionSummary definition, string instanceType, string prettyPath, string location = null)
+        private TypedElementOnSourceNode(TypedElementOnSourceNode parent, ISourceNode source, IElementDefinitionSummary? definition, string instanceType, string prettyPath, string location)
         {
             _source = source;
             ShortPath = prettyPath;
@@ -79,9 +81,9 @@ namespace Hl7.Fhir.ElementModel
             Location = location;
         }
 
-        public ExceptionNotificationHandler ExceptionHandler { get; set; }
+        public ExceptionNotificationHandler ExceptionHandler { get; set; } = null!;
 
-        private void raiseTypeError(string message, object source, bool warning = false, string location = null)
+        private void raiseTypeError(string message, object source, bool warning = false, string? location = null)
         {
             var exMessage = $"Type checking the data: {message}";
             if (!string.IsNullOrEmpty(location))
@@ -103,7 +105,7 @@ namespace Hl7.Fhir.ElementModel
 
         private readonly TypedElementSettings _settings;
 
-        public IElementDefinitionSummary Definition { get; private set; }
+        public IElementDefinitionSummary? Definition { get; private set; }
 
         public string Name => Definition?.ElementName ?? _source.Name;
 
@@ -122,7 +124,7 @@ namespace Hl7.Fhir.ElementModel
         // R3 and R4, these value (and url and id elements by the way) will indicate which type
         // of system types there are, implicitly specifying the mapping between primitive
         // FHIR types and system types.
-        private static Type tryMapFhirPrimitiveTypeToSystemType(string fhirType)
+        private static Type? tryMapFhirPrimitiveTypeToSystemType(string fhirType)
         {
             switch (fhirType)
             {
@@ -160,7 +162,7 @@ namespace Hl7.Fhir.ElementModel
             }
         }
 
-        private object valueFactory()
+        private object? valueFactory()
         {
             string sourceText = _source.Text;
 
@@ -211,7 +213,7 @@ namespace Hl7.Fhir.ElementModel
                     if (P.Any.TryParse(sourceText, typeof(P.DateTime), out var dateTimeVal))
                     {
                         // TruncateToDate converts 1991-02-03T11:22:33Z to 1991-02-03+00:00 which is not a valid date! 
-                        var date = (dateTimeVal as P.DateTime).TruncateToDate();
+                        var date = (dateTimeVal as P.DateTime)!.TruncateToDate();
                         // so we cut off timezone by converting it to timeoffset and cast back to date.
                         return P.Date.FromDateTimeOffset(date.ToDateTimeOffset(0, 0, 0, TimeSpan.Zero));
                     }
@@ -222,13 +224,13 @@ namespace Hl7.Fhir.ElementModel
             }
         }
 
-        private object _value;
+        private object? _value;
         private bool _valueInitialized = false;
         private static object _initializationLock = new();
 
-        public object Value => LazyInitializer.EnsureInitialized(ref _value, ref _valueInitialized, ref _initializationLock, valueFactory);
+        public object Value => LazyInitializer.EnsureInitialized(ref _value, ref _valueInitialized, ref _initializationLock, valueFactory)!;
 
-        private string deriveInstanceType(ISourceNode current, IElementDefinitionSummary info)
+        private string? deriveInstanceType(ISourceNode current, IElementDefinitionSummary info)
         {
             var resourceTypeIndicator = current.GetResourceTypeIndicator();
 
@@ -340,7 +342,7 @@ namespace Hl7.Fhir.ElementModel
             return pos > -1 ? type.Substring(pos + 1) : type;
         }
 
-        private bool tryGetBySuffixedName(Dictionary<string, IElementDefinitionSummary> dis, string name, out IElementDefinitionSummary info)
+        private bool tryGetBySuffixedName(Dictionary<string, IElementDefinitionSummary> dis, string name, out IElementDefinitionSummary? info)
         {
             // Simplest case, one on one match between name and element name
             if (dis.TryGetValue(name, out info))
@@ -363,7 +365,7 @@ namespace Hl7.Fhir.ElementModel
             }
         }
 
-        private IEnumerable<TypedElementOnSourceNode> enumerateElements(Dictionary<string, IElementDefinitionSummary> dis, ISourceNode parent, string name)
+        private IEnumerable<TypedElementOnSourceNode> enumerateElements(Dictionary<string, IElementDefinitionSummary> dis, ISourceNode parent, string? name)
         {
             IEnumerable<ISourceNode> childSet;
 
@@ -374,17 +376,17 @@ namespace Hl7.Fhir.ElementModel
             {
                 var hit = dis.TryGetValue(name, out var info);
                 childSet = hit
-                    ? (info.IsChoiceElement ? parent.Children(name + "*") : parent.Children(name))
+                    ? (info!.IsChoiceElement ? parent.Children(name + "*") : parent.Children(name))
                     : Enumerable.Empty<ISourceNode>();
             }
 
-            string lastName = null;
+            string? lastName = null;
             int _nameIndex = 0;
 
             foreach (var scan in childSet)
             {
                 var hit = tryGetBySuffixedName(dis, scan.Name, out var info);
-                string instanceType = info == null ? null :
+                string? instanceType = info == null ? null :
                     deriveInstanceType(scan, info);
 
                 // If we have definitions for the children, but we didn't find definitions for this 
@@ -408,16 +410,16 @@ namespace Hl7.Fhir.ElementModel
                 }
 
                 var prettyPath =
-                 hit && !info.IsCollection ? $"{ShortPath}.{info.ElementName}" : $"{ShortPath}.{scan.Name}[{_nameIndex}]";
+                 hit && !info!.IsCollection ? $"{ShortPath}.{info.ElementName}" : $"{ShortPath}.{scan.Name}[{_nameIndex}]";
 
                 var location =
-                    hit ? $"{Location}.{info.ElementName}[{_nameIndex}]" : $"{Location}.{scan.Name}[{_nameIndex}]";
+                    hit ? $"{Location}.{info!.ElementName}[{_nameIndex}]" : $"{Location}.{scan.Name}[{_nameIndex}]";
 
                 // Special condition for ccda.
                 // If we encounter a xhtml node in a ccda document we will flatten all childnodes
                 // and use their content to build up the xml.
                 // The xml will be put in this node and children will be ignored.
-                if (instanceType == XHTML_INSTANCETYPE && info.Representation == XmlRepresentation.CdaText)
+                if (instanceType == XHTML_INSTANCETYPE && info!.Representation == XmlRepresentation.CdaText)
                 {
 #pragma warning disable CS0618 // Type or member is obsolete
                     var xmls = scan.Children().Select(c => c.Annotation<ICdaInfoSupplier>()?.XHtmlText);
@@ -428,11 +430,11 @@ namespace Hl7.Fhir.ElementModel
                     continue;
                 }
 
-                yield return new TypedElementOnSourceNode(this, scan, info, instanceType, prettyPath, location);
+                yield return new TypedElementOnSourceNode(this, scan, info, instanceType!, prettyPath, location);
             }
         }
 
-        public IEnumerable<ITypedElement> Children(string name = null)
+        public IEnumerable<ITypedElement> Children(string? name = null)
         {
             // If we have an xhtml typed node and there is not a div tag around the content
             // then we will not enumerate through the children of this node, since there will be no types
@@ -457,7 +459,7 @@ namespace Hl7.Fhir.ElementModel
                 else
                     // Ok, pass through the untyped members, but since there is no type information, 
                     // don't bother to run the additional rules
-                    return enumerateElements(childElementDefs, _source, name);
+                    return enumerateElements(childElementDefs, _source, name!);
             }
             else
                 return runAdditionalRules(enumerateElements(childElementDefs, _source, name));
@@ -468,11 +470,12 @@ namespace Hl7.Fhir.ElementModel
 #pragma warning disable 612, 618
             var additionalRules = _source.Annotations(typeof(AdditionalStructuralRule));
             var stateBag = new Dictionary<AdditionalStructuralRule, object>();
+            IEnumerable<object> enumerable = additionalRules as object[] ?? additionalRules.ToArray();
             foreach (var child in children)
             {
-                foreach (var rule in additionalRules.Cast<AdditionalStructuralRule>())
+                foreach (var rule in enumerable.Cast<AdditionalStructuralRule>())
                 {
-                    stateBag.TryGetValue(rule, out object state);
+                    stateBag.TryGetValue(rule, out object? state);
                     state = rule(child, this, state);
                     if (state != null) stateBag[rule] = state;
                 }
@@ -501,6 +504,6 @@ namespace Hl7.Fhir.ElementModel
     }
 
     [Obsolete("This class is used for internal purposes and is subject to change without notice. Don't use.")]
-    public delegate object AdditionalStructuralRule(ITypedElement node, IExceptionSource ies, object state);
+    public delegate object AdditionalStructuralRule(ITypedElement node, IExceptionSource ies, object? state);
 }
 

--- a/src/Hl7.Fhir.Base/ElementModel/TypedElementOnSourceNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/TypedElementOnSourceNode.cs
@@ -33,7 +33,7 @@ namespace Hl7.Fhir.ElementModel
             if (source is IExceptionSource ies && ies.ExceptionHandler == null)
                 ies.ExceptionHandler = (o, a) => ExceptionHandler.NotifyOrThrow(o, a);
 
-            Location = source.Location;
+            Location = source.Name;
             ShortPath = source.Name;
             _source = source;
             (InstanceType, Definition) = buildRootPosition(type);

--- a/src/Hl7.Fhir.Base/ElementModel/TypedElementOnSourceNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/TypedElementOnSourceNode.cs
@@ -31,6 +31,7 @@ namespace Hl7.Fhir.ElementModel
             if (source is IExceptionSource ies && ies.ExceptionHandler == null)
                 ies.ExceptionHandler = (o, a) => ExceptionHandler.NotifyOrThrow(o, a);
 
+            Location = source.Location;
             ShortPath = source.Name;
             _source = source;
             (InstanceType, Definition) = buildRootPosition(type);
@@ -66,7 +67,7 @@ namespace Hl7.Fhir.ElementModel
         }
 
 
-        private TypedElementOnSourceNode(TypedElementOnSourceNode parent, ISourceNode source, IElementDefinitionSummary definition, string instanceType, string prettyPath)
+        private TypedElementOnSourceNode(TypedElementOnSourceNode parent, ISourceNode source, IElementDefinitionSummary definition, string instanceType, string prettyPath, string location = null)
         {
             _source = source;
             ShortPath = prettyPath;
@@ -75,6 +76,7 @@ namespace Hl7.Fhir.ElementModel
             Definition = definition;
             InstanceType = instanceType;
             _settings = parent._settings;
+            Location = location;
         }
 
         public ExceptionNotificationHandler ExceptionHandler { get; set; }
@@ -408,6 +410,9 @@ namespace Hl7.Fhir.ElementModel
                 var prettyPath =
                  hit && !info.IsCollection ? $"{ShortPath}.{info.ElementName}" : $"{ShortPath}.{scan.Name}[{_nameIndex}]";
 
+                var location =
+                    hit ? $"{Location}.{info.ElementName}[{_nameIndex}]" : $"{Location}.{scan.Name}[{_nameIndex}]";
+
                 // Special condition for ccda.
                 // If we encounter a xhtml node in a ccda document we will flatten all childnodes
                 // and use their content to build up the xml.
@@ -419,11 +424,11 @@ namespace Hl7.Fhir.ElementModel
 #pragma warning restore CS0618 // Type or member is obsolete
 
                     var source = SourceNode.Valued(scan.Name, string.Join(string.Empty, xmls));
-                    yield return new TypedElementOnSourceNode(this, source, info, instanceType, prettyPath);
+                    yield return new TypedElementOnSourceNode(this, source, info, instanceType, prettyPath, location);
                     continue;
                 }
 
-                yield return new TypedElementOnSourceNode(this, scan, info, instanceType, prettyPath);
+                yield return new TypedElementOnSourceNode(this, scan, info, instanceType, prettyPath, location);
             }
         }
 
@@ -477,7 +482,7 @@ namespace Hl7.Fhir.ElementModel
 #pragma warning restore 612, 618
         }
 
-        public string Location => _source.Location;
+        public string Location { get; init; }
 
         public string ShortPath { get; private set; }
 

--- a/src/Hl7.Fhir.ElementModel.Shared.Tests/ScopedNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Shared.Tests/ScopedNodeTests.cs
@@ -267,7 +267,7 @@ namespace Hl7.Fhir.ElementModel.Tests
             Assert.AreEqual(1, assertXHtml.Count());
             Assert.AreEqual("text", assertXHtml.First().Name);
             Assert.AreEqual("xhtml", assertXHtml.First().InstanceType);
-            Assert.AreEqual("text", assertXHtml.First().Location);
+            Assert.AreEqual("Section.text[0]", assertXHtml.First().Location);
             Assert.IsNotNull(assertXHtml.First().Value);
 
 

--- a/src/Hl7.Fhir.ElementModel.Shared.Tests/TypedElementOnSourceNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Shared.Tests/TypedElementOnSourceNodeTests.cs
@@ -25,16 +25,12 @@ namespace Hl7.Fhir.ElementModel.Tests
             var _ = typedBundle.Children("entry").First().Value;
         }
         
-        private SourceNode getAnnotatedNode => SourceNode.Valued("valueString", "hello");
-        
         private SourceNode testPatient => SourceNode.Node("Patient",
             SourceNode.Resource("contained", "Observation", SourceNode.Valued("valueBoolean", "true")),
             SourceNode.Valued("active", "true",
-                getAnnotatedNode,
                 SourceNode.Valued("id", "myId2"),
                 SourceNode.Node("extension",
-                    SourceNode.Valued("url", "http://example.org/ext")),
-                SourceNode.Node("extension",
+                    SourceNode.Valued("url", "http://example.org/ext"),
                     SourceNode.Valued("valueString", "world!"))));
         
         private TypedElementOnSourceNode getTestPatient => (TypedElementOnSourceNode)testPatient.ToTypedElement(ModelInfo.ModelInspector, "Patient");
@@ -48,7 +44,7 @@ namespace Hl7.Fhir.ElementModel.Tests
             Assert.AreEqual("Patient.active[0]", getTestPatient.Children("active").First().Location);
             Assert.AreEqual("Patient.active[0].id[0]", getTestPatient.Children("active").First().Children("id").First().Location);
             Assert.AreEqual("Patient.active[0].extension[0].url[0]", getTestPatient.Children("active").First().Children("extension").First().Children("url").First().Location);
-            Assert.AreEqual("Patient.active[0].extension[1].value[0]", getTestPatient.Children("active").First().Children("extension").Skip(1).First().Children("value").First().Location);
+            Assert.AreEqual("Patient.active[0].extension[0].value[0]", getTestPatient.Children("active").First().Children("extension").First().Children("value").First().Location);
         }
     }
 }

--- a/src/Hl7.Fhir.ElementModel.Shared.Tests/TypedElementOnSourceNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Shared.Tests/TypedElementOnSourceNodeTests.cs
@@ -33,7 +33,7 @@ namespace Hl7.Fhir.ElementModel.Tests
                 getAnnotatedNode,
                 SourceNode.Valued("id", "myId2"),
                 SourceNode.Node("extension",
-                    SourceNode.Valued("valueInt", "4")),
+                    SourceNode.Valued("url", "http://example.org/ext")),
                 SourceNode.Node("extension",
                     SourceNode.Valued("valueString", "world!"))));
         
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.ElementModel.Tests
             Assert.AreEqual("Patient.contained[0].value[0]", getTestPatient.Children("contained").First().Children("value").First().Location);
             Assert.AreEqual("Patient.active[0]", getTestPatient.Children("active").First().Location);
             Assert.AreEqual("Patient.active[0].id[0]", getTestPatient.Children("active").First().Children("id").First().Location);
-            Assert.AreEqual("Patient.active[0].extension[0].value[0]", getTestPatient.Children("active").First().Children("extension").First().Children("value").First().Location);
+            Assert.AreEqual("Patient.active[0].extension[0].url[0]", getTestPatient.Children("active").First().Children("extension").First().Children("url").First().Location);
             Assert.AreEqual("Patient.active[0].extension[1].value[0]", getTestPatient.Children("active").First().Children("extension").Skip(1).First().Children("value").First().Location);
         }
     }

--- a/src/Hl7.Fhir.ElementModel.Shared.Tests/TypedElementOnSourceNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Shared.Tests/TypedElementOnSourceNodeTests.cs
@@ -1,9 +1,11 @@
-﻿using System;
+﻿using Hl7.Fhir.Model;
+using System;
 using System.Linq;
-using System.Threading.Tasks;
 using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Specification;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using Task = System.Threading.Tasks.Task;
 
 namespace Hl7.Fhir.ElementModel.Tests
 {
@@ -21,6 +23,32 @@ namespace Hl7.Fhir.ElementModel.Tests
             var typedBundle = bundle.ToTypedElement(provider, "Bundle");
 
             var _ = typedBundle.Children("entry").First().Value;
+        }
+        
+        private SourceNode getAnnotatedNode => SourceNode.Valued("valueString", "hello");
+        
+        private SourceNode testPatient => SourceNode.Node("Patient",
+            SourceNode.Resource("contained", "Observation", SourceNode.Valued("valueBoolean", "true")),
+            SourceNode.Valued("active", "true",
+                getAnnotatedNode,
+                SourceNode.Valued("id", "myId2"),
+                SourceNode.Node("extension",
+                    SourceNode.Valued("valueInt", "4")),
+                SourceNode.Node("extension",
+                    SourceNode.Valued("valueString", "world!"))));
+        
+        private TypedElementOnSourceNode getTestPatient => (TypedElementOnSourceNode)testPatient.ToTypedElement(ModelInfo.ModelInspector, "Patient");
+        
+        [TestMethod]
+        public void KnowsPath()
+        {
+            var tp = getTestPatient;
+            Assert.AreEqual("Patient", getTestPatient.Location);
+            Assert.AreEqual("Patient.contained[0].value[0]", getTestPatient.Children("contained").First().Children("value").First().Location);
+            Assert.AreEqual("Patient.active[0]", getTestPatient.Children("active").First().Location);
+            Assert.AreEqual("Patient.active[0].id[0]", getTestPatient.Children("active").First().Children("id").First().Location);
+            Assert.AreEqual("Patient.active[0].extension[0].value[0]", getTestPatient.Children("active").First().Children("extension").First().Children("value").First().Location);
+            Assert.AreEqual("Patient.active[0].extension[1].value[0]", getTestPatient.Children("active").First().Children("extension").Skip(1).First().Children("value").First().Location);
         }
     }
 }

--- a/src/Hl7.Fhir.Serialization.Shared.Tests/RoundtripAllSerializers.cs
+++ b/src/Hl7.Fhir.Serialization.Shared.Tests/RoundtripAllSerializers.cs
@@ -28,12 +28,12 @@ namespace Hl7.Fhir.Serialization.Tests
             engine.SerializeToXml(
                 engine.DeserializeFromJson(
                     engine.SerializeToJson(
-                        engine.DeserializeFromXml(original))));
+                        engine.DeserializeFromXml(original)!))!);
         public string RoundTripJson(string original) => 
             engine.SerializeToJson(
                 engine.DeserializeFromXml(
                     engine.SerializeToXml(
-                        engine.DeserializeFromJson(original))));
+                        engine.DeserializeFromJson(original)!))!);
     }
     
     internal class TypedElementBasedRoundtripper(IStructureDefinitionSummaryProvider provider) : IRoundTripper
@@ -249,7 +249,7 @@ namespace Hl7.Fhir.Serialization.Tests
                 ? NEW_POCO_ENGINE.DeserializeFromXml(input)
                 : NEW_POCO_ENGINE.DeserializeFromJson(input);
 
-            var r2 = (Resource)resource.DeepCopy();
+            var r2 = (Resource)resource!.DeepCopy();
             Assert.IsTrue(resource.Matches(r2),
                 "Serialization of " + name + " did not match output - Matches test");
             Assert.IsTrue(resource.IsExactly(r2),

--- a/src/Hl7.Fhir.Support.Poco.Tests/Rest/TransactionBuilderTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Rest/TransactionBuilderTests.cs
@@ -13,166 +13,165 @@ using Hl7.Fhir.Utility;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 
-namespace Hl7.Fhir.Test
+namespace Hl7.Fhir.Test;
+
+[TestClass]
+public class TransactionBuilderTests
 {
-    [TestClass]
-    public class TransactionBuilderTests
+    [TestMethod]
+    public void TestBuild()
     {
-        [TestMethod]
-        public void TestBuild()
-        {
-            var p = new TestPatient();
-            var b = new TransactionBuilder("http://myserver.org/fhir")
-                        .Create(p)
-                        .ResourceHistory("Patient", "7")
-                        .Delete("Patient", "8")
-                        .Read("Patient", "9", versionId: "bla")
-                        .ToBundle();
+        var p = new TestPatient();
+        var b = new TransactionBuilder("http://myserver.org/fhir")
+            .Create(p)
+            .ResourceHistory("Patient", "7")
+            .Delete("Patient", "8")
+            .Read("Patient", "9", versionId: "bla")
+            .ToBundle();
 
-            Assert.AreEqual(4, b.Entry.Count);
+        Assert.AreEqual(4, b.Entry.Count);
 
-            Assert.AreEqual(Bundle.HTTPVerb.POST, b.Entry[0].Request.Method);
-            Assert.AreEqual(p, b.Entry[0].Resource);
+        Assert.AreEqual(Bundle.HTTPVerb.POST, b.Entry[0].Request.Method);
+        Assert.AreEqual(p, b.Entry[0].Resource);
 
-            Assert.AreEqual(Bundle.HTTPVerb.GET, b.Entry[1].Request.Method);
-            Assert.AreEqual("Patient/7/_history", b.Entry[1].Request.Url);
+        Assert.AreEqual(Bundle.HTTPVerb.GET, b.Entry[1].Request.Method);
+        Assert.AreEqual("Patient/7/_history", b.Entry[1].Request.Url);
 
-            Assert.AreEqual(Bundle.HTTPVerb.DELETE, b.Entry[2].Request.Method);
-            Assert.AreEqual("Patient/8", b.Entry[2].Request.Url);
+        Assert.AreEqual(Bundle.HTTPVerb.DELETE, b.Entry[2].Request.Method);
+        Assert.AreEqual("Patient/8", b.Entry[2].Request.Url);
 
-            Assert.AreEqual(Bundle.HTTPVerb.GET, b.Entry[3].Request.Method);
-            Assert.AreEqual("Patient/9", b.Entry[3].Request.Url);
-            Assert.AreEqual("W/\"bla\"", b.Entry[3].Request.IfNoneMatch);
-        }
+        Assert.AreEqual(Bundle.HTTPVerb.GET, b.Entry[3].Request.Method);
+        Assert.AreEqual("Patient/9", b.Entry[3].Request.Url);
+        Assert.AreEqual("W/\"bla\"", b.Entry[3].Request.IfNoneMatch);
+    }
 
-        [TestMethod]
-        public void TestInteractionType()
-        {
-            // just try a few
-            var tx = new TransactionBuilder("http://myserver.org/fhir").ServerHistory();
-            Assert.AreEqual(InteractionType.History, tx.ToBundle().Entry[0].Annotation<InteractionType>());
+    [TestMethod]
+    public void TestInteractionType()
+    {
+        // just try a few
+        var tx = new TransactionBuilder("http://myserver.org/fhir").ServerHistory();
+        Assert.AreEqual(InteractionType.History, tx.ToBundle().Entry[0].Annotation<InteractionType>());
 
-            tx = new TransactionBuilder("http://myserver.org/fhir").ServerOperation("$everything", null);
-            Assert.AreEqual(InteractionType.Operation, tx.ToBundle().Entry[0].Annotation<InteractionType>());
+        tx = new TransactionBuilder("http://myserver.org/fhir").ServerOperation("$everything", null);
+        Assert.AreEqual(InteractionType.Operation, tx.ToBundle().Entry[0].Annotation<InteractionType>());
 
-            var p = new TestPatient();
-            tx = new TransactionBuilder("http://myserver.org/fhir").Create(p);
-            Assert.AreEqual(InteractionType.Create, tx.ToBundle().Entry[0].Annotation<InteractionType>());
+        var p = new TestPatient();
+        tx = new TransactionBuilder("http://myserver.org/fhir").Create(p);
+        Assert.AreEqual(InteractionType.Create, tx.ToBundle().Entry[0].Annotation<InteractionType>());
 
-            tx = new TransactionBuilder("http://myserver.org/fhir").Search(new SearchParams().Where("name=ewout"), resourceType: "Patient");
-            Assert.AreEqual(InteractionType.Search, tx.ToBundle().Entry[0].Annotation<InteractionType>());
-        }
+        tx = new TransactionBuilder("http://myserver.org/fhir").Search(new SearchParams().Where("name=ewout"), resourceType: "Patient");
+        Assert.AreEqual(InteractionType.Search, tx.ToBundle().Entry[0].Annotation<InteractionType>());
+    }
 
 
-        [TestMethod]
-        public void TestConditionalCreate()
-        {
-            var p = new TestPatient();
-            var tx = new TransactionBuilder("http://myserver.org/fhir")
-                        .Create(p, new SearchParams().Where("name=foobar"));
-            var b = tx.ToBundle();
+    [TestMethod]
+    public void TestConditionalCreate()
+    {
+        var p = new TestPatient();
+        var tx = new TransactionBuilder("http://myserver.org/fhir")
+            .ConditionalCreate(p, new SearchParams().Where("name=foobar"));
+        var b = tx.ToBundle();
 
-            Assert.AreEqual("name=foobar", b.Entry[0].Request.IfNoneExist);
-        }
+        Assert.AreEqual("name=foobar", b.Entry[0].Request.IfNoneExist);
+    }
 
 
-        [TestMethod]
-        public void TestConditionalUpdate()
-        {
-            var p = new TestPatient();
-            var tx = new TransactionBuilder("http://myserver.org/fhir")
-                        .Update(new SearchParams().Where("name=foobar"), p, versionId: "314");
-            var b = tx.ToBundle();
+    [TestMethod]
+    public void TestConditionalUpdate()
+    {
+        var p = new TestPatient();
+        var tx = new TransactionBuilder("http://myserver.org/fhir")
+            .ConditionalUpdate(new SearchParams().Where("name=foobar"), p, versionId: "314");
+        var b = tx.ToBundle();
 
-            Assert.AreEqual("W/\"314\"", b.Entry[0].Request.IfMatch);
-        }
+        Assert.AreEqual("W/\"314\"", b.Entry[0].Request.IfMatch);
+    }
 
-        /// <summary>
-        /// Unit test to prove issue 536: 
-        /// https://github.com/FirelyTeam/firely-net-sdk/issues/536
-        /// </summary>
-        [TestMethod]
-        public void TestTransactionWithForwardSlash()
-        {
-            var tx2 = new TransactionBuilder("http://myserver.org/fhir/");
-            var bundle = tx2.Get("@Patient/1").ToBundle();
+    /// <summary>
+    /// Unit test to prove issue 536: 
+    /// https://github.com/FirelyTeam/firely-net-sdk/issues/536
+    /// </summary>
+    [TestMethod]
+    public void TestTransactionWithForwardSlash()
+    {
+        var tx2 = new TransactionBuilder("http://myserver.org/fhir/");
+        var bundle = tx2.Get("@Patient/1").ToBundle();
 
-            var tx = new TransactionBuilder("http://myserver.org/fhir/")
-                .Transaction(bundle);
+        var tx = new TransactionBuilder("http://myserver.org/fhir/")
+            .Transaction(bundle);
 
-            var b = tx.ToBundle();
-            Assert.IsFalse(b.Entry[0].Request.Url.EndsWith(@"/"), "Url cannot end with forward slash");
-        }
+        var b = tx.ToBundle();
+        Assert.IsFalse(b.Entry[0].Request.Url.EndsWith(@"/"), "Url cannot end with forward slash");
+    }
 
-        [TestMethod]
-        public void TestTransactionWithAbsoluteUri()
-        {
-            var patient = new TestPatient();
-            var endpoint = "http://fhirtest.uhn.ca/baseDstu2";
+    [TestMethod]
+    public void TestTransactionWithAbsoluteUri()
+    {
+        var patient = new TestPatient();
+        var endpoint = "http://fhirtest.uhn.ca/baseDstu2";
 
-            var transaction = new TransactionBuilder(endpoint)
-                .Create(patient)
-                .Get("Patient/1");
-            var bundle = transaction.ToBundle();
-            bundle.Type = Bundle.BundleType.Transaction;
+        var transaction = new TransactionBuilder(endpoint)
+            .Create(patient)
+            .Get("Patient/1");
+        var bundle = transaction.ToBundle();
+        bundle.Type = Bundle.BundleType.Transaction;
 
-            Assert.AreEqual(2, bundle.Entry.Count);
-            Assert.IsFalse(bundle.Entry[0].Request.Url.StartsWith(endpoint), "Entries in the transaction bundle cannot contain absolute url.");
-            Assert.AreEqual("Patient", bundle.Entry[0].Request.Url, "Entry must be a relative url");
-        }
+        Assert.AreEqual(2, bundle.Entry.Count);
+        Assert.IsFalse(bundle.Entry[0].Request.Url.StartsWith(endpoint), "Entries in the transaction bundle cannot contain absolute url.");
+        Assert.AreEqual("Patient", bundle.Entry[0].Request.Url, "Entry must be a relative url");
+    }
 
-        [TestMethod]
-        public void TransactionBuilderWithFullUrlTest()
-        {
-            var fullUrl = "http://myserver.org/fhir/123";
-            var p = new TestPatient();
-            var tx = new TransactionBuilder("http://myserver.org/fhir")
-                        .Update(new SearchParams().Where("name=foobar"), p, versionId: "314", fullUrl);
-            var bundle = tx.ToBundle();
+    [TestMethod]
+    public void TransactionBuilderWithFullUrlTest()
+    {
+        var fullUrl = "http://myserver.org/fhir/123";
+        var p = new TestPatient();
+        var tx = new TransactionBuilder("http://myserver.org/fhir")
+            .ConditionalUpdate(new SearchParams().Where("name=foobar"), p, versionId: "314", fullUrl);
+        var bundle = tx.ToBundle();
 
-            bundle.Entry.Should().ContainSingle().Which.FullUrl.Should().Be(fullUrl);
+        bundle.Entry.Should().ContainSingle().Which.FullUrl.Should().Be(fullUrl);
 
-            tx.Read("TestPatient", "123");
+        tx.Read("TestPatient", "123");
 
-            bundle = tx.ToBundle();
+        bundle = tx.ToBundle();
 
-            bundle.Entry.Skip(1).Should().ContainSingle().Which.FullUrl.Should().BeNull();
+        bundle.Entry.Skip(1).Should().ContainSingle().Which.FullUrl.Should().BeNull();
 
-        }
+    }
 
-        [TestMethod]
-        public void TestConditionalDeleteWithIfmatch()
-        {
-            var p = new TestPatient();
-            var tx = new TransactionBuilder("http://myserver.org/fhir")
-                .ConditionalDeleteSingle(new SearchParams().Where("name=foobar"), p.TypeName, versionId: "314");
-            var b = tx.ToBundle();
+    [TestMethod]
+    public void TestConditionalDeleteWithIfmatch()
+    {
+        var p = new TestPatient();
+        var tx = new TransactionBuilder("http://myserver.org/fhir")
+            .ConditionalDeleteSingle(new SearchParams().Where("name=foobar"), p.TypeName, versionId: "314");
+        var b = tx.ToBundle();
 
-            Assert.AreEqual("W/\"314\"", b.Entry[0].Request.IfMatch);
-        }
+        Assert.AreEqual("W/\"314\"", b.Entry[0].Request.IfMatch);
+    }
 
-        [TestMethod]
-        public void TestDeleteHistory()
-        {
-            var p = new TestPatient();
-            var tx = new TransactionBuilder("http://myserver.org/fhir")
-                .DeleteHistory("Patient", "7");
-            var b = tx.ToBundle();
+    [TestMethod]
+    public void TestDeleteHistory()
+    {
+        var p = new TestPatient();
+        var tx = new TransactionBuilder("http://myserver.org/fhir")
+            .DeleteHistory("Patient", "7");
+        var b = tx.ToBundle();
             
-            Assert.AreEqual(Bundle.HTTPVerb.DELETE, b.Entry[0].Request.Method);
-            Assert.AreEqual("Patient/7/_history", b.Entry[0].Request.Url);
-        }
+        Assert.AreEqual(Bundle.HTTPVerb.DELETE, b.Entry[0].Request.Method);
+        Assert.AreEqual("Patient/7/_history", b.Entry[0].Request.Url);
+    }
 
-        [TestMethod]
-        public void TestDeleteHistoryVersion()
-        {
-            var p = new TestPatient();
-            var tx = new TransactionBuilder("http://myserver.org/fhir")
-                .DeleteHistoryVersion("Patient", "7", "1");
-            var b = tx.ToBundle();
+    [TestMethod]
+    public void TestDeleteHistoryVersion()
+    {
+        var p = new TestPatient();
+        var tx = new TransactionBuilder("http://myserver.org/fhir")
+            .DeleteHistoryVersion("Patient", "7", "1");
+        var b = tx.ToBundle();
             
-            Assert.AreEqual(Bundle.HTTPVerb.DELETE, b.Entry[0].Request.Method);
-            Assert.AreEqual("Patient/7/_history/1", b.Entry[0].Request.Url);
-        }
+        Assert.AreEqual(Bundle.HTTPVerb.DELETE, b.Entry[0].Request.Method);
+        Assert.AreEqual("Patient/7/_history/1", b.Entry[0].Request.Url);
     }
 }


### PR DESCRIPTION
## Description
TypedElementOnSourceNode.Location should now correctly omit choice type suffixes (like in PocoElementNode)

## Related issues
Fixes issue #2642 

## Testing
Added new unit tests testing some edge cases