### PR TITLE
Enable resolvers to be able to report errors

### DIFF
--- a/src/Hl7.Fhir.Base/Specification/Source/CachedResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/CachedResolver.cs
@@ -75,7 +75,7 @@ namespace Hl7.Fhir.Specification.Source
         /// <remarks>Return data from memory cache if available, otherwise load on demand from the internal artifact source.</remarks>
         public async Task<Resource> ResolveByUriAsync(string url)
         {
-            var result = await TryResolveByUriAsync(url);
+            var result = await TryResolveByUriAsync(url).ConfigureAwait(false);
             return result.Value;
         }
 
@@ -91,7 +91,7 @@ namespace Hl7.Fhir.Specification.Source
         /// <remarks>Return data from memory cache if available, otherwise load on demand from the internal artifact source.</remarks>
         public async Task<Resource> ResolveByUriAsync(string url, CachedResolverLoadingStrategy strategy)
         {
-            var result = await TryResolveByUriAsync(url, strategy);
+            var result = await TryResolveByUriAsync(url, strategy).ConfigureAwait(false);
             return result.Value;
         }
         
@@ -120,7 +120,7 @@ namespace Hl7.Fhir.Specification.Source
         /// <remarks>Return data from memory cache if available, otherwise load on demand from the internal artifact source.</remarks>
         public async Task<Resource> ResolveByCanonicalUriAsync(string url)
         {
-            var result = await TryResolveByCanonicalUriAsync(url);
+            var result = await TryResolveByCanonicalUriAsync(url).ConfigureAwait(false);
             return result.Value;
         }
 

--- a/src/Hl7.Fhir.Base/Specification/Source/CachedResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/CachedResolver.cs
@@ -98,7 +98,7 @@ namespace Hl7.Fhir.Specification.Source
         /// <summary>Retrieve the artifact with the specified url.</summary>
         /// <param name="url">The url of the target artifact.</param>
         /// <param name="strategy">Option flag to control the loading strategy.</param>
-        /// <returns>A <see cref="Resource"/> instance, or <c>null</c> if unavailable.</returns>
+        /// <returns>A <see cref="ResolverResult"/> instance, with either <see cref="ResolverResult.Value"/> or <see cref="ResolverResult.Error"/>.</returns>
         /// <remarks>Return data from memory cache if available, otherwise load on demand from the internal artifact source.</remarks>
         public async Task<ResolverResult> TryResolveByUriAsync(string url, CachedResolverLoadingStrategy strategy)
         {
@@ -110,9 +110,11 @@ namespace Hl7.Fhir.Specification.Source
         [Obsolete("CachedResolver now works best with asynchronous resolvers. Use TryResolveByCanonicalUriAsync() instead.")]
         public Resource ResolveByCanonicalUri(string url) => TryResolveByCanonicalUri(url).Value;
 
+        /// <inheritdoc cref="TryResolveByUriAsync(string)" />
         [Obsolete("CachedResolver now works best with asynchronous resolvers. Use TryResolveByUriAsync() instead.")]
         public ResolverResult TryResolveByUri(string uri) => TaskHelper.Await(() => TryResolveByUriAsync(uri));
 
+        /// <inheritdoc cref="TryResolveByCanonicalUriAsync(string)" />
         [Obsolete("CachedResolver now works best with asynchronous resolvers. Use TryResolveByCanonicalUriAsync() instead.")]
         public ResolverResult TryResolveByCanonicalUri(string uri) => TaskHelper.Await(() => TryResolveByCanonicalUriAsync(uri));
 
@@ -125,9 +127,17 @@ namespace Hl7.Fhir.Specification.Source
             var result = await TryResolveByCanonicalUriAsync(url).ConfigureAwait(false);
             return result.Value;
         }
-
+        
+        /// <summary>Retrieve the artifact with the specified url.</summary>
+        /// <param name="uri">The url of the target artifact.</param>
+        /// <returns>A <see cref="ResolverResult"/> instance, with either <see cref="ResolverResult.Value"/> or <see cref="ResolverResult.Error"/>.</returns>
+        /// <remarks>Return data from memory cache if available, otherwise load on demand from the internal artifact source.</remarks>
         public async Task<ResolverResult> TryResolveByUriAsync(string uri) => await TryResolveByUriAsync(uri, CachedResolverLoadingStrategy.LoadOnDemand).ConfigureAwait(false);
 
+        /// <summary>Retrieve the conformance resource with the specified canonical url.</summary>
+        /// <param name="uri">The canonical url of the target conformance resource.</param>
+        /// <returns>A <see cref="ResolverResult"/> instance, with either <see cref="ResolverResult.Value"/> or <see cref="ResolverResult.Error"/>.</returns>
+        /// <remarks>Return data from memory cache if available, otherwise load on demand from the internal artifact source.</remarks>
         public async Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => await TryResolveByCanonicalUriAsync(uri, CachedResolverLoadingStrategy.LoadOnDemand).ConfigureAwait(false);
 
         /// <inheritdoc cref="ResolveByCanonicalUriAsync(string, CachedResolverLoadingStrategy)" />
@@ -146,6 +156,11 @@ namespace Hl7.Fhir.Specification.Source
             return result.Value;
         }
         
+        /// <summary>Retrieve the conformance resource with the specified canonical url.</summary>
+        /// <param name="uri">The canonical url of the target conformance resource.</param>
+        /// <param name="strategy">Option flag to control the loading strategy.</param>
+        /// <returns>A <see cref="ResolverResult"/> instance, with either <see cref="ResolverResult.Value"/> or <see cref="ResolverResult.Error"/>.</returns>
+        /// <remarks>Return data from memory cache if available, otherwise load on demand from the internal artifact source.</remarks>
         public async Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri, CachedResolverLoadingStrategy strategy)
         {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));

--- a/src/Hl7.Fhir.Base/Specification/Source/CachedResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/CachedResolver.cs
@@ -32,8 +32,8 @@ namespace Hl7.Fhir.Specification.Source
         /// <summary>Default expiration time for cached entries.</summary>
         public const int DEFAULT_CACHE_DURATION = 4 * 3600;     // 4 hours
 
-        private readonly Cache<ResolverResult> _resourcesByUri;
-        private readonly Cache<ResolverResult> _resourcesByCanonical;
+        private readonly ResolverCache _resourcesByUri;
+        private readonly ResolverCache _resourcesByCanonical;
 
         /// <summary>Creates a new artifact resolver that caches loaded resources in memory.</summary>
         /// <param name="source">Resolver from which artifacts are initially resolved on a cache miss.</param>
@@ -228,15 +228,15 @@ namespace Hl7.Fhir.Specification.Source
         internal protected virtual string DebuggerDisplay
             => $"{GetType().Name} for {AsyncResolver.DebuggerDisplayString()}";
 
