### PR TITLE
Fixed base url for FhirClient resources

### DIFF
--- a/src/Hl7.Fhir.Base/Rest/HttpContentParsers.cs
+++ b/src/Hl7.Fhir.Base/Rest/HttpContentParsers.cs
@@ -179,11 +179,11 @@ namespace Hl7.Fhir.Rest
             }
 
             // Sets the Resource.ResourceBase to the location given in the RequestUri of the response message.
-            if (result.BodyResource is not null && message.GetRequestUri()?.OriginalString is string location)
+            if (result.BodyResource is not null && (message.Headers.Location?.OriginalString ?? message.RequestMessage?.RequestUri?.OriginalString) is {} location)
             {
                 var ri = new ResourceIdentity(location);
                 result.BodyResource.ResourceBase = ri.HasBaseUri && ri.Form == ResourceIdentityForm.AbsoluteRestUrl
-                    ? ResourceIdentity.Build(ri.BaseUri, ri.ResourceType, ri.Id, ri.VersionId)
+                    ? ri.BaseUri
                     : new Uri(location, UriKind.Absolute);
             }
 

--- a/src/Hl7.Fhir.Base/Rest/HttpContentParsers.cs
+++ b/src/Hl7.Fhir.Base/Rest/HttpContentParsers.cs
@@ -179,7 +179,7 @@ namespace Hl7.Fhir.Rest
             }
 
             // Sets the Resource.ResourceBase to the location given in the RequestUri of the response message.
-            if (result.BodyResource is not null && (message.Headers.Location?.OriginalString ?? message.RequestMessage?.RequestUri?.OriginalString) is {} location)
+            if (result.BodyResource is not null && (message.Headers.Location?.OriginalString ?? message.GetRequestUri()?.OriginalString) is {} location)
             {
                 var ri = new ResourceIdentity(location);
                 result.BodyResource.ResourceBase = ri.HasBaseUri && ri.Form == ResourceIdentityForm.AbsoluteRestUrl

--- a/src/Hl7.Fhir.Base/Rest/ResourceIdentity.cs
+++ b/src/Hl7.Fhir.Base/Rest/ResourceIdentity.cs
@@ -298,7 +298,7 @@ namespace Hl7.Fhir.Rest
 
                 if (uri.IsAbsoluteUri)
                 {
-                    var baseUri = url.Substring(0, url.IndexOf("/" + ResourceType + "/")).EnsureEndsWith("/");
+                    var baseUri = url.Substring(0, url.IndexOf("/" + ResourceType + "/", StringComparison.Ordinal)).EnsureEndsWith("/");
                     BaseUri = new Uri(baseUri, UriKind.Absolute);
                 }
 

--- a/src/Hl7.Fhir.Support.Poco.Tests/Rest/FhirClientMockTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Rest/FhirClientMockTests.cs
@@ -123,14 +123,15 @@ namespace Hl7.Fhir.Core.Tests.Rest
                 RequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.com/Patient?name=henry"),
             };
 
-            response.Headers.Add("Location", "/fhir/*/Bundle/example");
+            response.Headers.Add("Location", "https://example.com/fhir/Bundle/example");
 
             using var client = new SubstituteBuilder()
                 .Send(response, h => h.RequestUri == new Uri("http://example.com/Patient?name=henry"))
                 .AsClient();
             var patient = await client.SearchAsync<Patient>(new string[] { "name=henry" });
 
-            client.LastResult!.Location.Should().Be("/fhir/*/Bundle/example");
+            client.LastResult!.Location.Should().Be("https://example.com/fhir/Bundle/example");
+            patient!.ResourceBase.Should().Be(new Uri("https://example.com/fhir/"));
         }
 
         [DataTestMethod]

--- a/src/Hl7.Fhir.Support.Poco.Tests/Rest/ResponseMessageTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Rest/ResponseMessageTests.cs
@@ -66,7 +66,7 @@ namespace Hl7.Fhir.Test
         }
 
         private const string DEFAULT_XML = "<Patient xmlns=\"http://hl7.org/fhir\"><active value=\"true\" /></Patient>";
-        private static readonly Uri REQUEST_URI = new("http://server.nl/fhir/SomeResource/1", UriKind.Absolute);
+        private static readonly Uri REQUEST_URI = new("http://server.nl/fhir/", UriKind.Absolute);
         private static HttpContent makeXmlContent(string? xml = null) =>
             new StringContent(xml ?? DEFAULT_XML, Encoding.UTF8, ContentType.XML_CONTENT_HEADER);
         private static HttpResponseMessage makeXmlMessage(HttpStatusCode status = HttpStatusCode.OK, string? xml = null) =>


### PR DESCRIPTION
## Description
ResourceBase in FhirClient resources should now correctly return the base url of the server (instead of some other URL)

## Related issues
Fixes #2795 

## Testing
Integration test against FS and some (changed) old tests