### PR TITLE
FhirPath indexOf method for collections

### DIFF
--- a/src/Hl7.Fhir.Base/FhirPath/Expressions/SymbolTableInit.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Expressions/SymbolTableInit.cs
@@ -167,6 +167,10 @@ namespace Hl7.FhirPath.Expressions
             t.Add("split", (string f, string seperator) => f.FpSplit(seperator), doNullProp: true);
             t.Add("join", (IEnumerable<ITypedElement> f, string separator) => f.FpJoin(separator), doNullProp: true);
             t.Add("join", (IEnumerable<ITypedElement> f) => f.FpJoin(), doNullProp: true);
+            t.Add("indexOf", (IEnumerable<ITypedElement> f, ITypedElement elem, int start) => f.IndexOf(elem, start), doNullProp: true);
+            t.Add("indexOf", (IEnumerable<ITypedElement> f, ITypedElement elem) => f.IndexOf(elem), doNullProp: true);
+            t.Add("lastIndexOf", (IEnumerable<ITypedElement> f, ITypedElement elem, int start) => f.LastIndexOf(elem, start), doNullProp: true);
+            t.Add("lastIndexOf", (IEnumerable<ITypedElement> f, ITypedElement elem) => f.LastIndexOf(elem), doNullProp: true);
 
             // Math functions
             t.Add("abs", (decimal f) => Math.Abs(f), doNullProp: true);

--- a/src/Hl7.Fhir.Base/FhirPath/Functions/CollectionOperators.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Functions/CollectionOperators.cs
@@ -65,6 +65,34 @@ namespace Hl7.FhirPath.Functions
         public static IEnumerable<ITypedElement> Exclude(this IEnumerable<ITypedElement> focus, IEnumerable<ITypedElement> other)
             => focus.Where(f => !other.Contains(f));
 
+        public static int IndexOf(this IEnumerable<ITypedElement> focus, ITypedElement item, int start = 0)
+        {
+            var typedElements = focus as ITypedElement[] ?? focus.ToArray();
+            for (int i = start; i < typedElements.Length; i++)
+            {
+                if (EqualityOperators.TypedElementEqualityComparer.Equals(typedElements[i], item))
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        public static int LastIndexOf(this IEnumerable<ITypedElement> focus, ITypedElement item, int to = -1)
+        {
+            var typedElements = focus as ITypedElement[] ?? focus.ToArray();
+            to = to < 0 ? typedElements.Count() - 1 : to;
+            for (int i = to; i >= 0; i--)
+            {
+                if (EqualityOperators.TypedElementEqualityComparer.Equals(typedElements[i], item))
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+        
+
         public static IEnumerable<ITypedElement> Navigate(this IEnumerable<ITypedElement> elements, string name)
             => elements.SelectMany(e => e.Navigate(name));
 

--- a/src/Hl7.FhirPath.Tests/Functions/FunctionsTests.cs
+++ b/src/Hl7.FhirPath.Tests/Functions/FunctionsTests.cs
@@ -278,7 +278,7 @@ namespace HL7.FhirPath.Tests
                     ("'abcdefg'.indexOf('bc') = 1", true, false),
                     ("'abcdefg'.indexOf('x') = -1", true, false),
                     ("'abcdefg'.indexOf('abcdefg') = 0", true, false),
-                    ("('a' | 'b').indexOf('a')", true, true),  // should throw an error
+                    ("('a' | 'b').indexOf('a') = 0", true, false), // used to throw an exception, but indexOf is now implemented for collections
 
                     // function substring(start : Integer [, length : Integer]) : String
                     ("{}.substring(0).empty()", true, false),

--- a/src/Hl7.FhirPath.Tests/Tests/BasicFunctionTests.cs
+++ b/src/Hl7.FhirPath.Tests/Tests/BasicFunctionTests.cs
@@ -258,6 +258,16 @@ namespace Hl7.FhirPath.Tests
             Assert.IsNotNull(result);
             CollectionAssert.AreEqual(new[] { "", "ONE", "", "TWO", "", "", "THREE", "", "" }, result.Select(r => r.Value.ToString()).ToArray());
         }
+        
+        [DataTestMethod]
+        [DataRow("(1 | 2 | 3).indexOf(3)", 2)]
+        [DataRow("((1 | 2 | 3).combine(2)).indexOf(2, 2)", 3)]
+        [DataRow("((1 | 2 | 3).combine(2)).lastIndexOf(2)", 3)]
+        [DataRow("(1 | 2).combine(2 | 1).lastIndexOf(1, 2)", 0)]
+        public void TestStringIndexOf(string expr, int expected)
+        {
+            Assert.AreEqual(expected, scalar(expr));
+        }
 
         [TestMethod]
         public void TestDivZero()

--- a/src/Hl7.FhirPath.Tests/Tests/FhirPathGrammarTest.cs
+++ b/src/Hl7.FhirPath.Tests/Tests/FhirPathGrammarTest.cs
@@ -83,7 +83,7 @@ namespace Hl7.FhirPath.Tests
             AssertParser.SucceedsMatch(parser, "{}", NewNodeListInitExpression.Empty);
             AssertParser.SucceedsMatch(parser, "@2014-12-13T12:00:00+02:00", new ConstantExpression(P.DateTime.Parse("2014-12-13T12:00:00+02:00")));
             AssertParser.SucceedsMatch(parser, "78 'kg'", new ConstantExpression(new P.Quantity(78m, "kg")));
-            AssertParser.SucceedsMatch(parser, "10.1 'mg'", new ConstantExpression(new P.Quantity(10.1m, "mg")));
+            AssertParser.SucceedsMatch(parser, "10.1 'mg'", new ConstantExpression(new P.Quantity(10.1m, "mg"))); 
         }
 
         [TestMethod]
@@ -129,6 +129,7 @@ namespace Hl7.FhirPath.Tests
 
             AssertParser.SucceedsMatch(parser, "Patient.name.doSomething(true)",
                     new FunctionCallExpression(PATIENTNAME, "doSomething", TypeSpecifier.Any, new ConstantExpression(true)));
+            AssertParser.SucceedsMatch(parser, "\'ewout\'.indexOf(\'o\', 2)", new FunctionCallExpression(new ConstantExpression("ewout"), "indexOf", TypeSpecifier.Any, [new ConstantExpression("o"), new ConstantExpression(2)]));
 
             AssertParser.FailsMatch(parser, "Patient.");
             //AssertParser.FailsMatch(parser, "Patient. name");     //oops


### PR DESCRIPTION
## Description
Added FhirPath indexOf and lastIndexOf methods for collections in accordance with https://jira.hl7.org/browse/FHIR-32882?jql=text%20~%20%22indexOf%22

## Related issues
Closes #2761 

## Testing
Added unit tests to verify correct behaviour of the function