### PR TITLE
Use proper snapshot generation settings, fixed obsolete warnings

### DIFF
--- a/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
+++ b/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
@@ -9,6 +9,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.FhirPath.FhirEvaluationContext.WithResourceOverrides(Hl7.Fhir.ElementModel.ITypedElement,Hl7.Fhir.ElementModel.ITypedElement)</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Hl7.Fhir.Rest.ContentType.BuildContentType(Hl7.Fhir.Rest.ResourceFormat,System.String)</Target>
     <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
     <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
@@ -19,6 +26,20 @@
     <Target>M:Hl7.Fhir.Rest.ContentType.BuildMediaType(Hl7.Fhir.Rest.ResourceFormat,System.String)</Target>
     <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
     <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.FhirPath.EvaluationContext.WithResourceOverrides(Hl7.Fhir.ElementModel.ITypedElement,Hl7.Fhir.ElementModel.ITypedElement)</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.FhirPath.FhirEvaluationContext.WithResourceOverrides(Hl7.Fhir.ElementModel.ITypedElement,Hl7.Fhir.ElementModel.ITypedElement)</Target>
+    <Left>lib/netstandard2.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.0/Hl7.Fhir.Base.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
@@ -31,6 +52,13 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Hl7.Fhir.Rest.ContentType.BuildMediaType(Hl7.Fhir.Rest.ResourceFormat,System.String)</Target>
+    <Left>lib/netstandard2.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.FhirPath.EvaluationContext.WithResourceOverrides(Hl7.Fhir.ElementModel.ITypedElement,Hl7.Fhir.ElementModel.ITypedElement)</Target>
     <Left>lib/netstandard2.0/Hl7.Fhir.Base.dll</Left>
     <Right>lib/netstandard2.0/Hl7.Fhir.Base.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Hl7.Fhir.Base/FhirPath/EvaluationContext.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/EvaluationContext.cs
@@ -41,12 +41,6 @@ public class EvaluationContext
     {
         Environment = environment;
     }
-
-    /// <summary>
-    /// Explicitly override the values of %resource and %rootResource in the evaluation context.
-    /// </summary>
-    public static EvaluationContext WithResourceOverrides(ITypedElement? resource, ITypedElement? rootResource = null) =>
-        new EvaluationContext { Resource = resource, RootResource = rootResource ?? resource };
     
     /// <summary>
     /// The data represented by <c>%rootResource</c>.
@@ -67,4 +61,14 @@ public class EvaluationContext
     /// A delegate that handles the output for the <c>trace()</c> function.
     /// </summary>
     public Action<string, IEnumerable<ITypedElement>>? Tracer { get; set; }
+}
+
+public static class EvaluationContextExtensions
+{
+    public static T WithResourceOverrides<T>(this T context, ITypedElement? resource, ITypedElement? rootResource = null) where T : EvaluationContext
+    {
+        context.Resource = resource;
+        context.RootResource = rootResource ?? resource;
+        return context;
+    }
 }

--- a/src/Hl7.Fhir.Base/FhirPath/FhirEvaluationContext.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/FhirEvaluationContext.cs
@@ -63,12 +63,7 @@ namespace Hl7.Fhir.FhirPath
         {
             RootResource = Resource is ScopedNode sn ? sn.ResourceContext : node;
         }
-
-        /// <summary>
-        /// Explicitly override the values of %resource and %rootResource in the evaluation context.
-        /// </summary>
-        public static new FhirEvaluationContext WithResourceOverrides(ITypedElement? resource, ITypedElement? rootResource = null) =>
-            (FhirEvaluationContext)EvaluationContext.WithResourceOverrides(resource, rootResource);
+        
         public ITerminologyService? TerminologyService { get; set; }
 
         private static ITypedElement toNearestResource(ScopedNode node)

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
@@ -2228,7 +2228,9 @@ namespace Hl7.Fhir.Specification.Snapshot
                 {
                     RegenerationSettings.TRY_USE_EXISTING => !sd.HasSnapshot,
                     RegenerationSettings.REGENERATE_ONCE => !sd.HasSnapshot || !sd.Snapshot.IsCreatedBySnapshotGenerator(),
-                    RegenerationSettings.FORCE_REGENERATE => true,
+#pragma warning disable CS0618 // Type or member is obsolete
+                    RegenerationSettings.FORCE_REGENERATE => true, // possible infinite recursion
+#pragma warning restore CS0618 // Type or member is obsolete
                     _ => throw new InvalidOperationException($"Invalid RegenerationSettings value {_settings.RegenerationBehaviour}")
                 };
                 
