### PR TITLE
Allow code "xml", "json", and "ttl" as valid mimetypes

### DIFF
--- a/src/Hl7.Fhir.Base/Specification/Terminology/MimeTypeTerminologyService.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/MimeTypeTerminologyService.cs
@@ -12,14 +12,24 @@ namespace Hl7.Fhir.Specification.Terminology
         private const string MIMETYPE_SYSTEM = "urn:ietf:bcp:13";
         public const string MIMETYPE_VALUESET_R4_AND_UP = "http://hl7.org/fhir/ValueSet/mimetypes";
         public const string MIMETYPE_VALUESET_STU3 = "http://www.rfc-editor.org/bcp/bcp13.txt";
+        private const string XML_CODE = "xml";
+        private const string JSON_CODE = "json";
+        private const string TTL_CODE = "ttl";
 
         public MimeTypeTerminologyService() : base("MIME type", MIMETYPE_SYSTEM, [MIMETYPE_VALUESET_STU3, MIMETYPE_VALUESET_R4_AND_UP])
         {
         }
-        
+
         //mime-type format: type "/" [tree "."] subtype ["+" suffix]* [";" parameter];
+        //FHIR also allows for the following codes: xml, json, ttl
         override protected bool ValidateCodeType(string code)
         {
+            //This is a temporary fix until we support additional bindings.
+            if (code == XML_CODE || code == JSON_CODE || code == TTL_CODE)
+            {
+                return true;
+            }
+
             var entries = code.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             return entries.Length == 2;
         }

--- a/src/Hl7.Fhir.Support.Tests/Specification/MimeTypeTerminologyServiceTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/Specification/MimeTypeTerminologyServiceTests.cs
@@ -40,6 +40,15 @@ namespace Hl7.Fhir.Specification.Tests
                 .Subject.Value.Should().BeEquivalentTo(new FhirBoolean(true));
 
             parameters = new ValidateCodeParameters()
+                    .WithValueSet(MIMETYPEVS)
+                    .WithCode(code: "json")
+                    .Build();
+
+            result = await _service.ValueSetValidateCode(parameters);
+            result.Parameter.Should().Contain(p => p.Name == "result")
+                .Subject.Value.Should().BeEquivalentTo(new FhirBoolean(true));
+
+            parameters = new ValidateCodeParameters()
                    .WithValueSet(ADMINGENDERVS)
                    .WithCode(code: "application/json", context: "context")
                    .Build();
@@ -58,6 +67,11 @@ namespace Hl7.Fhir.Specification.Tests
                   .WithValueSet(MIMETYPEVS)
                   .WithCode(code: "male", system: "http://hl7.org/fhir/administrative-gender")
                   .Build();
+
+            validateCode = async () => await _service.ValueSetValidateCode(parameters);
+            await validateCode.Should().ThrowAsync<FhirOperationException>().WithMessage("Unknown system 'http://hl7.org/fhir/administrative-gender'");
+
+
 
             validateCode = async () => await _service.ValueSetValidateCode(parameters);
             await validateCode.Should().ThrowAsync<FhirOperationException>().WithMessage("Unknown system 'http://hl7.org/fhir/administrative-gender'");


### PR DESCRIPTION
fixes #3011