-        private class Cache<T>
+        private class ResolverCache
         {
-            readonly Func<string, Task<T>> _onCacheMiss;
+            readonly Func<string, Task<ResolverResult>> _onCacheMiss;
             readonly int _duration;
 
             readonly Object _getLock = new Object();
-            readonly Dictionary<string, CacheEntry<T>> _cache = new Dictionary<string, CacheEntry<T>>();
+            readonly Dictionary<string, CacheEntry<ResolverResult>> _cache = new Dictionary<string, CacheEntry<ResolverResult>>();
 
-            public Cache(Func<string, Task<T>> onCacheMiss, int duration)
+            public ResolverCache(Func<string, Task<ResolverResult>> onCacheMiss, int duration)
             {
                 _onCacheMiss = onCacheMiss;
                 _duration = duration;
@@ -244,16 +244,16 @@ namespace Hl7.Fhir.Specification.Source
 
 
             public bool Contains(string identifier) =>
-                _cache.TryGetValue(identifier, out var entry) && !entry.IsExpired && entry.Data != null;
+                _cache.TryGetValue(identifier, out var entry) && !entry.IsExpired && entry.Data.Success;
 
-            public async Task<T> Get(string identifier, CachedResolverLoadingStrategy strategy)
+            public async Task<ResolverResult> Get(string identifier, CachedResolverLoadingStrategy strategy)
             {
                 lock (_getLock)
                 {
                     // Check the cache
                     if (strategy != CachedResolverLoadingStrategy.LoadFromSource)
                     {
-                        if (_cache.TryGetValue(identifier, out CacheEntry<T> entry))
+                        if (_cache.TryGetValue(identifier, out CacheEntry<ResolverResult> entry))
                         {
                             // If we still have a fresh entry, return it
                             if (!entry.IsExpired)
@@ -271,14 +271,14 @@ namespace Hl7.Fhir.Specification.Source
                 if (strategy != CachedResolverLoadingStrategy.LoadFromCache)
                 {
                     // Otherwise, fetch it and cache it.
-                    T newData = await _onCacheMiss(identifier).ConfigureAwait(false);
+                    ResolverResult newData = await _onCacheMiss(identifier).ConfigureAwait(false);
 
                     lock (_getLock)
                     {
                         // finally double check whether some other thread has not created and added it by now, 
                         // since we had to release the lock to run the async onCacheMiss.
                         if (strategy != CachedResolverLoadingStrategy.LoadFromSource &&
-                            _cache.TryGetValue(identifier, out CacheEntry<T> existingEntry))
+                            _cache.TryGetValue(identifier, out CacheEntry<ResolverResult> existingEntry))
                             return existingEntry.Data;
                         else
                         {
@@ -286,7 +286,7 @@ namespace Hl7.Fhir.Specification.Source
                             // Note that an entry is created, even if the newData is null. 
                             // This ensures we don't keep trying to fetch the same url over and over again,
                             // even if the source cannot resolve it.
-                            _cache[identifier] = new CacheEntry<T>(newData, identifier, DateTimeOffset.UtcNow.AddSeconds(_duration));
+                            _cache[identifier] = new CacheEntry<ResolverResult>(newData, identifier, DateTimeOffset.UtcNow.AddSeconds(_duration));
                             return newData;
                         }
                     }

--- a/src/Hl7.Fhir.Base/Specification/Source/CachedResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/CachedResolver.cs
@@ -66,7 +66,7 @@ namespace Hl7.Fhir.Specification.Source
         public int CacheDuration { get; }
 
         /// <inheritdoc cref="ResolveByUriAsync(string)"/>
-        [Obsolete("CachedResolver now works best with asynchronous resolvers. Use ResolveByUriAsync() instead.")]
+        [Obsolete("CachedResolver now works best with asynchronous resolvers. Use TryResolveByUriAsync() instead.")]
         public Resource ResolveByUri(string url) => TryResolveByUri(url).Value;
 
         /// <summary>Retrieve the artifact with the specified url.</summary>
@@ -80,7 +80,7 @@ namespace Hl7.Fhir.Specification.Source
         }
 
         /// <inheritdoc cref="ResolveByUriAsync(string, CachedResolverLoadingStrategy)"/>
-        [Obsolete("CachedResolver now works best with asynchronous resolvers. Use ResolveByUriAsync() instead.")]
+        [Obsolete("CachedResolver now works best with asynchronous resolvers. Use TryResolveByUriAsync() instead.")]
         public Resource ResolveByUri(string url, CachedResolverLoadingStrategy strategy) =>
                 TaskHelper.Await(() => ResolveByUriAsync(url, strategy));
 
@@ -107,11 +107,13 @@ namespace Hl7.Fhir.Specification.Source
         }
 
         /// <inheritdoc cref="ResolveByCanonicalUriAsync(string)" />
-        [Obsolete("CachedResolver now works best with asynchronous resolvers. Use ResolveByCanonicalUriAsync() instead.")]
+        [Obsolete("CachedResolver now works best with asynchronous resolvers. Use TryResolveByCanonicalUriAsync() instead.")]
         public Resource ResolveByCanonicalUri(string url) => TryResolveByCanonicalUri(url).Value;
 
+        [Obsolete("CachedResolver now works best with asynchronous resolvers. Use TryResolveByUriAsync() instead.")]
         public ResolverResult TryResolveByUri(string uri) => TaskHelper.Await(() => TryResolveByUriAsync(uri));
 
+        [Obsolete("CachedResolver now works best with asynchronous resolvers. Use TryResolveByCanonicalUriAsync() instead.")]
         public ResolverResult TryResolveByCanonicalUri(string uri) => TaskHelper.Await(() => TryResolveByCanonicalUriAsync(uri));
 
         /// <summary>Retrieve the conformance resource with the specified canonical url.</summary>
@@ -129,7 +131,7 @@ namespace Hl7.Fhir.Specification.Source
         public async Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => await TryResolveByCanonicalUriAsync(uri, CachedResolverLoadingStrategy.LoadOnDemand).ConfigureAwait(false);
 
         /// <inheritdoc cref="ResolveByCanonicalUriAsync(string, CachedResolverLoadingStrategy)" />
-        [Obsolete("CachedResolver now works best with asynchronous resolvers. Use ResolveByCanonicalUriAsync() instead.")]
+        [Obsolete("CachedResolver now works best with asynchronous resolvers. Use TryResolveByCanonicalUriAsync() instead.")]
         public Resource ResolveByCanonicalUri(string url, CachedResolverLoadingStrategy strategy) =>
                 TaskHelper.Await(() => ResolveByCanonicalUriAsync(url, strategy));
 

--- a/src/Hl7.Fhir.Base/Specification/Source/CachedResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/CachedResolver.cs
@@ -32,8 +32,8 @@ namespace Hl7.Fhir.Specification.Source
         /// <summary>Default expiration time for cached entries.</summary>
         public const int DEFAULT_CACHE_DURATION = 4 * 3600;     // 4 hours
 
-        readonly Cache<Resource> _resourcesByUri;
-        readonly Cache<Resource> _resourcesByCanonical;
+        private readonly Cache<ResolverResult> _resourcesByUri;
+        private readonly Cache<ResolverResult> _resourcesByCanonical;
 
         /// <summary>Creates a new artifact resolver that caches loaded resources in memory.</summary>
         /// <param name="source">Resolver from which artifacts are initially resolved on a cache miss.</param>
@@ -46,8 +46,8 @@ namespace Hl7.Fhir.Specification.Source
             AsyncResolver = source.AsAsync();
             CacheDuration = cacheDuration;
 
-            _resourcesByUri = new Cache<Resource>(id => InternalResolveByUri(id), CacheDuration);
-            _resourcesByCanonical = new Cache<Resource>(id => InternalResolveByCanonicalUri(id), CacheDuration);
+            _resourcesByUri = new(InternalResolveByUri, CacheDuration);
+            _resourcesByCanonical = new(InternalResolveByCanonicalUri, CacheDuration);
         }
 
         /// <summary>
@@ -67,16 +67,16 @@ namespace Hl7.Fhir.Specification.Source
 
         /// <inheritdoc cref="ResolveByUriAsync(string)"/>
         [Obsolete("CachedResolver now works best with asynchronous resolvers. Use ResolveByUriAsync() instead.")]
-        public Resource ResolveByUri(string url) => TaskHelper.Await(() => ResolveByUriAsync(url));
-      
+        public Resource ResolveByUri(string url) => TryResolveByUri(url).Value;
+
         /// <summary>Retrieve the artifact with the specified url.</summary>
         /// <param name="url">The url of the target artifact.</param>
         /// <returns>A <see cref="Resource"/> instance, or <c>null</c> if unavailable.</returns>
         /// <remarks>Return data from memory cache if available, otherwise load on demand from the internal artifact source.</remarks>
         public async Task<Resource> ResolveByUriAsync(string url)
         {
-            if (url == null) throw Error.ArgumentNull(nameof(url));
-            return await _resourcesByUri.Get(url, CachedResolverLoadingStrategy.LoadOnDemand).ConfigureAwait(false);
+            var result = await TryResolveByUriAsync(url);
+            return result.Value;
         }
 
         /// <inheritdoc cref="ResolveByUriAsync(string, CachedResolverLoadingStrategy)"/>
@@ -91,13 +91,28 @@ namespace Hl7.Fhir.Specification.Source
         /// <remarks>Return data from memory cache if available, otherwise load on demand from the internal artifact source.</remarks>
         public async Task<Resource> ResolveByUriAsync(string url, CachedResolverLoadingStrategy strategy)
         {
+            var result = await TryResolveByUriAsync(url, strategy);
+            return result.Value;
+        }
+        
+        /// <summary>Retrieve the artifact with the specified url.</summary>
+        /// <param name="url">The url of the target artifact.</param>
+        /// <param name="strategy">Option flag to control the loading strategy.</param>
+        /// <returns>A <see cref="Resource"/> instance, or <c>null</c> if unavailable.</returns>
+        /// <remarks>Return data from memory cache if available, otherwise load on demand from the internal artifact source.</remarks>
+        public async Task<ResolverResult> TryResolveByUriAsync(string url, CachedResolverLoadingStrategy strategy)
+        {
             if (url == null) throw Error.ArgumentNull(nameof(url));
             return await _resourcesByUri.Get(url, strategy).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="ResolveByCanonicalUriAsync(string)" />
         [Obsolete("CachedResolver now works best with asynchronous resolvers. Use ResolveByCanonicalUriAsync() instead.")]
-        public Resource ResolveByCanonicalUri(string url) => TaskHelper.Await(() => ResolveByCanonicalUriAsync(url));
+        public Resource ResolveByCanonicalUri(string url) => TryResolveByCanonicalUri(url).Value;
+
+        public ResolverResult TryResolveByUri(string uri) => TaskHelper.Await(() => TryResolveByUriAsync(uri));
+
+        public ResolverResult TryResolveByCanonicalUri(string uri) => TaskHelper.Await(() => TryResolveByCanonicalUriAsync(uri));
 
         /// <summary>Retrieve the conformance resource with the specified canonical url.</summary>
         /// <param name="url">The canonical url of the target conformance resource.</param>
@@ -105,9 +120,13 @@ namespace Hl7.Fhir.Specification.Source
         /// <remarks>Return data from memory cache if available, otherwise load on demand from the internal artifact source.</remarks>
         public async Task<Resource> ResolveByCanonicalUriAsync(string url)
         {
-            if (url == null) throw Error.ArgumentNull(nameof(url));
-            return await _resourcesByCanonical.Get(url, CachedResolverLoadingStrategy.LoadOnDemand).ConfigureAwait(false);
+            var result = await TryResolveByCanonicalUriAsync(url);
+            return result.Value;
         }
+
+        public async Task<ResolverResult> TryResolveByUriAsync(string uri) => await TryResolveByUriAsync(uri, CachedResolverLoadingStrategy.LoadOnDemand).ConfigureAwait(false);
+
+        public async Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => await TryResolveByCanonicalUriAsync(uri, CachedResolverLoadingStrategy.LoadOnDemand).ConfigureAwait(false);
 
         /// <inheritdoc cref="ResolveByCanonicalUriAsync(string, CachedResolverLoadingStrategy)" />
         [Obsolete("CachedResolver now works best with asynchronous resolvers. Use ResolveByCanonicalUriAsync() instead.")]
@@ -121,8 +140,14 @@ namespace Hl7.Fhir.Specification.Source
         /// <remarks>Return data from memory cache if available, otherwise load on demand from the internal artifact source.</remarks>
         public async Task<Resource> ResolveByCanonicalUriAsync(string url, CachedResolverLoadingStrategy strategy)
         {
-            if (url == null) throw Error.ArgumentNull(nameof(url));
-            return await _resourcesByCanonical.Get(url, strategy).ConfigureAwait(false);
+            var result = await TryResolveByCanonicalUriAsync(url, strategy).ConfigureAwait(false);
+            return result.Value;
+        }
+        
+        public async Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri, CachedResolverLoadingStrategy strategy)
+        {
+            if (uri == null) throw Error.ArgumentNull(nameof(uri));
+            return await _resourcesByCanonical.Get(uri, strategy).ConfigureAwait(false);
         }
 
         /// <summary>Clear the cache entry for the artifact with the specified url, if it exists.</summary>
@@ -183,17 +208,17 @@ namespace Hl7.Fhir.Specification.Source
         /// <summary>Called when an artifact is loaded into the cache.</summary>
         protected virtual void OnLoad(string url, Resource resource) => Load?.Invoke(this, new LoadResourceEventArgs(url, resource));
 
-        internal async Task<Resource> InternalResolveByUri(string url)
+        internal async Task<ResolverResult> InternalResolveByUri(string url)
         {
-            var resource = await AsyncResolver.ResolveByUriAsync(url).ConfigureAwait(false);
-            OnLoad(url, resource);
+            var resource = await AsyncResolver.TryResolveByUriAsync(url).ConfigureAwait(false);
+            OnLoad(url, resource.Value);
             return resource;
         }
 
-        internal async Task<Resource> InternalResolveByCanonicalUri(string url)
+        internal async Task<ResolverResult> InternalResolveByCanonicalUri(string url)
         {
-            var resource = await AsyncResolver.ResolveByCanonicalUriAsync(url).ConfigureAwait(false);
-            OnLoad(url, resource);
+            var resource = await AsyncResolver.TryResolveByCanonicalUriAsync(url).ConfigureAwait(false);
+            OnLoad(url, resource.Value);
             return resource;
         }
 

--- a/src/Hl7.Fhir.Base/Specification/Source/IResourceResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/IResourceResolver.cs
@@ -5,11 +5,11 @@
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
-
 using System;
 using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 
+#nullable enable
 namespace Hl7.Fhir.Specification.Source
 {
     /// <summary>Interface for resolving FHIR artifacts by (canonical) uri.</summary>
@@ -19,13 +19,13 @@ namespace Hl7.Fhir.Specification.Source
     {
         /// <summary>Find a resource based on its relative or absolute uri.</summary>
         /// <param name="uri">A resource uri.</param>
-        [Obsolete("This does not provide information about the kind of error that lead to us returning null. Consider implementing TryResolveByUri instead.")]
-        Resource ResolveByUri(string uri);
+        [Obsolete("This method does not provide information about the kind of error that lead to us returning null. Consider using TryResolveByUri instead.")]
+        Resource? ResolveByUri(string uri);
 
         /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
         /// <param name="uri">The canonical url of a (conformance) resource.</param>
-        [Obsolete("This does not provide information about the kind of error that lead to us returning null. Consider implementing TryResolveByCanonicalUri instead.")]
-        Resource ResolveByCanonicalUri(string uri);
+        [Obsolete("This method does not provide information about the kind of error that lead to us returning null. Consider using TryResolveByCanonicalUri instead.")]
+        Resource? ResolveByCanonicalUri(string uri);
 
         /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
         /// <param name="uri">The canonical url of a (conformance) resource.</param>
@@ -65,14 +65,14 @@ namespace Hl7.Fhir.Specification.Source
     {
         /// <summary>Find a resource based on its relative or absolute uri.</summary>
         /// <param name="uri">A resource uri.</param>
-        [Obsolete("This does not provide information about the kind of error that lead to us returning null. Consider implementing TryResolveByUriAsync instead.")]
-        Task<Resource> ResolveByUriAsync(string uri);
+        [Obsolete("This method does not provide information about the kind of error that lead to us returning null. Consider using TryResolveByUriAsync instead.")]
+        Task<Resource?> ResolveByUriAsync(string uri);
 
 
         /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
         /// <param name="uri">The canonical url of a (conformance) resource.</param>
-        [Obsolete("This does not provide information about the kind of error that lead to us returning null. Consider implementing TryResolveByCanonicalUriAsync instead.")]
-        Task<Resource> ResolveByCanonicalUriAsync(string uri); // IConformanceResource
+        [Obsolete("This method does not provide information about the kind of error that lead to us returning null. Consider using TryResolveByCanonicalUriAsync instead.")]
+        Task<Resource?> ResolveByCanonicalUriAsync(string uri); // IConformanceResource
 
         /// <summary>Find a resource based on its relative or absolute uri.</summary>
         /// <param name="uri">A resource uri.</param>

--- a/src/Hl7.Fhir.Base/Specification/Source/IResourceResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/IResourceResolver.cs
@@ -18,7 +18,6 @@ namespace Hl7.Fhir.Specification.Source
 #pragma warning restore CS0618 // Type or member is obsolete
     {
         /// <summary>Find a resource based on its relative or absolute uri.</summary>
-        /// <param name="uri">A resource uri.</param>
         [Obsolete("This method does not provide information about the kind of error that lead to us returning null. Consider using TryResolveByUri instead.")]
         Resource? ResolveByUri(string uri);
 
@@ -27,8 +26,8 @@ namespace Hl7.Fhir.Specification.Source
         [Obsolete("This method does not provide information about the kind of error that lead to us returning null. Consider using TryResolveByCanonicalUri instead.")]
         Resource? ResolveByCanonicalUri(string uri);
 
-        /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
-        /// <param name="uri">The canonical url of a (conformance) resource.</param>
+        /// <summary>Find a resource based on its relative or absolute uri.</summary>
+        /// <param name="uri">A resource uri.</param>
         /// <returns><see cref="ResolverResult"/> with an actual resource, or the <see cref="ResolverResult.Error"/>.</returns>
         ResolverResult TryResolveByUri(string uri)
         {
@@ -42,8 +41,8 @@ namespace Hl7.Fhir.Specification.Source
             return ResolverException.NotFound();
         }
         
-        /// <summary>Find a resource based on its relative or absolute uri.</summary>
-        /// <param name="uri">A resource uri.</param>
+        /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
+        /// <param name="uri">The canonical url of a (conformance) resource.</param>
         /// <returns><see cref="ResolverResult"/> with an actual resource, or the <see cref="ResolverResult.Error"/>.</returns>
         ResolverResult TryResolveByCanonicalUri(string uri)
         {

--- a/src/Hl7.Fhir.Base/Specification/Source/IResourceResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/IResourceResolver.cs
@@ -80,7 +80,7 @@ namespace Hl7.Fhir.Specification.Source
         async Task<ResolverResult> TryResolveByUriAsync(string uri)
         {
 #pragma warning disable CS0618 // Type or member is obsolete
-            var resource = await this.ResolveByUriAsync(uri);
+            var resource = await this.ResolveByUriAsync(uri).ConfigureAwait(false);
 #pragma warning restore CS0618 // Type or member is obsolete
 
             if (resource is not null)
@@ -95,7 +95,7 @@ namespace Hl7.Fhir.Specification.Source
         async Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri)
         {
 #pragma warning disable CS0618 // Type or member is obsolete
-            var resource = await this.ResolveByCanonicalUriAsync(uri); 
+            var resource = await this.ResolveByCanonicalUriAsync(uri).ConfigureAwait(false); 
 #pragma warning restore CS0618 // Type or member is obsolete
 
             if (resource is not null) 

--- a/src/Hl7.Fhir.Base/Specification/Source/IResourceResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/IResourceResolver.cs
@@ -19,12 +19,43 @@ namespace Hl7.Fhir.Specification.Source
     {
         /// <summary>Find a resource based on its relative or absolute uri.</summary>
         /// <param name="uri">A resource uri.</param>
+        [Obsolete("This does not provide information about the kind of error that lead to us returning null. Consider implementing TryResolveByUri instead.")]
         Resource ResolveByUri(string uri);
-
 
         /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
         /// <param name="uri">The canonical url of a (conformance) resource.</param>
+        [Obsolete("This does not provide information about the kind of error that lead to us returning null. Consider implementing TryResolveByCanonicalUri instead.")]
         Resource ResolveByCanonicalUri(string uri);
+
+        /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
+        /// <param name="uri">The canonical url of a (conformance) resource.</param>
+        /// <returns><see cref="ResolverResult"/> with an actual resource, or the <see cref="ResolverResult.Error"/>.</returns>
+        ResolverResult TryResolveByUri(string uri)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            var resource = this.ResolveByUri(uri); 
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            if (resource is not null) 
+                return resource;
+            
+            return ResolverException.NotFound();
+        }
+        
+        /// <summary>Find a resource based on its relative or absolute uri.</summary>
+        /// <param name="uri">A resource uri.</param>
+        /// <returns><see cref="ResolverResult"/> with an actual resource, or the <see cref="ResolverResult.Error"/>.</returns>
+        ResolverResult TryResolveByCanonicalUri(string uri)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            var resource = this.ResolveByCanonicalUri(uri); 
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            if (resource is not null) 
+                return resource;
+            
+            return ResolverException.NotFound();
+        }
     }
 
 
@@ -34,12 +65,44 @@ namespace Hl7.Fhir.Specification.Source
     {
         /// <summary>Find a resource based on its relative or absolute uri.</summary>
         /// <param name="uri">A resource uri.</param>
+        [Obsolete("This does not provide information about the kind of error that lead to us returning null. Consider implementing TryResolveByUriAsync instead.")]
         Task<Resource> ResolveByUriAsync(string uri);
 
 
         /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
         /// <param name="uri">The canonical url of a (conformance) resource.</param>
+        [Obsolete("This does not provide information about the kind of error that lead to us returning null. Consider implementing TryResolveByCanonicalUriAsync instead.")]
         Task<Resource> ResolveByCanonicalUriAsync(string uri); // IConformanceResource
+
+        /// <summary>Find a resource based on its relative or absolute uri.</summary>
+        /// <param name="uri">A resource uri.</param>
+        /// <returns><see cref="ResolverResult"/> with an actual resource, or the <see cref="ResolverResult.Error"/>.</returns>
+        async Task<ResolverResult> TryResolveByUriAsync(string uri)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            var resource = await this.ResolveByUriAsync(uri);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            if (resource is not null)
+                return resource;
+
+            return ResolverException.NotFound();
+        }
+
+        /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
+        /// <param name="uri">The canonical url of a (conformance) resource.</param>
+        /// <returns><see cref="ResolverResult"/> with an actual resource, or the <see cref="ResolverResult.Error"/>.</returns>
+        async Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            var resource = await this.ResolveByCanonicalUriAsync(uri); 
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            if (resource is not null) 
+                return resource;
+            
+            return ResolverException.NotFound();
+        }
     }
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/Specification/Source/InMemoryResourceResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/InMemoryResourceResolver.cs
@@ -94,10 +94,36 @@ namespace Hl7.Fhir.Specification.Source
                 : null;
         }
 
+        public ResolverResult TryResolveByUri(string uri)
+        {
+            var resource = _resources
+                .Where(r => r.Uri == uri)
+                .Select(r => r.Resource)
+                .FirstOrDefault();
+
+            if (resource is not null)
+                return resource;
+            
+            return new ResolverException("NOTFOUND", $"No resource matching the {nameof(uri)} found");
+        }
+
+        public ResolverResult TryResolveByCanonicalUri(string uri)
+        {
+            var resource =  _resources
+                .Where(r => r.Url == uri)
+                .Select(r => r.Resource)
+                .FirstOrDefault();
+            
+            if (resource is not null)
+                return resource;
+
+            return new ResolverException("NOTFOUND", $"No resource matching the {nameof(uri)} found");
+        }
+
         ///<inheritdoc/>
         public Resource? ResolveByCanonicalUri(string uri)
         {
-            return _resources.Where(r => r.Url == uri)?.Select(r => r.Resource).FirstOrDefault();
+            return TryResolveByCanonicalUri(uri).Value;
         }
 
         ///<inheritdoc/>
@@ -105,17 +131,27 @@ namespace Hl7.Fhir.Specification.Source
         {
             return Task.FromResult(ResolveByCanonicalUri(uri));
         }
-
+        
         ///<inheritdoc/>
         public Resource? ResolveByUri(string uri)
         {
-            return _resources.Where(r => r.Uri == uri)?.Select(r => r.Resource).FirstOrDefault();
+            return TryResolveByUri(uri).Value;
         }
 
         ///<inheritdoc/>
         public Task<Resource?> ResolveByUriAsync(string uri)
         {
             return Task.FromResult(ResolveByUri(uri));
+        }
+
+        public Task<ResolverResult> TryResolveByUriAsync(string uri)
+        {
+            return Task.FromResult(TryResolveByUri(uri));
+        }
+
+        public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri)
+        {
+            return Task.FromResult(TryResolveByCanonicalUri(uri));
         }
     }
 }

--- a/src/Hl7.Fhir.Base/Specification/Source/InMemoryResourceResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/InMemoryResourceResolver.cs
@@ -104,7 +104,7 @@ namespace Hl7.Fhir.Specification.Source
             if (resource is not null)
                 return resource;
             
-            return new ResolverException("NOTFOUND", $"No resource matching the {nameof(uri)} found");
+            return ResolverException.NotFound();
         }
 
         public ResolverResult TryResolveByCanonicalUri(string uri)
@@ -117,7 +117,7 @@ namespace Hl7.Fhir.Specification.Source
             if (resource is not null)
                 return resource;
 
-            return new ResolverException("NOTFOUND", $"No resource matching the {nameof(uri)} found");
+            return ResolverException.NotFound();
         }
 
         ///<inheritdoc/>

--- a/src/Hl7.Fhir.Base/Specification/Source/InMemoryResourceResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/InMemoryResourceResolver.cs
@@ -94,6 +94,7 @@ namespace Hl7.Fhir.Specification.Source
                 : null;
         }
 
+        ///<inheritdoc/>
         public ResolverResult TryResolveByUri(string uri)
         {
             var resource = _resources
@@ -107,6 +108,7 @@ namespace Hl7.Fhir.Specification.Source
             return ResolverException.NotFound();
         }
 
+        ///<inheritdoc/>
         public ResolverResult TryResolveByCanonicalUri(string uri)
         {
             var resource =  _resources
@@ -144,11 +146,13 @@ namespace Hl7.Fhir.Specification.Source
             return Task.FromResult(ResolveByUri(uri));
         }
 
