### PR TITLE
DEVOPS-354: Use v1 of Firely Azure templates

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -32,7 +32,9 @@ resources:
   - repository: templates
     type: github
     name: FirelyTeam/azure-pipeline-templates
-    endpoint: FirelyTeam 
+    endpoint: FirelyTeam
+    ref: refs/tags/v1
+    
 
 stages:
 - stage: build


### PR DESCRIPTION
## Description
Use version `v1` (base version) of the Firely Azure templates (FirelyTeam/azure-pipeline-templates).

## Related issues
DEVOPS-354

## Testing
See Azure Devops for successful build: https://dev.azure.com/firely/firely-net-sdk/_build?definitionId=144

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes