### PR TITLE
Make RemoveAllNonInheritableExtensions public

### DIFF
--- a/src/Hl7.Fhir.Base/Specification/Snapshot/SnapshotGeneratorExtensions.cs
+++ b/src/Hl7.Fhir.Base/Specification/Snapshot/SnapshotGeneratorExtensions.cs
@@ -76,8 +76,12 @@ namespace Hl7.Fhir.Specification.Snapshot
             }
         }
 
-
-        internal static void RemoveAllNonInheritableExtensions(this Element element)
+        /// <summary>
+        /// This extension removes all non-inheritable extensions from the specified element definition and all it's child objects.
+        /// Non-inheritable extensions are extensions that should not be inherited by derived profiles.
+        /// </summary>
+        /// <param name="element"></param>
+        public static void RemoveAllNonInheritableExtensions(this Element element)
         {
             if (element == null) { throw Error.ArgumentNull(nameof(element)); }
             element.RemoveNonInheritableExtensions();


### PR DESCRIPTION
Kindly generated by CoPilot:

This pull request includes changes to `src/Hl7.Fhir.Base/Specification/Snapshot/SnapshotGeneratorExtensions.cs` to improve the documentation and accessibility of a method. The most important change is the modification of the `RemoveAllNonInheritableExtensions` method.

Documentation and accessibility improvements:

* [`src/Hl7.Fhir.Base/Specification/Snapshot/SnapshotGeneratorExtensions.cs`](diffhunk://#diff-390e7ee1acdebc147109c8aa662b3b9f8caed40f5e467c36732ab1104e6062f5L79-R84): Added a summary comment to describe the purpose of the `RemoveAllNonInheritableExtensions` method and changed its access modifier from `internal` to `public`.