### PR TITLE
Added exceptions for value sets that cannot be expanded

### DIFF
--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/ValueSetExpander.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/ValueSetExpander.cs
@@ -290,7 +290,18 @@ namespace Hl7.Fhir.Specification.Terminology
 
             var importedCs = await Settings.ValueSetSource.AsAsync().FindCodeSystemAsync(uri).ConfigureAwait(false)
                 ?? throw new ValueSetUnknownException($"The ValueSet expander cannot find codesystem '{uri}', so the expansion cannot be completed.");
-
+            
+            if(importedCs.Compositional is true)
+                throw new ValueSetExpansionTooComplexException($"The ValueSet expander cannot expand compositional code system '{uri}', so the expansion cannot be completed.");
+            
+#if STU3
+            var contentNotPresent = importedCs.Content == CodeSystem.CodeSystemContentMode.NotPresent;
+#else 
+            var contentNotPresent = importedCs.Content == CodeSystemContentMode.NotPresent;
+#endif
+            if(contentNotPresent)
+                throw new ValueSetExpansionTooComplexException($"The ValueSet expander cannot expand code system '{uri}' without content, so the expansion cannot be completed.");
+            
             return importedCs.Concept.Select(c => c.ToContainsComponent(importedCs, Settings));
         }
     }

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Terminology/LocalTerminologyServiceTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Terminology/LocalTerminologyServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Hl7.Fhir.Model;
+using Hl7.Fhir.Rest;
 using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Specification.Terminology;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -68,6 +69,43 @@ namespace Hl7.Fhir.Specification.Tests
 
             result.Parameter.Should().Contain(p => p.Name == "result")
                .Subject.Value.Should().BeEquivalentTo(new FhirBoolean(true));
+        }
+        
+        [TestMethod]
+        public async Task CheckErrorBarrier()
+        {
+
+            var valueSet = new ValueSet()
+            {
+                Url = "http://fire.ly/ValueSet/AllOfSnomed",
+                Compose = new ValueSet.ComposeComponent()
+                {
+                    Include = new System.Collections.Generic.List<ValueSet.ConceptSetComponent>()
+                    {
+                        new () {System = "http://snomed.info/sct" }
+                    }
+                }
+            };
+
+            LocalTerminologyService _service = new(
+                new CachedResolver(
+                    new MultiResolver(
+                        ZipSource.CreateValidationSource(),
+                        new InMemoryResourceResolver(valueSet)
+                    )
+                ));
+
+
+            var parameters = new ValidateCodeParameters()
+                .WithValueSet("http://fire.ly/ValueSet/AllOfSnomed")
+                .WithCode("255848005", context: "AllergyIntolerance.code.coding[0].code");
+
+
+
+            var ac = () => _service.ValueSetValidateCode(parameters.Build());
+            
+            var ex = await ac.Should().ThrowAsync<FhirOperationException>();
+            ex.WithMessage("*compositional code system*");
         }
     }
 }


### PR DESCRIPTION
## Description
Attempting to expand a compositional value set or a value set without content should now throw an appropriate exception.

## Related issues
Resolves #2756 

## Testing
New unit test to check this behaviour