### PR TITLE
Bugfix/2854 fix validate code

### DIFF
--- a/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
+++ b/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
@@ -7,4 +7,18 @@
     <Left>lib/netstandard2.0/Hl7.Fhir.Base.dll</Left>
     <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
   </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Specification.Terminology.ValidateCodeParameters.WithCode(System.String,System.String,System.String,System.String,System.String,System.String)</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Specification.Terminology.ValidateCodeParameters.WithCode(System.String,System.String,System.String,System.String,System.String,System.String)</Target>
+    <Left>lib/netstandard2.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
 </Suppressions>

--- a/src/Hl7.Fhir.Base/FhirPath/ElementNavFhirExtensions.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/ElementNavFhirExtensions.cs
@@ -278,7 +278,7 @@ namespace Hl7.Fhir.FhirPath
 
             inParams = input.InstanceType switch
             {
-                "code" when input is ScopedNode sn => inParams.WithCode(code: sn.Value as string, context: sn.LocalLocation),
+                "code" when input is ScopedNode sn => inParams.WithCode(code: sn.Value as string, context: sn.LocalLocation, inferSystem: true),
                 "Coding" => inParams.WithCoding(input.ParseCoding()),
                 "CodeableConcept" => inParams.WithCodeableConcept(input.ParseCodeableConcept()),
                 "string" or "System.String" => inParams.WithCode(code: input.Value as string, context: "No context available"),

--- a/src/Hl7.Fhir.Base/Model/ParametersExtensions.cs
+++ b/src/Hl7.Fhir.Base/Model/ParametersExtensions.cs
@@ -11,7 +11,6 @@ namespace Hl7.Fhir.Model
         private const string CODEATTRIBUTE = "code";
         private const string URLATTRIBUTE = "url";
         private const string SYSTEMATTRIBUTE = "system";
-        private const string USERATTRIBUTE = "inferSystem";
         private const string CONTEXTATTRIBUTE = "context";
 
         public static bool TryGetDuplicates(this Parameters parameters, out IEnumerable<string> duplicates)

--- a/src/Hl7.Fhir.Base/Model/ParametersExtensions.cs
+++ b/src/Hl7.Fhir.Base/Model/ParametersExtensions.cs
@@ -9,7 +9,9 @@ namespace Hl7.Fhir.Model
     public static class ParametersExtensions
     {
         private const string CODEATTRIBUTE = "code";
+        private const string URLATTRIBUTE = "url";
         private const string SYSTEMATTRIBUTE = "system";
+        private const string USERATTRIBUTE = "inferSystem";
         private const string CONTEXTATTRIBUTE = "context";
 
         public static bool TryGetDuplicates(this Parameters parameters, out IEnumerable<string> duplicates)
@@ -39,12 +41,13 @@ namespace Hl7.Fhir.Model
         {
             parameters.NoDuplicates();
 
-            //If a code is provided, a system or a context must be provided (http://hl7.org/fhir/valueset-operation-validate-code.html)
-            if (parameters.Parameter.Any(p => p.Name == CODEATTRIBUTE) && !(parameters.Parameter.Any(p => p.Name == SYSTEMATTRIBUTE) ||
+            //This error was changed from system to url. See: https://chat.fhir.org/#narrow/channel/179202-terminology/topic/Required.20.24validate-code.20parameters/near/482250225
+            //If a code is provided, a url or a context must be provided (http://hl7.org/fhir/valueset-operation-validate-code.html)
+            if (parameters.Parameter.Any(p => p.Name == CODEATTRIBUTE) && !(parameters.Parameter.Any(p => p.Name == URLATTRIBUTE) ||
                                                                                     parameters.Parameter.Any(p => p.Name == CONTEXTATTRIBUTE)))
             {
                 //422 Unproccesable Entity
-                throw new FhirOperationException($"If a code is provided, a system or a context must be provided", (HttpStatusCode)422);
+                throw new FhirOperationException($"If a code is provided, a url or a context must be provided", (HttpStatusCode)422);
             }
         }
     }

--- a/src/Hl7.Fhir.Base/Specification/Terminology/ValidateCodeParameters.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/ValidateCodeParameters.cs
@@ -25,6 +25,7 @@ namespace Hl7.Fhir.Specification.Terminology
         private readonly string _dateAttribute = "date";
         private readonly string _abstractAttribute = "abstract";
         private readonly string _displayLanguageAttribute = "displayLanguage";
+        private readonly string _inferSystemAttribute = "inferSystem";
 
         public ValidateCodeParameters(Parameters parameters)
         {
@@ -41,6 +42,7 @@ namespace Hl7.Fhir.Specification.Terminology
             Date = parameters.GetSingleValue<FhirDateTime>(_dateAttribute);
             Abstract = parameters.GetSingleValue<FhirBoolean>(_abstractAttribute);
             DisplayLanguage = parameters.GetSingleValue<Code>(_displayLanguageAttribute);
+            InferSystem = parameters.GetSingleValue<FhirBoolean>(_inferSystemAttribute);
         }
 
 
@@ -58,7 +60,7 @@ namespace Hl7.Fhir.Specification.Terminology
             return this;
         }
 
-        public ValidateCodeParameters WithCode(string code = null, string system = null, string systemVersion = null, string display = null, string displayLanguage = null, string context = null)
+        public ValidateCodeParameters WithCode(string code = null, string system = null, string systemVersion = null, string display = null, string displayLanguage = null, string context = null, bool? inferSystem = null)
         {
             if (!string.IsNullOrWhiteSpace(code)) Code = new Code(code);
             if (!string.IsNullOrWhiteSpace(system)) System = new FhirUri(system);
@@ -66,6 +68,7 @@ namespace Hl7.Fhir.Specification.Terminology
             if (!string.IsNullOrWhiteSpace(display)) Display = new FhirString(display);
             if (!string.IsNullOrWhiteSpace(displayLanguage)) DisplayLanguage = new Code(displayLanguage);
             if (!string.IsNullOrWhiteSpace(context)) Context = new FhirUri(context);
+            if (inferSystem is { }) InferSystem = new FhirBoolean(inferSystem);
             return this;
         }
 
@@ -151,6 +154,8 @@ namespace Hl7.Fhir.Specification.Terminology
         /// </summary>
         public Code DisplayLanguage { get; private set; }
 
+        public FhirBoolean InferSystem { get; private set; }
+
         /// <summary>
         /// 
         /// </summary>
@@ -159,9 +164,9 @@ namespace Hl7.Fhir.Specification.Terminology
         {
             var result = new Parameters();
 
-            if (Url is { }) result.Add(_urlAttribute, Url);
-            if (Context is { }) result.Add(_contextAttribute, Context);
-            if (ValueSet is { }) result.Add(_valueSetAttribute, ValueSet);
+            if (Url is { }) result.Add(_urlAttribute, Url); //Either Url, ValueSet or Context is allowed. So try Url first.
+            if (ValueSet is { } && Url is not { }) result.Add(_valueSetAttribute, ValueSet);
+            if (Context is { } && ValueSet is not { } && Url is not { }) result.Add(_contextAttribute, Context); //And then context as last resort.            
             if (ValueSetVersion is { }) result.Add(_valueSetVersionAttribute, ValueSetVersion);
             if (Code is { }) result.Add(_codeAttribute, Code);
             if (System is { }) result.Add(_systemAttribute, System);
@@ -172,7 +177,7 @@ namespace Hl7.Fhir.Specification.Terminology
             if (Date is { }) result.Add(_dateAttribute, Date);
             if (Abstract is { }) result.Add(_abstractAttribute, Abstract);
             if (DisplayLanguage is { }) result.Add(_displayAttribute, DisplayLanguage);
-
+            if (InferSystem is { }) result.Add(_inferSystemAttribute, InferSystem);
             return result;
         }
     }

--- a/src/Hl7.Fhir.Base/Specification/Terminology/ValidateCodeParameters.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/ValidateCodeParameters.cs
@@ -164,9 +164,9 @@ namespace Hl7.Fhir.Specification.Terminology
         {
             var result = new Parameters();
 
-            if (Url is { }) result.Add(_urlAttribute, Url); //Either Url, ValueSet or Context is allowed. So try Url first.
-            if (ValueSet is { } && Url is not { }) result.Add(_valueSetAttribute, ValueSet);
-            if (Context is { } && ValueSet is not { } && Url is not { }) result.Add(_contextAttribute, Context); //And then context as last resort.            
+            if (Url is { }) result.Add(_urlAttribute, Url);
+            if (ValueSet is { }) result.Add(_valueSetAttribute, ValueSet);
+            if (Context is { }) result.Add(_contextAttribute, Context);
             if (ValueSetVersion is { }) result.Add(_valueSetVersionAttribute, ValueSetVersion);
             if (Code is { }) result.Add(_codeAttribute, Code);
             if (System is { }) result.Add(_systemAttribute, System);
@@ -176,7 +176,7 @@ namespace Hl7.Fhir.Specification.Terminology
             if (CodeableConcept is { }) result.Add(_codeableConceptAttribute, CodeableConcept);
             if (Date is { }) result.Add(_dateAttribute, Date);
             if (Abstract is { }) result.Add(_abstractAttribute, Abstract);
-            if (DisplayLanguage is { }) result.Add(_displayAttribute, DisplayLanguage);
+            if (DisplayLanguage is { }) result.Add(_displayLanguageAttribute, DisplayLanguage);
             if (InferSystem is { }) result.Add(_inferSystemAttribute, InferSystem);
             return result;
         }

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Source/TerminologyTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Source/TerminologyTests.cs
@@ -757,6 +757,52 @@ namespace Hl7.Fhir.Specification.Tests
             }
         }
 
