### PR TITLE
Canonical now parses fragment only URLs

### DIFF
--- a/src/Hl7.Fhir.Base/Model/Canonical.cs
+++ b/src/Hl7.Fhir.Base/Model/Canonical.cs
@@ -50,14 +50,13 @@ namespace Hl7.Fhir.Model
         /// </summary>
         public Canonical(string? uri, string? version, string? fragment = null)
         {
-            if (uri == null) throw Error.ArgumentNull(nameof(uri));
-            if (uri.IndexOfAny(['|', '#']) != -1)
+            if ((uri is not null) && uri.IndexOfAny(['|', '#']) != -1)
                 throw Error.Argument(nameof(uri), "cannot contain version/fragment data");
 
-            if (version != null && version.IndexOfAny(['|', '#']) != -1)
+            if ((version is not null) && version.IndexOfAny(['|', '#']) != -1)
                 throw Error.Argument(nameof(version), "cannot contain version/fragment data");
 
-            if (fragment != null && fragment.IndexOfAny(['|', '#']) != -1)
+            if ((fragment is not null) && fragment.IndexOfAny(['|', '#']) != -1)
                 throw Error.Argument(nameof(fragment), "already contains version/fragment data");
 
 

--- a/src/Hl7.Fhir.Base/Specification/Terminology/ValidateCodeParameters.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/ValidateCodeParameters.cs
@@ -62,6 +62,19 @@ namespace Hl7.Fhir.Specification.Terminology
             return this;
         }
 
+        /// <summary>
+        /// Takes a canonical and splits it into the correct "url", and "valueSetVersion" parameters. 
+        /// </summary>
+        /// <param name="canonical">Canonical to be split up</param>
+        /// <returns></returns>
+        public ValidateCodeParameters WithValueSet(Canonical canonical)
+        {
+            var (uri, version, fragment) = canonical;
+            Url = new FhirUri(new Canonical(uri, null, fragment));
+            if (!string.IsNullOrWhiteSpace(version)) ValueSetVersion = new FhirString(version);
+            return this;
+        }
+
         public ValidateCodeParameters WithCode(string? code = null, string? system = null,
             string? systemVersion = null, string? display = null, string? displayLanguage = null,
             string? context = null, bool? inferSystem = null)

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Source/TerminologyTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Source/TerminologyTests.cs
@@ -801,6 +801,16 @@ namespace Hl7.Fhir.Specification.Tests
             paramResource.Parameter.Should().ContainSingle(p => p.Name == "context" && ((FhirUri)p.Value).Value == "Patient.gender");
             paramResource.Parameter.Should().ContainSingle(p => p.Name == "valueSet" && ((ValueSet)p.Resource) != null);
             paramResource.Parameter.Should().ContainSingle(p => p.Name == "valueSetVersion" && ((FhirString)p.Value).Value == "1.0.4");
+
+
+            parameters = new ValidateCodeParameters()
+              .WithValueSet(new Canonical("http://foo.bar/ValueSet/foo|1.0.4#fragment"));
+            parameters.Url.Value.Should().Be("http://foo.bar/ValueSet/foo#fragment");
+            parameters.ValueSetVersion.Value.Should().Be("1.0.4");
+
+            parameters = new ValidateCodeParameters()
+              .WithValueSet(new Canonical("#fragment"));
+            parameters.Url.Value.Should().Be("#fragment");
         }
 
 


### PR DESCRIPTION
Also adds `WithValueSet(Canonical canonical)` to ValidateCodeParameters