+        ///<inheritdoc/>
         public Task<ResolverResult> TryResolveByUriAsync(string uri)
         {
             return Task.FromResult(TryResolveByUri(uri));
         }
 
+        ///<inheritdoc/>
         public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri)
         {
             return Task.FromResult(TryResolveByCanonicalUri(uri));

--- a/src/Hl7.Fhir.Base/Specification/Source/MultiResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/MultiResolver.cs
@@ -13,7 +13,8 @@ using System.Linq;
 using Hl7.Fhir.Utility;
 using System.Diagnostics;
 using System.Threading.Tasks;
-
+    
+#nullable enable
 namespace Hl7.Fhir.Specification.Source
 {
     /// <summary>
@@ -72,16 +73,10 @@ namespace Hl7.Fhir.Specification.Source
         private IEnumerable<IAsyncResourceResolver> allSourcesAsAsync() => _sources.Select(src => src.AsAsync());
 
 
-        [Obsolete("MultiResolver now works best with asynchronous resolvers. Use ResolveByUriAsync() instead.")]
+        [Obsolete("MultiResolver now works best with asynchronous resolvers. Use TryResolveByUriAsync() instead.")]
         public Resource ResolveByUri(string uri) => TryResolveByUri(uri).Value;
 
-        public async Task<Resource> ResolveByUriAsync(string uri)
-        {
-            var resource = await TryResolveByUriAsync(uri);
-            return resource.Value;
-        }
-
-        [Obsolete("MultiResolver now works best with asynchronous resolvers. Use ResolveByCanonicalUriAsync() instead.")]
+        [Obsolete("MultiResolver now works best with asynchronous resolvers. Use TryResolveByCanonicalUriAsync() instead.")]
         public Resource ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
         
         [Obsolete("MultiResolver now works best with asynchronous resolvers. Use TryResolveByUriAsync() instead.")]
@@ -90,7 +85,13 @@ namespace Hl7.Fhir.Specification.Source
         [Obsolete("MultiResolver now works best with asynchronous resolvers. Use TryResolveByCanonicalUriAsync() instead.")]
         public ResolverResult TryResolveByCanonicalUri(string uri) => TaskHelper.Await(() => TryResolveByCanonicalUriAsync(uri));
 
-        public async Task<Resource> ResolveByCanonicalUriAsync(string uri)
+        public async Task<Resource?> ResolveByUriAsync(string uri)
+        {
+            var resource = await TryResolveByUriAsync(uri);
+            return resource.Value;
+        }
+        
+        public async Task<Resource?> ResolveByCanonicalUriAsync(string uri)
         {
             var resource = await TryResolveByCanonicalUriAsync(uri);
             return resource.Value;

--- a/src/Hl7.Fhir.Base/Specification/Source/MultiResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/MultiResolver.cs
@@ -73,53 +73,81 @@ namespace Hl7.Fhir.Specification.Source
 
 
         [Obsolete("MultiResolver now works best with asynchronous resolvers. Use ResolveByUriAsync() instead.")]
-        public Resource ResolveByUri(string uri) => TaskHelper.Await(() => ResolveByUriAsync(uri));
+        public Resource ResolveByUri(string uri) => TryResolveByUri(uri).Value;
 
         public async Task<Resource> ResolveByUriAsync(string uri)
         {
+            var resource = await TryResolveByUriAsync(uri);
+            return resource.Value;
+        }
+
+        [Obsolete("MultiResolver now works best with asynchronous resolvers. Use ResolveByCanonicalUriAsync() instead.")]
+        public Resource ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
+        
+        [Obsolete("MultiResolver now works best with asynchronous resolvers. Use TryResolveByUriAsync() instead.")]
+        public ResolverResult TryResolveByUri(string uri) => TaskHelper.Await(() => TryResolveByUriAsync(uri));
+
+        [Obsolete("MultiResolver now works best with asynchronous resolvers. Use TryResolveByCanonicalUriAsync() instead.")]
+        public ResolverResult TryResolveByCanonicalUri(string uri) => TaskHelper.Await(() => TryResolveByCanonicalUriAsync(uri));
+
+        public async Task<Resource> ResolveByCanonicalUriAsync(string uri)
+        {
+            var resource = await TryResolveByCanonicalUriAsync(uri);
+            return resource.Value;
+        }
+
+        public async Task<ResolverResult> TryResolveByUriAsync(string uri)
+        {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));
 
+            List<ResolverException> innerErrors = new();
             foreach (IAsyncResourceResolver source in allSourcesAsAsync())
             {
                 try
                 {
-                    var result = await source.ResolveByUriAsync(uri).ConfigureAwait(false);
+                    var result = await source.TryResolveByUriAsync(uri).ConfigureAwait(false);
 
-                    if (result != null) return result;
+                    if (result.Success) 
+                        return result;
+                    
+                    innerErrors.Add(result.Error);
                 }
-                catch(NotImplementedException)
+                catch(NotImplementedException ex)
                 {
+                    innerErrors.Add(ResolverException.NotImplemented(ex));
                     // Don't do anything, just try the next IArtifactSource
                 }
             }
 
             // None of the IArtifactSources succeeded in returning a result
-            return null;
+            return ResolverException.MultiResolverNotFound(innerErrors);
         }
 
-        [Obsolete("MultiResolver now works best with asynchronous resolvers. Use ResolveByCanonicalUriAsync() instead.")]
-        public Resource ResolveByCanonicalUri(string uri) => TaskHelper.Await(() => ResolveByCanonicalUriAsync(uri));
-
-        public async Task<Resource> ResolveByCanonicalUriAsync(string uri)
+        public async Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri)
         {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));
 
+            List<ResolverException> innerErrors = new();
             foreach (var source in allSourcesAsAsync())
             {
                 try
                 {
-                    var result = await source.ResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
+                    var result = await source.TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
 
-                    if (result != null) return result;
+                    if (result.Success)
+                        return result;
+                    
+                    innerErrors.Add(result.Error);
                 }
-                catch (NotImplementedException)
+                catch (NotImplementedException ex)
                 {
+                    innerErrors.Add(ResolverException.NotImplemented(ex));
                     // Don't do anything, just try the next IArtifactSource
                 }
             }
 
             // None of the IArtifactSources succeeded in returning a result
-            return null;
+            return ResolverException.MultiResolverNotFound(innerErrors);
         }
 
         // Allow derived classes to override

--- a/src/Hl7.Fhir.Base/Specification/Source/MultiResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/MultiResolver.cs
@@ -79,9 +79,11 @@ namespace Hl7.Fhir.Specification.Source
         [Obsolete("MultiResolver now works best with asynchronous resolvers. Use TryResolveByCanonicalUriAsync() instead.")]
         public Resource ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
         
+        ///<inheritdoc/>
         [Obsolete("MultiResolver now works best with asynchronous resolvers. Use TryResolveByUriAsync() instead.")]
         public ResolverResult TryResolveByUri(string uri) => TaskHelper.Await(() => TryResolveByUriAsync(uri));
 
+        ///<inheritdoc/>
         [Obsolete("MultiResolver now works best with asynchronous resolvers. Use TryResolveByCanonicalUriAsync() instead.")]
         public ResolverResult TryResolveByCanonicalUri(string uri) => TaskHelper.Await(() => TryResolveByCanonicalUriAsync(uri));
 
@@ -97,6 +99,7 @@ namespace Hl7.Fhir.Specification.Source
             return resource.Value;
         }
 
+        ///<inheritdoc/>
         public async Task<ResolverResult> TryResolveByUriAsync(string uri)
         {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));
@@ -124,6 +127,7 @@ namespace Hl7.Fhir.Specification.Source
             return ResolverException.MultiResolverNotFound(innerErrors);
         }
 
+        ///<inheritdoc/>
         public async Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri)
         {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));

--- a/src/Hl7.Fhir.Base/Specification/Source/ResolverException.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/ResolverException.cs
@@ -6,19 +6,56 @@ using System.Linq;
 
 namespace Hl7.Fhir.Specification.Source;
 
+/// <summary>
+/// Exception reporting issues during resolving in <see cref="IResourceResolver"/> and <see cref="IAsyncResourceResolver"/>.
+/// It is built on top of <see cref="CodedException"/> reporting errors as code and reacting to relevant issues appropriatelly.
+/// </summary>
 public class ResolverException : CodedException
 {
+    /// <summary>
+    /// The used resolve operation was not implemented.
+    /// </summary>
     public const string NOT_IMPLEMENTED = "RESOLVE101";
+    /// <summary>
+    /// The requested resource could not be found.
+    /// </summary>
     public const string NOT_FOUND = "RESOLVE102";
+    /// <summary>
+    /// Failure during snapshot generation.
+    /// </summary>
     public const string SNAPSHOT_FAILURE = "RESOLVE103";
+    /// <summary>
+    /// Failure during requested operation.
+    /// </summary>
     public const string OPERATION_FAILURE = "RESOLVE104";
+    /// <summary>
+    /// No match has been found in the artifact summary for the requested uri.
+    /// </summary>
     public const string ARTIFACT_SUMMARY_NO_MATCH = "RESOLVE105";
-    public const string INVALID_RESOURCE_IDENTITY = "RESOLVE106";
+    /// <summary>
+    /// Artifact summary has been found, but required information to resolve the resource were missing.
+    /// </summary>
+    public const string ARTIFACT_SUMMARY_ARGUMENT_EXCEPTION = "RESOLVE106";
+    /// <summary>
+    /// Resource identity does not represent a valid URI.
+    /// </summary>
+    public const string INVALID_RESOURCE_IDENTITY = "RESOLVE107";
     
+    /// <summary>
+    /// Constructor for <see cref="ResolverException"/>.
+    /// </summary>
+    /// <param name="errorCode">Code relevant for the issue the exception represents</param>
+    /// <param name="message">Description of the issues</param>
     public ResolverException(string errorCode, string message) : base(errorCode, message)
     {
     }
 
+    /// <summary>
+    /// Constructor for <see cref="ResolverException"/>.
+    /// </summary>
+    /// <param name="errorCode">Code relevant for the issue the exception represents</param>
+    /// <param name="message">Description of the issues</param>
+    /// <param name="innerException">Inner exception that is being wrapped by resolver</param>
     public ResolverException(string errorCode, string message, Exception innerException) : base(errorCode, message, innerException)
     {
     }
@@ -42,6 +79,11 @@ public class ResolverException : CodedException
     internal static ResolverException ArtifactSummaryNoMatch(string uri)
     {
         return new ResolverException(ARTIFACT_SUMMARY_NO_MATCH, $"No summary matching the provided {nameof(uri)}: {uri}");
+    }
+    
+    internal static ResolverException ArtifactSummaryArgumentException(ArgumentException ex)
+    {
+        return new ResolverException(ARTIFACT_SUMMARY_ARGUMENT_EXCEPTION, ex.Message, ex);
     }
 
     internal static ResolverException NotValidResourceIdentity(string uri)

--- a/src/Hl7.Fhir.Base/Specification/Source/ResolverException.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/ResolverException.cs
@@ -11,7 +11,9 @@ public class ResolverException : CodedException
     public const string NOT_IMPLEMENTED = "RESOLVE101";
     public const string NOT_FOUND = "RESOLVE102";
     public const string SNAPSHOT_FAILURE = "RESOLVE103";
-    public const string ARTIFACT_SUMMARY_NO_MATCH = "RESOLVE104";
+    public const string OPERATION_FAILURE = "RESOLVE104";
+    public const string ARTIFACT_SUMMARY_NO_MATCH = "RESOLVE105";
+    public const string INVALID_RESOURCE_IDENTITY = "RESOLVE106";
     
     public ResolverException(string errorCode, string message) : base(errorCode, message)
     {
@@ -31,13 +33,23 @@ public class ResolverException : CodedException
 
         return new ResolverException(NOT_FOUND, $"None of the resolvers could find the resource. Following errors reported: {Environment.NewLine}{commaSeparatedErrors}", new AggregateException(innerErrors));
     }
-    public static ResolverException SnapshotOutcome(OperationOutcome generatorOutcome)
+    internal static ResolverException SnapshotOutcome(OperationOutcome generatorOutcome)
     {
         var outcomeMessages = string.Join(Environment.NewLine, generatorOutcome.Issue.Select(x => x.ToString()));
         return new ResolverException(SNAPSHOT_FAILURE, outcomeMessages);
     }
-    public static ResolverException ArtifactSummaryNoMatch(string uri)
+
+    internal static ResolverException ArtifactSummaryNoMatch(string uri)
     {
         return new ResolverException(ARTIFACT_SUMMARY_NO_MATCH, $"No summary matching the provided {nameof(uri)}: {uri}");
+    }
+
+    internal static ResolverException NotValidResourceIdentity(string uri)
+    {
+        return new ResolverException(INVALID_RESOURCE_IDENTITY, $"Provided {nameof(uri)} is not a valid resource identity URI: {uri}");
+    }
+    internal static ResolverException OperationFailed(string message, Exception innerException)
+    {
+        return new ResolverException(OPERATION_FAILURE, message, innerException);
     }
 }

--- a/src/Hl7.Fhir.Base/Specification/Source/ResolverException.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/ResolverException.cs
@@ -1,0 +1,43 @@
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Hl7.Fhir.Specification.Source;
+
+public class ResolverException : CodedException
+{
+    public const string NOT_IMPLEMENTED = "RESOLVE101";
+    public const string NOT_FOUND = "RESOLVE102";
+    public const string SNAPSHOT_FAILURE = "RESOLVE103";
+    public const string ARTIFACT_SUMMARY_NO_MATCH = "RESOLVE104";
+    
+    public ResolverException(string errorCode, string message) : base(errorCode, message)
+    {
+    }
+
+    public ResolverException(string errorCode, string message, Exception innerException) : base(errorCode, message, innerException)
+    {
+    }
+
+    internal static ResolverException NotImplemented(Exception ex) => new(NOT_IMPLEMENTED, "Resolver does not implement the used Resolve method.", ex);
+    internal static ResolverException NotFound() => new(NOT_FOUND, "Resource could not be found.");
+    internal static ResolverException MultiResolverNotFound(List<ResolverException> innerErrors)
+    {
+        var commaSeparatedErrors = string.Join(", ", innerErrors
+            .OrderBy(x => x.ErrorCode)
+            .Select(x => x.Message));
+
+        return new ResolverException(NOT_FOUND, $"None of the resolvers could find the resource. Following errors reported: {Environment.NewLine}{commaSeparatedErrors}", new AggregateException(innerErrors));
+    }
+    public static ResolverException SnapshotOutcome(OperationOutcome generatorOutcome)
+    {
+        var outcomeMessages = string.Join(Environment.NewLine, generatorOutcome.Issue.Select(x => x.ToString()));
+        return new ResolverException(SNAPSHOT_FAILURE, outcomeMessages);
+    }
+    public static ResolverException ArtifactSummaryNoMatch(string uri)
+    {
+        return new ResolverException(ARTIFACT_SUMMARY_NO_MATCH, $"No summary matching the provided {nameof(uri)}: {uri}");
+    }
+}

--- a/src/Hl7.Fhir.Base/Specification/Source/ResolverResult.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/ResolverResult.cs
@@ -1,22 +1,40 @@
 using Hl7.Fhir.Model;
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Hl7.Fhir.Specification.Source;
 
+/// <summary>
+/// Choice type representing the current result of resolve operation
+/// </summary>
 public readonly record struct ResolverResult
 {
+    /// <summary>
+    /// Whether the operation successfully retrieved a resource
+    /// </summary>
     public bool Success => Value != null;
-        
+      
+    /// <summary>
+    /// Value retrieved from resource resolver
+    /// </summary>
 #if NET8_0_OR_GREATER
     [MemberNotNullWhen(true, nameof(Success))]
 #endif
     public Resource Value { get; private init; }
     
+    /// <summary>
+    /// Error encountered while attempting retrieval of resource
+    /// </summary>
 #if NET8_0_OR_GREATER
     [MemberNotNullWhen(false, nameof(Success))]
 #endif
     public ResolverException Error { get; private init; }
 
+    /// <summary>
+    /// Constructor for successfully resolved resource
+    /// </summary>
+    /// <param name="value">Resolved resource</param>
+    /// <exception cref="ArgumentNullException">Resource provided was null</exception>
 #if NET8_0_OR_GREATER
     [SetsRequiredMembers]
 #endif
@@ -26,6 +44,10 @@ public readonly record struct ResolverResult
         Error = null;
     }
 
+    /// <summary>
+    /// Constructor for failure to resolve, resulting in error
+    /// </summary>
+    /// <param name="error">Error encountered during resolve</param>
     #if NET8_0_OR_GREATER
     [SetsRequiredMembers]
     #endif
