### PR TITLE
fix ElementResolver nullability

### DIFF
--- a/src/Hl7.Fhir.Base/FhirPath/FhirEvaluationContext.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/FhirEvaluationContext.cs
@@ -78,9 +78,14 @@ namespace Hl7.Fhir.FhirPath
             return scan;
         }
 
-        private Func<string, ITypedElement>? _elementResolver;
+        private Func<string, ITypedElement?>? _elementResolver;
 
-        public Func<string, ITypedElement>? ElementResolver
+        /// <summary>
+        /// A function that is invoked when resolve() is called in the fhirpath expression.
+        /// Should return the ITypedElement for the given Id. Example: Patient/1234
+        /// Should returns null if the resource cannot be found.
+        /// </summary>
+        public Func<string, ITypedElement?>? ElementResolver
         {
             get { return _elementResolver; }
             set { _elementResolver = value; }


### PR DESCRIPTION
## Description
`ElementResolver` signature now requires a TypedElement to be returned when fhirpath resolve is invoked, which is not the right way to represent it.  See `Resolve()` at `src/Hl7.Fhir.Base/ElementModel/ScopedNodeExtensions.cs` .

My understanding is that the `ElementResolver` should return null when the resource could not be find.

I think this behavior was introduced by:
https://github.com/FirelyTeam/firely-net-sdk/commit/6b3667017b68ebfa2f5ee1a2944c17d01a66fa4e#diff-d709f853b86e1727a99b190e1663bbba64c50078b5f0a3980edb3ca9c6292e6cR15

## Related issues
Closes|Fixes|Resolves [issue #].

## Testing
I built the project.

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes