### PR TITLE
contained resource ref cache fix

### DIFF
--- a/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs
@@ -182,7 +182,7 @@ namespace Hl7.Fhir.ElementModel
             if (AtResource)
             {
                 var referenceEntryPairs = from contained in this.Children("contained")
-                    let id = $"#{contained.Children("id").FirstOrDefault()?.Value as string}"
+                    let id = contained.Children("id").FirstOrDefault()?.Value is string s ? $"#{s}" : null
                     let resource = contained as ScopedNode
                     select new KeyValuePair<string, ScopedNode?>(id, resource);
                 _cache.ContainedResources = new ReferencedResourceCache(referenceEntryPairs);


### PR DESCRIPTION
## Description
Fixed an incorrect string concatenation and subsequent argument exception when the Id of a contained resource was not set. 