@@ -35,6 +57,12 @@ public readonly record struct ResolverResult
         Value = null;
     }
     
+    /// <summary>
+    /// Constructor for when a resource was successfully resolved, but additional initialization logic failed
+    /// </summary>
+    /// <param name="value">Resolved resource</param>
+    /// <param name="error">Error encountered during additional initialization</param>
+    /// <exception cref="ArgumentNullException">Resource provided was null</exception>
 #if NET8_0_OR_GREATER
     [SetsRequiredMembers]
 #endif
@@ -43,8 +71,23 @@ public readonly record struct ResolverResult
         Error = error;
     }
     
+    /// <summary>
+    /// Implicit conversion of the <see cref="ResolverResult"/> to boolean.
+    /// </summary>
+    /// <param name="result">Instance of <see cref="ResolverResult"/></param>
+    /// <returns><c>true</c> if choice type has a <see cref="Value"/>. otherwise <c>false</c>.</returns>
     public static implicit operator bool(ResolverResult result) => result.Success;
 
+    /// <summary>
+    /// Implicit conversion of a resource to <see cref="ResolverResult"/>
+    /// </summary>
+    /// <param name="value">Resolved resource</param>
+    /// <returns><see cref="ResolverResult"/> representing the successfully retrieved <see cref="Resource"/>.</returns>
     public static implicit operator ResolverResult(Resource value) => new(value);
+    /// <summary>
+    /// Implicit conversion of an error to <see cref="ResolverResult"/>
+    /// </summary>
+    /// <param name="error">Error encountered during resolving of resource</param>
+    /// <returns><see cref="ResolverResult"/> representing the provided error.</returns>
     public static implicit operator ResolverResult(ResolverException error) => new(error);
 }

--- a/src/Hl7.Fhir.Base/Specification/Source/ResolverResult.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/ResolverResult.cs
@@ -1,0 +1,42 @@
+using Hl7.Fhir.Model;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Hl7.Fhir.Specification.Source;
+
+public readonly record struct ResolverResult
+{
+    public bool Success => Value != null;
+        
+#if NET8_0_OR_GREATER
+    [MemberNotNullWhen(true, nameof(Success))]
+#endif
+    public Resource Value { get; private init; }
+    
+#if NET8_0_OR_GREATER
+    [MemberNotNullWhen(false, nameof(Success))]
+#endif
+    public ResolverException Error { get; private init; }
+
+#if NET8_0_OR_GREATER
+    [SetsRequiredMembers]
+#endif
+    public ResolverResult(Resource value)
+    {
+        Value = value ?? throw Utility.Error.ArgumentNull(nameof(value));
+        Error = null;
+    }
+
+    #if NET8_0_OR_GREATER
+    [SetsRequiredMembers]
+    #endif
+    public ResolverResult(ResolverException error)
+    {
+        Error = error;
+        Value = null;
+    }
+        
+    public static implicit operator bool(ResolverResult result) => result.Success;
+
+    public static implicit operator ResolverResult(Resource value) => new(value);
+    public static implicit operator ResolverResult(ResolverException error) => new(error);
+}

--- a/src/Hl7.Fhir.Base/Specification/Source/ResolverResult.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/ResolverResult.cs
@@ -34,7 +34,15 @@ public readonly record struct ResolverResult
         Error = error;
         Value = null;
     }
-        
+    
+#if NET8_0_OR_GREATER
+    [SetsRequiredMembers]
+#endif
+    public ResolverResult(Resource value, ResolverException error) : this(value)
+    {
+        Error = error;
+    }
+    
     public static implicit operator bool(ResolverResult result) => result.Success;
 
     public static implicit operator ResolverResult(Resource value) => new(value);

--- a/src/Hl7.Fhir.Base/Specification/Source/SyncToAsyncResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/SyncToAsyncResolver.cs
@@ -35,11 +35,13 @@ namespace Hl7.Fhir.Specification.Source
             return Task.FromResult(result);
         }
 
+        ///<inheritdoc/>
         public Task<ResolverResult> TryResolveByUriAsync(string uri)
         {
             return Task.FromResult(SyncResolver.TryResolveByUri(uri));
         }
 
+        ///<inheritdoc/>
         public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri)
         {
             return Task.FromResult(SyncResolver.TryResolveByCanonicalUri(uri));

--- a/src/Hl7.Fhir.Base/Specification/Source/SyncToAsyncResolver.cs
+++ b/src/Hl7.Fhir.Base/Specification/Source/SyncToAsyncResolver.cs
@@ -7,6 +7,7 @@
  */
 
 using Hl7.Fhir.Model;
+using Hl7.Fhir.Utility;
 using System;
 using System.Threading.Tasks;
 
@@ -23,15 +24,25 @@ namespace Hl7.Fhir.Specification.Source
 
         public Task<Resource> ResolveByUriAsync(string uri)
         {
-            var result = SyncResolver.ResolveByUri(uri);
+            var result = SyncResolver.TryResolveByUri(uri).Value;
 
             return Task.FromResult(result);
         }
 
         public Task<Resource> ResolveByCanonicalUriAsync(string uri)
         {
-            var result = SyncResolver.ResolveByCanonicalUri(uri);
+            var result = SyncResolver.TryResolveByCanonicalUri(uri).Value;
             return Task.FromResult(result);
+        }
+
+        public Task<ResolverResult> TryResolveByUriAsync(string uri)
+        {
+            return Task.FromResult(SyncResolver.TryResolveByUri(uri));
+        }
+
+        public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri)
+        {
+            return Task.FromResult(SyncResolver.TryResolveByCanonicalUri(uri));
         }
     }
 

--- a/src/Hl7.Fhir.Conformance/Specification/Source/CommonDirectorySource.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Source/CommonDirectorySource.cs
@@ -592,8 +592,16 @@ namespace Hl7.Fhir.Specification.Source
 
             if(summary is null)
                 return ResolverException.ArtifactSummaryNoMatch(uri);
-            
-            var resource = loadResourceInternal<Resource>(summary);
+
+            Resource? resource;
+            try
+            {
+                resource = loadResourceInternal<Resource>(summary);
+            }
+            catch(ArgumentException ex)
+            {
+                return ResolverException.ArtifactSummaryArgumentException(ex);
+            }
 
             if (resource is null)
                 return ResolverException.NotFound();
@@ -609,7 +617,15 @@ namespace Hl7.Fhir.Specification.Source
             if(summary is null)
                 return ResolverException.ArtifactSummaryNoMatch(uri);
             
-            var resource = loadResourceInternal<Resource>(summary);
+            Resource? resource;
+            try
+            {
+                resource = loadResourceInternal<Resource>(summary);
+            }
+            catch(ArgumentException ex)
+            {
+                return ResolverException.ArtifactSummaryArgumentException(ex);
+            }
 
             if (resource is null)
                 return ResolverException.NotFound();

--- a/src/Hl7.Fhir.Conformance/Specification/Source/CommonDirectorySource.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Source/CommonDirectorySource.cs
@@ -579,20 +579,42 @@ namespace Hl7.Fhir.Specification.Source
 
         /// <summary>Find a resource based on its relative or absolute uri.</summary>
         /// <param name="uri">A resource uri.</param>
-        public Resource? ResolveByUri(string uri)
-        {
-            if (uri == null) throw Error.ArgumentNull(nameof(uri));
-            var summary = GetSummaries().ResolveByUri(uri, _inspector);
-            return summary is not null ? loadResourceInternal<Resource>(summary) : null;
-        }
+        public Resource? ResolveByUri(string uri) => TryResolveByUri(uri).Value;
 
         /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
         /// <param name="uri">The canonical url of a (conformance) resource.</param>
-        public Resource? ResolveByCanonicalUri(string uri)
+        public Resource? ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
+
+        public ResolverResult TryResolveByUri(string uri)
+        {
+            if (uri == null) throw Error.ArgumentNull(nameof(uri));
+            var summary = GetSummaries().ResolveByUri(uri, _inspector);
+
+            if(summary is null)
+                return ResolverException.ArtifactSummaryNoMatch(uri);
+            
+            var resource = loadResourceInternal<Resource>(summary);
+
+            if (resource is null)
+                return ResolverException.NotFound();
+            
+            return resource;
+        }
+
+        public ResolverResult TryResolveByCanonicalUri(string uri)
         {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));
             var summary = GetSummaries().ResolveByCanonicalUri(uri, _inspector);
-            return summary is not null ? loadResourceInternal<Resource>(summary) : null;
+
+            if(summary is null)
+                return ResolverException.ArtifactSummaryNoMatch(uri);
+            
+            var resource = loadResourceInternal<Resource>(summary);
+
+            if (resource is null)
+                return ResolverException.NotFound();
+            
+            return resource;
         }
 
         #endregion
@@ -1001,6 +1023,8 @@ namespace Hl7.Fhir.Specification.Source
         public Tasks.Task<Resource?> ResolveByUriAsync(string uri) => Tasks.Task.FromResult(ResolveByUri(uri));
 
         public Tasks.Task<Resource?> ResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult(ResolveByCanonicalUri(uri));
+        public Tasks.Task<ResolverResult> TryResolveByUriAsync(string uri) => Tasks.Task.FromResult(TryResolveByUri(uri));
+        public Tasks.Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult(TryResolveByCanonicalUri(uri));
 
         #endregion
 

--- a/src/Hl7.Fhir.Conformance/Specification/Source/CommonDirectorySource.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Source/CommonDirectorySource.cs
@@ -585,6 +585,7 @@ namespace Hl7.Fhir.Specification.Source
         /// <param name="uri">The canonical url of a (conformance) resource.</param>
         public Resource? ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
 
+        ///<inheritdoc/>
         public ResolverResult TryResolveByUri(string uri)
         {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));
@@ -609,6 +610,7 @@ namespace Hl7.Fhir.Specification.Source
             return resource;
         }
 
+        ///<inheritdoc/>
         public ResolverResult TryResolveByCanonicalUri(string uri)
         {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));

--- a/src/Hl7.Fhir.Conformance/Specification/Source/CommonWebResolver.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Source/CommonWebResolver.cs
@@ -64,9 +64,7 @@ namespace Hl7.Fhir.Specification.Source
         {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));
             if (!ResourceIdentity.IsRestResourceIdentity(uri))
-            {
-                return new ResolverException("NOTVALIDARG", "Provided uri is not a valid resource identity URI");
-            }
+                return ResolverException.NotValidResourceIdentity(uri);
             
             var id = new ResourceIdentity(uri);
             var client = _clientFactory(id.BaseUri);
@@ -83,12 +81,12 @@ namespace Hl7.Fhir.Specification.Source
             catch (FhirOperationException foe)
             {
                 LastError = foe;
-                return new ResolverException("OPERATIONEXCEPTION", "Error occurred during Fhir operation", foe);
+                return ResolverException.OperationFailed("Error occurred during Fhir operation", foe);
             }
             catch (WebException we)
             {
                 LastError = we;
-                return new ResolverException("OPERATIONEXCEPTION", "Error occurred during web operation", we);
+                return ResolverException.OperationFailed("Error occurred during web operation", we);
             }
             // Other runtime exceptions are fatal...
         }

--- a/src/Hl7.Fhir.Conformance/Specification/Source/CommonWebResolver.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Source/CommonWebResolver.cs
@@ -52,23 +52,30 @@ namespace Hl7.Fhir.Specification.Source
 
         public Resource? ResolveByUri(string uri)
         {
-            if (uri is null) throw Error.ArgumentNull(nameof(uri));
+            return TryResolveByUri(uri).Value;
+        }
+
+        public Resource? ResolveByCanonicalUri(string uri)
+        {
+            return TryResolveByCanonicalUri(uri).Value;
+        }
+
+        public ResolverResult TryResolveByUri(string uri)
+        {
+            if (uri == null) throw Error.ArgumentNull(nameof(uri));
             if (!ResourceIdentity.IsRestResourceIdentity(uri))
             {
-                // Weakness in FhirClient, need to have the base :-(  So return null if we cannot determine it.
-                return null;
+                return new ResolverException("NOTVALIDARG", "Provided uri is not a valid resource identity URI");
             }
-
+            
             var id = new ResourceIdentity(uri);
-
             var client = _clientFactory(id.BaseUri);
-
             client.Settings.Timeout = this.TimeOut;
             client.Settings.ParserSettings = this.ParserSettings;
 
             try
             {
-                var resultResource = TaskHelper.Await( () => client.ReadAsync<Resource>(id));
+                var resultResource = TaskHelper.Await(() => client.ReadAsync<Resource>(id));
                 resultResource.SetOrigin(uri);
                 LastError = null;
                 return resultResource;
@@ -76,23 +83,33 @@ namespace Hl7.Fhir.Specification.Source
             catch (FhirOperationException foe)
             {
                 LastError = foe;
-                return null;
+                return new ResolverException("OPERATIONEXCEPTION", "Error occurred during Fhir operation", foe);
             }
             catch (WebException we)
             {
                 LastError = we;
-                return null;
+                return new ResolverException("OPERATIONEXCEPTION", "Error occurred during web operation", we);
             }
             // Other runtime exceptions are fatal...
         }
 
-        public Resource? ResolveByCanonicalUri(string uri)
-        {
-            return ResolveByUri(uri);
-        }
+        public ResolverResult TryResolveByCanonicalUri(string uri) => TryResolveByUri(uri);
 
-        public Tasks.Task<Resource?> ResolveByUriAsync(string uri) => Tasks.Task.FromResult(ResolveByUri(uri));
-        public Tasks.Task<Resource?> ResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult(ResolveByCanonicalUri(uri));
+        public async Tasks.Task<Resource?> ResolveByUriAsync(string uri)
+        {
+            var result = await TryResolveByUriAsync(uri).ConfigureAwait(false);
+            return result.Value;
+        }
+        
+        public async Tasks.Task<Resource?> ResolveByCanonicalUriAsync(string uri)
+        {
+            var result = await TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
+            return result.Value;
+        }
+        
+        public Tasks.Task<ResolverResult> TryResolveByUriAsync(string uri) => Tasks.Task.FromResult(TryResolveByUri(uri));
+        
+        public Tasks.Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult(TryResolveByCanonicalUri(uri));
 
         // Allow derived classes to override
         // http://blogs.msdn.com/b/jaredpar/archive/2011/03/18/debuggerdisplay-attribute-best-practices.aspx

--- a/src/Hl7.Fhir.Conformance/Specification/Source/CommonWebResolver.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Source/CommonWebResolver.cs
@@ -60,6 +60,7 @@ namespace Hl7.Fhir.Specification.Source
             return TryResolveByCanonicalUri(uri).Value;
         }
 
+        ///<inheritdoc/>
         public ResolverResult TryResolveByUri(string uri)
         {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));
@@ -91,6 +92,7 @@ namespace Hl7.Fhir.Specification.Source
             // Other runtime exceptions are fatal...
         }
 
+        ///<inheritdoc/>
         public ResolverResult TryResolveByCanonicalUri(string uri) => TryResolveByUri(uri);
 
         public async Tasks.Task<Resource?> ResolveByUriAsync(string uri)
@@ -105,8 +107,10 @@ namespace Hl7.Fhir.Specification.Source
             return result.Value;
         }
         
+        ///<inheritdoc/>
         public Tasks.Task<ResolverResult> TryResolveByUriAsync(string uri) => Tasks.Task.FromResult(TryResolveByUri(uri));
         
+        ///<inheritdoc/>
         public Tasks.Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult(TryResolveByCanonicalUri(uri));
 
         // Allow derived classes to override

--- a/src/Hl7.Fhir.Conformance/Specification/Source/CommonZipSource.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Source/CommonZipSource.cs
@@ -161,13 +161,17 @@ namespace Hl7.Fhir.Specification.Source
         /// <param name="uri">The canonical url of a (conformance) resource.</param>
         public Resource? ResolveByCanonicalUri(string uri) => FileSource.ResolveByCanonicalUri(uri);
 
+        ///<inheritdoc/>
         public ResolverResult TryResolveByUri(string uri) => FileSource.TryResolveByUri(uri);
+        ///<inheritdoc/>
         public ResolverResult TryResolveByCanonicalUri(string uri) => FileSource.TryResolveByCanonicalUri(uri);
 
         public Task<Resource?> ResolveByUriAsync(string uri) => FileSource.ResolveByUriAsync(uri);
         public Task<Resource?> ResolveByCanonicalUriAsync(string uri) => FileSource.ResolveByCanonicalUriAsync(uri);
         
+        ///<inheritdoc/>
         public Task<ResolverResult> TryResolveByUriAsync(string uri) => FileSource.TryResolveByUriAsync(uri);
+        ///<inheritdoc/>
         public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => FileSource.TryResolveByCanonicalUriAsync(uri);
 
         #endregion

