### PR TITLE
Scoped node cache overhaul

### DIFF
--- a/src/Hl7.Fhir.Base/ElementModel/ReferencedResourceCache.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ReferencedResourceCache.cs
@@ -19,9 +19,9 @@ internal class ReferencedResourceCache : IEnumerable<ScopedNode.BundledResource>
         }
     }
     
-    public IEnumerable<ScopedNode> Resources => _items.Values.OfType<ScopedNode>();
+    internal IEnumerable<ScopedNode> Resources => _items.Values.OfType<ScopedNode>();
 
-    public ScopedNode? resolveReference(string reference)
+    internal ScopedNode? ResolveReference(string reference)
     {
         return _items.TryGetValue(reference, out var node) ? node : null;
     }

--- a/src/Hl7.Fhir.Base/ElementModel/ReferencedResourceCache.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ReferencedResourceCache.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Hl7.Fhir.ElementModel;
+
+#nullable enable
+
+internal class ReferencedResourceCache : IEnumerable<ScopedNode.BundledResource>
+{
+    private Dictionary<string, ScopedNode?> _items;
+    
+    public ReferencedResourceCache(IEnumerable<KeyValuePair<string, ScopedNode?>> items)
+    {
+        _items = new Dictionary<string, ScopedNode?>();
+        foreach (var item in items)
+        {
+            _items.Add(item.Key, item.Value);
+        }
+    }
+    
+    public IEnumerable<ScopedNode> Resources => _items.Values.OfType<ScopedNode>();
+
+    public ScopedNode? resolveReference(string reference)
+    {
+        return _items.TryGetValue(reference, out var node) ? node : null;
+    }
+
+    public IEnumerator<ScopedNode.BundledResource> GetEnumerator() => _items.Select(i => new ScopedNode.BundledResource(i.Key, i.Value)).GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+#nullable restore

--- a/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs
@@ -184,7 +184,7 @@ namespace Hl7.Fhir.ElementModel
             if (AtResource)
             {
                 var referenceEntryPairs = from contained in this.Children("contained")
-                    let id = contained.Children("id").FirstOrDefault()?.Value as string
+                    let id = $"#{contained.Children("id").FirstOrDefault()?.Value as string}"
                     let resource = contained as ScopedNode
                     select new KeyValuePair<string, ScopedNode?>(id, resource);
                 _cache.ContainedResources = new ReferencedResourceCache(referenceEntryPairs);

--- a/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs
@@ -177,7 +177,7 @@ namespace Hl7.Fhir.ElementModel
             return _cache.ContainedResources.Resources;
         }
 
-        public IEnumerable<BundledResource> ContainedResourcesWithId()
+        internal ReferencedResourceCache ContainedResourcesWithId()
         {
             if (_cache.ContainedResources != null) return _cache.ContainedResources;
             

--- a/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs
@@ -232,9 +232,6 @@ namespace Hl7.Fhir.ElementModel
             return _cache.BundledResources;
         }
 
-        internal ReferencedResourceCache? getContainedCache() => _cache.ContainedResources;
-        internal ReferencedResourceCache? getBundledCache() => _cache.BundledResources;
-
         private readonly string? _fullUrl = null;
 
         /// <summary>

--- a/src/Hl7.Fhir.Base/ElementModel/ScopedNodeExtensions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ScopedNodeExtensions.cs
@@ -110,14 +110,14 @@ namespace Hl7.Fhir.ElementModel
                 {
                     if (parent.InstanceType == FhirTypeConstants.BUNDLE)
                     {
-                        var result = parent.BundledResources().FirstOrDefault(br => br.FullUrl == url)?.Resource;
-                        if (result != null) return result;
+                        if (parent.BundledResources() is ReferencedResourceCache result) return result.resolveReference(url);
+                        return null;
                     }
                     else
                     {
                         if (parent.Id() == url) return parent;
-                        var result = parent.ContainedResources().FirstOrDefault(cr => cr.Id() == url);
-                        if (result != null) return result;
+                        if (parent.ContainedResourcesWithId() is ReferencedResourceCache result) return result.resolveReference(url);
+                        return null;
                     }
                 }
 

--- a/src/Hl7.Fhir.Base/ElementModel/ScopedNodeExtensions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ScopedNodeExtensions.cs
@@ -113,13 +113,11 @@ namespace Hl7.Fhir.ElementModel
                     {
                         return ((ReferencedResourceCache)parent.BundledResources()).ResolveReference(url); // safe cast but we cannot change the signature
                     }
-                    else
-                    {
-                        if (parent.Id() == url)
-                            return parent;
-                        if (parent.ContainedResourcesWithId().ResolveReference(url) is { } resource) // safe cast but we cannot change the signature
-                            return resource;
-                    }
+
+                    if (parent.Id() == url)
+                        return parent;
+                    if (parent.ContainedResourcesWithId().ResolveReference(url) is { } resource) // safe cast but we cannot change the signature
+                        return resource;
                 }
 
                 return null;

