### PR TITLE
Add serialization engine extensions allow for arbitrary stream writers and reader

### DIFF
--- a/src/Hl7.Fhir.Base/Serialization/engine/IFhirSerializationEngine.cs
+++ b/src/Hl7.Fhir.Base/Serialization/engine/IFhirSerializationEngine.cs
@@ -10,6 +10,10 @@
 #nullable enable
 
 using Hl7.Fhir.Model;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Xml;
 
 namespace Hl7.Fhir.Serialization
 {
@@ -41,6 +45,71 @@ namespace Hl7.Fhir.Serialization
         /// Serialize a FHIR Resource POCO into a string of Xml.
         /// </summary>
         public string SerializeToXml(Resource instance);
+    }
+    
+    /// <summary>
+    /// Extension methods for the <see cref="IFhirSerializationEngine"/> interface when the underlying engine is NOT a legacy engine.
+    /// </summary>
+    public static class SerializationEngineExtensions
+    {
+        /// <summary>
+        /// Deserialize a FHIR Resource from a JSON reader.
+        /// </summary>
+        /// <returns>The resource, or null if the operation failed</returns>
+        /// <exception cref="InvalidOperationException">Thrown if the underlying engine is a legacy engine</exception>
+        /// <exception cref="DeserializationFailedException">Thrown if a FHIR error was encountered in the data</exception>
+        public static Resource? SerializeReaderToJson(this IFhirSerializationEngine engine, ref Utf8JsonReader reader)
+        {
+            if (engine is not PocoSerializationEngine pse)
+            {
+                throw new InvalidOperationException("stream reading is not supported by legacy engines");
+            }
+            
+            return pse.DeserializeFromJson(ref reader);
+        }
+
+        /// <summary>
+        /// Deserialize a FHIR Resource from an XML reader.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if the underlying engine is a legacy engine</exception>
+        /// <exception cref="DeserializationFailedException">Thrown if a FHIR error was encountered in the data</exception>
+        public static Resource? SerializeReaderToXml(this IFhirSerializationEngine engine, XmlReader reader)
+        {
+            if (engine is not PocoSerializationEngine pse)
+            {
+                throw new InvalidOperationException("stream reading is not supported by legacy engines");
+            }
+            
+            return pse.DeserializeFromXml(reader);
+        }
+        
+        /// <summary>
+        /// Serialize a FHIR Resource to a JSON writer.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
+        public static void SerializeToJsonWriter(this IFhirSerializationEngine engine, Resource instance, Utf8JsonWriter writer)
+        {
+            if (engine is not PocoSerializationEngine pse)
+            {
+                throw new InvalidOperationException("stream writing is not supported by legacy engines");
+            }
+            
+            pse.SerializeToJsonWriter(instance, writer);
+        }
+        
+        /// <summary>
+        /// Serialize a FHIR Resource to an XML writer.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if the underlying engine is a legacy engine</exception>
+        public static void SerializeToXmlWriter(this IFhirSerializationEngine engine, Resource instance, XmlWriter writer)
+        {
+            if (engine is not PocoSerializationEngine pse)
+            {
+                throw new InvalidOperationException("stream writing is not supported by legacy engines");
+            }
+            
+            pse.SerializeToXmlWriter(instance, writer);
+        }
     }
 }
 

--- a/src/Hl7.Fhir.Base/Serialization/engine/PocoSerializationEngine_Xml.cs
+++ b/src/Hl7.Fhir.Base/Serialization/engine/PocoSerializationEngine_Xml.cs
@@ -64,4 +64,11 @@ internal partial class PocoSerializationEngine
             return (instance, issues);
         });
     }
+    
+    /// <summary>
+    /// Serializes an element to the supplied writer
+    /// </summary>
+    /// <param name="instance">An instance of Base or any of its children</param>
+    /// <param name="writer">The XML writer</param>
+    public void SerializeToXmlWriter(Base instance, XmlWriter writer) => getXmlSerializer().Serialize(instance, writer);
 }


### PR DESCRIPTION
## Description
The serialization engine class was supposed to be the wonder kid that could do anything, but unfortunately it was not. It took strings and processed them only if they were perfectly formatted for our use case. Normally, System.Text.Json would give us the correct tokens even if the starting JSON was not perfect, but in reality, our own teams wanted to use the serialization engine for permissive parsing as well. I decided to expose a small chunk of our internal PocoSerializationEngine class to the public in the shape of extension methods which allow for arbitrary stream writers and readers to be given to the methods.

Since these methods are not supposed to work on legacy engines, attempting to call them while using a legacy engine will throw an InvalidOperationException. This seemed like an acceptable compromise as opposed to exposing and maintaining our Poco engine API.

## Related issues
workaround for #2823 and #2824