--- a/src/Hl7.Fhir.Conformance/Specification/Source/CommonZipSource.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Source/CommonZipSource.cs
@@ -161,8 +161,14 @@ namespace Hl7.Fhir.Specification.Source
         /// <param name="uri">The canonical url of a (conformance) resource.</param>
         public Resource? ResolveByCanonicalUri(string uri) => FileSource.ResolveByCanonicalUri(uri);
 
+        public ResolverResult TryResolveByUri(string uri) => FileSource.TryResolveByUri(uri);
+        public ResolverResult TryResolveByCanonicalUri(string uri) => FileSource.TryResolveByCanonicalUri(uri);
+
         public Task<Resource?> ResolveByUriAsync(string uri) => FileSource.ResolveByUriAsync(uri);
         public Task<Resource?> ResolveByCanonicalUriAsync(string uri) => FileSource.ResolveByCanonicalUriAsync(uri);
+        
+        public Task<ResolverResult> TryResolveByUriAsync(string uri) => FileSource.TryResolveByUriAsync(uri);
+        public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => FileSource.TryResolveByCanonicalUriAsync(uri);
 
         #endregion
 

--- a/src/Hl7.Fhir.Conformance/Specification/Source/ResourceResolverExtensions.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Source/ResourceResolverExtensions.cs
@@ -34,7 +34,8 @@ namespace Hl7.Fhir.Specification.Source
         /// <returns>Returns a StructureDefinition if it is resolvable and defines an extension, otherwise <c>null</c>.</returns>
         public static async Tasks.Task<StructureDefinition> FindExtensionDefinitionAsync(this IAsyncResourceResolver resolver, string uri)
         {
-            if (await resolver.ResolveByCanonicalUriAsync(uri).ConfigureAwait(false) is not StructureDefinition sd) return null;
+            var result = await resolver.TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
+            if (result.Value is not StructureDefinition sd) return null;
 
             if (!sd.IsExtension)
                 throw Error.Argument(nameof(uri), $"Found StructureDefinition at '{uri}', but is not an extension");
@@ -52,7 +53,10 @@ namespace Hl7.Fhir.Specification.Source
         /// </summary>
         /// <returns>The resolved StructureDefinition or <c>null</c> if it cannot be resolved or does not resolve to a StructureDefinition.</returns>
         public static async Tasks.Task<StructureDefinition> FindStructureDefinitionAsync(this IAsyncResourceResolver resolver, string uri)
-            => await resolver.ResolveByCanonicalUriAsync(uri).ConfigureAwait(false) as StructureDefinition;
+        {
+            var result = await resolver.TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
+            return result.Value as StructureDefinition;
+        }
 
         /// <inheritdoc cref="FindStructureDefinitionForCoreTypeAsync(IAsyncResourceResolver, string)"/>
         [Obsolete("Using synchronous resolvers is not recommended anymore, use FindStructureDefinitionForCoreTypeAsync() instead.")]
@@ -84,7 +88,10 @@ namespace Hl7.Fhir.Specification.Source
         /// Find a ValueSet by canonical url.
         /// </summary>
         public static async Tasks.Task<ValueSet> FindValueSetAsync(this IAsyncResourceResolver source, string uri)
-            => await source.ResolveByCanonicalUriAsync(uri).ConfigureAwait(false) as ValueSet;
+        {
+            var result = await source.TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
+            return result.Value as ValueSet;
+        }
 
         /// <inheritdoc cref="FindCodeSystemAsync(IAsyncResourceResolver, string)"/>
         [Obsolete("Using synchronous resolvers is not recommended anymore, use FindCodeSystemAsync() instead.")]
@@ -95,8 +102,9 @@ namespace Hl7.Fhir.Specification.Source
         /// Find a CodeSystem by canonical url.
         /// </summary>
         public static async Tasks.Task<CodeSystem> FindCodeSystemAsync(this IAsyncResourceResolver source, string uri)
-            => await source.ResolveByCanonicalUriAsync(uri).ConfigureAwait(false) as CodeSystem;
-
-
+        {
+            var result = await source.TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
+            return result.Value as CodeSystem;
+        }
     }
 }

--- a/src/Hl7.Fhir.ElementModel.Shared.Tests/ElementNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Shared.Tests/ElementNodeTests.cs
@@ -394,6 +394,12 @@ namespace Hl7.FhirPath.Tests
 
             public async Task<Resource> ResolveByCanonicalUriAsync(string uri)
             {
+                var resource = await TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
+                return resource.Value;
+            }
+
+            public async Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri)
+            {
                 var sd = await _resolver.FindStructureDefinitionAsync(uri);
                 if (!sd.HasSnapshot)
                 {
@@ -404,6 +410,8 @@ namespace Hl7.FhirPath.Tests
 
                 return sd;
             }
+
+            public Task<ResolverResult> TryResolveByUriAsync(string uri) => throw new NotImplementedException();
 
             public Task<Resource> ResolveByUriAsync(string uri) => throw new NotImplementedException();
         }

--- a/src/Hl7.Fhir.ElementModel.Shared.Tests/ScopedNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Shared.Tests/ScopedNodeTests.cs
@@ -297,6 +297,12 @@ namespace Hl7.Fhir.ElementModel.Tests
 
             public async Tasks.Task<Resource> ResolveByCanonicalUriAsync(string uri)
             {
+                var result = await TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
+                return result.Value;
+            }
+
+            public async Tasks.Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri)
+            { 
                 if (_cache.TryGetValue(uri, out StructureDefinition? sd))
                     return sd;
 
@@ -310,6 +316,8 @@ namespace Hl7.Fhir.ElementModel.Tests
 
                 return sd;
             }
+            
+            public Tasks.Task<ResolverResult> TryResolveByUriAsync(string uri) => throw new NotImplementedException();
 
             public Tasks.Task<Resource> ResolveByUriAsync(string uri) => throw new NotImplementedException();
         }

--- a/src/Hl7.Fhir.ElementModel.Shared.Tests/ScopedNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Shared.Tests/ScopedNodeTests.cs
@@ -295,7 +295,7 @@ namespace Hl7.Fhir.ElementModel.Tests
                     new DirectorySource("TestData/TestSd")));
             }
 
-            public async Tasks.Task<Resource> ResolveByCanonicalUriAsync(string uri)
+            public async Tasks.Task<Resource?> ResolveByCanonicalUriAsync(string uri)
             {
                 var result = await TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
                 return result.Value;
@@ -319,7 +319,7 @@ namespace Hl7.Fhir.ElementModel.Tests
             
             public Tasks.Task<ResolverResult> TryResolveByUriAsync(string uri) => throw new NotImplementedException();
 
-            public Tasks.Task<Resource> ResolveByUriAsync(string uri) => throw new NotImplementedException();
+            public Tasks.Task<Resource?> ResolveByUriAsync(string uri) => throw new NotImplementedException();
         }
 
         private class TypedElementWithoutDefinition : ITypedElement, IResourceTypeSupplier

--- a/src/Hl7.Fhir.STU3/Specification/Source/DirectorySource.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Source/DirectorySource.cs
@@ -614,18 +614,48 @@ namespace Hl7.Fhir.Specification.Source
         /// <param name="uri">A resource uri.</param>
         public Resource ResolveByUri(string uri)
         {
-            if (uri == null) throw Error.ArgumentNull(nameof(uri));
-            var summary = GetSummaries().ResolveByUri(uri);
-            return loadResourceInternal<Resource>(summary);
+            return TryResolveByUri(uri).Value;
         }
 
         /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
         /// <param name="uri">The canonical url of a (conformance) resource.</param>
         public Resource ResolveByCanonicalUri(string uri)
         {
+            return TryResolveByCanonicalUri(uri).Value;
+        }
+
+        public ResolverResult TryResolveByUri(string uri)
+        {
+            if (uri == null) throw Error.ArgumentNull(nameof(uri));
+            var summary = GetSummaries().ResolveByUri(uri);
+
+            if(summary is null)
+                return ResolverException.ArtifactSummaryNoMatch(uri);
+            
+            var resource = loadResourceInternal<Resource>(summary);
+
+            if (resource is null)
+                return ResolverException.NotFound();
+            
+            return resource;
+        }
+
+        /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
+        /// <param name="uri">The canonical url of a (conformance) resource.</param>
+        public ResolverResult TryResolveByCanonicalUri(string uri)
+        {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));
             var summary = GetSummaries().ResolveByCanonicalUri(uri);
-            return loadResourceInternal<Resource>(summary);
+
+            if(summary is null)
+                return ResolverException.ArtifactSummaryNoMatch(uri);
+            
+            var resource = loadResourceInternal<Resource>(summary);
+
+            if (resource is null)
+                return ResolverException.NotFound();
+            
+            return resource;
         }
 
         #endregion
@@ -1007,6 +1037,9 @@ namespace Hl7.Fhir.Specification.Source
         public Tasks.Task<Resource> ResolveByUriAsync(string uri) => Tasks.Task.FromResult(ResolveByUri(uri));
 
         public Tasks.Task<Resource> ResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult(ResolveByCanonicalUri(uri));
+        public Tasks.Task<ResolverResult> TryResolveByUriAsync(string uri) => Tasks.Task.FromResult(TryResolveByUri(uri));
+
+        public Tasks.Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult(TryResolveByCanonicalUri(uri));
 
         #endregion
 

--- a/src/Hl7.Fhir.STU3/Specification/Source/DirectorySource.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Source/DirectorySource.cs
@@ -624,6 +624,7 @@ namespace Hl7.Fhir.Specification.Source
             return TryResolveByCanonicalUri(uri).Value;
         }
 
+        /// <inheritdoc/>
         public ResolverResult TryResolveByUri(string uri)
         {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));
@@ -640,8 +641,7 @@ namespace Hl7.Fhir.Specification.Source
             return resource;
         }
 
-        /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
-        /// <param name="uri">The canonical url of a (conformance) resource.</param>
+        /// <inheritdoc/>
         public ResolverResult TryResolveByCanonicalUri(string uri)
         {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));

--- a/src/Hl7.Fhir.STU3/Specification/Source/ResourceResolverExtensions.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Source/ResourceResolverExtensions.cs
@@ -38,7 +38,9 @@ namespace Hl7.Fhir.Specification.Source
         /// <returns>Returns a StructureDefinition if it is resolvable and defines an extension, otherwise <c>null</c>.</returns>
         public static async Tasks.Task<StructureDefinition> FindExtensionDefinitionAsync(this IAsyncResourceResolver resolver, string uri)
         {
-            if (await resolver.ResolveByCanonicalUriAsync(uri).ConfigureAwait(false) is not StructureDefinition sd) return null;
+            var result = await resolver.TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
+            
+            if (result.Value is not StructureDefinition sd) return null;
 
             if (!sd.IsExtension)
                 throw Error.Argument(nameof(uri), $"Found StructureDefinition at '{uri}', but is not an extension");
@@ -56,7 +58,10 @@ namespace Hl7.Fhir.Specification.Source
         /// </summary>
         /// <returns>The resolved StructureDefinition or <c>null</c> if it cannot be resolved or does not resolve to a StructureDefinition.</returns>
         public static async Tasks.Task<StructureDefinition> FindStructureDefinitionAsync(this IAsyncResourceResolver resolver, string uri)
-            => await resolver.ResolveByCanonicalUriAsync(uri).ConfigureAwait(false) as StructureDefinition;
+        {
+            var result = await resolver.TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
+            return result.Value as StructureDefinition;
+        }
 
         /// <inheritdoc cref="FindStructureDefinitionForCoreTypeAsync(IAsyncResourceResolver, string)"/>
         [Obsolete("Using synchronous resolvers is not recommended anymore, use FindStructureDefinitionForCoreTypeAsync() instead.")]
@@ -97,7 +102,10 @@ namespace Hl7.Fhir.Specification.Source
         /// Find a ValueSet by canonical url.
         /// </summary>
         public static async Tasks.Task<ValueSet> FindValueSetAsync(this IAsyncResourceResolver source, string uri)
-            => await source.ResolveByCanonicalUriAsync(uri).ConfigureAwait(false) as ValueSet;
+        {
+            var result = await source.TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
+            return result.Value as ValueSet;
+        }
 
         /// <inheritdoc cref="FindCodeSystemAsync(IAsyncResourceResolver, string)"/>
         [Obsolete("Using synchronous resolvers is not recommended anymore, use FindCodeSystemAsync() instead.")]
@@ -108,7 +116,10 @@ namespace Hl7.Fhir.Specification.Source
         /// Find a CodeSystem by canonical url.
         /// </summary>
         public static async Tasks.Task<CodeSystem> FindCodeSystemAsync(this IAsyncResourceResolver source, string uri)
-            => await source.ResolveByCanonicalUriAsync(uri).ConfigureAwait(false) as CodeSystem;
+        {
+            var result = await source.TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
+            return result.Value as CodeSystem;
+        }
 
         public static IEnumerable<T> FindAll<T>(this IConformanceSource source) where T : Resource
         {
@@ -118,7 +129,10 @@ namespace Hl7.Fhir.Specification.Source
             {
                 var resourceType = EnumUtility.ParseLiteral<ResourceType>(type);
                 var uris = source.ListResourceUris(resourceType);
-                return uris.Select(u => source.ResolveByUri(u) as T).Where(r => r != null);
+                return uris.Select(source.TryResolveByUri)
+                    .Where(r => r.Success)
+                    .Select(x => x.Value as T)
+                    .Where(r => r != null);
             }
             else
                 return null;

--- a/src/Hl7.Fhir.STU3/Specification/Source/WebResolver.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Source/WebResolver.cs
@@ -52,13 +52,22 @@ namespace Hl7.Fhir.Specification.Source
 
         public Resource ResolveByUri(string uri)
         {
+            return TryResolveByUri(uri).Value;
+        }
+
+        public Resource ResolveByCanonicalUri(string uri)
+        {
+            return ResolveByUri(uri);
+        }
+
+        public ResolverResult TryResolveByUri(string uri)
+        {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));
             if (!ResourceIdentity.IsRestResourceIdentity(uri))
             {
-                // Weakness in FhirClient, need to have the base :-(  So return null if we cannot determine it.
-                return null;
+                return new ResolverException("NOTVALIDARG", "Provided uri is not a valid resource identity URI");
             }
-
+            
             var id = new ResourceIdentity(uri);
             var client = _clientFactory?.Invoke(id.BaseUri)
                          ?? new FhirClient(id.BaseUri);
@@ -75,23 +84,21 @@ namespace Hl7.Fhir.Specification.Source
             catch (FhirOperationException foe)
             {
                 LastError = foe;
-                return null;
+                return new ResolverException("OPERATIONEXCEPTION", "Error occurred during Fhir operation", foe);
             }
             catch (WebException we)
             {
                 LastError = we;
-                return null;
+                return new ResolverException("OPERATIONEXCEPTION", "Error occurred during web operation", we);
             }
             // Other runtime exceptions are fatal...
         }
 
-        public Resource ResolveByCanonicalUri(string uri)
-        {
-            return ResolveByUri(uri);
-        }
-
+        public ResolverResult TryResolveByCanonicalUri(string uri) => TryResolveByUri(uri);
         public Tasks.Task<Resource> ResolveByUriAsync(string uri) => Tasks.Task.FromResult(ResolveByUri(uri));
         public Tasks.Task<Resource> ResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult(ResolveByCanonicalUri(uri));
+        public Tasks.Task<ResolverResult> TryResolveByUriAsync(string uri) => Tasks.Task.FromResult(TryResolveByUri(uri));
+        public Tasks.Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult(TryResolveByUri(uri));
 
         // Allow derived classes to override
         // http://blogs.msdn.com/b/jaredpar/archive/2011/03/18/debuggerdisplay-attribute-best-practices.aspx

--- a/src/Hl7.Fhir.STU3/Specification/Source/WebResolver.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Source/WebResolver.cs
@@ -64,9 +64,7 @@ namespace Hl7.Fhir.Specification.Source
         {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));
             if (!ResourceIdentity.IsRestResourceIdentity(uri))
-            {
-                return new ResolverException("NOTVALIDARG", "Provided uri is not a valid resource identity URI");
-            }
+                return ResolverException.NotValidResourceIdentity(uri);
             
             var id = new ResourceIdentity(uri);
             var client = _clientFactory?.Invoke(id.BaseUri)
@@ -84,12 +82,12 @@ namespace Hl7.Fhir.Specification.Source
             catch (FhirOperationException foe)
             {
                 LastError = foe;
-                return new ResolverException("OPERATIONEXCEPTION", "Error occurred during Fhir operation", foe);
+                return ResolverException.OperationFailed("Error occurred during Fhir operation", foe);
             }
             catch (WebException we)
             {
                 LastError = we;
-                return new ResolverException("OPERATIONEXCEPTION", "Error occurred during web operation", we);
+                return ResolverException.OperationFailed("Error occurred during web operation", we);
             }
             // Other runtime exceptions are fatal...
         }