@@ -2317,8 +2319,10 @@ namespace Hl7.Fhir.Specification.Snapshot
             var hasValidRoot = _settings.RegenerationBehaviour switch
             {
                 RegenerationSettings.TRY_USE_EXISTING => sd.HasSnapshot,
-                RegenerationSettings.REGENERATE_ONCE => sd.HasSnapshot,
-                RegenerationSettings.FORCE_REGENERATE => sd.HasSnapshot && sd.Snapshot.IsCreatedBySnapshotGenerator(),
+                RegenerationSettings.REGENERATE_ONCE => sd.HasSnapshot && sd.Snapshot.IsCreatedBySnapshotGenerator(),
+#pragma warning disable CS0618 // Type or member is obsolete
+                RegenerationSettings.FORCE_REGENERATE => false,
+#pragma warning restore CS0618 // Type or member is obsolete
                 _ => throw new InvalidOperationException($"Invalid RegenerationSettings value {_settings.RegenerationBehaviour}")
             };
             

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
@@ -2228,7 +2228,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 {
                     RegenerationSettings.TRY_USE_EXISTING => !sd.HasSnapshot,
                     RegenerationSettings.REGENERATE_ONCE => !sd.HasSnapshot || !sd.Snapshot.IsCreatedBySnapshotGenerator(),
-                    RegenerationSettings.FORCE_REGENERATE => true,
+                    RegenerationSettings.FORCE_REGENERATE => !sd.HasSnapshot || !sd.Snapshot.IsCreatedBySnapshotGenerator(), // cannot set to true, infinite recursion!
                     _ => throw new InvalidOperationException($"Invalid RegenerationSettings value {_settings.RegenerationBehaviour}")
                 };
                 

