### PR TITLE
FS location issue fix

### DIFF
--- a/src/Hl7.Fhir.Base/ElementModel/TypedElementOnSourceNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/TypedElementOnSourceNode.cs
@@ -33,7 +33,7 @@ namespace Hl7.Fhir.ElementModel
             if (source is IExceptionSource ies && ies.ExceptionHandler == null)
                 ies.ExceptionHandler = (o, a) => ExceptionHandler.NotifyOrThrow(o, a);
 
-            Location = source.Name;
+            Location = source.Location;
             ShortPath = source.Name;
             _source = source;
             (InstanceType, Definition) = buildRootPosition(type);


### PR DESCRIPTION
## Description
Fixes the location issue that FS was encountering. A source node with contained FHIR resources will now include the non-FHIR structures around the resources in the source node locations. I am not sure if this is the behaviour we should be having, but it does meet FS expectations, and since we decided to assume that location is not important for implementations, we should adjust it to allow FS to upgrade

## Related issues
Closes #2784 (again)

## Testing
Tested using the FS test base (dotnet pack then import into a fork of their code base)