--- a/src/Hl7.Fhir.STU3/Specification/Source/WebResolver.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Source/WebResolver.cs
@@ -60,6 +60,12 @@ namespace Hl7.Fhir.Specification.Source
             return ResolveByUri(uri);
         }
 
+        /// <summary>
+        /// Uses provided <paramref name="uri"/> to construct <see cref="ResourceIdentity"/> and then tries to read the resource from that source.
+        /// </summary>
+        /// <param name="uri">Uri to attempt resolving on</param>
+        /// <returns><see cref="ResolverResult"/> with an actual resource, or the <see cref="ResolverResult.Error"/>.</returns>
+        /// <exception cref="ArgumentNullException">Provided <paramref name="uri"/> is <c>null</c>.</exception>
         public ResolverResult TryResolveByUri(string uri)
         {
             if (uri == null) throw Error.ArgumentNull(nameof(uri));
@@ -92,10 +98,13 @@ namespace Hl7.Fhir.Specification.Source
             // Other runtime exceptions are fatal...
         }
 
+        /// <inheritdoc cref="TryResolveByUri"/>
         public ResolverResult TryResolveByCanonicalUri(string uri) => TryResolveByUri(uri);
         public Tasks.Task<Resource> ResolveByUriAsync(string uri) => Tasks.Task.FromResult(ResolveByUri(uri));
         public Tasks.Task<Resource> ResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult(ResolveByCanonicalUri(uri));
+        /// <inheritdoc cref="TryResolveByUri"/>
         public Tasks.Task<ResolverResult> TryResolveByUriAsync(string uri) => Tasks.Task.FromResult(TryResolveByUri(uri));
+        /// <inheritdoc cref="TryResolveByUri"/>
         public Tasks.Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult(TryResolveByUri(uri));
 
         // Allow derived classes to override

--- a/src/Hl7.Fhir.STU3/Specification/Source/ZipSource.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Source/ZipSource.cs
@@ -221,14 +221,32 @@ namespace Hl7.Fhir.Specification.Source
 
         /// <summary>Find a resource based on its relative or absolute uri.</summary>
         /// <param name="uri">A resource uri.</param>
-        public Resource ResolveByUri(string uri) => FileSource.ResolveByUri(uri);
+        public Resource ResolveByUri(string uri) => TryResolveByUri(uri).Value;
 
         /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
         /// <param name="uri">The canonical url of a (conformance) resource.</param>
-        public Resource ResolveByCanonicalUri(string uri) => FileSource.ResolveByCanonicalUri(uri);
+        public Resource ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
 
-        public Task<Resource> ResolveByUriAsync(string uri) => FileSource.ResolveByUriAsync(uri);
-        public Task<Resource> ResolveByCanonicalUriAsync(string uri) => FileSource.ResolveByCanonicalUriAsync(uri);
+        /// <summary>Find a resource based on its relative or absolute uri.</summary>
+        /// <param name="uri">A resource uri.</param>
+        public ResolverResult TryResolveByUri(string uri) => FileSource.TryResolveByUri(uri);
+        /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
+        /// <param name="uri">The canonical url of a (conformance) resource.</param>
+        public ResolverResult TryResolveByCanonicalUri(string uri) => FileSource.TryResolveByCanonicalUri(uri);
+
+        public async Task<Resource> ResolveByUriAsync(string uri)
+        {
+            var result = await TryResolveByUriAsync(uri).ConfigureAwait(false);
+            return result.Value;
+        }
+        public async Task<Resource> ResolveByCanonicalUriAsync(string uri)
+        {
+            var result = await TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
+            return result.Value;
+        }
+        
+        public Task<ResolverResult> TryResolveByUriAsync(string uri) => FileSource.TryResolveByUriAsync(uri);
+        public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => FileSource.TryResolveByCanonicalUriAsync(uri);
 
         #endregion
 

--- a/src/Hl7.Fhir.STU3/Specification/Source/ZipSource.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Source/ZipSource.cs
@@ -245,7 +245,9 @@ namespace Hl7.Fhir.Specification.Source
             return result.Value;
         }
         
+        /// <inheritdoc/>
         public Task<ResolverResult> TryResolveByUriAsync(string uri) => FileSource.TryResolveByUriAsync(uri);
+        /// <inheritdoc/>
         public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => FileSource.TryResolveByCanonicalUriAsync(uri);
 
         #endregion

--- a/src/Hl7.Fhir.Shims.Base/Specification/Source/SnapshotSource.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Source/SnapshotSource.cs
@@ -116,7 +116,7 @@ namespace Hl7.Fhir.Specification.Source
                 {
                     await Generator.UpdateAsync(sd).ConfigureAwait(false);
                     
-                    if(!Generator.Outcome.Success)
+                    if(Generator.Outcome?.Success is false)
                     {
                         return ResolverException.SnapshotOutcome(Generator.Outcome);
                     }

--- a/src/Hl7.Fhir.Shims.Base/Specification/Source/SnapshotSource.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Source/SnapshotSource.cs
@@ -118,7 +118,7 @@ namespace Hl7.Fhir.Specification.Source
                     
                     if(Generator.Outcome?.Success is false)
                     {
-                        return ResolverException.SnapshotOutcome(Generator.Outcome);
+                        return new ResolverResult(sd, ResolverException.SnapshotOutcome(Generator.Outcome));
                     }
                 }
             }

--- a/src/Hl7.Fhir.Shims.Base/Specification/Source/SnapshotSource.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Source/SnapshotSource.cs
@@ -74,31 +74,52 @@ namespace Hl7.Fhir.Specification.Source
 
         /// <summary>Find a resource based on its relative or absolute uri.</summary>
         /// <remarks>The source ensures that resolved <see cref="StructureDefinition"/> instances have a snapshot component.</remarks>
-        public async Tasks.Task<Resource> ResolveByUriAsync(string uri) => await ensureSnapshot(await _resolver.ResolveByUriAsync(uri).ConfigureAwait(false)).ConfigureAwait(false);
+        public async Tasks.Task<Resource> ResolveByUriAsync(string uri) 
+        {
+            var result = await TryResolveByUriAsync(uri).ConfigureAwait(false);
+            return result.Value;
+        }
 
         /// <inheritdoc cref="ResolveByUriAsync(string)"/>
         [Obsolete("SnapshotSource now works best with asynchronous resolvers. Use ResolveByUriAsync() instead.")]
-        public Resource ResolveByUri(string uri) => TaskHelper.Await(() => ResolveByUriAsync(uri));
+        public Resource ResolveByUri(string uri) => TryResolveByUri(uri).Value;
 
         /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
         /// <remarks>The source ensures that resolved <see cref="StructureDefinition"/> instances have a snapshot component.</remarks>
-        public async Tasks.Task<Resource> ResolveByCanonicalUriAsync(string uri) => await ensureSnapshot(await _resolver.ResolveByCanonicalUriAsync(uri).ConfigureAwait(false)).ConfigureAwait(false);
+        public async Tasks.Task<Resource> ResolveByCanonicalUriAsync(string uri)
+        {
+            var result = await TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
+            return result.Value;
+        }
+
+        public async  Tasks.Task<ResolverResult> TryResolveByUriAsync(string uri) => await ensureSnapshot(await _resolver.TryResolveByUriAsync(uri).ConfigureAwait(false)).ConfigureAwait(false);
+
+        public async Tasks.Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => await ensureSnapshot(await _resolver.TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false)).ConfigureAwait(false);
 
         /// <inheritdoc cref="ResolveByCanonicalUriAsync(string)"/>
         [Obsolete("SnapshotSource now works best with asynchronous resolvers. Use ResolveByCanonicalUriAsync() instead.")]
-        public Resource ResolveByCanonicalUri(string uri) => TaskHelper.Await(() => ResolveByCanonicalUriAsync(uri));
+        public Resource ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
+
+        public ResolverResult TryResolveByUri(string uri) => TaskHelper.Await(() => TryResolveByUriAsync(uri));
+
+        public ResolverResult TryResolveByCanonicalUri(string uri)  => TaskHelper.Await(() => TryResolveByCanonicalUriAsync(uri));
 
         #endregion
 
         // If the specified resource is a StructureDefinition,
         // then ensure snapshot component is available, (re-)generate on demand
-        private async Tasks.Task<Resource> ensureSnapshot(Resource res)
+        private async Tasks.Task<ResolverResult> ensureSnapshot(ResolverResult res)
         {
-            if (res is StructureDefinition sd)
+            if (res.Value is StructureDefinition sd)
             {
                 if (!sd.HasSnapshot || Generator.Settings.ForceRegenerateSnapshots || !sd.Snapshot.IsCreatedBySnapshotGenerator())
                 {
                     await Generator.UpdateAsync(sd).ConfigureAwait(false);
+                    
+                    if(!Generator.Outcome.Success)
+                    {
+                        return ResolverException.SnapshotOutcome(Generator.Outcome);
+                    }
                 }
             }
             return res;

--- a/src/Hl7.Fhir.Shims.Base/Specification/Source/SnapshotSource.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Source/SnapshotSource.cs
@@ -72,6 +72,20 @@ namespace Hl7.Fhir.Specification.Source
 
         private IAsyncResourceResolver _resolver => Generator.AsyncResolver;
 
+        /// <inheritdoc cref="ResolveByUriAsync(string)"/>
+        [Obsolete("SnapshotSource now works best with asynchronous resolvers. Use TryResolveByUriAsync() instead.")]
+        public Resource ResolveByUri(string uri) => TryResolveByUri(uri).Value;
+
+        /// <inheritdoc cref="ResolveByCanonicalUriAsync(string)"/>
+        [Obsolete("SnapshotSource now works best with asynchronous resolvers. Use TryResolveByCanonicalUriAsync() instead.")]
+        public Resource ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
+
+        [Obsolete("SnapshotSource now works best with asynchronous resolvers. Use TryResolveByUriAsync() instead.")]
+        public ResolverResult TryResolveByUri(string uri) => TaskHelper.Await(() => TryResolveByUriAsync(uri));
+
+        [Obsolete("SnapshotSource now works best with asynchronous resolvers. Use TryResolveByCanonicalUriAsync() instead.")]
+        public ResolverResult TryResolveByCanonicalUri(string uri)  => TaskHelper.Await(() => TryResolveByCanonicalUriAsync(uri));
+
         /// <summary>Find a resource based on its relative or absolute uri.</summary>
         /// <remarks>The source ensures that resolved <see cref="StructureDefinition"/> instances have a snapshot component.</remarks>
         public async Tasks.Task<Resource> ResolveByUriAsync(string uri) 
@@ -79,11 +93,7 @@ namespace Hl7.Fhir.Specification.Source
             var result = await TryResolveByUriAsync(uri).ConfigureAwait(false);
             return result.Value;
         }
-
-        /// <inheritdoc cref="ResolveByUriAsync(string)"/>
-        [Obsolete("SnapshotSource now works best with asynchronous resolvers. Use ResolveByUriAsync() instead.")]
-        public Resource ResolveByUri(string uri) => TryResolveByUri(uri).Value;
-
+        
         /// <summary>Find a (conformance) resource based on its canonical uri.</summary>
         /// <remarks>The source ensures that resolved <see cref="StructureDefinition"/> instances have a snapshot component.</remarks>
         public async Tasks.Task<Resource> ResolveByCanonicalUriAsync(string uri)
@@ -95,14 +105,6 @@ namespace Hl7.Fhir.Specification.Source
         public async  Tasks.Task<ResolverResult> TryResolveByUriAsync(string uri) => await ensureSnapshot(await _resolver.TryResolveByUriAsync(uri).ConfigureAwait(false)).ConfigureAwait(false);
 
         public async Tasks.Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => await ensureSnapshot(await _resolver.TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false)).ConfigureAwait(false);
-
-        /// <inheritdoc cref="ResolveByCanonicalUriAsync(string)"/>
-        [Obsolete("SnapshotSource now works best with asynchronous resolvers. Use ResolveByCanonicalUriAsync() instead.")]
-        public Resource ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
-
-        public ResolverResult TryResolveByUri(string uri) => TaskHelper.Await(() => TryResolveByUriAsync(uri));
-
-        public ResolverResult TryResolveByCanonicalUri(string uri)  => TaskHelper.Await(() => TryResolveByCanonicalUriAsync(uri));
 
         #endregion
 

--- a/src/Hl7.Fhir.Shims.Base/Specification/Source/SnapshotSource.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Source/SnapshotSource.cs
@@ -80,9 +80,11 @@ namespace Hl7.Fhir.Specification.Source
         [Obsolete("SnapshotSource now works best with asynchronous resolvers. Use TryResolveByCanonicalUriAsync() instead.")]
         public Resource ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
 
+        /// <inheritdoc cref="TryResolveByUriAsync(string)"/>
         [Obsolete("SnapshotSource now works best with asynchronous resolvers. Use TryResolveByUriAsync() instead.")]
         public ResolverResult TryResolveByUri(string uri) => TaskHelper.Await(() => TryResolveByUriAsync(uri));
 
+        /// <inheritdoc cref="TryResolveByCanonicalUriAsync(string)"/>
         [Obsolete("SnapshotSource now works best with asynchronous resolvers. Use TryResolveByCanonicalUriAsync() instead.")]
         public ResolverResult TryResolveByCanonicalUri(string uri)  => TaskHelper.Await(() => TryResolveByCanonicalUriAsync(uri));
 
@@ -102,8 +104,20 @@ namespace Hl7.Fhir.Specification.Source
             return result.Value;
         }
 
+        /// <summary>
+        /// Find a resource based on it's relative or absolute uri.
+        /// </summary>
+        /// <param name="uri">A resource uri</param>
+        /// <returns><see cref="ResolverResult"/> with an actual resource, combined with the <see cref="ResolverResult.Error"/> if snapshot generation failed.</returns>
+        /// <remarks>The source ensures that resolved <see cref="StructureDefinition"/> instances have a snapshot component. If the snapshot generation failed, the <see cref="ResolverResult.Error"/> will be populated.</remarks>
         public async  Tasks.Task<ResolverResult> TryResolveByUriAsync(string uri) => await ensureSnapshot(await _resolver.TryResolveByUriAsync(uri).ConfigureAwait(false)).ConfigureAwait(false);
 
+        /// <summary>
+        /// Find a (conformance) resource based on it's canonical uri.
+        /// </summary>
+        /// <param name="uri">A canonical uri of a (conformance) resource.</param>
+        /// <returns><see cref="ResolverResult"/> with an actual resource, combined with the <see cref="ResolverResult.Error"/> if snapshot generation failed.</returns>
+        /// <remarks>The source ensures that resolved <see cref="StructureDefinition"/> instances have a snapshot component. If the snapshot generation failed, the <see cref="ResolverResult.Error"/> will be populated.</remarks>
         public async Tasks.Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => await ensureSnapshot(await _resolver.TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false)).ConfigureAwait(false);
 
         #endregion

--- a/src/Hl7.Fhir.Shims.R4AndUp/Specification/Source/ResourceResolverExtensions.cs
+++ b/src/Hl7.Fhir.Shims.R4AndUp/Specification/Source/ResourceResolverExtensions.cs
@@ -42,7 +42,11 @@ namespace Hl7.Fhir.Specification.Source
             {
                 var resourceType = EnumUtility.ParseLiteral<ResourceType>(typeName);
                 var uris = source.ListResourceUris(resourceType);
-                return uris.Select(u => source.ResolveByUri(u) as T).Where(r => r != null);
+                return uris
+                    .Select(source.TryResolveByUri)
+                    .Where(x => x.Success)
+                    .Select(x => x.Value as T)
+                    .Where(r => r != null);
             }
             else
                 return null;

--- a/src/Hl7.Fhir.Specification.STU3.Tests/DiscriminatorInterpreterTests.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/DiscriminatorInterpreterTests.cs
@@ -2,6 +2,7 @@
 using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Specification.Source;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
 using System.Linq;
 using Tasks = System.Threading.Tasks;
 
@@ -16,7 +17,7 @@ namespace Hl7.Fhir.Specification.Tests
             return new CachedResolver(
                 new SnapshotSource(
                 new MultiResolver(
-                    new DirectorySource(@"TestData\validation"),
+                    new DirectorySource(Path.Combine("TestData", "validation")),
                     new ZipSource("specification.zip"))));
         }
 

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/InMemoryProfileResolver.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/InMemoryProfileResolver.cs
@@ -33,12 +33,24 @@ namespace Hl7.Fhir.Specification.Tests
 
         #region IResourceResolver
 
-        public Resource ResolveByCanonicalUri(string uri) => _resources[uri].FirstOrDefault();
+        public Resource ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
+        public ResolverResult TryResolveByUri(string uri) => ResolverException.NotFound();
 
