### PR TITLE
keep snapshot when differential is missing

### DIFF
--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
@@ -143,11 +143,14 @@ namespace Hl7.Fhir.Specification.Snapshot
         /// <param name="structure">A <see cref="StructureDefinition"/> instance.</param>
         public async T.Task UpdateAsync(StructureDefinition structure)
         {
-            structure.Snapshot = new StructureDefinition.SnapshotComponent()
+            if (structure.Differential != null)
             {
-                Element = await GenerateAsync(structure).ConfigureAwait(false)
-            };
-            structure.Snapshot.SetCreatedBySnapshotGenerator();
+                structure.Snapshot = new StructureDefinition.SnapshotComponent()
+                {
+                    Element = await GenerateAsync(structure).ConfigureAwait(false)
+                };
+                structure.Snapshot.SetCreatedBySnapshotGenerator();
+            }
 
             // [WMR 20170209] TODO: also merge global StructureDefinition.Mapping components
             // structure.Mappings = ElementDefnMerger.Merge(...)

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
@@ -144,13 +144,10 @@ namespace Hl7.Fhir.Specification.Snapshot
         public async T.Task UpdateAsync(StructureDefinition structure)
         {
                 var result = await GenerateAsync(structure).ConfigureAwait(false);
-                
-                if(result == null) return;
-                
-                structure.Snapshot = new StructureDefinition.SnapshotComponent()
-                {
-                    Element = result
-                };
+
+                if (result == null && structure.Snapshot?.Element != null) return;
+
+                structure.Snapshot = new StructureDefinition.SnapshotComponent { Element = result };
                 structure.Snapshot.SetCreatedBySnapshotGenerator();
 
                 // [WMR 20170209] TODO: also merge global StructureDefinition.Mapping components

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
@@ -143,17 +143,18 @@ namespace Hl7.Fhir.Specification.Snapshot
         /// <param name="structure">A <see cref="StructureDefinition"/> instance.</param>
         public async T.Task UpdateAsync(StructureDefinition structure)
         {
-            if (structure.Differential != null)
-            {
+                var result = await GenerateAsync(structure).ConfigureAwait(false);
+                
+                if(result == null) return;
+                
                 structure.Snapshot = new StructureDefinition.SnapshotComponent()
                 {
-                    Element = await GenerateAsync(structure).ConfigureAwait(false)
+                    Element = result
                 };
                 structure.Snapshot.SetCreatedBySnapshotGenerator();
-            }
 
-            // [WMR 20170209] TODO: also merge global StructureDefinition.Mapping components
-            // structure.Mappings = ElementDefnMerger.Merge(...)
+                // [WMR 20170209] TODO: also merge global StructureDefinition.Mapping components
+                // structure.Mappings = ElementDefnMerger.Merge(...)
         }
 
         /// <inheritdoc cref="UpdateAsync(StructureDefinition)"/>

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -3193,6 +3193,42 @@ namespace Hl7.Fhir.Specification.Tests
             }
         };
 
+        private static StructureDefinition LogicalModelWithoutDiff => new()
+        {
+            Name = "MyLogicalModel",
+            Url = "http://example.org/fhir/StructureDefinition/MyLogicalModel",
+            Type = "http://foo.org/bar",
+            Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+            BaseDefinition = "http://hl7.org/fhir/StructureDefinition/Base",
+            Kind = StructureDefinition.StructureDefinitionKind.Logical,
+            Snapshot = new()
+            {
+                Element = new()
+               {
+                   new()
+                   {
+                       ElementId = "logicalmodel",
+                       Path = "logicalmodel",
+                       Short = "root"
+
+                   },
+                    new()
+                   {
+                       ElementId = "logicalmodel.Identifier",
+                       Path = "logicalmodel.Identifier",
+                       Short = "Identifier",
+                       Min = 1,
+                       Max = "*",
+                       Type = new()
+                       {
+                           new() {Code = "Identifier"}
+                       }
+                   },
+               }
+            }
+
+        };
+
         [Conditional("DEBUG")]
         private void dumpElements(IEnumerable<ElementDefinition> elements, string header = null) => dumpElements(elements.ToList(), header);
 
@@ -3283,6 +3319,23 @@ namespace Hl7.Fhir.Specification.Tests
             // Create a profile without a differential
             var profile = ObservationTypeSliceProfile;
             profile.Differential = null;
+
+            var resolver = new InMemoryResourceResolver(profile);
+            var multiResolver = new MultiResolver(_testResolver, resolver);
+            _generator = new SnapshotGenerator(multiResolver, _settings);
+
+            var (_, expanded) = await generateSnapshotAndCompare(profile);
+            Assert.IsNotNull(expanded);
+            Assert.IsTrue(expanded.HasSnapshot);
+
+            expanded.Snapshot.Element.Dump();
+        }
+
+        [TestMethod]
+        public async T.Task TestMissingDifferentialLogicalModel()
+        {
+            // Create a profile without a differential
+            var profile = LogicalModelWithoutDiff;
 
             var resolver = new InMemoryResourceResolver(profile);
             var multiResolver = new MultiResolver(_testResolver, resolver);


### PR DESCRIPTION
## Description
SnapshotGenerator should now do a no-op when asked to update a snapshot if the structure has no differential. In some cases this used to lead to removal of a snapshot.

## Related issues
Fixes #2586 

## Testing
Added unit test to check the specific case in which this bug would occur