### PR TITLE
Preserve self links when a count summary is conducted

### DIFF
--- a/src/Hl7.Fhir.Base/ElementModel/MaskingNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/MaskingNode.cs
@@ -16,7 +16,6 @@ namespace Hl7.Fhir.ElementModel
 {
     public class MaskingNode : ITypedElement, IAnnotated, IExceptionSource
     {
-
         /// <summary>
         /// Set to true when a complex type property is mandatory so all its children need to be included
         /// </summary>
@@ -59,7 +58,7 @@ namespace Hl7.Fhir.ElementModel
           new MaskingNode(node, new MaskingNodeSettings
           {
               IncludeMandatory = true,
-              IncludeElements = new[] { "id", "total" },
+              IncludeElements = new[] { "id", "total", "link" },
           });
 
         public MaskingNode(ITypedElement source, MaskingNodeSettings settings = null)

--- a/src/Hl7.Fhir.Base/Serialization/SerializationFilter.cs
+++ b/src/Hl7.Fhir.Base/Serialization/SerializationFilter.cs
@@ -53,6 +53,13 @@ namespace Hl7.Fhir.Serialization
                 IncludeMandatory = true
             }));
 
+        public static SerializationFilter ForCount() => new BundleFilter(new TopLevelFilter(
+            new ElementMetadataFilter()
+            {
+                IncludeMandatory = true,
+                IncludeNames = new[] { "id", "total", "link" }
+            }));
+
         /// <summary>
         /// Construct a new filter that conforms to the `_summary=data` summarized form.
         /// </summary>

--- a/src/Hl7.Fhir.Serialization.Shared.Tests/SummaryTests.cs
+++ b/src/Hl7.Fhir.Serialization.Shared.Tests/SummaryTests.cs
@@ -1,4 +1,5 @@
-﻿using Hl7.Fhir.ElementModel;
+﻿using FluentAssertions;
+using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Specification;
 using Hl7.Fhir.Specification.Source;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -73,6 +74,17 @@ namespace Hl7.Fhir.Serialization.Tests
 
             ITypedElement getXmlNodeSDSP(string xml, FhirXmlParsingSettings s = null) =>
                 XmlParsingHelpers.ParseToTypedElement(xml, new StructureDefinitionSummaryProvider(ZipSource.CreateValidationSource()), s);
+        }
+
+        [TestMethod]
+        public void TestSummaryCountSelfLinks()
+        {
+            var tpXml = File.ReadAllText(Path.Combine("TestData", "no-namespace.xml"));
+
+            var nav = new ScopedNode(getXmlNode(tpXml));
+            var masker = MaskingNode.ForCount(nav);
+            
+            masker.Children("link").Children("relation").First().Value.Should().BeEquivalentTo("self");
         }
     }
 }

--- a/src/Hl7.Fhir.Serialization.Shared.Tests/TestData/no-namespace.xml
+++ b/src/Hl7.Fhir.Serialization.Shared.Tests/TestData/no-namespace.xml
@@ -3,6 +3,10 @@
   <meta>
     <lastUpdated value="2014-08-18T01:43:30Z"/>
   </meta>
+  <link>
+    <relation value="self"/>
+    <url value="https://example.com/base/Observation?subject=Patient/347"/>
+  </link>
   <type value="searchset"/>
   <total value="3"/>
   <entry>

--- a/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/SummaryFilterIntegrationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/SummaryFilterIntegrationTests.cs
@@ -144,6 +144,15 @@ namespace Hl7.Fhir.Support.Poco.Tests
                 traverse(full.StatusElement).Count());
         }
 
+        [TestMethod]
+        public void SummaryCount()
+        {
+            var (full, summarized) = runSummarize<Bundle>("simple-bundle.xml", SerializationFilter.ForCount());
+            
+            // check if result contains the link
+            traverse(summarized).Should().ContainKey("link");
+        }
+
         private (T full, T summarized) runSummarize<T>(string filename, SerializationFilter filter) where T : Resource
         {
             var fullXml = File.ReadAllText(Path.Combine("TestData", filename));

--- a/src/Hl7.Fhir.Support.Poco.Tests/TestData/simple-bundle.xml
+++ b/src/Hl7.Fhir.Support.Poco.Tests/TestData/simple-bundle.xml
@@ -1,0 +1,12 @@
+<Bundle xmlns="http://hl7.org/fhir">
+    <id value="bundle-example"/>
+    <meta>
+        <lastUpdated value="2014-08-18T01:43:30Z"/>
+    </meta>
+    <type value="searchset"/>
+    <total value="0"/>
+    <link>
+        <relation value="self"/>
+        <url value="https://example.com/base/Observation?subject=Patient/347"/>
+    </link>
+</Bundle>


### PR DESCRIPTION
## Description
links are now preserved even when _summary=count is specified

## Related issues
Closes #826 

## Testing
Tested both maskingnode and serializationfilter implementations against a sample bundle