### PR TITLE
#3018 Improved parameter validation

### DIFF
--- a/src/Hl7.Fhir.Base/Model/ParametersExtensions.cs
+++ b/src/Hl7.Fhir.Base/Model/ParametersExtensions.cs
@@ -10,8 +10,8 @@ namespace Hl7.Fhir.Model
     {
         private const string CODEATTRIBUTE = "code";
         private const string URLATTRIBUTE = "url";
-        private const string SYSTEMATTRIBUTE = "system";
         private const string CONTEXTATTRIBUTE = "context";
+        private const string VALUESETATTRIBUTE = "valueSet";
 
         public static bool TryGetDuplicates(this Parameters parameters, out IEnumerable<string> duplicates)
         {
@@ -41,13 +41,19 @@ namespace Hl7.Fhir.Model
             parameters.NoDuplicates();
 
             //This error was changed from system to url. See: https://chat.fhir.org/#narrow/channel/179202-terminology/topic/Required.20.24validate-code.20parameters/near/482250225
-            //If a code is provided, a url or a context must be provided (http://hl7.org/fhir/valueset-operation-validate-code.html)
-            if (parameters.Parameter.Any(p => p.Name == CODEATTRIBUTE) && !(parameters.Parameter.Any(p => p.Name == URLATTRIBUTE) ||
-                                                                                    parameters.Parameter.Any(p => p.Name == CONTEXTATTRIBUTE)))
+            //If a code is provided, an inline valueset, url or a context must be provided (http://hl7.org/fhir/valueset-operation-validate-code.html)
+            if (parameters.HasParam(CODEATTRIBUTE) && !hasValueSet(parameters))
             {
                 //422 Unproccesable Entity
                 throw new FhirOperationException($"If a code is provided, a url or a context must be provided", (HttpStatusCode)422);
             }
+
+            static bool hasValueSet(Parameters p) =>
+                p.HasParam(URLATTRIBUTE) || p.HasParam(CONTEXTATTRIBUTE) || p.HasParam(VALUESETATTRIBUTE);
+
         }
+
+        internal static bool HasParam(this Parameters parameters, string name)
+            => parameters.Parameter.Any(p => p.Name == name);
     }
 }

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Terminology/LocalTerminologyServiceTests.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Terminology/LocalTerminologyServiceTests.cs
@@ -1,8 +1,10 @@
 ﻿using FluentAssertions;
 using Hl7.Fhir.Model;
+using Hl7.Fhir.Rest;
 using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Specification.Terminology;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using Task = System.Threading.Tasks.Task;
 
 namespace Hl7.Fhir.Specification.Tests
@@ -68,6 +70,30 @@ namespace Hl7.Fhir.Specification.Tests
 
             result.Parameter.Should().Contain(p => p.Name == "result")
                .Subject.Value.Should().BeEquivalentTo(new FhirBoolean(true));
+        }
+
+        [TestMethod]
+        [DataRow("code", null, null, null, true)]
+        [DataRow("code", "<ValueSet />", null, null, false)]
+        [DataRow("code", null, "http://nu.nl/valueset", null, false)]
+        [DataRow("code", null, null, "context", false)]
+        [DataRow("code", "<ValueSet />", null, "context", false)]
+        public void CheckValidateCodeParams(string code, string valueset, string url, string context, bool throws)
+        {
+            var parameters = new Parameters()
+            {
+                { "code", code is not null ? new FhirString(code) : null },
+                { "url", url is not null ? new FhirUri("http://hl7.org/fhir/ValueSet/administrative-gender") : null },
+                { "context", context is not null ? new FhirUri("context") : null },
+                { "valueSet", valueset is not null ? new ValueSet() : null }
+            };
+
+            Action validate = () => parameters.CheckForValidityOfValidateCodeParams();
+
+            if (!throws)
+                validate.Should().NotThrow();
+            else
+                validate.Should().Throw<FhirOperationException>();
         }
     }
 }

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Terminology/LocalTerminologyServiceTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Terminology/LocalTerminologyServiceTests.cs
@@ -4,6 +4,7 @@ using Hl7.Fhir.Rest;
 using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Specification.Terminology;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using Task = System.Threading.Tasks.Task;
 
 namespace Hl7.Fhir.Specification.Tests
@@ -113,6 +114,30 @@ namespace Hl7.Fhir.Specification.Tests
 
             var ex = await ac.Should().ThrowAsync<FhirOperationException>();
             ex.WithMessage("*compositional code system*");
+        }
+
+        [TestMethod]
+        [DataRow("code", null, null, null, true)]
+        [DataRow("code", "<ValueSet />", null, null, false)]
+        [DataRow("code", null, "http://nu.nl/valueset", null, false)]
+        [DataRow("code", null, null, "context", false)]
+        [DataRow("code", "<ValueSet />", null, "context", false)]
+        public void CheckValidateCodeParams(string code, string valueset, string url, string context, bool throws)
+        {
+            var parameters = new Parameters()
+            {
+                { "code", code is not null ? new FhirString(code) : null },
+                { "url", url is not null ? new FhirUri("http://hl7.org/fhir/ValueSet/administrative-gender") : null },
+                { "context", context is not null ? new FhirUri("context") : null },
+                { "valueSet", valueset is not null ? new ValueSet() : null }
+            };
+
+            Action validate = () => parameters.CheckForValidityOfValidateCodeParams();
+
+            if (!throws)
+                validate.Should().NotThrow();
+            else
+                validate.Should().Throw<FhirOperationException>();
         }
     }
 }


### PR DESCRIPTION
Fixes #3018.

Now allows for code + any not null combination of (url, context, valueset).