### PR TITLE
ValueSet expander: excluding a code, shouldn't remove its children

### DIFF
--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/ValueSetExpander.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/ValueSetExpander.cs
@@ -322,7 +322,11 @@ namespace Hl7.Fhir.Specification.Terminology
 
         public static void Remove(this List<ValueSet.ContainsComponent> dest, string system, string code)
         {
+            var children = dest.Where(c => c.System == system && c.Code == code).SelectMany(c => c.Contains).ToList();
             dest.RemoveAll(c => c.System == system && c.Code == code);
+
+            //add children back to the list, they do not necessarily need to be removed when the parent is removed.
+            dest.AddRange(children);
 
             // Look for this code in children too
             foreach (var component in dest)
@@ -334,9 +338,15 @@ namespace Hl7.Fhir.Specification.Terminology
 
         public static void Remove(this List<ValueSet.ContainsComponent> dest, List<ValueSet.ContainsComponent> source)
         {
-            //TODO: Pretty unclear what to do with child concepts in the source - they all need to be removed from dest?
             foreach (var sourceConcept in source)
+            {
                 dest.Remove(sourceConcept.System, sourceConcept.Code);
+
+                //check if there are children that need to be removed too.
+                if (sourceConcept.Contains.Any())
+                    dest.Remove(sourceConcept.Contains);
+            }
+
         }
 
         internal static ValueSet.ContainsComponent ToContainsComponent(this CodeSystem.ConceptDefinitionComponent source, CodeSystem system, ValueSetExpanderSettings settings)


### PR DESCRIPTION
fixes #2792