### PR TITLE
#2264 fixing language terminology support

### DIFF
--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/TerminologyServiceFactory.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/TerminologyServiceFactory.cs
@@ -48,7 +48,7 @@ namespace Hl7.Fhir.Specification.Terminology
                 }
             };
 
-            return new MultiTerminologyService(mimeTypeRoutingSettings, localTermRoutingSettings);
+            return new MultiTerminologyService(mimeTypeRoutingSettings, languageRoutingSettings, localTermRoutingSettings);
         }
 
     }


### PR DESCRIPTION
## Description
variable "languageRoutingSettings" has never been used 

## Related issues
Fixes issue #2264.

## Testing
Describe how this change was tested.