--- a/src/Hl7.Fhir.STU3.Tests/Model/ValidateAllExamplesSearchExtractionTest.cs
+++ b/src/Hl7.Fhir.STU3.Tests/Model/ValidateAllExamplesSearchExtractionTest.cs
@@ -154,7 +154,7 @@ namespace Hl7.Fhir.Tests.Model
 
             try
             {
-                var results = resourceModel.Select(index.Expression, new EvaluationContext(resourceModel));
+                var results = resourceModel.Select(index.Expression, new EvaluationContext());
                 if (results.Count() > 0)
                 {
                     foreach (var t2 in results)

--- a/src/Hl7.Fhir.STU3.Tests/Validation/SearchDataExtraction.cs
+++ b/src/Hl7.Fhir.STU3.Tests/Validation/SearchDataExtraction.cs
@@ -20,6 +20,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Xml;
+using FhirEvaluationContext = Hl7.Fhir.FhirPath.FhirEvaluationContext;
 
 namespace Hl7.Fhir.Test.Validation
 {
@@ -34,7 +35,7 @@ namespace Hl7.Fhir.Test.Validation
         [TestCategory("LongRunner")]
         public void SearchExtractionAllExamples()
         {
-            string examplesZip = @"TestData\examples.zip";
+            string examplesZip = @"TestData/examples.zip";
 
             FhirXmlParser parser = new FhirXmlParser();
             int errorCount = 0;
@@ -130,7 +131,7 @@ namespace Hl7.Fhir.Test.Validation
 
         private static void ExtractExamplesFromResource(Dictionary<string, int> exampleSearchValues, Resource resource, ModelInfo.SearchParamDefinition index, string key)
         {
-            var results = resource.Select(index.Expression, new FhirEvaluationContext(resource.ToTypedElement()));
+            var results = resource.Select(index.Expression, new FhirEvaluationContext());
             if (results.Any())
             {
                 // we perform the Select on a Poco, because then we get the FHIR dialect of FhirPath as well.

--- a/src/Hl7.Fhir.STU3/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Snapshot/SnapshotGenerator.cs
@@ -1944,7 +1944,9 @@ namespace Hl7.Fhir.Specification.Snapshot
                 {
                     RegenerationSettings.TRY_USE_EXISTING => !sd.HasSnapshot,
                     RegenerationSettings.REGENERATE_ONCE => !sd.HasSnapshot || !sd.Snapshot.IsCreatedBySnapshotGenerator(),
+#pragma warning disable CS0618 // Type or member is obsolete
                     RegenerationSettings.FORCE_REGENERATE => true,
+#pragma warning restore CS0618 // Type or member is obsolete
                     _ => throw new InvalidOperationException($"Invalid RegenerationSettings value {_settings.RegenerationBehaviour}")
                 };
                 
@@ -2034,7 +2036,9 @@ namespace Hl7.Fhir.Specification.Snapshot
             {
                 RegenerationSettings.TRY_USE_EXISTING => sd.HasSnapshot,
                 RegenerationSettings.REGENERATE_ONCE => sd.HasSnapshot,
-                RegenerationSettings.FORCE_REGENERATE => sd.HasSnapshot && sd.Snapshot.IsCreatedBySnapshotGenerator(),
+#pragma warning disable CS0618 // Type or member is obsolete
+                RegenerationSettings.FORCE_REGENERATE => false,
+#pragma warning restore CS0618 // Type or member is obsolete
                 _ => throw new InvalidOperationException($"Invalid RegenerationSettings value {_settings.RegenerationBehaviour}")
             };
             

--- a/src/Hl7.Fhir.STU3/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Snapshot/SnapshotGenerator.cs
@@ -2035,7 +2035,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             var hasValidRoot = _settings.RegenerationBehaviour switch
             {
                 RegenerationSettings.TRY_USE_EXISTING => sd.HasSnapshot,
-                RegenerationSettings.REGENERATE_ONCE => sd.HasSnapshot,
+                RegenerationSettings.REGENERATE_ONCE => sd.HasSnapshot && sd.Snapshot.IsCreatedBySnapshotGenerator(),
 #pragma warning disable CS0618 // Type or member is obsolete
                 RegenerationSettings.FORCE_REGENERATE => false,
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Hl7.Fhir.STU3/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Snapshot/SnapshotGenerator.cs
@@ -1944,7 +1944,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 {
                     RegenerationSettings.TRY_USE_EXISTING => !sd.HasSnapshot,
                     RegenerationSettings.REGENERATE_ONCE => !sd.HasSnapshot || !sd.Snapshot.IsCreatedBySnapshotGenerator(),
-                    RegenerationSettings.FORCE_REGENERATE => true,
+                    RegenerationSettings.FORCE_REGENERATE => !sd.HasSnapshot || !sd.Snapshot.IsCreatedBySnapshotGenerator(), // cannot put true here, infinite recursion!
                     _ => throw new InvalidOperationException($"Invalid RegenerationSettings value {_settings.RegenerationBehaviour}")
                 };
                 

--- a/src/Hl7.Fhir.STU3/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Snapshot/SnapshotGenerator.cs
@@ -1940,9 +1940,15 @@ namespace Hl7.Fhir.Specification.Snapshot
 
             try
             {
-                if (_settings.GenerateSnapshotForExternalProfiles
-                && (!sd.HasSnapshot || (_settings.RegenerationBehaviour == RegenerationSettings.FORCE_REGENERATE && !sd.Snapshot.IsCreatedBySnapshotGenerator()))
-                )
+                var shouldGenerate = _settings.RegenerationBehaviour switch
+                {
+                    RegenerationSettings.TRY_USE_EXISTING => !sd.HasSnapshot,
+                    RegenerationSettings.REGENERATE_ONCE => !sd.HasSnapshot || !sd.Snapshot.IsCreatedBySnapshotGenerator(),
+                    RegenerationSettings.FORCE_REGENERATE => true,
+                    _ => throw new InvalidOperationException($"Invalid RegenerationSettings value {_settings.RegenerationBehaviour}")
+                };
+                
+                if (_settings.GenerateSnapshotForExternalProfiles && shouldGenerate)
                 {
                     // Automatically expand external profiles on demand
                     // Debug.Print($"[{nameof(SnapshotGenerator)}.{nameof(ensureSnapshot)}] Recursively generate snapshot for type profile with url: '{sd.Url}' ...");
@@ -2024,9 +2030,16 @@ namespace Hl7.Fhir.Specification.Snapshot
             var cachedRoot = sd.GetSnapshotRootElementAnnotation();
             if (cachedRoot != null) { return cachedRoot; }
 #endif
-
+            var hasValidRoot = _settings.RegenerationBehaviour switch
+            {
+                RegenerationSettings.TRY_USE_EXISTING => sd.HasSnapshot,
+                RegenerationSettings.REGENERATE_ONCE => sd.HasSnapshot,
+                RegenerationSettings.FORCE_REGENERATE => sd.HasSnapshot && sd.Snapshot.IsCreatedBySnapshotGenerator(),
+                _ => throw new InvalidOperationException($"Invalid RegenerationSettings value {_settings.RegenerationBehaviour}")
+            };
+            
             // 2. Return root element definition from existing (pre-generated) snapshot, if it exists
-            if (sd.HasSnapshot && (sd.Snapshot.IsCreatedBySnapshotGenerator() || _settings.RegenerationBehaviour != RegenerationSettings.FORCE_REGENERATE))
+            if (hasValidRoot)
             {
                 // Debug.Print($"[{nameof(SnapshotGenerator)}.{nameof(getSnapshotRootElement)}] {nameof(profileUri)} = '{profileUri}' - use existing root element definition from snapshot: #{sd.Snapshot.Element[0].GetHashCode()}");
                 // No need to save root ElemDef annotation, as the snapshot has already been fully expanded

--- a/src/Hl7.Fhir.Shared.Tests/Validation/SearchDataExtraction.cs
+++ b/src/Hl7.Fhir.Shared.Tests/Validation/SearchDataExtraction.cs
@@ -131,7 +131,7 @@ namespace Hl7.Fhir.Test.Validation
             try
             {
                 // we perform the Select on a Poco, because then we get the FHIR dialect of FhirPath as well.
-                results = resource.Select(index.Expression, new FhirEvaluationContext(resource.ToTypedElement()) { ElementResolver = mockResolver });
+                results = resource.Select(index.Expression!, new FhirEvaluationContext { ElementResolver = mockResolver });
             }
             catch (Exception)
             {

--- a/src/Hl7.Fhir.Shims.Base/Specification/Snapshot/SnapshotGeneratorSettings.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Snapshot/SnapshotGeneratorSettings.cs
@@ -35,9 +35,7 @@ namespace Hl7.Fhir.Specification.Snapshot
         {
             if (other == null) { throw Error.ArgumentNull(nameof(other)); }
             other.GenerateSnapshotForExternalProfiles = GenerateSnapshotForExternalProfiles;
-#pragma warning disable CS0618 // Type or member is obsolete
-            other.ForceRegenerateSnapshots = ForceRegenerateSnapshots;
-#pragma warning restore CS0618 // Type or member is obsolete
+            other.RegenerationBehaviour = RegenerationBehaviour;
             other.GenerateExtensionsOnConstraints = GenerateExtensionsOnConstraints;
             other.GenerateAnnotationsOnConstraints = GenerateAnnotationsOnConstraints;
             other.GenerateElementIds = GenerateElementIds;

--- a/src/Hl7.Fhir.Shims.Base/Specification/Snapshot/SnapshotGeneratorSettings.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Snapshot/SnapshotGeneratorSettings.cs
@@ -57,11 +57,11 @@ namespace Hl7.Fhir.Specification.Snapshot
         /// If disabled (default), then the snapshot generator relies on existing snapshot components, if they exist.
         /// </summary>
         [Obsolete(
-            "This setting does not work as intended. When set to true, it regenerates a snapshot every time (which is not useful), and when set to false, it still regenerates a snapshot once, even if it already exists. We will consider removing it in a future major release. Use the new RegenerationBehaviour setting instead. See also https://github.com/FirelyTeam/firely-net-sdk/pull/2803")]
+            "This setting does not work as intended. We will maintain the old behaviour for now, and we will consider removing it in a future major release. Use the new RegenerationBehaviour setting instead. See also https://github.com/FirelyTeam/firely-net-sdk/pull/2803")]
         public bool ForceRegenerateSnapshots
         {
-            get { return this.RegenerationBehaviour == RegenerationSettings.FORCE_REGENERATE; } 
-            set { this.RegenerationBehaviour = value ? RegenerationSettings.FORCE_REGENERATE : RegenerationSettings.REGENERATE_ONCE; }
+            get { return this.RegenerationBehaviour == RegenerationSettings.REGENERATE_ONCE; } 
+            set { this.RegenerationBehaviour = value ? RegenerationSettings.REGENERATE_ONCE : RegenerationSettings.TRY_USE_EXISTING; }
         } // ForceExpandAll
         
         /// <summary>

--- a/src/Hl7.Fhir.Shims.Base/Specification/Snapshot/SnapshotGeneratorSettings.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Snapshot/SnapshotGeneratorSettings.cs
@@ -113,6 +113,7 @@ namespace Hl7.Fhir.Specification.Snapshot
         /// <summary>
         /// Regenerate the snapshot every time. This is useful for debugging and testing purposes.
         /// </summary>
+        [Obsolete("Watch out when using this setting! it could lead to infinite recursion and is mainly meant for debugging and testing purposes. If you previously had ForceRegenerateSnapshots set to true, consider using REGENERATE_ONCE instead.")]
         FORCE_REGENERATE,
     }
 }

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -7979,7 +7979,6 @@ namespace Hl7.Fhir.Specification.Tests
             var element = snapshot.Should().Contain(e => e.Path == "Observation.subject").Subject;
             var constraint = element.Constraint.Where(c => c.Key == "ref-1").FirstOrDefault();
             constraint.Source.Should().Be("http://hl7.org/fhir/StructureDefinition/Reference");
-
         }
 
 

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -49,7 +49,7 @@ namespace Hl7.Fhir.Specification.Tests
         {
             // Throw on unresolved profile references; must include in TestData folder
             GenerateSnapshotForExternalProfiles = true,
-            ForceRegenerateSnapshots = true,
+            RegenerationBehaviour = RegenerationSettings.REGENERATE_ONCE,
             GenerateExtensionsOnConstraints = false,
             GenerateAnnotationsOnConstraints = false,
             GenerateElementIds = true // STU3

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorManifestTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorManifestTests.cs
@@ -799,6 +799,8 @@ namespace Hl7.Fhir.Specification.Tests
                 Id = id ?? throw new ArgumentNullException(nameof(id));
                 Assert.AreEqual(id, generated.Id);
                 this.Tracer = this.Trace;
+
+                this.WithResourceOverrides(Generated);
             }
 
             void Trace(string msg, IEnumerable<ITypedElement> elems)

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorManifestTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorManifestTests.cs
@@ -83,7 +83,7 @@ namespace Hl7.Fhir.Specification.Tests
 
         static readonly SnapshotGeneratorSettings _snapGenSettings = new SnapshotGeneratorSettings()
         {
-            ForceRegenerateSnapshots = true,
+            RegenerationBehaviour = RegenerationSettings.REGENERATE_ONCE,
             GenerateSnapshotForExternalProfiles = true
         };
 
@@ -788,7 +788,7 @@ namespace Hl7.Fhir.Specification.Tests
 
             public SnapshotEvaluationContext(
                 string testPath, IResourceResolver resolver, string id,
-                StructureDefinition input, StructureDefinition generated) : base(generated.ToTypedElement())
+                StructureDefinition input, StructureDefinition generated)
             {
                 _testPath = testPath ?? throw new ArgumentNullException(nameof(testPath));
                 TestResolver = resolver ?? throw new ArgumentNullException(nameof(resolver));

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -57,7 +57,7 @@ namespace Hl7.Fhir.Specification.Tests
         {
             // Throw on unresolved profile references; must include in TestData folder
             GenerateSnapshotForExternalProfiles = true,
-            ForceRegenerateSnapshots = true,
+            RegenerationBehaviour = RegenerationSettings.REGENERATE_ONCE,
             GenerateExtensionsOnConstraints = false,
             GenerateAnnotationsOnConstraints = false,
             GenerateElementIds = true // STU3

--- a/src/Hl7.Fhir.Support.Tests/FhirPath/FhirPathTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/FhirPath/FhirPathTests.cs
@@ -39,7 +39,7 @@ namespace Hl7.Fhir.Support.Tests
         {
             // resolve should handle an empty collection as input
             var evaluator = _compiler.Compile("{}.resolve()");
-            var result = evaluator(null, FhirEvaluationContext.CreateDefault());
+            var result = evaluator(null, new FhirEvaluationContext());
 
             Assert.IsFalse(result.Any());
         }
@@ -56,7 +56,7 @@ namespace Hl7.Fhir.Support.Tests
         public void HtmlChecks(string xml, bool expected, string because)
         {
             var evaluator = _compiler.Compile("htmlChecks()");
-            evaluator.Predicate(ElementNode.ForPrimitive(xml), FhirEvaluationContext.CreateDefault()).Should().Be(expected, because);
+            evaluator.Predicate(ElementNode.ForPrimitive(xml), new FhirEvaluationContext()).Should().Be(expected, because);
         }
 
         [DataTestMethod]
@@ -150,7 +150,7 @@ namespace Hl7.Fhir.Support.Tests
         public void AssertFhirPathTestcases(string expression, bool expected)
         {
             var evaluator = _compiler.Compile(expression);
-            var result = evaluator(null, FhirEvaluationContext.CreateDefault());
+            var result = evaluator(null, new FhirEvaluationContext());
 
             if (result.Any())
             {

--- a/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathEvaluatorTest.cs
+++ b/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathEvaluatorTest.cs
@@ -606,7 +606,7 @@ namespace Hl7.FhirPath.R4.Tests
             var expr = "defineVariable('root', 'r1-').select(defineVariable('v1', 'v1').defineVariable('v2', 'v2').select(%v1 | %v2)).select(%root & $this)";
             var compiler = new FhirPathCompiler();
             var exprCompiled = compiler.Compile(expr);
-            var r = exprCompiled(fixture.PatientExample.ToTypedElement(), FhirEvaluationContext.CreateDefault());
+            var r = exprCompiled(fixture.PatientExample.ToTypedElement(), new FhirEvaluationContext());
             Assert.AreEqual(2, r.Count());
             Assert.AreEqual("r1-v1", r.First().ToString());
             Assert.AreEqual("r1-v2", r.Skip(1).First().ToString());

--- a/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathEvaluatorTestFromSpec.cs
+++ b/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathEvaluatorTestFromSpec.cs
@@ -69,7 +69,7 @@ namespace Hl7.FhirPath.R4.Tests
             var input = focus.ToTypedElement();
             var container = resource?.ToTypedElement();
 
-            Assert.IsTrue(input.IsBoolean(expression, value, new EvaluationContext(container)));
+            Assert.IsTrue(input.IsBoolean(expression, value, new EvaluationContext()));
         }
 
         private enum ErrorType

--- a/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathParallelTest.cs
+++ b/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathParallelTest.cs
@@ -53,7 +53,7 @@ namespace Vonk.FhirPath.R4.Tests
             var processor = new ActionBlock<ValueSet>(r =>
                 {
                     var typedElement = r.ToTypedElement();
-                    var evalContext = new EvaluationContext(typedElement);
+                    var evalContext = new EvaluationContext();
                     var canonical = selector(typedElement, "url", evalContext).Single().Value.ToString();
                     actual.Add((canonical, r));
                 }
@@ -130,7 +130,7 @@ namespace Vonk.FhirPath.R4.Tests
         public static IEnumerable<ITypedElement> Select(this ITypedElement input, string expression, EvaluationContext ctx = null)
         {
             var evaluator = GetCompiledExpression(expression);
-            return evaluator(input, ctx ?? EvaluationContext.CreateDefault());
+            return evaluator(input, ctx ?? new EvaluationContext());
         }
 
     }

--- a/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
+++ b/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
@@ -21,7 +21,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks.Dataflow;
+using Vonk.FhirPath.R4.Tests;
 using P = Hl7.Fhir.ElementModel.Types;
+using ScopedNode = Hl7.Fhir.ElementModel.ScopedNode;
 
 namespace Hl7.FhirPath.R4.Tests
 {
@@ -187,8 +189,16 @@ namespace Hl7.FhirPath.R4.Tests
         //    Assert.False(TypeInfo.Any.CanBeCastTo(typeof(long)));
         //}
 
-        [TestMethod]
-        public void TestFhirPathRootResource()
+
+
+        [DataTestMethod]
+        [DataRow("entry.first().resource.contained", "contained-1", "patient-1")]
+        [DataRow("entry.first().resource.contained.id", "contained-1", "patient-1")]
+        [DataRow("entry.first().resource.id", "patient-1", "patient-1")]
+        [DataRow("entry.first().resource", "patient-1", "patient-1")]
+        [DataRow("Bundle", "bundle-1", "bundle-1")]
+        [DataRow("id", "bundle-1", "bundle-1")]
+        public void TestFhirPathRootResource(string expression, string resource, string rootResource)
         {
             var bundle = new Bundle() { Type = Bundle.BundleType.Collection, Id = "bundle-1" };
             var patient = new Patient() { Id = "patient-1" };
@@ -199,46 +209,9 @@ namespace Hl7.FhirPath.R4.Tests
 
             var patBundle = new ScopedNode(bundle.ToTypedElement());
 
-            // focus on the contained resource
-            var testNode = patBundle.Select("entry.first().resource.contained")?.FirstOrDefault() as ScopedNode;
-            EvaluationContext ctx = new FhirEvaluationContext();
-            Assert.AreEqual("contained-1", testNode.Scalar("%resource.id", ctx));
-            Assert.AreEqual("patient-1", testNode.Scalar("%rootResource.id", ctx));
-
-            // focus on the id of the contained resource
-            testNode = patBundle.Select("entry.first().resource.contained.id")?.FirstOrDefault() as ScopedNode;
-            ctx = new FhirEvaluationContext();
-            Assert.AreEqual("contained-1", testNode.Scalar("%resource.id", ctx));
-            Assert.AreEqual("patient-1", testNode.Scalar("%rootResource.id", ctx));
-
-            // focus on the property of the entry resource
-            testNode = patBundle.Select("entry.first().resource.id")?.FirstOrDefault() as ScopedNode;
-            ctx = new FhirEvaluationContext();
-            Assert.AreEqual("patient-1", testNode.Scalar("%resource.id", ctx));
-            Assert.AreEqual("patient-1", testNode.Scalar("%rootResource.id", ctx));
-
-            // focus on the entry resource
-            testNode = patBundle.Select("entry.first().resource")?.FirstOrDefault() as ScopedNode;
-            ctx = new FhirEvaluationContext();
-            Assert.AreEqual("patient-1", testNode.Scalar("%resource.id", ctx));
-            Assert.AreEqual("patient-1", testNode.Scalar("%rootResource.id", ctx));
-
-            // focus on bundle 
-            testNode = patBundle;
-            ctx = new FhirEvaluationContext();
-            Assert.AreEqual("bundle-1", testNode.Scalar("%resource.id", ctx));
-            Assert.AreEqual("bundle-1", testNode.Scalar("%rootResource.id", ctx));
-
-            // focus on a property of the bundle 
-            testNode = patBundle.Select("id")?.FirstOrDefault() as ScopedNode;
-            ctx = new FhirEvaluationContext();
-            Assert.AreEqual("bundle-1", testNode.Scalar("%resource.id", ctx));
-            Assert.AreEqual("bundle-1", testNode.Scalar("%rootResource.id", ctx));
-
-            // Testing %context and $this
-            var node = patBundle.Select("entry.first().resource.contained")?.FirstOrDefault();
-            Assert.AreEqual("contained-1", node.Scalar("%context.id", ctx));
-            Assert.AreEqual("contained-1", node.Scalar("$this.id", ctx));
+            var node = patBundle.Select(expression).FirstOrDefault()!;
+            node.Scalar("%resource.id").Should().Be(resource);
+            node.Scalar("%rootResource.id").Should().Be(rootResource);
         }
 
         [TestMethod]

--- a/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
+++ b/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
@@ -200,34 +200,40 @@ namespace Hl7.FhirPath.R4.Tests
             var patBundle = new ScopedNode(bundle.ToTypedElement());
 
             // focus on the contained resource
-            EvaluationContext ctx = new FhirEvaluationContext(patBundle.Select("entry.first().resource.contained")?.FirstOrDefault() as ScopedNode);
-            Assert.AreEqual("contained-1", patBundle.Scalar("%resource.id", ctx));
-            Assert.AreEqual("patient-1", patBundle.Scalar("%rootResource.id", ctx));
+            var testNode = patBundle.Select("entry.first().resource.contained")?.FirstOrDefault() as ScopedNode;
+            EvaluationContext ctx = new FhirEvaluationContext();
+            Assert.AreEqual("contained-1", testNode.Scalar("%resource.id", ctx));
+            Assert.AreEqual("patient-1", testNode.Scalar("%rootResource.id", ctx));
 
             // focus on the id of the contained resource
-            ctx = new FhirEvaluationContext(patBundle.Select("entry.first().resource.contained.id")?.FirstOrDefault() as ScopedNode);
-            Assert.AreEqual("contained-1", patBundle.Scalar("%resource.id", ctx));
-            Assert.AreEqual("patient-1", patBundle.Scalar("%rootResource.id", ctx));
+            testNode = patBundle.Select("entry.first().resource.contained.id")?.FirstOrDefault() as ScopedNode;
+            ctx = new FhirEvaluationContext();
+            Assert.AreEqual("contained-1", testNode.Scalar("%resource.id", ctx));
+            Assert.AreEqual("patient-1", testNode.Scalar("%rootResource.id", ctx));
 
             // focus on the property of the entry resource
-            ctx = new FhirEvaluationContext(patBundle.Select("entry.first().resource.id")?.FirstOrDefault() as ScopedNode);
-            Assert.AreEqual("patient-1", patBundle.Scalar("%resource.id", ctx));
-            Assert.AreEqual("patient-1", patBundle.Scalar("%rootResource.id", ctx));
+            testNode = patBundle.Select("entry.first().resource.id")?.FirstOrDefault() as ScopedNode;
+            ctx = new FhirEvaluationContext();
+            Assert.AreEqual("patient-1", testNode.Scalar("%resource.id", ctx));
+            Assert.AreEqual("patient-1", testNode.Scalar("%rootResource.id", ctx));
 
             // focus on the entry resource
-            ctx = new FhirEvaluationContext(patBundle.Select("entry.first().resource")?.FirstOrDefault() as ScopedNode);
-            Assert.AreEqual("patient-1", patBundle.Scalar("%resource.id", ctx));
-            Assert.AreEqual("patient-1", patBundle.Scalar("%rootResource.id", ctx));
+            testNode = patBundle.Select("entry.first().resource")?.FirstOrDefault() as ScopedNode;
+            ctx = new FhirEvaluationContext();
+            Assert.AreEqual("patient-1", testNode.Scalar("%resource.id", ctx));
+            Assert.AreEqual("patient-1", testNode.Scalar("%rootResource.id", ctx));
 
             // focus on bundle 
-            ctx = new FhirEvaluationContext(patBundle);
-            Assert.AreEqual("bundle-1", patBundle.Scalar("%resource.id", ctx));
-            Assert.AreEqual("bundle-1", patBundle.Scalar("%rootResource.id", ctx));
+            testNode = patBundle;
+            ctx = new FhirEvaluationContext();
+            Assert.AreEqual("bundle-1", testNode.Scalar("%resource.id", ctx));
+            Assert.AreEqual("bundle-1", testNode.Scalar("%rootResource.id", ctx));
 
             // focus on a property of the bundle 
-            ctx = new FhirEvaluationContext(patBundle.Select("id")?.FirstOrDefault() as ScopedNode);
-            Assert.AreEqual("bundle-1", patBundle.Scalar("%resource.id", ctx));
-            Assert.AreEqual("bundle-1", patBundle.Scalar("%rootResource.id", ctx));
+            testNode = patBundle.Select("id")?.FirstOrDefault() as ScopedNode;
+            ctx = new FhirEvaluationContext();
+            Assert.AreEqual("bundle-1", testNode.Scalar("%resource.id", ctx));
+            Assert.AreEqual("bundle-1", testNode.Scalar("%rootResource.id", ctx));
 
             // Testing %context and $this
             var node = patBundle.Select("entry.first().resource.contained")?.FirstOrDefault();
@@ -350,8 +356,7 @@ namespace Hl7.FhirPath.R4.Tests
         [DynamicData(nameof(MemberOfTestData), DynamicDataSourceType.Method)]
         public void MemberOfTests(Base poco, string expression, bool? expectedResult)
         {
-            var context = FhirEvaluationContext.CreateDefault();
-            context.TerminologyService = new LocalTerminologyService(resolver: ZipSource.CreateValidationSource());
+            var context = new FhirEvaluationContext { TerminologyService = new LocalTerminologyService(resolver: ZipSource.CreateValidationSource()) };
 
             var result = poco.Scalar(expression, context);
 
@@ -405,7 +410,7 @@ namespace Hl7.FhirPath.R4.Tests
         [TestMethod]
         public void MemberOfTestsWithoutTerminologyService()
         {
-            var context = FhirEvaluationContext.CreateDefault();
+            var context = new FhirEvaluationContext();
 
             Action action = () => new Code("male").Scalar("memberOf('http://hl7.org/fhir/ValueSet/administrative-gender')", context);
 
@@ -415,8 +420,7 @@ namespace Hl7.FhirPath.R4.Tests
         [TestMethod]
         public void MemberOfTestWithExampleFromSpecification()
         {
-            var context = FhirEvaluationContext.CreateDefault();
-            context.TerminologyService = new LocalTerminologyService(resolver: ZipSource.CreateValidationSource());
+            var context = new FhirEvaluationContext { TerminologyService = new LocalTerminologyService(resolver: ZipSource.CreateValidationSource()) };
 
             Observation observation = new()
             {

--- a/src/Hl7.FhirPath.Tests/Functions/FunctionsTests.cs
+++ b/src/Hl7.FhirPath.Tests/Functions/FunctionsTests.cs
@@ -517,8 +517,7 @@ namespace HL7.FhirPath.Tests
         public void TraceTest()
         {
             ITypedElement dummy = ElementNode.ForPrimitive(true);
-            var ctx = EvaluationContext.CreateDefault();
-            ctx.Tracer = tracer;
+            var ctx = new EvaluationContext { Tracer = tracer };
             dummy.IsBoolean("(1 | 2).trace('test').empty()", true, ctx);
 
             static void tracer(string name, IEnumerable<ITypedElement> list)

--- a/src/Hl7.FhirPath.Tests/Tests/EnviromentTests.cs
+++ b/src/Hl7.FhirPath.Tests/Tests/EnviromentTests.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using Hl7.Fhir.ElementModel;
 using Hl7.FhirPath;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -15,7 +16,7 @@ public class EnviromentTests
         var compiler = new FhirPathCompiler();
         var expr = compiler.Compile("%var = 1");
         
-        expr.IsTrue(null, new EvaluationContext(null, null, new Dictionary<string, IEnumerable<ITypedElement>> { { "var", new [] { ElementNode.ForPrimitive(1) } } }));
-        expr.IsBoolean(false, null, new EvaluationContext(null, null, new Dictionary<string, IEnumerable<ITypedElement>> { { "var", new[] { ElementNode.ForPrimitive(2) } } }));
+        expr.IsTrue(null!, new EvaluationContext { Environment = new Dictionary<string, IEnumerable<ITypedElement>> {{ "var", new [] { ElementNode.ForPrimitive(1) }}}} ).Should().BeTrue();
+        expr.IsTrue(null!, new EvaluationContext { Environment = new Dictionary<string, IEnumerable<ITypedElement>> {{ "var", new [] { ElementNode.ForPrimitive(2) }}}} ).Should().BeFalse();
     }
 }


### PR DESCRIPTION
## Description
- Changed the SnapshotGenerator to use the new RegenerationBehaviour setting. Also aligned this behaviour more with the "expected" behaviour.
- Removed the obsolete warnings from our own code
- In doing so, changed the signature of EvaluationContext.WithResourceOverrides. This is breaking, but since this member has only existed for a month or so and the current signature was confusing and impractical, we deemed it necessary to change this BEFORE 6.x.x