### PR TITLE
Added links to new validator

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,9 +7,11 @@ assignees: ''
 
 ---
 
-:information_source: Do you want to ask something or start a discussion, then go [here](https://github.com/FirelyTeam/firely-net-sdk/discussions)
+:information_source: Do you want to ask something or start a discussion, then go [here](https://github.com/FirelyTeam/firely-net-sdk/discussions).
 
 :information_source: Is your feature request about Firely Server Facade, please send an email to [server@fire.ly](mailto:server@fire.ly) or submit a feature request to Jira if you are a paying customer.
+
+:information_source: If your feature request concerns the validator, please submit your issue to the validator repository [here](https://github.com/FirelyTeam/firely-validator-api).
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The SDK has been restructured for the 5.0 release. Please take note of the follo
 * The "old" `Hl7.Fhir.Specification.<release>` package is now a metapackage that will include these two packages.
 * You should not reference any other packages that existed pre-5.0 (`Hl7.Fhir.ElementModel` etc.)
 
-The profile validator has been split off into its own [repository](https://github.com/FirelyTeam/Hl7.Fhir.Validation.Legacy). The NuGet packages for the validator that are compatible with the SDK 5.0 release can be found on [NuGet](https://www.nuget.org/packages?q=Hl7.Fhir.Validation.Legacy).
+The profile validator has been split off into its own [repository](https://github.com/FirelyTeam/firely-validator-api). The NuGet packages for the validator that are compatible with the SDK 5.0 release can be found on [NuGet](https://www.nuget.org/packages?q=Hl7.Fhir.Validation.Legacy).
 
 ## Support 
 We actively monitor the issues coming in through the GitHub repository at [https://github.com/FirelyTeam/firely-net-sdk/issues](https://github.com/FirelyTeam/firely-net-sdk/issues). You are welcome to register your bugs and feature suggestions there. For questions and broader discussions, we use the .NET FHIR Implementers chat on [Zulip][netsdk-zulip].

--- a/contributors.md
+++ b/contributors.md
@@ -14,6 +14,7 @@ This library was a collective effort by the following developers:
 * Henley Devereux (Artisan Technology Group)
 * Kenneth Myhra (Kufu)
 * Gino Canessa (Microsoft)
+* Kas de Jong (Firely)
 
 Thanks to:
 * The Azure API for FHIR team at Microsoft for their PRs


### PR DESCRIPTION
## Description
1. Changed link in the sdk readme from the old validator to the new validator (this pr)
2. Added link in the old validator readme to the new validator (FirelyTeam/Hl7.Fhir.Validation.Legacy#74)
3. Added informational remark to the sdk feature request with link to new validator (this pr)
4. Added link in the new validator readme to the validator demo project (FirelyTeam/firely-validator-api#301)
5. Added my own name to the contributors list (this pr)

## Related issues
Closes #2705