### PR TITLE
Disallow validation of empty strings or markdown

### DIFF
--- a/src/Hl7.Fhir.Base/Model/FhirString.cs
+++ b/src/Hl7.Fhir.Base/Model/FhirString.cs
@@ -39,7 +39,9 @@ namespace Hl7.Fhir.Model
         /// <summary>
         /// Checks whether the given literal is correctly formatted.
         /// </summary>
-        public static bool IsValidValue(string value) => value.Length <= 1024 * 1024;    // Note that strings SHALL NOT exceed 1MB in size
+        public static bool IsValidValue(string value) => value.Length is <= 1024 * 1024 and > 0;    // Note that strings SHALL NOT exceed 1MB in size.
+        
+        // We do not match against the pattern since that is more expensive
     }
 }
 

--- a/src/Hl7.Fhir.Base/Model/Generated/FhirString.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/FhirString.cs
@@ -71,6 +71,7 @@ namespace Hl7.Fhir.Model
     [FhirElement("value", IsPrimitiveValue=true, XmlSerialization=XmlRepresentation.XmlAttr, InSummary=true, Order=30)]
     [DeclaredType(Type = typeof(SystemPrimitive.String))]
     [DataMember]
+    [StringPattern]
     public string Value
     {
       get { return (string)ObjectValue; }

--- a/src/Hl7.Fhir.Base/Model/Generated/Markdown.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/Markdown.cs
@@ -71,6 +71,7 @@ namespace Hl7.Fhir.Model
     [FhirElement("value", IsPrimitiveValue=true, XmlSerialization=XmlRepresentation.XmlAttr, InSummary=true, Order=30)]
     [DeclaredType(Type = typeof(SystemPrimitive.String))]
     [DataMember]
+    [StringPattern]
     public string Value
     {
       get { return (string)ObjectValue; }

--- a/src/Hl7.Fhir.Base/Validation/CodedValidationException.cs
+++ b/src/Hl7.Fhir.Base/Validation/CodedValidationException.cs
@@ -40,6 +40,7 @@ namespace Hl7.Fhir.Validation
         public const string INVALID_CODED_VALUE_CODE = "PVAL116";
         public const string CONTAINED_RESOURCE_CANNOT_HAVE_NARRATIVE_CODE = "PVAL117"; // This was removed in R4 and is no longer validated
         public const string CONTAINED_RESOURCES_CANNOT_BE_NESTED_CODE = "PVAL118";
+        public const string INVALID_STRING_LENGTH_CODE = "PVAL119";
 
         internal static COVE CHOICE_TYPE_NOT_ALLOWED(ValidationContext context, string TypeName) => Initialize(context, CHOICE_TYPE_NOT_ALLOWED_CODE, $"Value is of type '{TypeName}', which is not an allowed choice.", OO_Sev.Error, OO_Typ.Structure);
         internal static COVE INCORRECT_CARDINALITY_MIN(ValidationContext context, int count, int Min) => Initialize(context, INCORRECT_CARDINALITY_MIN_CODE, $"Element has {count} elements, but minimum cardinality is {Min}.", OO_Sev.Error, OO_Typ.Required);
@@ -59,6 +60,7 @@ namespace Hl7.Fhir.Validation
         internal static COVE INVALID_CODED_VALUE(ValidationContext context, object? value, string name) => Initialize(context, INVALID_CODED_VALUE_CODE, $"Value '{value}' is not a correct code for valueset '{name}'.", OO_Sev.Error, OO_Typ.CodeInvalid);
         // internal static COVE CONTAINED_RESOURCE_CANNOT_HAVE_NARRATIVE(ValidationContext context) => Initialize(context, CONTAINED_RESOURCE_CANNOT_HAVE_NARRATIVE_CODE, "Resource has contained resources with narrative, which is not allowed.", OO_Sev.Error, OO_Typ.Structure);
         internal static COVE CONTAINED_RESOURCES_CANNOT_BE_NESTED(ValidationContext context) => Initialize(context, CONTAINED_RESOURCES_CANNOT_BE_NESTED_CODE, "It is not allowed for a resource to contain resources which themselves contain resources.", OO_Sev.Error, OO_Typ.Structure);
+        internal static COVE INVALID_STRING_LENGTH(ValidationContext context, string name, string value) => Initialize(context, INVALID_STRING_LENGTH_CODE, (value.Length > 0 ? $"String {name} exceeds maximum length of 1MB." : $"String {name} is empty"), OO_Sev.Error, OO_Typ.Value);
 
         public CodedValidationException(string code, string message)
             : base(code, message, null, null, null, OO_Sev.Error, OO_Typ.Unknown)

--- a/src/Hl7.Fhir.Base/Validation/StringPatternAttribute.cs
+++ b/src/Hl7.Fhir.Base/Validation/StringPatternAttribute.cs
@@ -1,0 +1,24 @@
+using Hl7.Fhir.Model;
+using System;
+using System.ComponentModel.DataAnnotations;
+using COVE = Hl7.Fhir.Validation.CodedValidationException;
+
+namespace Hl7.Fhir.Validation;
+
+#nullable enable
+
+/// <summary>
+/// Validates an Uri value against the FHIR rules for Uri.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public class StringPatternAttribute : ValidationAttribute
+{
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext) =>
+        value switch
+        {
+            null => ValidationResult.Success,
+            string s when FhirString.IsValidValue(s) => ValidationResult.Success,
+            string s => COVE.INVALID_STRING_LENGTH(validationContext, validationContext.MemberName!, s).AsResult(validationContext),
+            _ => throw new ArgumentException($"{nameof(StringPatternAttribute)} attributes can only be applied to string properties.")
+        };
+}

--- a/src/Hl7.Fhir.Support.Poco.Tests/PocoValidationTests/ValidatableObjectTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/PocoValidationTests/ValidatableObjectTests.cs
@@ -1,10 +1,13 @@
 using FluentAssertions;
 using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Utility;
 using Hl7.Fhir.Validation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using COVE = Hl7.Fhir.Validation.CodedValidationException;
 
 #nullable enable
@@ -54,6 +57,20 @@ namespace Hl7.Fhir.Support.Poco.Tests
                 validationResult.Should().AllBeOfType<CodedValidationResult>();
                 validationResult.Should().ContainSingle(vr => ((CodedValidationResult)vr).ValidationException.ErrorCode == errorCode);
             }
+        }
+        
+        [TestMethod]
+        public void Test()
+        {
+            var bundle = new TestPatient{Name = new () {new () {Family = ""}}};
+            const string bundleString = """{ "resourceType":"Patient", "name":[{"family":""}] }""";
+            var options = new JsonSerializerOptions().ForFhir(typeof(TestPatient).Assembly);
+            
+            var shouldThrowOnValidate = () => bundle.Validate(true);
+            var shouldThrowOnDeserialize = () => _ = JsonSerializer.Deserialize<Bundle>(bundleString, options);
+            
+            shouldThrowOnValidate.Should().Throw<ValidationException>();
+            shouldThrowOnDeserialize.Should().Throw<DeserializationFailedException>();
         }
     }
 


### PR DESCRIPTION
⚠️ This branch should not be merged until the code generator generates the same annotations as this PR.

## Description
Added attribute validation annotations to strings and markdown. Strings are now no longer allowed to be empty


## Related issues
Resolves #2577 

## Testing
Tested according to the suggested test (which now correctly throws an error when validating an empty string)