### PR TITLE
Removed decimal to string conversions that did not use invariant culture

### DIFF
--- a/src/Hl7.Fhir.Base/FhirPath/Expressions/EchoVisitor.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Expressions/EchoVisitor.cs
@@ -5,6 +5,8 @@
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
+
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -113,7 +115,7 @@ namespace Hl7.FhirPath.Expressions
                 case "Quantity":
                     if (expression.Value is P.Quantity q)
                     {
-                        _result.Append($"{q?.Value}");
+                        _result.Append(q.Value.ToString(CultureInfo.InvariantCulture));
                         OutputSubToken(expression.Unit);
                     }
                     else

--- a/src/Hl7.Fhir.Base/FhirPath/Parser/Grammar.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Parser/Grammar.cs
@@ -11,6 +11,7 @@ using Hl7.FhirPath.Expressions;
 using Hl7.FhirPath.Sprache;
 using P = Hl7.Fhir.ElementModel.Types;
 using System;
+using System.Globalization;
 using System.Linq;
 
 namespace Hl7.FhirPath.Parser
@@ -24,7 +25,8 @@ namespace Hl7.FhirPath.Parser
             // Note that quantities are always parsed with a unit, otherwise they would be an integer or decimal
             // and the +/- are unary operators and not a part of the quantity itself.
             var result = (
-                from val in Lexer.DecimalNumber.Select(n => $"{n}").Or(Lexer.IntegerNumber.Select(n => $"{n}")).Select(v => new SubToken(v)).Positioned()
+                from val in Lexer.DecimalNumber.Select(n => n.ToString(CultureInfo.InvariantCulture))
+                    .Or(Lexer.IntegerNumber.Select(n => n.ToString(CultureInfo.InvariantCulture))).Select(v => new SubToken(v)).Positioned()
                 from ws in WhitespaceOrComments()
                 from unit in Lexer.String.Select(u => $"'{u.Replace("'", "\\'")}'").Or(Lexer.Id).Select(v => new SubToken(v).WithLeadingWS(ws)).Positioned()
                 select (valToken: val, unitToken: unit)


### PR DESCRIPTION
The recent FhirPath PRs by @brianpos introduced a few conversions from decimal to string that did not use the invariant culture. Our build server misses these, as the build server is located in the US, but it does break when running the tests (and the SDK) on a non-US culture machine.