+        [Fact]
+        public void TestValidateCodeParametersCode()
+        {
+            var parameters = new ValidateCodeParameters()
+                .WithCode("bar", "http://foo.com", "1.0.4", "barDisplay", "nl-NL", "Patient.gender", true);
+
+            parameters.Code.Value.Should().Be("bar");
+            parameters.System.Value.Should().Be("http://foo.com");
+            parameters.SystemVersion.Value.Should().Be("1.0.4");
+            parameters.DisplayLanguage.Value.Should().Be("nl-NL");
+            parameters.Display.Value.Should().Be("barDisplay");
+            parameters.Context.Value.Should().Be("Patient.gender");
+            parameters.InferSystem.Value.Should().Be(true);
+
+            var paramResource = parameters.Build();
+
+            paramResource.Parameter.Should().HaveCount(7);
+            paramResource.Parameter.Should().ContainSingle(p => p.Name == "code" && ((Code)p.Value).Value == "bar");
+            paramResource.Parameter.Should().ContainSingle(p => p.Name == "system" && ((FhirUri)p.Value).Value == "http://foo.com");
+            paramResource.Parameter.Should().ContainSingle(p => p.Name == "systemVersion" && ((FhirString)p.Value).Value == "1.0.4");
+            paramResource.Parameter.Should().ContainSingle(p => p.Name == "display" && ((FhirString)p.Value).Value == "barDisplay");
+            paramResource.Parameter.Should().ContainSingle(p => p.Name == "displayLanguage" && ((Code)p.Value).Value == "nl-NL");
+            paramResource.Parameter.Should().ContainSingle(p => p.Name == "context" && ((FhirUri)p.Value).Value == "Patient.gender");
+            paramResource.Parameter.Should().ContainSingle(p => p.Name == "inferSystem" && ((FhirBoolean)p.Value).Value == true);
+        }
+
+        [Fact]
+        public void TestValidateCodeParametersValueSet()
+        {
+            var parameters = new ValidateCodeParameters()
+               .WithValueSet("http://foo.bar", "Patient.gender", new ValueSet(), "1.0.4");
+
+            parameters.Url.Value.Should().Be("http://foo.bar");
+            parameters.Context.Value.Should().Be("Patient.gender");
+            parameters.ValueSet.Should().NotBeNull();
+            parameters.ValueSetVersion.Value.Should().Be("1.0.4");
+
+            var paramResource = parameters.Build();
+
+            paramResource.Parameter.Should().HaveCount(4);
+            paramResource.Parameter.Should().ContainSingle(p => p.Name == "url" && ((FhirUri)p.Value).Value == "http://foo.bar");
+            paramResource.Parameter.Should().ContainSingle(p => p.Name == "context" && ((FhirUri)p.Value).Value == "Patient.gender");
+            paramResource.Parameter.Should().ContainSingle(p => p.Name == "valueSet" && ((ValueSet)p.Resource) != null);
+            paramResource.Parameter.Should().ContainSingle(p => p.Name == "valueSetVersion" && ((FhirString)p.Value).Value == "1.0.4");
+        }
+
 
         #region helper functions
         private static Tasks.Task<Parameters> validateCodedValue(ITerminologyService service, string url = null, string context = null, string code = null,

--- a/src/Hl7.Fhir.Support.Tests/Specification/LanguageTerminologyServiceTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/Specification/LanguageTerminologyServiceTests.cs
@@ -36,7 +36,7 @@ namespace Hl7.Fhir.Specification.Tests
             result = await _service.ValueSetValidateCode(parameters);
             result.Parameter.Should().Contain(p => p.Name == "result")
                 .Subject.Value.Should().BeEquivalentTo(new FhirBoolean(true));
-            
+
             parameters = new ValidateCodeParameters()
                 .WithValueSet(LANGUAGE_VS)
                 .WithCode(code: "fr-CH", context: "context")
@@ -59,7 +59,7 @@ namespace Hl7.Fhir.Specification.Tests
                   .Build();
 
             validateCode = async () => await _service.ValueSetValidateCode(parameters);
-            await validateCode.Should().ThrowAsync<FhirOperationException>().WithMessage("If a code is provided, a system or a context must be provided");
+            await validateCode.Should().ThrowAsync<FhirOperationException>().WithMessage("If a code is provided, a url or a context must be provided");
 
             parameters = new ValidateCodeParameters()
                   .WithValueSet(LANGUAGE_VS)

--- a/src/Hl7.Fhir.Support.Tests/Specification/MimeTypeTerminologyServiceTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/Specification/MimeTypeTerminologyServiceTests.cs
@@ -52,7 +52,7 @@ namespace Hl7.Fhir.Specification.Tests
                   .Build();
 
             validateCode = async () => await _service.ValueSetValidateCode(parameters);
-            await validateCode.Should().ThrowAsync<FhirOperationException>().WithMessage("If a code is provided, a system or a context must be provided");
+            await validateCode.Should().ThrowAsync<FhirOperationException>().WithMessage("If a code is provided, a url or a context must be provided");
 
             parameters = new ValidateCodeParameters()
                   .WithValueSet(MIMETYPEVS)


### PR DESCRIPTION
This pull request includes several changes to the `Hl7.Fhir.Base` library, focusing on enhancing the `ValidateCodeParameters` class and associated functionality. The most important changes include adding a new attribute `inferSystem`, modifying validation logic, and updating relevant tests.

Enhancements to `ValidateCodeParameters`:

* Added a new private constant `URLATTRIBUTE` in `ParametersExtensions.cs` to support URL-based validation.
* Introduced a new attribute `inferSystem` in the `ValidateCodeParameters` class, along with corresponding getter and setter methods. [[1]](diffhunk://#diff-385407adaced0076219d12c383222a9fb25c74537e7e664634e7d3f210c3574cR28) [[2]](diffhunk://#diff-385407adaced0076219d12c383222a9fb25c74537e7e664634e7d3f210c3574cR45) [[3]](diffhunk://#diff-385407adaced0076219d12c383222a9fb25c74537e7e664634e7d3f210c3574cR157-R158)
* Updated the `WithCode` method in `ValidateCodeParameters.cs` to include the `inferSystem` parameter.

Validation logic updates:

* Changed the validation logic in `CheckForValidityOfValidateCodeParams` to require a URL or context instead of a system or context.
* Updated error messages in `LanguageTerminologyServiceTests.cs` and `MimeTypeTerminologyServiceTests.cs` to reflect the new validation logic. [[1]](diffhunk://#diff-cf38ad012df3bc0a20a6dddf78ccccdde1f88515303e522164883076c3baad96L62-R62) [[2]](diffhunk://#diff-c481393e0dcf936e347f0573a8468c8f4494a1328ca9fc7ecc955682d82675feL55-R55)

Test updates:

* Added new tests in `TerminologyTests.cs` to verify the functionality of `ValidateCodeParameters` with the new `inferSystem` attribute and URL-based validation.