-        public Resource ResolveByUri(string uri) => null;
+        public ResolverResult TryResolveByCanonicalUri(string uri)
+        {
+            var resource = _resources[uri].FirstOrDefault();
+            if (resource is not null)
+                return resource;
+
+            return ResolverException.NotFound();
+        }
+
+        public Resource ResolveByUri(string uri) => TryResolveByUri(uri).Value;
 
         public Tasks.Task<Resource> ResolveByUriAsync(string uri) => Tasks.Task.FromResult(ResolveByCanonicalUri(uri));
         public Tasks.Task<Resource> ResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult(ResolveByCanonicalUri(uri));
+        public Tasks.Task<ResolverResult> TryResolveByUriAsync(string uri) => Tasks.Task.FromResult(TryResolveByCanonicalUri(uri));
+        public Tasks.Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult(TryResolveByCanonicalUri(uri));
 
         #endregion
 

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -200,7 +200,7 @@ namespace Hl7.Fhir.Specification.Tests
             derivedSD.BaseDefinition = baseSD.Url;
 
             var resourceResolver = Substitute.For<IResourceResolver>();
-            resourceResolver.ResolveByCanonicalUri(Arg.Any<string>()).Returns(baseSD);
+            resourceResolver.TryResolveByCanonicalUri(Arg.Any<string>()).Returns(baseSD);
             var snapshotGenerator = new SnapshotGenerator(resourceResolver, new SnapshotGeneratorSettings());
             await snapshotGenerator.UpdateAsync(derivedSD);
 

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/TestProfileArtifactSource.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/TestProfileArtifactSource.cs
@@ -299,16 +299,21 @@ namespace Hl7.Fhir.STU3.Specification.Tests.Snapshot
 
             return result;
         }
-        public Resource ResolveByCanonicalUri(string uri)
-        {
-            return TestProfiles.SingleOrDefault(p => p.Url == uri);
-        }
+        
+        public Resource ResolveByCanonicalUri(string uri) =>  TryResolveByCanonicalUri(uri).Value;
 
-        public Resource ResolveByUri(string uri)
-        {
-            return ResolveByCanonicalUri(uri);
-        }
+        public Resource ResolveByUri(string uri) => ResolveByCanonicalUri(uri);
 
