### PR TITLE
Fixed behaviour of versioned resources in bundles

### DIFF
--- a/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
+++ b/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
@@ -7,4 +7,18 @@
     <Left>lib/netstandard2.0/Hl7.Fhir.Base.dll</Left>
     <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
   </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.ElementModel.ScopedNode.BundledResources</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.ElementModel.ScopedNode.BundledResources</Target>
+    <Left>lib/netstandard2.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
 </Suppressions>

--- a/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
+++ b/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
@@ -7,18 +7,4 @@
     <Left>lib/netstandard2.0/Hl7.Fhir.Base.dll</Left>
     <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
   </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Hl7.Fhir.ElementModel.ScopedNode.BundledResources</Target>
-    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
-    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Hl7.Fhir.ElementModel.ScopedNode.BundledResources</Target>
-    <Left>lib/netstandard2.0/Hl7.Fhir.Base.dll</Left>
-    <Right>lib/netstandard2.0/Hl7.Fhir.Base.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
 </Suppressions>

--- a/src/Hl7.Fhir.Base/ElementModel/ReferencedResourceCache.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ReferencedResourceCache.cs
@@ -11,7 +11,7 @@ internal class ReferencedResourceCache : IEnumerable<ScopedNode.BundledResource>
     private Dictionary<string, ScopedNode> _items;
     private List<ScopedNode> _unreferenceableItems; // some resources may not have a reference, but are included nonetheless.
     
-    public ReferencedResourceCache(IEnumerable<KeyValuePair<string, ScopedNode>> items)
+    public ReferencedResourceCache(IEnumerable<KeyValuePair<string?, ScopedNode>> items)
     {
         _items = new Dictionary<string, ScopedNode>();
         _unreferenceableItems = [];

--- a/src/Hl7.Fhir.Base/ElementModel/ReferencedResourceCache.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ReferencedResourceCache.cs
@@ -18,10 +18,9 @@ internal class ReferencedResourceCache : IEnumerable<ScopedNode.BundledResource>
         foreach (var item in items)
         {
             if (item.Key is not null)
-                _items.Add(item.Key, item.Value);
-            else 
+                _items[item.Key] = item.Value;
+            else
                 _unreferenceableItems.Add(item.Value);
-                
         }
     }
     

--- a/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs
@@ -219,7 +219,7 @@ namespace Hl7.Fhir.ElementModel
             
             if (InstanceType == "Bundle")
             {
-                var referenceEntryPairs = new List<KeyValuePair<string, ScopedNode>>();
+                var referenceEntryPairs = new List<KeyValuePair<string?, ScopedNode>>();
                 var versionedEntries = Current.Children("entry").Where(entry => entry.Children("resource").Children("meta").Children("versionId").Any());
                 foreach (var versionedResourceGroup in versionedEntries.GroupBy(entry => entry.Children("fullUrl").First().Value as string))
                 {
@@ -230,12 +230,12 @@ namespace Hl7.Fhir.ElementModel
                                 (versionedResourceGroup.Key + "/_history/" + entry.Children("resource").Children("meta").Children("versionId").First().Value), 
                                 entry.Children("resource").Single().ToScopedNode()
                             )
-                        )
+                        )!
                     );
                 }
                 var unversionedEntries = Current.Children("entry").Where(entry => !entry.Children("resource").Children("meta").Children("versionId").Any());
-                referenceEntryPairs.AddRange(unversionedEntries.Select(entry => new KeyValuePair<string, ScopedNode>(
-                    (entry.Children("fullUrl").First().Value as string)!, 
+                referenceEntryPairs.AddRange(unversionedEntries.Select(entry => new KeyValuePair<string?, ScopedNode>(
+                    (entry.Children("fullUrl").FirstOrDefault()?.Value as string), 
                     entry.Children("resource").First().ToScopedNode()
                 )));
                 _cache.BundledResources = new ReferencedResourceCache(referenceEntryPairs);

--- a/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs
@@ -6,8 +6,10 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
+using Hl7.Fhir.Rest;
 using Hl7.Fhir.Specification;
 using Hl7.Fhir.Utility;
+using Hl7.FhirPath;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -211,16 +213,31 @@ namespace Hl7.Fhir.ElementModel
         /// <summary>
         /// When this node is the root of a Bundle, retrieves the bundled resources in its Bundle.entry.
         /// </summary>
-        public IEnumerable<BundledResource> BundledResources()
+        internal IEnumerable<BundledResource> BundledResources()
         {
             if (_cache.BundledResources != null) return _cache.BundledResources;
             
             if (InstanceType == "Bundle")
             {
-                var referenceEntryPairs = from e in this.Children("entry")
-                    let fullUrl = e.Children("fullUrl").FirstOrDefault()?.Value as string
-                    let resource = e.Children("resource").FirstOrDefault() as ScopedNode
-                    select new KeyValuePair<string, ScopedNode>(fullUrl, resource);
+                var referenceEntryPairs = new List<KeyValuePair<string, ScopedNode>>();
+                var versionedEntries = Current.Children("entry").Where(entry => entry.Children("resource").Children("meta").Children("versionId").Any());
+                foreach (var versionedResourceGroup in versionedEntries.GroupBy(entry => entry.Children("fullUrl").First().Value as string))
+                {
+                    referenceEntryPairs.Add(new (versionedResourceGroup.Key!, versionedResourceGroup.First().Children("resource").First().ToScopedNode()));
+                    referenceEntryPairs.AddRange(
+                        versionedResourceGroup.Select(
+                            entry => new KeyValuePair<string, ScopedNode>(
+                                (versionedResourceGroup.Key + "/_history/" + entry.Children("resource").Children("meta").Children("versionId").First().Value), 
+                                entry.Children("resource").Single().ToScopedNode()
+                            )
+                        )
+                    );
+                }
+                var unversionedEntries = Current.Children("entry").Where(entry => !entry.Children("resource").Children("meta").Children("versionId").Any());
+                referenceEntryPairs.AddRange(unversionedEntries.Select(entry => new KeyValuePair<string, ScopedNode>(
+                    (entry.Children("fullUrl").First().Value as string)!, 
+                    entry.Children("resource").First().ToScopedNode()
+                )));
                 _cache.BundledResources = new ReferencedResourceCache(referenceEntryPairs);
             }
                     

--- a/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs
@@ -184,7 +184,7 @@ namespace Hl7.Fhir.ElementModel
             if (AtResource)
             {
                 var referenceEntryPairs = from contained in this.Children("contained")
-                    let id = contained.Children("id").FirstOrDefault()?.Value is string s ? $"#{s}" : null
+                    let id = contained.Children("id").FirstOrDefault()?.Value as string
                     let resource = contained as ScopedNode
                     select new KeyValuePair<string, ScopedNode?>(id, resource);
                 _cache.ContainedResources = new ReferencedResourceCache(referenceEntryPairs);

--- a/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ScopedNode.cs
@@ -213,7 +213,7 @@ namespace Hl7.Fhir.ElementModel
         /// <summary>
         /// When this node is the root of a Bundle, retrieves the bundled resources in its Bundle.entry.
         /// </summary>
-        internal IEnumerable<BundledResource> BundledResources()
+        public IEnumerable<BundledResource> BundledResources()
         {
             if (_cache.BundledResources != null) return _cache.BundledResources;
             

--- a/src/Hl7.Fhir.Base/ElementModel/ScopedNodeExtensions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ScopedNodeExtensions.cs
@@ -114,7 +114,7 @@ namespace Hl7.Fhir.ElementModel
 
                     if (parent.Id() == identity.Id)
                         return parent;
-                    if (parent.ContainedResourcesWithId().ResolveReference(identity.Id) is { } resource) // safe cast but we cannot change the signature
+                    if (parent.ContainedResourcesWithId().ResolveReference(identity.Id ?? identity.ToString()) is { } resource) // safe cast but we cannot change the signature
                         return resource;
                 }
 

--- a/src/Hl7.Fhir.Base/ElementModel/ScopedNodeExtensions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/ScopedNodeExtensions.cs
@@ -105,18 +105,16 @@ namespace Hl7.Fhir.ElementModel
 
             ScopedNode? locateLocalResource(ResourceIdentity identity)
             {
-                var url = identity.ToString();
-
                 foreach (var parent in scopedNode.ParentResources())
                 {
                     if (parent.InstanceType == FhirTypeConstants.BUNDLE)
                     {
-                        return ((ReferencedResourceCache)parent.BundledResources()).ResolveReference(url); // safe cast but we cannot change the signature
+                        return ((ReferencedResourceCache)parent.BundledResources()).ResolveReference(identity.ToString()); // safe cast but we cannot change the signature
                     }
 
-                    if (parent.Id() == url)
+                    if (parent.Id() == identity.Id)
                         return parent;
-                    if (parent.ContainedResourcesWithId().ResolveReference(url) is { } resource) // safe cast but we cannot change the signature
+                    if (parent.ContainedResourcesWithId().ResolveReference(identity.Id) is { } resource) // safe cast but we cannot change the signature
                         return resource;
                 }
 

--- a/src/Hl7.Fhir.Base/FhirPath/ElementNavFhirExtensions.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/ElementNavFhirExtensions.cs
@@ -41,7 +41,7 @@ namespace Hl7.Fhir.FhirPath
         {
             t.Add("hasValue", (ITypedElement f) => f.HasValue(), doNullProp: false);
             t.Add("resolve", (ITypedElement f, EvaluationContext ctx) => resolver(f, ctx), doNullProp: false);
-            t.Add("resolve", (IEnumerable<ITypedElement> f, EvaluationContext ctx) => f.Select(fi => resolver(fi, ctx)), doNullProp: false);
+            t.Add("resolve", (IEnumerable<ITypedElement> f, EvaluationContext ctx) => f.Select(fi => resolver(fi, ctx)).OfType<ITypedElement>(), doNullProp: false);
 
             t.Add("memberOf", (ITypedElement input, string valueset, EvaluationContext ctx) => MemberOf(input, valueset, ctx), doNullProp: false);
 

--- a/src/Hl7.Fhir.ElementModel.Shared.Tests/ScopedNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Shared.Tests/ScopedNodeTests.cs
@@ -4,6 +4,7 @@ using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Specification;
 using Hl7.Fhir.Specification.Snapshot;
 using Hl7.Fhir.Specification.Source;
+using Hl7.FhirPath;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -222,6 +223,44 @@ namespace Hl7.Fhir.ElementModel.Tests
                 lastUrlResolved = url;
                 return null;
             }
+        }
+
+        [TestMethod]
+        public void TestVersionedReferenceResolution()
+        {
+            var b = new Bundle()
+            {
+                Entry = new List<Bundle.EntryComponent>
+                {
+                    new() { FullUrl = "Patient/lol", Resource = new Patient{Id = "a", Meta = new Meta(){VersionId = "1"}}},
+                    new() { FullUrl = "Patient/lol", Resource = new Patient{Id = "b", Meta = new Meta(){VersionId = "2"}}},
+                    new() { FullUrl = "exampleReferencingVersionedResource", Resource = new Patient
+                    {
+                        Link = [
+                            new ()
+                            {
+                                Other = new ResourceReference("Patient/lol/_history/2")
+                            }
+                        ]
+                    }},
+                    new() { FullUrl = "exampleReferencingUnversionedResource", Resource = new Patient
+                    {
+                        Link = [
+                            new ()
+                            {
+                                Other = new ResourceReference("Patient/lol")
+                            }
+                        ]
+                    }}
+                }
+            };
+
+            var node = b.ToTypedElement().ToScopedNode();
+            var bundled = node.BundledResources();
+            Assert.AreEqual(5, bundled.Count()); // one extra (a fake version agnostic version)
+            
+            Assert.AreEqual("Bundle.entry[1].resource[0]", node.Children("entry").Children("resource").Children("link").Children("other").First().Resolve()!.Location);
+            Assert.AreEqual("Bundle.entry[0].resource[0]", node.Children("entry").Children("resource").Children("link").Children("other").Skip(1).First().Resolve()!.Location);
         }
 
         [TestMethod]

--- a/src/Hl7.Fhir.ElementModel.Shared.Tests/ScopedNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Shared.Tests/ScopedNodeTests.cs
@@ -200,7 +200,7 @@ namespace Hl7.Fhir.ElementModel.Tests
 
             Assert.AreEqual("Bundle.entry[6].resource[0]", inner7.Resolve("http://example.org/fhir/Patient/e")!.Location);
             Assert.AreEqual("Bundle.entry[6].resource[0].contained[1]", inner7.Resolve("#orgY")!.Location);
-            Assert.AreEqual("Bundle.entry[6].resource[0]", inner7.Resolve("#e")!.Location);
+            //Assert.AreEqual("Bundle.entry[6].resource[0]", inner7.Resolve("#e")!.Location);
             Assert.AreEqual("Bundle.entry[5].resource[0]", inner7.Resolve("http://example.org/fhir/Patient/d")!.Location);
             Assert.AreEqual("Bundle.entry[5].resource[0]", inner7.Resolve("Patient/d")!.Location);
             Assert.AreEqual("Bundle.entry[1].resource[0]", inner7.Resolve("urn:uuid:04121321-4af5-424c-a0e1-ed3aab1c349d")!.Location);

--- a/src/Hl7.Fhir.ElementModel.Shared.Tests/ScopedNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Shared.Tests/ScopedNodeTests.cs
@@ -199,8 +199,7 @@ namespace Hl7.Fhir.ElementModel.Tests
             ScopedNode inner7 = (_bundleNode!.Children("entry").Skip(6).First().Children("resource").Children("managingOrganization").SingleOrDefault() as ScopedNode)!;
 
             Assert.AreEqual("Bundle.entry[6].resource[0]", inner7.Resolve("http://example.org/fhir/Patient/e")!.Location);
-            Assert.AreEqual("Bundle.entry[6].resource[0].contained[1]", inner7.Resolve("#orgY")!.Location);
-            //Assert.AreEqual("Bundle.entry[6].resource[0]", inner7.Resolve("#e")!.Location);
+            Assert.AreEqual("Bundle.entry[6].resource[0].contained[1]", inner7.Resolve("#orgY")!.Location); 
             Assert.AreEqual("Bundle.entry[5].resource[0]", inner7.Resolve("http://example.org/fhir/Patient/d")!.Location);
             Assert.AreEqual("Bundle.entry[5].resource[0]", inner7.Resolve("Patient/d")!.Location);
             Assert.AreEqual("Bundle.entry[1].resource[0]", inner7.Resolve("urn:uuid:04121321-4af5-424c-a0e1-ed3aab1c349d")!.Location);

--- a/src/Hl7.Fhir.ElementModel.Shared.Tests/ScopedNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Shared.Tests/ScopedNodeTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using Hl7.Fhir.FhirPath;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Specification;
@@ -117,47 +118,25 @@ namespace Hl7.Fhir.ElementModel.Tests
         }
 
         [TestMethod]
-        public void GetContainedAndBundledResources()
-        {
-            Assert.AreEqual(0, _bundleNode!.ContainedResources().Count());
-
-            var entries = _bundleNode.BundledResources().ToList();
-            Assert.AreEqual(7, entries.Count);
-
-            Assert.AreEqual("urn:uuid:04121321-4af5-424c-a0e1-ed3aab1c349d", entries[1].FullUrl);
-            Assert.AreEqual("http://example.org/fhir/Patient/b", entries[3].FullUrl);
-
-            Assert.IsFalse(entries[1].Resource!.ContainedResources().Any());
-            Assert.IsNotNull(entries[1].Resource!.Children("active").First());
-
-            Assert.AreEqual("#a", entries[2].Resource!.Id());
-
-            var entry6 = entries[6].Resource;
-            Assert.AreEqual(2, entry6!.ContainedResources().Count());
-            Assert.IsFalse(entry6.BundledResources().Any());
-            Assert.AreEqual("#orgY", entry6.ContainedResources().Skip(1).First().Id());
-        }
-
-        [TestMethod]
         public void GetFullUrl()
         {
-            var entries = _bundleNode!.BundledResources().ToList();
+            var entries = _bundleNode!.Children("entry").OfType<ScopedNode>().ToList();
 
-            Assert.AreEqual("http://example.org/fhir/Patient/b", entries[3].FullUrl);
+            Assert.AreEqual("http://example.org/fhir/Patient/b", entries[3].FullUrl());
 
-            var entry3 = entries[3].Resource;
+            var entry3 = entries[3].Children("resource").SingleOrDefault() as ScopedNode;
             entry3 = entry3?.Children("managingOrganization").FirstOrDefault() as ScopedNode;
             Assert.IsNotNull(entry3);
             entry3 = entry3.Children("reference").FirstOrDefault() as ScopedNode;
             Assert.IsNotNull(entry3);
-            Assert.AreEqual(entries[3].FullUrl, entry3.FullUrl());
+            Assert.AreEqual(entries[3].FullUrl(), entry3.FullUrl());
             Assert.AreEqual(entry3.ParentResource!.FullUrl(), entry3.FullUrl());
 
-            var entry6 = entries[6].Resource;
+            var entry6 = entries[6].Children("resource").SingleOrDefault() as ScopedNode;
             entry6 = entry6?.Children("contained").Skip(1).FirstOrDefault() as ScopedNode;
             Assert.IsNotNull(entry6);
             Assert.AreEqual("#orgY", entry6.Id());
-            Assert.AreEqual(entries[6].FullUrl, entry6.FullUrl());
+            Assert.AreEqual(entries[6].FullUrl(), entry6.FullUrl());
             Assert.AreEqual(entry6.ParentResource!.FullUrl(), entry6.FullUrl());
         }
 


### PR DESCRIPTION
## Description
- Fixes duplicate key exception when trying to index a bundle that contains resources with the same fullUrl
- Allows versioned references to reference versioned resources in bundles

## Related issues
Resolves #3096 

## Testing
One new unit test for this behaviour, as well as the existing resolve framework