### PR TITLE
Added CDS Hooks (de)serialization

### DIFF
--- a/src/Hl7.Fhir.Base/Model/CdsHooks/AccessToken.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/AccessToken.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+[CdsHookElement]
 public class Authorization
 {
     [JsonPropertyName("access_token")]

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/AccessToken.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/AccessToken.cs
@@ -4,15 +4,17 @@ using System.Text.Json.Serialization;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+[System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
 [CdsHookElement]
 public class Authorization
 {
-    [JsonPropertyName("access_token")]
-    public string? AccessToken { get; set; } // we need this naming for the deserialization
-    [JsonPropertyName("token_type")]
-    public string? TokenType { get; set; }
-    [JsonPropertyName("expires_in")]
-    public int? ExpiresIn { get; set; }
+    [JsonPropertyName("access_token")] public string? AccessToken { get; set; } // we need this naming for the deserialization
+    [JsonPropertyName("token_type")] public string? TokenType { get; set; }
+    [JsonPropertyName("expires_in")] public int? ExpiresIn { get; set; }
     public string? Scope { get; set; }
     public string? Subject { get; set; }
     public string? Patient { get; set; }

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/AccessToken.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/AccessToken.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+using System.Text.Json.Serialization;
+
+namespace Hl7.Fhir.Model.CdsHooks;
+
+public class Authorization
+{
+    [JsonPropertyName("access_token")]
+    public string? AccessToken { get; set; } // we need this naming for the deserialization
+    [JsonPropertyName("token_type")]
+    public string? TokenType { get; set; }
+    [JsonPropertyName("expires_in")]
+    public int? ExpiresIn { get; set; }
+    public string? Scope { get; set; }
+    public string? Subject { get; set; }
+    public string? Patient { get; set; }
+}

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Action.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Action.cs
@@ -4,6 +4,7 @@ using Hl7.Fhir.Model;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+[CdsHookElement]
 public class Action
 {
     public string? Type { get; set; }

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Action.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Action.cs
@@ -4,6 +4,11 @@ using Hl7.Fhir.Model;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+[System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
 [CdsHookElement]
 public class Action
 {

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Action.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Action.cs
@@ -1,0 +1,13 @@
+using Hl7.Fhir.Model;
+
+#nullable enable
+
+namespace Hl7.Fhir.Model.CdsHooks;
+
+public class Action
+{
+    public string? Type { get; set; }
+    public string? Description { get; set; }
+    public Resource? Resource { get; set; }
+    public string? Label { get; set; }
+}

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Card.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Card.cs
@@ -4,6 +4,11 @@ using System.Collections.Generic;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+[System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
 [CdsHookElement]
 public class Card
 {

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Card.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Card.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+[CdsHookElement]
 public class Card
 {
     public string? Uuid { get; set; }

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Card.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Card.cs
@@ -1,0 +1,18 @@
+#nullable enable
+using Hl7.Fhir.Model;
+using System.Collections.Generic;
+
+namespace Hl7.Fhir.Model.CdsHooks;
+
+public class Card
+{
+    public string? Uuid { get; set; }
+    public string? Summary { get; set; }
+    public string? Detail { get; set; }
+    public string? Indicator { get; set; }
+    public Source? Source { get; set; }
+    public List<Suggestion>? Suggestions { get; set; }
+    public string? SelectionBehavior { get; set; }
+    public List<Coding>? OverrideReasons { get; set; }
+    public List<Link>? Links { get; set; }
+}

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/CdsHookElementAttribute.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/CdsHookElementAttribute.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace Hl7.Fhir.Model.CdsHooks;
+
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class CdsHookElementAttribute() : Attribute;

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Context.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Context.cs
@@ -1,0 +1,15 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Hl7.Fhir.Model.CdsHooks;
+
+public class Context
+{
+    public string? UserId { get; set; }
+    public string? PatientId { get; set; }
+    public string? EncounterId { get; set; }
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? Fields { get; set; }
+}

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Context.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Context.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Serialization;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+[CdsHookElement]
 public class Context
 {
     public string? UserId { get; set; }

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Context.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Context.cs
@@ -5,12 +5,16 @@ using System.Text.Json.Serialization;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+[System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
 [CdsHookElement]
 public class Context
 {
     public string? UserId { get; set; }
     public string? PatientId { get; set; }
     public string? EncounterId { get; set; }
-    [JsonExtensionData]
-    public Dictionary<string, JsonElement>? Fields { get; set; }
+    [JsonExtensionData] public Dictionary<string, JsonElement>? Fields { get; set; }
 }

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/DiscoveryResponse.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/DiscoveryResponse.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Hl7.Fhir.Model.CdsHooks;
+
+public class DiscoveryResponse
+{
+    public List<Service>? Services { get; set; }
+}

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/DiscoveryResponse.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/DiscoveryResponse.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+[CdsHookElement]
 public class DiscoveryResponse
 {
     public List<Service>? Services { get; set; }

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/DiscoveryResponse.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/DiscoveryResponse.cs
@@ -4,6 +4,11 @@ using System.Collections.Generic;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+[System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
 [CdsHookElement]
 public class DiscoveryResponse
 {

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Feedback.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Feedback.cs
@@ -4,6 +4,7 @@ namespace Hl7.Fhir.Model.CdsHooks;
 
 #nullable enable
 
+[CdsHookElement]
 public class Feedback
 {
     public string? Card { get; set; }

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Feedback.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Feedback.cs
@@ -4,6 +4,11 @@ namespace Hl7.Fhir.Model.CdsHooks;
 
 #nullable enable
 
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+[System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
 [CdsHookElement]
 public class Feedback
 {

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Feedback.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Feedback.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Hl7.Fhir.Model.CdsHooks;
+
+#nullable enable
+
+public class Feedback
+{
+    public string? Card { get; set; }
+    public string? Outcome { get; set; }
+    public List<Identifier>? AcceptedSuggestions { get; set; }
+    public OverrideReason? OverrideReason { get; set; }
+    public string? OutcomeTimeStamp { get; set; }
+}

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Identifier.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Identifier.cs
@@ -1,6 +1,8 @@
 namespace Hl7.Fhir.Model.CdsHooks;
 
 #nullable enable
+
+[CdsHookElement]
 public class Identifier
 {
     public string? Id { get; set; }

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Identifier.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Identifier.cs
@@ -2,6 +2,11 @@ namespace Hl7.Fhir.Model.CdsHooks;
 
 #nullable enable
 
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+[System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
 [CdsHookElement]
 public class Identifier
 {

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Identifier.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Identifier.cs
@@ -1,0 +1,7 @@
+namespace Hl7.Fhir.Model.CdsHooks;
+
+#nullable enable
+public class Identifier
+{
+    public string? Id { get; set; }
+}

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Link.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Link.cs
@@ -4,6 +4,11 @@ using System;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+[System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
 [CdsHookElement]
 public class Link
 {

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Link.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Link.cs
@@ -1,0 +1,14 @@
+#nullable enable
+
+using System;
+
+namespace Hl7.Fhir.Model.CdsHooks;
+
+public class Link
+{
+    public string? Label { get; set; }
+    public Uri? Url { get; set; }
+    public string? Type { get; set; }
+    public string? AppContext { get; set; }
+    public bool? Autolaunchable { get; set; }
+}

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Link.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Link.cs
@@ -4,6 +4,7 @@ using System;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+[CdsHookElement]
 public class Link
 {
     public string? Label { get; set; }

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/OverrideReason.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/OverrideReason.cs
@@ -1,0 +1,6 @@
+namespace Hl7.Fhir.Model.CdsHooks;
+
+public class OverrideReason
+{
+    
+}

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/OverrideReason.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/OverrideReason.cs
@@ -1,6 +1,9 @@
+#nullable enable
+
 namespace Hl7.Fhir.Model.CdsHooks;
 
 public class OverrideReason
 {
-    
+    public Coding? Reason { get; set; }
+    public string? UserComment { get; set; }
 }

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/OverrideReason.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/OverrideReason.cs
@@ -2,6 +2,7 @@
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+[CdsHookElement]
 public class OverrideReason
 {
     public Coding? Reason { get; set; }

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/OverrideReason.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/OverrideReason.cs
@@ -2,6 +2,11 @@
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+[System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
 [CdsHookElement]
 public class OverrideReason
 {

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Request.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Request.cs
@@ -1,0 +1,17 @@
+#nullable enable
+using Hl7.Fhir.Model;
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Hl7.Fhir.Model.CdsHooks;
+
+public class Request
+{
+    public string? HookInstance { get; set; }
+    public Uri? FhirServer { get; set; }
+    public string? Hook { get; set; }
+    public Authorization? FhirAuthorization { get; set; }
+    public Context? Context { get; set; }
+    public Dictionary<string, Resource>? Prefetch { get; set; }
+}

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Request.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Request.cs
@@ -6,6 +6,11 @@ using System.Text.Json;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+[System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
 [CdsHookElement]
 public class Request
 {

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Request.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Request.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+[CdsHookElement]
 public class Request
 {
     public string? HookInstance { get; set; }

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Response.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Response.cs
@@ -1,0 +1,11 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Hl7.Fhir.Model.CdsHooks;
+
+public class Response
+{
+    public List<Card>? Cards { get; set; }
+    public List<Action>? SystemActions { get; set; }
+}

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Response.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Response.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+[CdsHookElement]
 public class Response
 {
     public List<Card>? Cards { get; set; }

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Response.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Response.cs
@@ -4,6 +4,11 @@ using System.Collections.Generic;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+[System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
 [CdsHookElement]
 public class Response
 {

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Service.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Service.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Hl7.Fhir.Model.CdsHooks;
+
+public class Service
+{
+    public string? Hook { get; set; }
+    public string? Title { get; set; }
+    public string? Description { get; set; }
+    public string? Id { get; set; }
+    public Dictionary<string, string>? Prefetch { get; set; }
+    public string? UsageRequirements { get; set; }
+}

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Service.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Service.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+[CdsHookElement]
 public class Service
 {
     public string? Hook { get; set; }

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Service.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Service.cs
@@ -4,6 +4,11 @@ using System.Collections.Generic;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+[System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
 [CdsHookElement]
 public class Service
 {

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Source.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Source.cs
@@ -5,6 +5,11 @@ using System;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+[System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
 [CdsHookElement]
 public class Source
 {

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Source.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Source.cs
@@ -1,0 +1,14 @@
+using Hl7.Fhir.Model;
+using System;
+
+#nullable enable
+
+namespace Hl7.Fhir.Model.CdsHooks;
+
+public class Source
+{
+    public string? Label { get; set; }
+    public Uri? Url { get; set; }
+    public Uri? Icon { get; set; }
+    public Coding? Coding { get; set; }
+}

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Source.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Source.cs
@@ -5,6 +5,7 @@ using System;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+[CdsHookElement]
 public class Source
 {
     public string? Label { get; set; }

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Suggestion.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Suggestion.cs
@@ -4,6 +4,11 @@ using System.Collections.Generic;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+[System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
 [CdsHookElement]
 public class Suggestion
 {

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Suggestion.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Suggestion.cs
@@ -1,0 +1,13 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Hl7.Fhir.Model.CdsHooks;
+
+public class Suggestion
+{
+    public string? Label { get; set; }
+    public string? Uuid { get; set; }
+    public bool IsRecommended { get; set; }
+    public List<Action>? Actions { get; set; }
+}

--- a/src/Hl7.Fhir.Base/Model/CdsHooks/Suggestion.cs
+++ b/src/Hl7.Fhir.Base/Model/CdsHooks/Suggestion.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 
 namespace Hl7.Fhir.Model.CdsHooks;
 
+[CdsHookElement]
 public class Suggestion
 {
     public string? Label { get; set; }

--- a/src/Hl7.Fhir.Base/Serialization/JsonSerializerOptionsExtensions.cs
+++ b/src/Hl7.Fhir.Base/Serialization/JsonSerializerOptionsExtensions.cs
@@ -1,7 +1,7 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2021, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
- * 
+ *
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
@@ -33,13 +33,26 @@ namespace Hl7.Fhir.Serialization
         /// <summary>
         /// Initialize the options to serialize using the CDS Hooks specific (de)serializers. Note that this also adds the FHIR specific converters, since FHIR is expected in the CDS Hooks messages.
         /// </summary>
-        public static JsonSerializerOptions ForCdsHooks(this JsonSerializerOptions options, ModelInspector inspector, FhirJsonPocoSerializerSettings? serializerSettings = null, FhirJsonPocoDeserializerSettings? deserializerSettings = null) => 
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+        [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
+        public static JsonSerializerOptions ForCdsHooks(this JsonSerializerOptions options, ModelInspector inspector, FhirJsonPocoSerializerSettings? serializerSettings = null,
+            FhirJsonPocoDeserializerSettings? deserializerSettings = null) =>
             options.ForFhir(inspector, serializerSettings ?? new FhirJsonPocoSerializerSettings(), deserializerSettings ?? new FhirJsonPocoDeserializerSettings()).addCdsHooks();
 
+
         /// <inheritdoc cref="ForCdsHooks(JsonSerializerOptions, ModelInspector, FhirJsonPocoSerializerSettings, FhirJsonPocoDeserializerSettings)"/>
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+        [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
         public static JsonSerializerOptions ForCdsHooks(this JsonSerializerOptions options, Assembly modelAssembly, FhirJsonPocoSerializerSettings? serializerSettings = null,
-            FhirJsonPocoDeserializerSettings? deserializerSettings = null) => 
-            options.ForFhir(modelAssembly, serializerSettings ?? new FhirJsonPocoSerializerSettings(), deserializerSettings ?? new FhirJsonPocoDeserializerSettings()).addCdsHooks();
+            FhirJsonPocoDeserializerSettings? deserializerSettings = null) =>
+            options.ForFhir(modelAssembly, serializerSettings ?? new FhirJsonPocoSerializerSettings(), deserializerSettings ?? new FhirJsonPocoDeserializerSettings())
+                .addCdsHooks();
 
         private static JsonSerializerOptions addCdsHooks(this JsonSerializerOptions options)
         {
@@ -50,12 +63,12 @@ namespace Hl7.Fhir.Serialization
             static void changeCdsHookPropertyNames(JsonTypeInfo ti)
             {
                 if (ti.Type.GetCustomAttribute<CdsHookElementAttribute>() is null) return;
-                
-                foreach (var p in ti.Properties) 
+
+                foreach (var p in ti.Properties)
                     p.Name = char.ToLower(p.Name.First()) + p.Name.Substring(1);
             }
         }
-        
+
         /// <summary>
         /// Initialize the options to serialize using the JsonFhirConverter, producing compact output without whitespace.
         /// </summary>
@@ -68,15 +81,15 @@ namespace Hl7.Fhir.Serialization
 
         /// <inheritdoc cref="ForFhir(JsonSerializerOptions, Assembly)"/>
         public static JsonSerializerOptions ForFhir(this JsonSerializerOptions options, Assembly modelAssembly, FhirJsonPocoDeserializerSettings deserializerSettings) =>
-        options.ForFhir(modelAssembly, new(), deserializerSettings);
+            options.ForFhir(modelAssembly, new(), deserializerSettings);
 
         /// <inheritdoc cref="ForFhir(JsonSerializerOptions, Assembly)"/>
         public static JsonSerializerOptions ForFhir(
-                this JsonSerializerOptions options,
-                Assembly modelAssembly,
-                FhirJsonPocoSerializerSettings serializerSettings,
-                FhirJsonPocoDeserializerSettings deserializerSettings
-                )
+            this JsonSerializerOptions options,
+            Assembly modelAssembly,
+            FhirJsonPocoSerializerSettings serializerSettings,
+            FhirJsonPocoDeserializerSettings deserializerSettings
+        )
         {
             var converter = new FhirJsonConverterFactory(modelAssembly, serializerSettings, deserializerSettings);
             return options.ForFhir(converter);
@@ -95,11 +108,11 @@ namespace Hl7.Fhir.Serialization
 
         /// <inheritdoc cref="ForFhir(JsonSerializerOptions, Assembly)"/>
         public static JsonSerializerOptions ForFhir(
-                this JsonSerializerOptions options,
-                ModelInspector inspector,
-                FhirJsonPocoSerializerSettings serializerSettings,
-                FhirJsonPocoDeserializerSettings deserializerSettings
-                )
+            this JsonSerializerOptions options,
+            ModelInspector inspector,
+            FhirJsonPocoSerializerSettings serializerSettings,
+            FhirJsonPocoDeserializerSettings deserializerSettings
+        )
         {
             var converter = new FhirJsonConverterFactory(inspector, serializerSettings, deserializerSettings);
             return options.ForFhir(converter);
@@ -126,7 +139,7 @@ namespace Hl7.Fhir.Serialization
 
             return options;
         }
-        
+
         /// <summary>
         /// Modify the options to use a preset list of errors to ignore by specifying a mode. This can be any member of <see cref="DeserializerModes"/>
         /// </summary>
@@ -205,17 +218,20 @@ namespace Hl7.Fhir.Serialization
         /// Do not ignore any errors (default behaviour for most implementations)
         /// </summary>
         Strict,
+
         /// <summary>
         /// An issue is recoverable if all data present in the parsed data could be retrieved and
         /// captured in the POCO model, even if the syntax or the data was not fully FHIR compliant.
         /// </summary>
         Recoverable,
+
         /// <summary>
         /// An issue is allowable for backwards compatibility if it could be caused because an older parser encounters data coming from a newer 
         /// FHIR release. This means allowing unknown elements, attributes, codes and types in a choice element. Note that the POCO model cannot capture
         /// these newer elements and data, so this means data loss may occur.
         /// </summary>
         BackwardsCompatible,
+
         /// <summary>
         /// Ignore all errors. Useful for debugging and/or when you know the data to be parsed is a correct instance.
         /// </summary>

--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/FallbackTerminologyService.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/FallbackTerminologyService.cs
@@ -70,7 +70,8 @@ namespace Hl7.Fhir.Specification.Terminology
 
         /// <inheritdoc/>
         public Task<Parameters> ValueSetValidateCode(Parameters parameters, string? id = null, bool useGet = false) =>
-            tryFallback((s, p) => s.ValueSetValidateCode(p, id, useGet), parameters);
+            tryFallback((s, p) => s.
+                ValueSetValidateCode(p, id, useGet), parameters);
 
         /// <inheritdoc/>
         public Task<Parameters> CodeSystemValidateCode(Parameters parameters, string? id = null, bool useGet = false) =>

--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/FallbackTerminologyService.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/FallbackTerminologyService.cs
@@ -70,8 +70,7 @@ namespace Hl7.Fhir.Specification.Terminology
 
         /// <inheritdoc/>
         public Task<Parameters> ValueSetValidateCode(Parameters parameters, string? id = null, bool useGet = false) =>
-            tryFallback((s, p) => s.
-                ValueSetValidateCode(p, id, useGet), parameters);
+            tryFallback((s, p) => s.ValueSetValidateCode(p, id, useGet), parameters);
 
         /// <inheritdoc/>
         public Task<Parameters> CodeSystemValidateCode(Parameters parameters, string? id = null, bool useGet = false) =>

--- a/src/Hl7.Fhir.Shims.STU3AndUp/Serialization/JsonSerializationOptionsExtensions.cs
+++ b/src/Hl7.Fhir.Shims.STU3AndUp/Serialization/JsonSerializationOptionsExtensions.cs
@@ -1,7 +1,7 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2021, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
- * 
+ *
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
@@ -10,7 +10,6 @@
 
 #if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
 
-using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
 using System.Text.Json;
 
@@ -26,13 +25,20 @@ namespace Hl7.Fhir.Serialization
         /// Initialize the options to serialize using the JsonFhirConverter, producing compact output without whitespace.
         /// </summary>
         public static JsonSerializerOptions ForFhir(this JsonSerializerOptions options) => options.ForFhir(ModelInfo.ModelInspector);
-        
+
         /// <summary>
         /// Initialize the options to serialize using the CDS Hooks specific (de)serializers. Note that this also adds the FHIR specific converters, since FHIR is expected in the CDS Hooks messages.
         /// </summary>
-        public static JsonSerializerOptions ForCdsHooks(this JsonSerializerOptions options, FhirJsonPocoSerializerSettings? serializerSettings = null, FhirJsonPocoDeserializerSettings? deserializerSettings = null) => 
-            options.ForCdsHooks(ModelInfo.ModelInspector, serializerSettings ?? new FhirJsonPocoSerializerSettings(), deserializerSettings ?? new FhirJsonPocoDeserializerSettings());      
-        
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+        [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
+        public static JsonSerializerOptions ForCdsHooks(this JsonSerializerOptions options, FhirJsonPocoSerializerSettings? serializerSettings = null,
+            FhirJsonPocoDeserializerSettings? deserializerSettings = null) =>
+            options.ForCdsHooks(ModelInfo.ModelInspector, serializerSettings ?? new FhirJsonPocoSerializerSettings(),
+                deserializerSettings ?? new FhirJsonPocoDeserializerSettings());
+
         /// <inheritdoc cref="ForFhir(JsonSerializerOptions)"/>
         public static JsonSerializerOptions ForFhir(
             this JsonSerializerOptions options,

--- a/src/Hl7.Fhir.Shims.STU3AndUp/Serialization/JsonSerializationOptionsExtensions.cs
+++ b/src/Hl7.Fhir.Shims.STU3AndUp/Serialization/JsonSerializationOptionsExtensions.cs
@@ -10,6 +10,7 @@
 
 #if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
 
+using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
 using System.Text.Json;
 
@@ -25,7 +26,13 @@ namespace Hl7.Fhir.Serialization
         /// Initialize the options to serialize using the JsonFhirConverter, producing compact output without whitespace.
         /// </summary>
         public static JsonSerializerOptions ForFhir(this JsonSerializerOptions options) => options.ForFhir(ModelInfo.ModelInspector);
-
+        
+        /// <summary>
+        /// Initialize the options to serialize using the CDS Hooks specific (de)serializers. Note that this also adds the FHIR specific converters, since FHIR is expected in the CDS Hooks messages.
+        /// </summary>
+        public static JsonSerializerOptions ForCdsHooks(this JsonSerializerOptions options, FhirJsonPocoSerializerSettings? serializerSettings = null, FhirJsonPocoDeserializerSettings? deserializerSettings = null) => 
+            options.ForCdsHooks(ModelInfo.ModelInspector, serializerSettings ?? new FhirJsonPocoSerializerSettings(), deserializerSettings ?? new FhirJsonPocoDeserializerSettings());      
+        
         /// <inheritdoc cref="ForFhir(JsonSerializerOptions)"/>
         public static JsonSerializerOptions ForFhir(
             this JsonSerializerOptions options,

--- a/src/Hl7.Fhir.Support.Poco.Tests/CdsHooks/CdsHooksDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/CdsHooks/CdsHooksDeserializationTests.cs
@@ -2,6 +2,7 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Model.CdsHooks;
 using Hl7.Fhir.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Hl7.Fhir.Support.Poco.Tests.CdsHooks;
@@ -9,7 +10,8 @@ namespace Hl7.Fhir.Support.Poco.Tests.CdsHooks;
 [TestClass]
 public class CdsHooksDeserializationTests
 {
-    [TestMethod] 
+    [TestMethod]
+    [Experimental("ExperimentalApi")]
     public void CdsHookList_Deserialize()
     {
         var json = """
@@ -72,6 +74,7 @@ public class CdsHooksDeserializationTests
     }
 
     [TestMethod]
+    [Experimental("ExperimentalApi")]
     public void CdsHookWithResource_Deserialize()
     {
         var json = """
@@ -125,6 +128,7 @@ public class CdsHooksDeserializationTests
     }
 
     [TestMethod]
+    [Experimental("ExperimentalApi")]
     public void CdsHookWithUnderscoreProperties_Deserialize()
     {
         var json = """
@@ -150,6 +154,7 @@ public class CdsHooksDeserializationTests
     }
 
     [TestMethod]
+    [Experimental("ExperimentalApi")]
     public void CdsHookCombined_Deserialize()
     {
         var json = """

--- a/src/Hl7.Fhir.Support.Poco.Tests/CdsHooks/CdsHooksDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/CdsHooks/CdsHooksDeserializationTests.cs
@@ -44,7 +44,7 @@ public class CdsHooksDeserializationTests
                      ]
                    }
                    """;
-        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }.ForFhir();
+        var options = new JsonSerializerOptions().ForCdsHooks();
         var result = JsonSerializer.Deserialize<DiscoveryResponse>(json, options);
         Assert.IsNotNull(result);
         Assert.IsNotNull(result.Services);
@@ -102,7 +102,7 @@ public class CdsHooksDeserializationTests
                      }
                    }
                    """;
-        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }.ForFhir();
+        var options = new JsonSerializerOptions().ForCdsHooks();
         var result = JsonSerializer.Deserialize<Request>(json, options);
         Assert.IsNotNull(result);
         Assert.AreEqual("d1577c69-dfbe-44ad-ba6d-3e05e953b2ea", result.HookInstance);
@@ -138,7 +138,7 @@ public class CdsHooksDeserializationTests
                      }
                    }
                    """;
-        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }.ForFhir();
+        var options = new JsonSerializerOptions().ForCdsHooks();
         var result = JsonSerializer.Deserialize<Request>(json, options);
         Assert.IsNotNull(result);
         Assert.IsNotNull(result.FhirAuthorization);
@@ -218,7 +218,7 @@ public class CdsHooksDeserializationTests
                      }
                    }
                    """;
-        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }.ForFhir();
+        var options = new JsonSerializerOptions().ForCdsHooks();
         var result = JsonSerializer.Deserialize<Request>(json, options);
 
         // Validate hookInstance
@@ -260,7 +260,7 @@ public class CdsHooksDeserializationTests
 
     private Resource getResourceFromJson(string json)
     {
-        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }.ForFhir();
+        var options = new JsonSerializerOptions().ForFhir();
         return JsonSerializer.Deserialize<Resource>(json, options);
     }
 }

--- a/src/Hl7.Fhir.Support.Poco.Tests/CdsHooks/CdsHooksDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/CdsHooks/CdsHooksDeserializationTests.cs
@@ -1,0 +1,266 @@
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Model.CdsHooks;
+using Hl7.Fhir.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+
+namespace Hl7.Fhir.Support.Poco.Tests.CdsHooks;
+
+[TestClass]
+public class CdsHooksDeserializationTests
+{
+    [TestMethod] 
+    public void CdsHookList_Deserialize()
+    {
+        var json = """
+                   {
+                     "services": [
+                       {
+                         "hook": "patient-view",
+                         "title": "Static CDS Service Example",
+                         "description": "An example of a CDS Service that returns a static set of cards",
+                         "id": "static-patient-greeter",
+                         "prefetch": {
+                           "patientToGreet": "Patient/{{context.patientId}}"
+                         }
+                       },
+                       {
+                         "hook": "order-select",
+                         "title": "Order Echo CDS Service",
+                         "description": "An example of a CDS Service that simply echoes the order(s) being placed",
+                         "id": "order-echo",
+                         "prefetch": {
+                           "patient": "Patient/{{context.patientId}}",
+                           "medications": "MedicationRequest?patient={{context.patientId}}"
+                         }
+                       },
+                       {
+                         "hook": "order-sign",
+                         "title": "Pharmacogenomics CDS Service",
+                         "description": "An example of a more advanced, precision medicine CDS Service",
+                         "id": "pgx-on-order-sign",
+                         "usageRequirements": "Note: functionality of this CDS Service is degraded without access to a FHIR Restful API as part of CDS recommendation generation."
+                       }
+                     ]
+                   }
+                   """;
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }.ForFhir();
+        var result = JsonSerializer.Deserialize<DiscoveryResponse>(json, options);
+        Assert.IsNotNull(result);
+        Assert.IsNotNull(result.Services);
+        Assert.AreEqual(3, result.Services.Count);
+        Assert.AreEqual("patient-view", result.Services[0].Hook);
+        Assert.AreEqual("Static CDS Service Example", result.Services[0].Title);
+        Assert.AreEqual("An example of a CDS Service that returns a static set of cards", result.Services[0].Description);
+        Assert.AreEqual("static-patient-greeter", result.Services[0].Id);
+        Assert.IsNotNull(result.Services[0].Prefetch);
+        Assert.AreEqual(1, result.Services[0].Prefetch.Count);
+        Assert.AreEqual("Patient/{{context.patientId}}", result.Services[0].Prefetch["patientToGreet"]);
+        Assert.AreEqual("order-select", result.Services[1].Hook);
+        Assert.AreEqual("Order Echo CDS Service", result.Services[1].Title);
+        Assert.AreEqual("An example of a CDS Service that simply echoes the order(s) being placed", result.Services[1].Description);
+        Assert.AreEqual("order-echo", result.Services[1].Id);
+        Assert.IsNotNull(result.Services[1].Prefetch);
+        Assert.AreEqual(2, result.Services[1].Prefetch.Count);
+        Assert.AreEqual("Patient/{{context.patientId}}", result.Services[1].Prefetch["patient"]);
+        Assert.AreEqual("MedicationRequest?patient={{context.patientId}}", result.Services[1].Prefetch["medications"]);
+        Assert.AreEqual("order-sign", result.Services[2].Hook);
+        Assert.AreEqual("Pharmacogenomics CDS Service", result.Services[2].Title);
+        Assert.AreEqual("An example of a more advanced, precision medicine CDS Service", result.Services[2].Description);
+        Assert.AreEqual("pgx-on-order-sign", result.Services[2].Id);
+        Assert.AreEqual("Note: functionality of this CDS Service is degraded without access to a FHIR Restful API as part of CDS recommendation generation.", result.Services[2].UsageRequirements);
+    }
+
+    [TestMethod]
+    public void CdsHookWithResource_Deserialize()
+    {
+        var json = """
+                   {
+                     "hookInstance": "d1577c69-dfbe-44ad-ba6d-3e05e953b2ea",
+                     "fhirServer": "http://hooks.smarthealthit.org:9080",
+                     "hook": "patient-view",
+                     "fhirAuthorization": {
+                       "access_token": "some-opaque-fhir-access-token",
+                       "token_type": "Bearer",
+                       "expires_in": 300,
+                       "scope": "user/Patient.read user/Observation.read",
+                       "subject": "cds-service4"
+                     },
+                     "context": {
+                       "userId": "Practitioner/example",
+                       "patientId": "1288992",
+                       "encounterId": "89284"
+                     },
+                     "prefetch": {
+                       "patientToGreet": {
+                         "resourceType": "Patient",
+                         "gender": "male",
+                         "birthDate": "1925-12-23",
+                         "id": "1288992",
+                         "active": true
+                       }
+                     }
+                   }
+                   """;
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }.ForFhir();
+        var result = JsonSerializer.Deserialize<Request>(json, options);
+        Assert.IsNotNull(result);
+        Assert.AreEqual("d1577c69-dfbe-44ad-ba6d-3e05e953b2ea", result.HookInstance);
+        Assert.AreEqual("http://hooks.smarthealthit.org:9080/", result.FhirServer?.ToString());
+        Assert.AreEqual("patient-view", result.Hook);
+        Assert.IsNotNull(result.FhirAuthorization);
+        Assert.IsNotNull(result.Context);
+        Assert.IsNotNull(result.Prefetch);
+        Assert.AreEqual(1, result.Prefetch.Count);
+        var patientJson = """
+                          {
+                            "resourceType": "Patient",
+                            "gender": "male",
+                            "birthDate": "1925-12-23",
+                            "id": "1288992",
+                            "active": true
+                          }
+                          """;
+        Assert.IsTrue(result.Prefetch["patientToGreet"].IsExactly(getResourceFromJson(patientJson)));
+    }
+
+    [TestMethod]
+    public void CdsHookWithUnderscoreProperties_Deserialize()
+    {
+        var json = """
+                   {
+                     "fhirAuthorization": {
+                       "access_token": "some-opaque-fhir-access-token",
+                       "token_type": "Bearer",
+                       "expires_in": 300,
+                       "scope": "user/Patient.read user/Observation.read",
+                       "subject": "cds-service4"
+                     }
+                   }
+                   """;
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }.ForFhir();
+        var result = JsonSerializer.Deserialize<Request>(json, options);
+        Assert.IsNotNull(result);
+        Assert.IsNotNull(result.FhirAuthorization);
+        Assert.AreEqual("some-opaque-fhir-access-token", result.FhirAuthorization.AccessToken);
+        Assert.AreEqual("Bearer", result.FhirAuthorization.TokenType);
+        Assert.AreEqual(300, result.FhirAuthorization.ExpiresIn);
+        Assert.AreEqual("user/Patient.read user/Observation.read", result.FhirAuthorization.Scope);
+        Assert.AreEqual("cds-service4", result.FhirAuthorization.Subject);
+    }
+
+    [TestMethod]
+    public void CdsHookCombined_Deserialize()
+    {
+        var json = """
+                   {
+                     "hookInstance": "d1577c69-dfbe-44ad-ba6d-3e05e953b2ea",
+                     "fhirServer": "http://fhir.example.com",
+                     "hook": "order-sign",
+                     "context": {
+                       "userId": "Practitioner/example",
+                       "medications": [
+                         {
+                           "resourceType": "MedicationOrder",
+                           "id": "medrx001",
+                           "dateWritten": "2017-05-05",
+                           "status": "draft",
+                           "patient": {
+                             "reference": "Patient/example"
+                           },
+                           "medicationCodeableConcept": {
+                             "coding": [
+                               {
+                                 "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                                 "code": "857001",
+                                 "display": "Acetaminophen 325 MG / Hydrocodone Bitartrate 10 MG Oral Tablet"
+                               }
+                             ]
+                           },
+                           "dosageInstruction": [
+                             {
+                               "text": "Take 1 tablet Oral every 4 hours as needed",
+                               "timing": {
+                                 "repeat": {
+                                   "frequency": 6,
+                                   "frequencyMax": 6,
+                                   "period": 1,
+                                   "unit": "d"
+                                 }
+                               },
+                               "asNeededBoolean": true,
+                               "doseQuantity": {
+                                 "value": 10,
+                                 "unit": "mg",
+                                 "system": "http://unitsofmeasure.org",
+                                 "code": "mg"
+                               }
+                             }
+                           ]
+                         }
+                       ],
+                       "patientId": "1288992"
+                     },
+                     "prefetch": {
+                       "patient": {
+                            "resourceType": "Patient",
+                            "id": "1288992",
+                            "active": true,
+                            "name": [
+                            {
+                                "family": "Shaw",
+                                "given": [
+                                "Amy"
+                                ]
+                            }
+                            ]
+                        }
+                     }
+                   }
+                   """;
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }.ForFhir();
+        var result = JsonSerializer.Deserialize<Request>(json, options);
+
+        // Validate hookInstance
+        Assert.IsNotNull(result);
+        Assert.AreEqual("d1577c69-dfbe-44ad-ba6d-3e05e953b2ea", result.HookInstance);
+
+        // Validate fhirServer
+        Assert.AreEqual("http://fhir.example.com/", result.FhirServer?.ToString());
+
+        // Validate hook
+        Assert.AreEqual("order-sign", result.Hook);
+
+        // Validate context
+        Assert.IsNotNull(result.Context);
+        Assert.AreEqual("Practitioner/example", result.Context.UserId);
+        Assert.AreEqual("1288992", result.Context.PatientId);
+        Assert.IsNotNull(result.Context.Fields); // we cannot explore this (yet), since we do not know its type
+
+        // Validate prefetch
+        Assert.IsNotNull(result.Prefetch);
+        Assert.IsNotNull(result.Prefetch["patient"]);
+        var resourceJson = """
+                           {
+                               "resourceType": "Patient",
+                               "id": "1288992",
+                               "active": true,
+                               "name": [
+                               {
+                                   "family": "Shaw",
+                                   "given": [
+                                   "Amy"
+                                   ]
+                               }
+                               ]
+                           }
+                           """;
+        Assert.IsTrue(result.Prefetch["patient"].IsExactly(getResourceFromJson(resourceJson)));
+    }
+
+    private Resource getResourceFromJson(string json)
+    {
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }.ForFhir();
+        return JsonSerializer.Deserialize<Resource>(json, options);
+    }
+}

--- a/src/Hl7.Fhir.Support.Poco.Tests/CdsHooks/CdsHooksSerializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/CdsHooks/CdsHooksSerializationTests.cs
@@ -5,6 +5,7 @@ using Hl7.Fhir.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -40,11 +41,11 @@ public class CdsHooksSerializationTests
             }
         };
 
-        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull }.ForFhir().Compact();
+        var options = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull }.ForCdsHooks().Compact();
         var json = JsonSerializer.Serialize(request, options);
 
         var expectedJson = """{"hookInstance":"d1577c69-dfbe-44ad-ba6d-3e05e953b2ea","fhirServer":"http://fhir.example.com","hook":"order-sign","context":{"userId":"Practitioner/example","patientId":"1288992"},"prefetch":{"patient":{"resourceType":"Patient","id":"1288992","active":true,"name":[{"family":"Shaw","given":["Amy"]}]}}}""";
 
-        expectedJson.Should().BeEquivalentTo(json);
+        expectedJson.Should().BeOneOf([json]);
     }
 }

--- a/src/Hl7.Fhir.Support.Poco.Tests/CdsHooks/CdsHooksSerializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/CdsHooks/CdsHooksSerializationTests.cs
@@ -5,6 +5,7 @@ using Hl7.Fhir.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -15,6 +16,7 @@ namespace Hl7.Fhir.Support.Poco.Tests.CdsHooks;
 public class CdsHooksSerializationTests
 {
     [TestMethod]
+    [Experimental("ExperimentalApi")]
     public void CdsHookCombined_Serialize()
     {
         var request = new Request

--- a/src/Hl7.Fhir.Support.Poco.Tests/CdsHooks/CdsHooksSerializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/CdsHooks/CdsHooksSerializationTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Model.CdsHooks;
+using Hl7.Fhir.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Hl7.Fhir.Support.Poco.Tests.CdsHooks;
+
+[TestClass]
+public class CdsHooksSerializationTests
+{
+    [TestMethod]
+    public void CdsHookCombined_Serialize()
+    {
+        var request = new Request
+        {
+            HookInstance = "d1577c69-dfbe-44ad-ba6d-3e05e953b2ea",
+            FhirServer = new Uri("http://fhir.example.com"),
+            Hook = "order-sign",
+            Context = new Context
+            {
+                UserId = "Practitioner/example",
+                PatientId = "1288992"
+            },
+            Prefetch = new Dictionary<string, Resource>
+            {
+                {
+                    "patient",
+                    new Patient
+                    {
+                        Id = "1288992",
+                        Active = true,
+                        Name = new List<HumanName> { new HumanName { Family = "Shaw", Given = new List<string> { "Amy" } } }
+                    }
+                }
+            }
+        };
+
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull }.ForFhir().Compact();
+        var json = JsonSerializer.Serialize(request, options);
+
+        var expectedJson = """{"hookInstance":"d1577c69-dfbe-44ad-ba6d-3e05e953b2ea","fhirServer":"http://fhir.example.com","hook":"order-sign","context":{"userId":"Practitioner/example","patientId":"1288992"},"prefetch":{"patient":{"resourceType":"Patient","id":"1288992","active":true,"name":[{"family":"Shaw","given":["Amy"]}]}}}""";
+
+        expectedJson.Should().BeEquivalentTo(json);
+    }
+}


### PR DESCRIPTION
## Description
Added support for serialization and deserialization of CDS Hooks (according to https://cds-hooks.hl7.org) using the .ForCdsHooks extension method on the JsonSerializerOptions object.

## Testing
Examples from the CDS hooks specification. Feel free to add more.