+        public ResolverResult TryResolveByUri(string uri) => TryResolveByCanonicalUri(uri);
+
+        public ResolverResult TryResolveByCanonicalUri(string uri) 
+        {
+            var resource = TestProfiles.SingleOrDefault(p => p.Url == uri);
+            if(resource is not null)
+                return resource;
+
+            return ResolverException.NotFound();
+        }
 
         private static StructureDefinition buildDutchPatient()
         {

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/TimingSource.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/TimingSource.cs
@@ -27,9 +27,13 @@ namespace Hl7.Fhir.Specification.Tests
         public IEnumerable<string> ListResourceUris(ResourceType? filter = default(ResourceType?)) => _source.ListResourceUris(filter);
         // => measureDuration(() => _source.ListResourceUris(filter));
 
-        public Resource ResolveByCanonicalUri(string uri) => measureDuration(() => _source.ResolveByCanonicalUri(uri));
+        public Resource ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
+            
+        public Resource ResolveByUri(string uri) => TryResolveByUri(uri).Value;   
+            
+        public ResolverResult TryResolveByUri(string uri) => measureDuration(() => _source.TryResolveByUri(uri));
 
-        public Resource ResolveByUri(string uri) => measureDuration(() => _source.ResolveByUri(uri));
+        public ResolverResult TryResolveByCanonicalUri(string uri) => measureDuration(() => _source.TryResolveByCanonicalUri(uri));
 
         T measureDuration<T>(Func<T> f)
         {

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Source/ResolverAndSourceExtensionTests.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Source/ResolverAndSourceExtensionTests.cs
@@ -135,20 +135,21 @@ namespace Hl7.Fhir.Specification.Tests
 
         private class LogicalModelTypeResourceResolver : IResourceResolver
         {
-            public Resource ResolveByCanonicalUri(string uri)
+            public ResolverResult TryResolveByCanonicalUri(string uri)
             {
                 var customLogicalModelDataTypeXml = File.ReadAllText(Path.Combine("TestData/ccda", "CCDA_ANY.xml"));
                 var sd = new FhirXmlParser().Parse<StructureDefinition>(customLogicalModelDataTypeXml);
                 if (sd.Type.Equals(uri))
                     return sd;
 
-                return null;
+                return ResolverException.NotFound();
             }
 
-            public Resource ResolveByUri(string uri)
-            {
-                throw new NotImplementedException();
-            }
+            public Resource ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
+            
+            public ResolverResult TryResolveByUri(string uri) => throw new NotImplementedException();
+            
+            public Resource ResolveByUri(string uri) => throw new NotImplementedException();
         }
 
     }

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Source/ResourceResolverTests.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Source/ResourceResolverTests.cs
@@ -37,32 +37,32 @@ namespace Hl7.Fhir.Specification.Tests
         [TestMethod]
         public void ResolveByCanonicalFromZip()
         {
-            var extDefn = source.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/data-absent-reason");
+            var extDefn = source.TryResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/data-absent-reason").Value;
             Assert.IsNotNull(extDefn);
             Assert.IsInstanceOfType(extDefn, typeof(StructureDefinition));
 
-            extDefn = source.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/Patient");
+            extDefn = source.TryResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/Patient").Value;
             Assert.IsNotNull(extDefn);
             Assert.IsInstanceOfType(extDefn, typeof(StructureDefinition));
 
-            extDefn = source.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/Patient");
+            extDefn = source.TryResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/Patient").Value;
             Assert.IsNotNull(extDefn);
             Assert.IsInstanceOfType(extDefn, typeof(StructureDefinition));
 
             var dirSource = new DirectorySource(Path.Combine("TestData", "validation"));
-            extDefn = dirSource.ResolveByCanonicalUri("http://example.com/StructureDefinition/patient-telecom-reslice-ek|1.0");
+            extDefn = dirSource.TryResolveByCanonicalUri("http://example.com/StructureDefinition/patient-telecom-reslice-ek|1.0").Value;
 
-            Assert.ThrowsException<ArgumentException>(() => dirSource.ResolveByCanonicalUri("http://example.com/StructureDefinition/patient-telecom-reslice-ek|1.0|"));
+            Assert.ThrowsException<ArgumentException>(() => dirSource.TryResolveByCanonicalUri("http://example.com/StructureDefinition/patient-telecom-reslice-ek|1.0|"));
         }
 
         [TestMethod]
         public void ResolveByUriFromZip()
         {
-            var extDefn = source.ResolveByUri("http://hl7.org/fhir/StructureDefinition/data-absent-reason");
+            var extDefn = source.TryResolveByUri("http://hl7.org/fhir/StructureDefinition/data-absent-reason").Value;
             Assert.IsNotNull(extDefn);
             Assert.IsInstanceOfType(extDefn, typeof(StructureDefinition));
 
-            extDefn = source.ResolveByUri("http://hl7.org/fhir/StructureDefinition/Patient");
+            extDefn = source.TryResolveByUri("http://hl7.org/fhir/StructureDefinition/Patient").Value;
             Assert.IsNotNull(extDefn);
             Assert.IsInstanceOfType(extDefn, typeof(StructureDefinition));
 
@@ -78,7 +78,7 @@ namespace Hl7.Fhir.Specification.Tests
         {
             var wa = new WebResolver() { TimeOut = DefaultTimeOut };
 
-            var artifact = wa.ResolveByUri("http://test.fhir.org/r3/StructureDefinition/Observation");
+            var artifact = wa.TryResolveByUri("http://test.fhir.org/r3/StructureDefinition/Observation").Value;
 
             Assert.IsNotNull(artifact);
             Assert.IsTrue(artifact is StructureDefinition);

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Source/TerminologyTests.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Source/TerminologyTests.cs
@@ -963,7 +963,7 @@ namespace Hl7.Fhir.Specification.Tests
                 return await Tasks.Task.FromResult(uri == _myOnlyVS.Url ? _myOnlyVS : null);
             }
 
-            public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult<ResolverResult>(uri == _myOnlyVS.Url ? _myOnlyVS : null);
+            public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult<ResolverResult>(uri == _myOnlyVS.Url ? _myOnlyVS : ResolverException.NotFound());
             
             public Task<ResolverResult> TryResolveByUriAsync(string uri) => throw new NotImplementedException();
 
@@ -1028,7 +1028,7 @@ namespace Hl7.Fhir.Specification.Tests
 
             public Task<ResolverResult> TryResolveByUriAsync(string uri) => throw new NotImplementedException();
 
-            public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult<ResolverResult>(uri == _onlyCs.Url ? _onlyCs : null);
+            public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult<ResolverResult>(uri == _onlyCs.Url ? _onlyCs : ResolverException.NotFound());
 
             public Resource ResolveByUri(string uri) => throw new NotImplementedException();
             public Task<Resource> ResolveByUriAsync(string uri) => throw new NotImplementedException();

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Source/TerminologyTests.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Source/TerminologyTests.cs
@@ -25,7 +25,8 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public async Tasks.Task ExpansionOfWholeSystem()
         {
-            var issueTypeVs = (await _resolverWithoutExpansions.ResolveByCanonicalUriAsync("http://hl7.org/fhir/ValueSet/issue-type")).DeepCopy() as ValueSet;
+            var result = await _resolverWithoutExpansions.TryResolveByCanonicalUriAsync("http://hl7.org/fhir/ValueSet/issue-type");
+            var issueTypeVs = result.Value.DeepCopy() as ValueSet;
             Assert.False(issueTypeVs.HasExpansion);
 
             // Wipe the version so we don't have to update our tests all the time
@@ -64,7 +65,8 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public async Tasks.Task ExpansionOfComposeInclude()
         {
-            var testVs = (await _resolverWithoutExpansions.ResolveByCanonicalUriAsync("http://hl7.org/fhir/ValueSet/marital-status")).DeepCopy() as ValueSet;
+            var result = await _resolverWithoutExpansions.TryResolveByCanonicalUriAsync("http://hl7.org/fhir/ValueSet/marital-status");
+            var testVs = result.Value.DeepCopy() as ValueSet;
             Assert.False(testVs.HasExpansion);
 
             var expander = new ValueSetExpander(new ValueSetExpanderSettings { ValueSetSource = _resolverWithoutExpansions });
@@ -76,7 +78,8 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public async Tasks.Task ExpansionOfComposeImport()
         {
-            var testVs = (await _resolverWithoutExpansions.ResolveByCanonicalUriAsync("http://hl7.org/fhir/ValueSet/v3-ObservationMethod")).DeepCopy() as ValueSet;
+            var result = await _resolverWithoutExpansions.TryResolveByCanonicalUriAsync("http://hl7.org/fhir/ValueSet/v3-ObservationMethod");
+            var testVs = result.Value.DeepCopy() as ValueSet;
             Assert.False(testVs.HasExpansion);
 
             var expander = new ValueSetExpander(new ValueSetExpanderSettings { ValueSetSource = _resolverWithoutExpansions });
@@ -92,7 +95,8 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public async Tasks.Task TestIncludeDesignation()
         {
-            var testVs = (await _resolverWithoutExpansions.ResolveByCanonicalUriAsync("http://hl7.org/fhir/ValueSet/animal-genderstatus")).DeepCopy() as ValueSet;
+            var result = await _resolverWithoutExpansions.TryResolveByCanonicalUriAsync("http://hl7.org/fhir/ValueSet/animal-genderstatus");
+            var testVs = result.Value.DeepCopy() as ValueSet;
             Assert.False(testVs.HasExpansion);
             var expander = new ValueSetExpander(new ValueSetExpanderSettings { ValueSetSource = _resolverWithoutExpansions });
 
@@ -959,6 +963,10 @@ namespace Hl7.Fhir.Specification.Tests
                 return await Tasks.Task.FromResult(uri == _myOnlyVS.Url ? _myOnlyVS : null);
             }
 
+            public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult<ResolverResult>(uri == _myOnlyVS.Url ? _myOnlyVS : null);
+            
+            public Task<ResolverResult> TryResolveByUriAsync(string uri) => throw new NotImplementedException();
+
             public Task<Resource> ResolveByUriAsync(string uri) => throw new NotImplementedException();
         }
 
@@ -1008,10 +1016,20 @@ namespace Hl7.Fhir.Specification.Tests
             public NamingSystem FindNamingSystem(string uniqueId) => throw new NotImplementedException();
             public IEnumerable<string> ListResourceUris(ResourceType? filter = null) => throw new NotImplementedException();
             public Resource ResolveByCanonicalUri(string uri) => throw new NotImplementedException();
+            public ResolverResult TryResolveByUri(string uri) => throw new NotImplementedException();
+
+            public ResolverResult TryResolveByCanonicalUri(string uri) => throw new NotImplementedException();
+
             public async Task<Resource> ResolveByCanonicalUriAsync(string uri)
             {
-                return await Tasks.Task.FromResult(uri == _onlyCs.Url ? _onlyCs : null);
+                var result = await TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
+                return result.Value;
             }
+
+            public Task<ResolverResult> TryResolveByUriAsync(string uri) => throw new NotImplementedException();
+
+            public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult<ResolverResult>(uri == _onlyCs.Url ? _onlyCs : null);
+
             public Resource ResolveByUri(string uri) => throw new NotImplementedException();
             public Task<Resource> ResolveByUriAsync(string uri) => throw new NotImplementedException();
         }

--- a/src/Hl7.Fhir.Specification.STU3.Tests/StructureDefinitionWalkerTests.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/StructureDefinitionWalkerTests.cs
@@ -3,6 +3,7 @@ using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Specification.Source;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
 using System.Linq;
 using Tasks = System.Threading.Tasks;
 
@@ -17,7 +18,7 @@ namespace Hl7.Fhir.Specification.Tests
             return new CachedResolver(
                 new SnapshotSource(
                 new MultiResolver(
-                    new DirectorySource(@"TestData\validation"),
+                    new DirectorySource(Path.Combine("TestData", "validation")),
                     ZipSource.CreateValidationSource())));
         }
 

--- a/src/Hl7.Fhir.Specification.STU3.Tests/TimingSource.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/TimingSource.cs
@@ -33,9 +33,13 @@ namespace Hl7.Fhir.Specification.Tests
             public IEnumerable<string> ListResourceUris(ResourceType? filter = default(ResourceType?)) => _source.ListResourceUris(filter);
             // => measureDuration(() => _source.ListResourceUris(filter));
 
-            public Resource ResolveByCanonicalUri(string uri) => measureDuration(() => _source.ResolveByCanonicalUri(uri));
+            public Resource ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
+            
+            public Resource ResolveByUri(string uri) => TryResolveByUri(uri).Value;   
+            
+            public ResolverResult TryResolveByUri(string uri) => measureDuration(() => _source.TryResolveByUri(uri));
 
-            public Resource ResolveByUri(string uri) => measureDuration(() => _source.ResolveByUri(uri));
+            public ResolverResult TryResolveByCanonicalUri(string uri) => measureDuration(() => _source.TryResolveByCanonicalUri(uri));
 
             T measureDuration<T>(Func<T> f)
             {

--- a/src/Hl7.Fhir.Specification.Shared.Tests/DiscriminatorInterpreterTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/DiscriminatorInterpreterTests.cs
@@ -2,6 +2,7 @@
 using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Specification.Source;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
 using System.Linq;
 using Tasks = System.Threading.Tasks;
 
@@ -16,7 +17,7 @@ namespace Hl7.Fhir.Specification.Tests
             return new CachedResolver(
                 new SnapshotSource(
                 new MultiResolver(
-                    new DirectorySource(@"TestData\validation"),
+                    new DirectorySource(Path.Combine("TestData", "validation")),
                     ZipSource.CreateValidationSource())));
         }
 

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -207,7 +207,7 @@ namespace Hl7.Fhir.Specification.Tests
             derivedSD.BaseDefinition = baseSD.Url;
 
             var resourceResolver = Substitute.For<IResourceResolver>();
-            resourceResolver.ResolveByCanonicalUri(Arg.Any<string>()).Returns(baseSD);
+            resourceResolver.TryResolveByCanonicalUri(Arg.Any<string>()).Returns(baseSD);
             var snapshotGenerator = new SnapshotGenerator(resourceResolver, new SnapshotGeneratorSettings());
             await snapshotGenerator.UpdateAsync(derivedSD);
 

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/TestProfileArtifactSource.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/TestProfileArtifactSource.cs
@@ -303,16 +303,21 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
             return result;
         }
-        public Resource ResolveByCanonicalUri(string uri)
-        {
-            return TestProfiles.SingleOrDefault(p => p.Url == uri);
-        }
+        
+        public Resource ResolveByCanonicalUri(string uri) =>  TryResolveByCanonicalUri(uri).Value;
 
-        public Resource ResolveByUri(string uri)
-        {
-            return ResolveByCanonicalUri(uri);
-        }
+        public Resource ResolveByUri(string uri) => ResolveByCanonicalUri(uri);
 
+        public ResolverResult TryResolveByUri(string uri) => TryResolveByCanonicalUri(uri);
+
+        public ResolverResult TryResolveByCanonicalUri(string uri) 
+        {
+            var resource = TestProfiles.SingleOrDefault(p => p.Url == uri);
+            if(resource is not null)
+                return resource;
+
+            return ResolverException.NotFound();
+        }
 
         private static StructureDefinition buildDutchPatient()
         {

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/TimingSource.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/TimingSource.cs
@@ -27,9 +27,13 @@ namespace Hl7.Fhir.Specification.Tests
         public IEnumerable<string> ListResourceUris(ResourceType? filter = default(ResourceType?)) => _source.ListResourceUris(filter);
         // => measureDuration(() => _source.ListResourceUris(filter));
 
-        public Resource ResolveByCanonicalUri(string uri) => measureDuration(() => _source.ResolveByCanonicalUri(uri));
+        public Resource ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
+            
+        public Resource ResolveByUri(string uri) => TryResolveByUri(uri).Value;   
+            
+        public ResolverResult TryResolveByUri(string uri) => measureDuration(() => _source.TryResolveByUri(uri));
 
-        public Resource ResolveByUri(string uri) => measureDuration(() => _source.ResolveByUri(uri));
+        public ResolverResult TryResolveByCanonicalUri(string uri) => measureDuration(() => _source.TryResolveByCanonicalUri(uri));
 
         T measureDuration<T>(Func<T> f)
         {

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Source/ResolverAndSourceExtensionTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Source/ResolverAndSourceExtensionTests.cs
@@ -137,20 +137,21 @@ namespace Hl7.Fhir.Specification.Tests
 
         private class LogicalModelTypeResourceResolver : IResourceResolver
         {
-            public Resource ResolveByCanonicalUri(string uri)
+            public ResolverResult TryResolveByCanonicalUri(string uri) 
             {
                 var customLogicalModelDataTypeXml = File.ReadAllText(Path.Combine("TestData/ccda", "CCDA_ANY.xml"));
                 var sd = new FhirXmlParser().Parse<StructureDefinition>(customLogicalModelDataTypeXml);
                 if (sd.Type.Equals(uri))
                     return sd;
 
-                return null;
+                return ResolverException.NotFound();
             }
 
-            public Resource ResolveByUri(string uri)
-            {
-                throw new NotImplementedException();
-            }
+            public Resource ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
+            
+            public ResolverResult TryResolveByUri(string uri) => throw new NotImplementedException();
+
+            public Resource ResolveByUri(string uri) => throw new NotImplementedException();
         }
 
     }

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Source/ResourceResolverTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Source/ResourceResolverTests.cs
@@ -37,32 +37,32 @@ namespace Hl7.Fhir.Specification.Tests
         [TestMethod]
         public void ResolveByCanonicalFromZip()
         {
-            var extDefn = source.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/data-absent-reason");
+            var extDefn = source.TryResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/data-absent-reason").Value;
             Assert.IsNotNull(extDefn);
             Assert.IsInstanceOfType(extDefn, typeof(StructureDefinition));
 
-            extDefn = source.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/Patient");
+            extDefn = source.TryResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/Patient").Value;
             Assert.IsNotNull(extDefn);
             Assert.IsInstanceOfType(extDefn, typeof(StructureDefinition));
 
-            extDefn = source.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/Patient");
+            extDefn = source.TryResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/Patient").Value;
             Assert.IsNotNull(extDefn);
             Assert.IsInstanceOfType(extDefn, typeof(StructureDefinition));
 
             var dirSource = new DirectorySource(Path.Combine("TestData", "validation"));
-            extDefn = dirSource.ResolveByCanonicalUri("http://example.com/StructureDefinition/patient-telecom-reslice-ek|1.0");
+            extDefn = dirSource.TryResolveByCanonicalUri("http://example.com/StructureDefinition/patient-telecom-reslice-ek|1.0").Value;
 
-            Assert.ThrowsException<ArgumentException>(() => dirSource.ResolveByCanonicalUri("http://example.com/StructureDefinition/patient-telecom-reslice-ek|1.0|"));
+            Assert.ThrowsException<ArgumentException>(() => dirSource.TryResolveByCanonicalUri("http://example.com/StructureDefinition/patient-telecom-reslice-ek|1.0|").Value);
         }
 
         [TestMethod]
         public void ResolveByUriFromFhirPackage()
         {
-            var extDefn = source.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/data-absent-reason");
+            var extDefn = source.TryResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/data-absent-reason").Value;
             Assert.IsNotNull(extDefn);
             Assert.IsInstanceOfType(extDefn, typeof(StructureDefinition));
 
-            extDefn = source.ResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/Patient");
+            extDefn = source.TryResolveByCanonicalUri("http://hl7.org/fhir/StructureDefinition/Patient").Value;
             Assert.IsNotNull(extDefn);
             Assert.IsInstanceOfType(extDefn, typeof(StructureDefinition));
 

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Source/TerminologyTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Source/TerminologyTests.cs
@@ -3,6 +3,7 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Specification.Terminology;
+using Hl7.Fhir.Validation;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -25,7 +26,8 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public async Tasks.Task ExpansionOfWholeSystem()
         {
-            var issueTypeVs = (await _resolverWithoutExpansions.ResolveByCanonicalUriAsync("http://hl7.org/fhir/ValueSet/issue-type")).DeepCopy() as ValueSet;
+            var result = await _resolverWithoutExpansions.TryResolveByCanonicalUriAsync("http://hl7.org/fhir/ValueSet/issue-type");
+            var issueTypeVs = result.Value.DeepCopy() as ValueSet;
             Assert.False(issueTypeVs.HasExpansion);
 
             // Wipe the version so we don't have to update our tests all the time
@@ -75,7 +77,8 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public async Tasks.Task ExpansionOfComposeInclude()
         {
-            var testVs = (await _resolver.ResolveByCanonicalUriAsync("http://hl7.org/fhir/ValueSet/resource-security-category")).DeepCopy() as ValueSet;
+            var result = await _resolver.TryResolveByCanonicalUriAsync("http://hl7.org/fhir/ValueSet/resource-security-category");
+            var testVs = result.Value.DeepCopy() as ValueSet;
             Assert.False(testVs.HasExpansion);
 
             var expander = new ValueSetExpander(new ValueSetExpanderSettings { ValueSetSource = _resolver });
@@ -87,7 +90,8 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public async Tasks.Task ExpansionOfComposeImport()
         {
-            var testVs = (await _resolverWithoutExpansions.ResolveByCanonicalUriAsync("http://hl7.org/fhir/ValueSet/FHIR-version")).DeepCopy() as ValueSet;
+            var result = await _resolverWithoutExpansions.TryResolveByCanonicalUriAsync("http://hl7.org/fhir/ValueSet/FHIR-version");
+            var testVs = result.Value.DeepCopy() as ValueSet;
             Assert.False(testVs.HasExpansion);
 
             var expander = new ValueSetExpander(new ValueSetExpanderSettings { ValueSetSource = _resolverWithoutExpansions });
@@ -104,7 +108,8 @@ namespace Hl7.Fhir.Specification.Tests
         [Fact]
         public async Tasks.Task TestIncludeDesignation()
         {
-            var testVs = (await _resolver.ResolveByCanonicalUriAsync("http://hl7.org/fhir/ValueSet/animal-genderstatus")).DeepCopy() as ValueSet;
+            var result = await _resolver.TryResolveByCanonicalUriAsync("http://hl7.org/fhir/ValueSet/animal-genderstatus");
+            var testVs = result.Value.DeepCopy() as ValueSet;
             Assert.False(testVs.HasExpansion);
             var expander = new ValueSetExpander(new ValueSetExpanderSettings { ValueSetSource = _resolver });
 
@@ -851,8 +856,13 @@ namespace Hl7.Fhir.Specification.Tests
             {
                 return await Tasks.Task.FromResult(uri == _myOnlyVS.Url) ? _myOnlyVS : null;
             }
-
+            
             public Task<Resource> ResolveByUriAsync(string uri) => throw new NotImplementedException();
+
+            public Task<ResolverResult> TryResolveByUriAsync(string uri) => throw new NotImplementedException();
+
+            public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult<ResolverResult>(uri == _myOnlyVS.Url ? _myOnlyVS : ResolverException.NotFound());
+
         }
 
         private class OnlyCodeSystemResolver : IAsyncResourceResolver, ICommonConformanceSource
@@ -899,10 +909,20 @@ namespace Hl7.Fhir.Specification.Tests
             }
             public IEnumerable<string> ListResourceUris(ResourceType? filter = null) => throw new NotImplementedException();
             public Resource ResolveByCanonicalUri(string uri) => throw new NotImplementedException();
+            public ResolverResult TryResolveByUri(string uri) => throw new NotImplementedException();
+
+            public ResolverResult TryResolveByCanonicalUri(string uri) => throw new NotImplementedException();
+
             public async Task<Resource> ResolveByCanonicalUriAsync(string uri)
             {
-                return await Tasks.Task.FromResult(uri == _onlyCs.Url ? _onlyCs : null);
+                var resource = await TryResolveByCanonicalUriAsync(uri).ConfigureAwait(false);
+                return resource.Value;
             }
+
+            public Task<ResolverResult> TryResolveByUriAsync(string uri) => throw new NotImplementedException();
+
+            public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri) => Tasks.Task.FromResult<ResolverResult>(uri == _onlyCs.Url ? _onlyCs : ResolverException.NotFound());
+
             public Resource ResolveByUri(string uri) => throw new NotImplementedException();
             public Task<Resource> ResolveByUriAsync(string uri) => throw new NotImplementedException();
             public IEnumerable<ConceptMap> FindConceptMaps(string sourceUri = null, string targetUri = null) => throw new NotImplementedException();

--- a/src/Hl7.Fhir.Specification.Shared.Tests/StructureDefinitionWalkerTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/StructureDefinitionWalkerTests.cs
@@ -3,6 +3,7 @@ using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Specification.Source;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
 using System.Linq;
 using Tasks = System.Threading.Tasks;
 
@@ -17,7 +18,7 @@ namespace Hl7.Fhir.Specification.Tests
             return new CachedResolver(
                 new SnapshotSource(
                 new MultiResolver(
-                    new DirectorySource(@"TestData\validation"),
+                    new DirectorySource(Path.Combine("TestData", "validation")),
                     ZipSource.CreateValidationSource())));
         }
 

--- a/src/Hl7.Fhir.Specification.Shared.Tests/TimingSource.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/TimingSource.cs
@@ -32,9 +32,13 @@ namespace Hl7.Fhir.Specification.Tests
             public IEnumerable<string> ListResourceUris(ResourceType? filter = default(ResourceType?)) => _source.ListResourceUris(filter);
             // => measureDuration(() => _source.ListResourceUris(filter));
 
-            public Resource ResolveByCanonicalUri(string uri) => measureDuration(() => _source.ResolveByCanonicalUri(uri));
+            public Resource ResolveByCanonicalUri(string uri) => TryResolveByCanonicalUri(uri).Value;
+            
+            public Resource ResolveByUri(string uri) => TryResolveByUri(uri).Value;   
+            
+            public ResolverResult TryResolveByUri(string uri) => measureDuration(() => _source.TryResolveByUri(uri));
 
-            public Resource ResolveByUri(string uri) => measureDuration(() => _source.ResolveByUri(uri));
+            public ResolverResult TryResolveByCanonicalUri(string uri) => measureDuration(() => _source.TryResolveByCanonicalUri(uri));
 
             T measureDuration<T>(Func<T> f)
             {

--- a/src/Hl7.Fhir.Support.Tests/Specification/AsyncSources.cs
+++ b/src/Hl7.Fhir.Support.Tests/Specification/AsyncSources.cs
@@ -17,15 +17,15 @@ namespace Hl7.Fhir.Utility.Tests
             var adaptee = new SyncResolver();
             var adapted = adaptee.AsAsync();
 
-            _ = await adapted.ResolveByUriAsync("");
-            _ = await adapted.ResolveByCanonicalUriAsync("");
-            _ = await adapted.ResolveByCanonicalUriAsync("");
+            _ = await adapted.TryResolveByUriAsync("");
+            _ = await adapted.TryResolveByCanonicalUriAsync("");
+            _ = await adapted.TryResolveByCanonicalUriAsync("");
 
             Assert.AreEqual(2, adaptee.ByCanonical);
             Assert.AreEqual(1, adaptee.ByUri);
 
             // Now call the async adapted sync resolver synchronously ;-)
-            TaskHelper.Await(() => adapted.ResolveByUriAsync(""));
+            TaskHelper.Await(() => adapted.TryResolveByUriAsync(""));
             Assert.AreEqual(2, adaptee.ByUri);
         }
 
@@ -36,7 +36,7 @@ namespace Hl7.Fhir.Utility.Tests
             var multi = new MultiResolver(sr,ar,sar);
 
             // calling *any* kind of resolve will involve all child resolvers, since they all return null.
-            _ = await multi.ResolveByUriAsync("");
+            _ = await multi.TryResolveByUriAsync("");
 #pragma warning disable CS0618 // Type or member is obsolete
             _ = multi.ResolveByCanonicalUri("");
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -107,14 +107,24 @@ namespace Hl7.Fhir.Utility.Tests
 
         public Resource ResolveByCanonicalUri(string uri)
         {
+            return TryResolveByCanonicalUri(uri).Value;
+        }
+
+        public ResolverResult TryResolveByUri(string uri)
+        {
+            ByUri += 1;
+            return Data is null ? ResolverException.NotFound() : Data;
+        }
+
+        public ResolverResult TryResolveByCanonicalUri(string uri)
+        {
             ByCanonical += 1;
-            return Data;
+            return Data is null ? ResolverException.NotFound() : Data;
         }
 
         public Resource ResolveByUri(string uri)
         {
-            ByUri += 1;
-            return Data;
+            return TryResolveByUri(uri).Value;
         }
     }
 
@@ -131,11 +141,22 @@ namespace Hl7.Fhir.Utility.Tests
             Data = data;
         }
 
-
         public Task<Resource> ResolveByCanonicalUriAsync(string uri)
         {
             ByCanonicalAsync += 1;
             return Task.FromResult(Data);
+        }
+
+        public Task<ResolverResult> TryResolveByUriAsync(string uri) 
+        {
+            ByUriAsync += 1;
+            return Task.FromResult<ResolverResult>(Data is null ? ResolverException.NotFound() : Data);
+        }
+
+        public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri)
+        {
+            ByCanonicalAsync += 1;
+            return Task.FromResult<ResolverResult>(Data is null ? ResolverException.NotFound() : Data);
         }
 
         public Task<Resource> ResolveByUriAsync(string uri)
@@ -164,20 +185,44 @@ namespace Hl7.Fhir.Utility.Tests
 
         public Resource ResolveByCanonicalUri(string uri)
         {
+            return TryResolveByCanonicalUri(uri).Value;
+        }
+
+        public ResolverResult TryResolveByUri(string uri)
+        {
+            ByUri += 1;
+            return Data is null ? ResolverException.NotFound() : Data;
+        }
+
+        public ResolverResult TryResolveByCanonicalUri(string uri)
+        {
             ByCanonical += 1;
-            return Data;
+            return Data is null ? ResolverException.NotFound() : Data;
         }
 
         public Resource ResolveByUri(string uri)
         {
-            ByUri += 1;
-            return Data;
+            return TryResolveByUri(uri).Value;
         }
+
+
 
         public Task<Resource> ResolveByCanonicalUriAsync(string uri)
         {
             ByCanonicalAsync += 1;
             return Task.FromResult(Data);
+        }
+
+        public Task<ResolverResult> TryResolveByUriAsync(string uri) 
+        {
+            ByUriAsync += 1;
+            return Task.FromResult<ResolverResult>(Data is null ? ResolverException.NotFound() : Data);
+        }
+
+        public Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri)
+        {
+            ByCanonicalAsync += 1;
+            return Task.FromResult<ResolverResult>(Data is null ? ResolverException.NotFound() : Data);
         }
 
         public Task<Resource> ResolveByUriAsync(string uri)


### PR DESCRIPTION
## Description
Adds an `TryResolve` overloads to resolver interfaces, and obsoletes the regular ones.
Default interface implementation used to make it backwards compatible, while producing warnings still.

## Related issues
Closes [#2778](https://github.com/FirelyTeam/firely-net-sdk/issues/2778)