--- a/src/Hl7.Fhir.Base/ElementModel/ScopedNodeExtensions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ScopedNodeExtensions.cs
@@ -117,7 +117,7 @@ namespace Hl7.Fhir.ElementModel
                     {
                         if (parent.Id() == url)
                             return parent;
-                        if (((ReferencedResourceCache)parent.ContainedResourcesWithId()).ResolveReference(url) is { } resource) // safe cast but we cannot change the signature
+                        if (parent.ContainedResourcesWithId().ResolveReference(url) is { } resource) // safe cast but we cannot change the signature
                             return resource;
                     }
                 }

--- a/src/Hl7.Fhir.Base/ElementModel/ScopedNodeExtensions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ScopedNodeExtensions.cs
@@ -111,14 +111,13 @@ namespace Hl7.Fhir.ElementModel
                 {
                     if (parent.InstanceType == FhirTypeConstants.BUNDLE)
                     {
-                        if (parent.BundledResources() is ReferencedResourceCache result) return result.resolveReference(url);
-                        return null;
+                        return ((ReferencedResourceCache)parent.BundledResources()).ResolveReference(url); // safe cast but we cannot change the signature
                     }
                     else
                     {
-                        if (parent.Id() == url) return parent;
-                        if (parent.ContainedResourcesWithId() is ReferencedResourceCache result 
-                            && result.resolveReference(url) is { } resource) 
+                        if (parent.Id() == url)
+                            return parent;
+                        if (((ReferencedResourceCache)parent.ContainedResourcesWithId()).ResolveReference(url) is { } resource) // safe cast but we cannot change the signature
                             return resource;
                     }
                 }

--- a/src/Hl7.Fhir.Base/ElementModel/ScopedNodeExtensions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ScopedNodeExtensions.cs
@@ -8,6 +8,7 @@
 
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Support.Poco;
+using Hl7.FhirPath.Sprache;
 using System;
 using System.Linq;
 
@@ -116,8 +117,9 @@ namespace Hl7.Fhir.ElementModel
                     else
                     {
                         if (parent.Id() == url) return parent;
-                        if (parent.ContainedResourcesWithId() is ReferencedResourceCache result) return result.resolveReference(url);
-                        return null;
+                        if (parent.ContainedResourcesWithId() is ReferencedResourceCache result 
+                            && result.resolveReference(url) is { } resource) 
+                            return resource;
                     }
                 }
 


### PR DESCRIPTION
## Description
Refactored scoped node caches to internally use dictionaries. This should help with performance.

Note that this might work inversely due to the higher base allocation of dictionaries. We do not have proper control over the children of our scoped nodes right now (they seem to be created with new all the time when they are enumerated). I will make an issue for that, which will need more research

## Related issues
Should be the first step to alleviating https://github.com/FirelyTeam/firely-validator-api/issues/334