### PR TITLE
Renamed ObjectValue to JsonValue

### DIFF
--- a/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
+++ b/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
@@ -444,6 +444,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.CompilerServices.TemporarilyChangedAttribute</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Hl7.Fhir.ElementModel.ElementNodeExtensions</Target>
     <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
     <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
@@ -879,6 +886,13 @@
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Hl7.Fhir.Validation.ValidationContextExtensions</Target>
+    <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.CompilerServices.TemporarilyChangedAttribute</Target>
     <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
     <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
@@ -56,7 +56,7 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
                 convertTypedElementValue(value);
 
             if(newInstance is PrimitiveType pt)
-                pt.ObjectValue = objectValue;
+                pt.JsonValue = objectValue;
             else
                 raiseFormatError($"{node.Name} is a primitive of type {value.GetType()}, but the target POCO is a {newInstance.GetType()}, " +
                                  $"which is not FHIR primitive.", node.Location);
@@ -278,7 +278,7 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
         // represented in the POCO as .NET primitives, not as FHIR datatypes, so we need to get the value out.
         try
         {
-            if (propertyMapping?.IsPrimitive == true && convertedValue is PrimitiveType { ObjectValue: { } value })
+            if (propertyMapping?.IsPrimitive == true && convertedValue is PrimitiveType { JsonValue: { } value })
                 target[node.Name] = value;
             else
                 target[node.Name] = convertedValue;

--- a/src/Hl7.Fhir.Base/ElementModel/PocoElementNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/PocoElementNode.cs
@@ -171,12 +171,12 @@ namespace Hl7.Fhir.ElementModel
         {
             get
             {
-                if (Current is not PrimitiveType { ObjectValue: not null } p) return null;
+                if (Current is not PrimitiveType { JsonValue: not null } p) return null;
 
-                if (p.ObjectValue == _lastCachedValue) return _value;
+                if (p.JsonValue == _lastCachedValue) return _value;
 
                 _value = ToITypedElementValue();
-                _lastCachedValue = p.ObjectValue;
+                _lastCachedValue = p.JsonValue;
                 return _value;
             }
         }
@@ -195,15 +195,15 @@ namespace Hl7.Fhir.ElementModel
                     Integer64 fint64 => fint64.Value,
                     PositiveInt pint => pint.Value,
                     UnsignedInt unsint => unsint.Value,
-                    Base64Binary { ObjectValue: { } b64 } => b64,
-                    PrimitiveType prim => prim.ObjectValue,
+                    Base64Binary { JsonValue: { } b64 } => b64,
+                    PrimitiveType prim => prim.JsonValue,
                     _ => null
                 };
             }
             catch (FormatException)
             {
                 // If it fails, just return the unparsed contents
-                return (Current as PrimitiveType)?.ObjectValue;
+                return (Current as PrimitiveType)?.JsonValue;
             }
         }
 

--- a/src/Hl7.Fhir.Base/ElementModel/PocoNode.Primitives.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/PocoNode.Primitives.cs
@@ -34,7 +34,7 @@ public partial record PocoNode
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     public static PocoNode ForPrimitive<T>(object value) where T : PrimitiveType, new() => 
-        new PrimitiveNode(new T { ObjectValue = value }, null, null);
+        new PrimitiveNode(new T { JsonValue = value }, null, null);
     
     /// <summary>
     /// Constructs a PocoNode from a list of PrimitiveTypes
@@ -92,5 +92,5 @@ internal record PrimitiveListNode(IReadOnlyList<PrimitiveType> Primitives, PocoN
     public override IEnumerator<PocoNode> GetEnumerator() =>
         Primitives.Select((primitive, index) => new PrimitiveNode(primitive, ParentNode, index, Name)).GetEnumerator();
 
-    internal IEnumerable<object?> Values => Primitives.Select(p => p.ObjectValue);
+    internal IEnumerable<object?> Values => Primitives.Select(p => p.JsonValue);
 }

--- a/src/Hl7.Fhir.Base/ElementModel/PocoNodeExtensions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/PocoNodeExtensions.cs
@@ -108,7 +108,7 @@ public static class PocoNodeExtensions
         {
             Canonical c => c.Value, // canonicals can be references
             ResourceReference r => r.Reference,
-            PrimitiveType {ObjectValue: string s} => s,
+            PrimitiveType {JsonValue: string s} => s,
             _ => throw new ArgumentException($"Error occurred during reference resolution: Parameter {nameof(node)} is not a reference.")
         };
 

--- a/src/Hl7.Fhir.Base/ElementModel/TypedElementParseExtensions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/TypedElementParseExtensions.cs
@@ -99,7 +99,7 @@ namespace Hl7.Fhir.ElementModel
 
             var comp = instance.Children("comparator").GetString();
             if (comp != null)
-                newQuantity.ComparatorElement = new Code<Quantity.QuantityComparator> { ObjectValue = comp };
+                newQuantity.ComparatorElement = new Code<Quantity.QuantityComparator> { JsonValue = comp };
 
             return newQuantity;
         }
@@ -113,7 +113,7 @@ namespace Hl7.Fhir.ElementModel
 
         [Obsolete("WARNING! Intended for internal API usage exclusively")]
         internal static T ParsePrimitiveInternal<T>(this ITypedElement instance) where T : PrimitiveType, new()
-                    => new() { ObjectValue = instance.Value };
+                    => new() { JsonValue = instance.Value };
 
         #endregion
 

--- a/src/Hl7.Fhir.Base/FhirPath/ElementNavFhirExtensions.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/ElementNavFhirExtensions.cs
@@ -89,7 +89,7 @@ namespace Hl7.Fhir.FhirPath
         /// <param name="focus"></param>
         /// <returns></returns>
         public static bool HtmlChecks(this PocoNode focus) =>
-            focus is PrimitiveNode {Primitive: XHtml {ObjectValue: string xhtml}} && XHtml.IsValidNarrativeXhtml(xhtml, out _, out _);
+            focus is PrimitiveNode {Primitive: XHtml {JsonValue: string xhtml}} && XHtml.IsValidNarrativeXhtml(xhtml, out _, out _);
 
         public static IEnumerable<Base?> ToFhirValues(this IEnumerable<PocoNode> results)
         {

--- a/src/Hl7.Fhir.Base/FhirPath/FPSystemTypes.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/FPSystemTypes.cs
@@ -10,7 +10,7 @@ internal class FPTime : CqlPrimitive
     public FPTime(P.Time value)
     {
         DynamicTypeName = "System.Time";
-        ObjectValue = value;
+        JsonValue = value;
     }
 }
 
@@ -19,7 +19,7 @@ internal class FPDateTime : CqlPrimitive
     public FPDateTime(P.DateTime value)
     {
         DynamicTypeName = "System.DateTime";
-        ObjectValue = value;
+        JsonValue = value;
     }
 }
 
@@ -28,7 +28,7 @@ internal class FPDate : CqlPrimitive
     public FPDate(P.Date value)
     {
         DynamicTypeName = "System.Date";
-        ObjectValue = value;
+        JsonValue = value;
     }
 }
 
@@ -37,7 +37,7 @@ internal class FPBoolean : CqlPrimitive
     public FPBoolean(bool value)
     {
         DynamicTypeName = "System.Boolean";
-        ObjectValue = value;
+        JsonValue = value;
     }
 }
 
@@ -46,7 +46,7 @@ internal class FPInteger : CqlPrimitive
     public FPInteger(int value)
     {
         DynamicTypeName = "System.Integer";
-        ObjectValue = value;
+        JsonValue = value;
     }
 }
 
@@ -55,7 +55,7 @@ internal class FPLong : CqlPrimitive
     public FPLong(long value)
     {
         DynamicTypeName = "System.Long";
-        ObjectValue = value;
+        JsonValue = value;
     }
 }
 
@@ -64,7 +64,7 @@ internal class FPDecimal : CqlPrimitive
     public FPDecimal(decimal value)
     {
         DynamicTypeName = "System.Decimal";
-        ObjectValue = value;
+        JsonValue = value;
     }
 }
 
@@ -73,7 +73,7 @@ internal class FPString : CqlPrimitive
     public FPString(string value)
     {
         DynamicTypeName = "System.String";
-        ObjectValue = value;
+        JsonValue = value;
     }
 }
 
@@ -82,6 +82,6 @@ internal class FPQuantity : CqlPrimitive
     public FPQuantity(P.Quantity value)
     {
         DynamicTypeName = "System.Quantity";
-        ObjectValue = value;
+        JsonValue = value;
     }
 }

--- a/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
@@ -377,7 +377,8 @@ namespace Hl7.Fhir.Introspection
             typeof(bool),
             typeof(DateTimeOffset),
             typeof(byte[]),
-            typeof(Enum)
+            typeof(Enum),
+            typeof(object)
         ];
 
         private static ClassMapping buildCqlClassMapping(Type t, FhirRelease release) =>

--- a/src/Hl7.Fhir.Base/Model/Base64Binary.cs
+++ b/src/Hl7.Fhir.Base/Model/Base64Binary.cs
@@ -62,26 +62,26 @@ public partial class Base64Binary
         set
         {
             _parsedValue = value;
-            base.ObjectValue = null;
+            base.JsonValue = null;
             OnPropertyChanged("Value");
         }
     }
 
-    public override object? ObjectValue
+    public override object? JsonValue
     {
         get
         {
-            if (_parsedValue is not null && base.ObjectValue is null)
+            if (_parsedValue is not null && base.JsonValue is null)
             {
-                base.ObjectValue = Convert.ToBase64String(_parsedValue);
+                base.JsonValue = Convert.ToBase64String(_parsedValue);
                 _parsedValue = null;    // Clear the parsed value to free up memory
             }
 
-            return base.ObjectValue;
+            return base.JsonValue;
         }
         set
         {
-            base.ObjectValue = value;
+            base.JsonValue = value;
             _parsedValue = null;
         }
     }
@@ -95,17 +95,17 @@ public partial class Base64Binary
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context)
     {
-        if (_parsedValue is not null || base.ObjectValue is null) return null;
+        if (_parsedValue is not null || base.JsonValue is null) return null;
         _parsedValue = null;
 
-        if (base.ObjectValue is not string unparsed)
-            return COVE.INCORRECT_LITERAL_VALUE_TYPE(context, ObjectValue, this.TypeName);
+        if (base.JsonValue is not string unparsed)
+            return COVE.INCORRECT_LITERAL_VALUE_TYPE(context, JsonValue, this.TypeName);
 
         _parsedValue = doParse(unparsed);
 
         // Clear the string value to free up memory if we have successfully parsed the value.
         if(_parsedValue is not null)
-            base.ObjectValue = null;
+            base.JsonValue = null;
 
         return _parsedValue is null ? COVE.INVALID_BASE64_VALUE(context, unparsed) : null;
     }
@@ -132,7 +132,7 @@ public partial class Base64Binary
     /// Constructs a Base64Binary instance from a string of base64-encoded data.
     /// </summary>
     public static Base64Binary FromBase64String(string base64Data) =>
-        new() { ObjectValue = base64Data };
+        new() { JsonValue = base64Data };
 
     /// <summary>
     /// Constructs a Base64Binary instance from a string of human-readable text.
@@ -152,7 +152,7 @@ public partial class Base64Binary
                                         throw new InvalidOperationException("Value is null.");
 
     protected internal override Any? TryConvertToSystemTypeInternal() =>
-        ObjectValue is string s
+        JsonValue is string s
         ? new P.String(s)
         : null;
 }

--- a/src/Hl7.Fhir.Base/Model/Canonical.cs
+++ b/src/Hl7.Fhir.Base/Model/Canonical.cs
@@ -100,12 +100,12 @@ public partial class Canonical
     /// Validates the JsonValue.
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context) =>
-        ObjectValue switch
+        JsonValue switch
         {
             null => null,
             string unparsed when IsValidValue(unparsed) => null,
             string unparsed => COVE.LITERAL_INVALID(context, unparsed, this.TypeName),
-            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, ObjectValue, this.TypeName)
+            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, JsonValue, this.TypeName)
         };
 
 

--- a/src/Hl7.Fhir.Base/Model/Code.cs
+++ b/src/Hl7.Fhir.Base/Model/Code.cs
@@ -60,13 +60,13 @@ public partial class Code : ICoded
     /// Validates the JsonValue.
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context) =>
-        ObjectValue switch
+        JsonValue switch
         {
             null => null,
             string unparsed => IsValidValue(unparsed)
                 ? null
                 : COVE.LITERAL_INVALID(context, unparsed, this.TypeName),
-            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, ObjectValue, this.TypeName)
+            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, JsonValue, this.TypeName)
         };
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/Model/CodeOfT.cs
+++ b/src/Hl7.Fhir.Base/Model/CodeOfT.cs
@@ -65,18 +65,18 @@ public class Code<T> : Code, INullableValue<T> where T : struct, Enum
     [NonSerialized] // To prevent binary serialization from serializing this field
     private T? _parsedValue = null;
 
-    public override object? ObjectValue
+    public override object? JsonValue
     {
         get
         {
-            if (_parsedValue is not null && base.ObjectValue is null)
-                base.ObjectValue = _parsedValue.GetLiteral();
+            if (_parsedValue is not null && base.JsonValue is null)
+                base.JsonValue = _parsedValue.GetLiteral();
 
-            return base.ObjectValue;
+            return base.JsonValue;
         }
         set
         {
-            base.ObjectValue = value;
+            base.JsonValue = value;
             _parsedValue = null;
         }
     }
@@ -98,7 +98,7 @@ public class Code<T> : Code, INullableValue<T> where T : struct, Enum
         set
         {
             _parsedValue = value;
-            base.ObjectValue = null;
+            base.JsonValue = null;
             OnPropertyChanged("Value");
         }
     }
@@ -108,12 +108,12 @@ public class Code<T> : Code, INullableValue<T> where T : struct, Enum
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context)
     {
-        if (_parsedValue is not null || base.ObjectValue is null) return null;
+        if (_parsedValue is not null || base.JsonValue is null) return null;
 
         _parsedValue = null;
 
-        if (base.ObjectValue is not string unparsed)
-            return COVE.INCORRECT_LITERAL_VALUE_TYPE(context, base.ObjectValue, this.TypeName);
+        if (base.JsonValue is not string unparsed)
+            return COVE.INCORRECT_LITERAL_VALUE_TYPE(context, base.JsonValue, this.TypeName);
 
         if(string.IsNullOrWhiteSpace(unparsed))
             return COVE.LITERAL_INVALID(context, unparsed,  this.TypeName);

--- a/src/Hl7.Fhir.Base/Model/Date.cs
+++ b/src/Hl7.Fhir.Base/Model/Date.cs
@@ -77,15 +77,15 @@ public partial class Date
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context)
     {
-        if (_parsedValue is not null || base.ObjectValue is null) return null;
+        if (_parsedValue is not null || base.JsonValue is null) return null;
 
         _parsedValue = null;
 
-        if (base.ObjectValue is not string unparsed)
-            return COVE.INCORRECT_LITERAL_VALUE_TYPE(context, base.ObjectValue, this.TypeName);
+        if (base.JsonValue is not string unparsed)
+            return COVE.INCORRECT_LITERAL_VALUE_TYPE(context, base.JsonValue, this.TypeName);
 
         _parsedValue = doParse(unparsed);
-        return _parsedValue is null ? COVE.LITERAL_INVALID(context, base.ObjectValue, this.TypeName) : null;
+        return _parsedValue is null ? COVE.LITERAL_INVALID(context, base.JsonValue, this.TypeName) : null;
     }
 
     private static P.Date? doParse(string value) =>
@@ -159,12 +159,12 @@ public partial class Date
     }
 
 
-    public override object? ObjectValue
+    public override object? JsonValue
     {
-        get => base.ObjectValue;
+        get => base.JsonValue;
         set
         {
-            base.ObjectValue = value;
+            base.JsonValue = value;
             _parsedValue = null;
         }
     }

--- a/src/Hl7.Fhir.Base/Model/DynamicDataType.cs
+++ b/src/Hl7.Fhir.Base/Model/DynamicDataType.cs
@@ -73,13 +73,13 @@ public class DynamicPrimitive : PrimitiveType, IDynamicType
 
     public override string TypeName => DynamicTypeName ?? base.TypeName;
 
-    // [FhirElement("value", IsPrimitiveValue=true, XmlSerialization=XmlRepresentation.XmlAttr, InSummary=true, Order=1000)]
-    // [DataMember]
-    // public object? Value
-    // {
-    //     get => ObjectValue;
-    //     set { ObjectValue = value; OnPropertyChanged("Value"); }
-    // }
+    [FhirElement("value", IsPrimitiveValue=true, XmlSerialization=XmlRepresentation.XmlAttr, InSummary=true, Order=1000)]
+    [DataMember]
+    public object? Value
+    {
+        get => JsonValue;
+        set { JsonValue = value; OnPropertyChanged("Value"); }
+    }
 
     protected internal override Base DeepCopyInternal()
     {
@@ -91,7 +91,7 @@ public class DynamicPrimitive : PrimitiveType, IDynamicType
     protected internal override Any? TryConvertToSystemTypeInternal() => null;
 
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? validationContext) =>
-        ObjectValue is string or bool or decimal or int
+        JsonValue is string or bool or decimal or int
             ? null
-            : COVE.INCORRECT_LITERAL_VALUE_TYPE(validationContext, ObjectValue, TypeName);
+            : COVE.INCORRECT_LITERAL_VALUE_TYPE(validationContext, JsonValue, TypeName);
 }

--- a/src/Hl7.Fhir.Base/Model/FhirBoolean.cs
+++ b/src/Hl7.Fhir.Base/Model/FhirBoolean.cs
@@ -44,10 +44,10 @@ public partial class FhirBoolean
     /// Validates the JsonValue.
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context) =>
-        ObjectValue switch
+        JsonValue switch
         {
             null or bool => null,
-            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, ObjectValue, this.TypeName)
+            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, JsonValue, this.TypeName)
         };
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/Model/FhirDateTime.cs
+++ b/src/Hl7.Fhir.Base/Model/FhirDateTime.cs
@@ -96,15 +96,15 @@ public partial class FhirDateTime
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context)
     {
-        if (_parsedValue is not null || base.ObjectValue is null) return null;
+        if (_parsedValue is not null || base.JsonValue is null) return null;
 
         _parsedValue = null;
 
-        if (base.ObjectValue is not string unparsed)
-            return COVE.INCORRECT_LITERAL_VALUE_TYPE(context, base.ObjectValue, this.TypeName);
+        if (base.JsonValue is not string unparsed)
+            return COVE.INCORRECT_LITERAL_VALUE_TYPE(context, base.JsonValue, this.TypeName);
 
         _parsedValue = doParse(unparsed);
-        return _parsedValue is null ? COVE.LITERAL_INVALID(context, base.ObjectValue, this.TypeName) : null;
+        return _parsedValue is null ? COVE.LITERAL_INVALID(context, base.JsonValue, this.TypeName) : null;
     }
 
     private static P.DateTime? doParse(string literal) =>
@@ -150,12 +150,12 @@ public partial class FhirDateTime
         return _parsedValue;
      }
 
-    public override object? ObjectValue
+    public override object? JsonValue
     {
-        get => base.ObjectValue;
+        get => base.JsonValue;
         set
         {
-            base.ObjectValue = value;
+            base.JsonValue = value;
             _parsedValue = null;
         }
     }

--- a/src/Hl7.Fhir.Base/Model/FhirDecimal.cs
+++ b/src/Hl7.Fhir.Base/Model/FhirDecimal.cs
@@ -44,10 +44,10 @@ public partial class FhirDecimal
     /// Validates the JsonValue.
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context) =>
-        ObjectValue switch
+        JsonValue switch
         {
             null or decimal => null,
-            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, ObjectValue, this.TypeName)
+            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, JsonValue, this.TypeName)
         };
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/Model/FhirString.cs
+++ b/src/Hl7.Fhir.Base/Model/FhirString.cs
@@ -44,12 +44,12 @@ public partial class FhirString : ICoded
     /// Validates the JsonValue.
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context) =>
-        ObjectValue switch
+        JsonValue switch
         {
             null => null,
             string s when IsValidValue(s) => null,
             string s => COVE.LITERAL_INVALID(context, s, this.TypeName),
-            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, ObjectValue, this.TypeName)
+            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, JsonValue, this.TypeName)
         };
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/Model/FhirUri.cs
+++ b/src/Hl7.Fhir.Base/Model/FhirUri.cs
@@ -50,12 +50,12 @@ public partial class FhirUri : ICoded
     /// Validates the JsonValue.
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context) =>
-        ObjectValue switch
+        JsonValue switch
         {
             null => null,
             string unparsed when IsValidValue(unparsed) => null,
             string unparsed => COVE.LITERAL_INVALID(context, unparsed, this.TypeName),
-            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, ObjectValue, this.TypeName)
+            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, JsonValue, this.TypeName)
         };
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/Model/FhirUrl.cs
+++ b/src/Hl7.Fhir.Base/Model/FhirUrl.cs
@@ -48,12 +48,12 @@ public partial class FhirUrl
     /// Validates the JsonValue.
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context) =>
-        ObjectValue switch
+        JsonValue switch
         {
             null => null,
             string unparsed when IsValidValue(unparsed) => null,
             string unparsed => COVE.LITERAL_INVALID(context, unparsed, this.TypeName),
-            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, ObjectValue, this.TypeName)
+            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, JsonValue, this.TypeName)
         };
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/Model/Generated/Canonical.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/Canonical.cs
@@ -79,8 +79,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public string? Value
     {
-      get { return ObjectValue is string or null ? (string?)ObjectValue : throw COVE.FromTypes(typeof(Canonical), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is string or null ? (string?)JsonValue : throw COVE.FromTypes(typeof(Canonical), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/Code.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/Code.cs
@@ -76,8 +76,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public string? Value
     {
-      get { return ObjectValue is string or null ? (string?)ObjectValue : throw COVE.FromTypes(typeof(Code), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is string or null ? (string?)JsonValue : throw COVE.FromTypes(typeof(Code), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/Date.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/Date.cs
@@ -76,8 +76,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public string? Value
     {
-      get { return ObjectValue is string or null ? (string?)ObjectValue : throw COVE.FromTypes(typeof(Date), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is string or null ? (string?)JsonValue : throw COVE.FromTypes(typeof(Date), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/FhirBoolean.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/FhirBoolean.cs
@@ -76,8 +76,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public bool? Value
     {
-      get { return ObjectValue is bool or null ? (bool?)ObjectValue : throw COVE.FromTypes(typeof(FhirBoolean), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is bool or null ? (bool?)JsonValue : throw COVE.FromTypes(typeof(FhirBoolean), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/FhirDateTime.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/FhirDateTime.cs
@@ -79,8 +79,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public string? Value
     {
-      get { return ObjectValue is string or null ? (string?)ObjectValue : throw COVE.FromTypes(typeof(FhirDateTime), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is string or null ? (string?)JsonValue : throw COVE.FromTypes(typeof(FhirDateTime), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/FhirDecimal.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/FhirDecimal.cs
@@ -79,8 +79,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public decimal? Value
     {
-      get { return ObjectValue is decimal or null ? (decimal?)ObjectValue : throw COVE.FromTypes(typeof(FhirDecimal), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is decimal or null ? (decimal?)JsonValue : throw COVE.FromTypes(typeof(FhirDecimal), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/FhirString.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/FhirString.cs
@@ -79,8 +79,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public string? Value
     {
-      get { return ObjectValue is string or null ? (string?)ObjectValue : throw COVE.FromTypes(typeof(FhirString), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is string or null ? (string?)JsonValue : throw COVE.FromTypes(typeof(FhirString), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/FhirUri.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/FhirUri.cs
@@ -79,8 +79,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public string? Value
     {
-      get { return ObjectValue is string or null ? (string?)ObjectValue : throw COVE.FromTypes(typeof(FhirUri), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is string or null ? (string?)JsonValue : throw COVE.FromTypes(typeof(FhirUri), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/FhirUrl.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/FhirUrl.cs
@@ -76,8 +76,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public string? Value
     {
-      get { return ObjectValue is string or null ? (string?)ObjectValue : throw COVE.FromTypes(typeof(FhirUrl), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is string or null ? (string?)JsonValue : throw COVE.FromTypes(typeof(FhirUrl), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/Id.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/Id.cs
@@ -79,8 +79,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public string? Value
     {
-      get { return ObjectValue is string or null ? (string?)ObjectValue : throw COVE.FromTypes(typeof(Id), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is string or null ? (string?)JsonValue : throw COVE.FromTypes(typeof(Id), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/Integer.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/Integer.cs
@@ -79,8 +79,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public int? Value
     {
-      get { return ObjectValue is int or null ? (int?)ObjectValue : throw COVE.FromTypes(typeof(Integer), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is int or null ? (int?)JsonValue : throw COVE.FromTypes(typeof(Integer), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/Markdown.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/Markdown.cs
@@ -79,8 +79,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public string? Value
     {
-      get { return ObjectValue is string or null ? (string?)ObjectValue : throw COVE.FromTypes(typeof(Markdown), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is string or null ? (string?)JsonValue : throw COVE.FromTypes(typeof(Markdown), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/Oid.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/Oid.cs
@@ -79,8 +79,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public string? Value
     {
-      get { return ObjectValue is string or null ? (string?)ObjectValue : throw COVE.FromTypes(typeof(Oid), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is string or null ? (string?)JsonValue : throw COVE.FromTypes(typeof(Oid), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/PositiveInt.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/PositiveInt.cs
@@ -76,8 +76,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public int? Value
     {
-      get { return ObjectValue is int or null ? (int?)ObjectValue : throw COVE.FromTypes(typeof(PositiveInt), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is int or null ? (int?)JsonValue : throw COVE.FromTypes(typeof(PositiveInt), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/PrimitiveType.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/PrimitiveType.cs
@@ -64,7 +64,7 @@ namespace Hl7.Fhir.Model
         throw new ArgumentException("Can only copy to an object of the same type", "other");
 
       base.CopyToInternal(dest);
-      if (ObjectValue != null) dest.ObjectValue = ObjectValue;
+      if (JsonValue != null) dest.JsonValue = JsonValue;
     }
 
     public override bool CompareChildren(Base other, IEqualityComparer<Base> comparer)
@@ -75,7 +75,7 @@ namespace Hl7.Fhir.Model
       #pragma warning disable CS8604 // Possible null reference argument - netstd2.1 has a wrong nullable signature here
       #pragma warning restore CS8604 // Possible null reference argument.
 
-      return Equals(ObjectValue, otherT.ObjectValue);
+      return Equals(JsonValue, otherT.JsonValue);
 
     }
 

--- a/src/Hl7.Fhir.Base/Model/Generated/Time.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/Time.cs
@@ -76,8 +76,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public string? Value
     {
-      get { return ObjectValue is string or null ? (string?)ObjectValue : throw COVE.FromTypes(typeof(Time), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is string or null ? (string?)JsonValue : throw COVE.FromTypes(typeof(Time), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/UnsignedInt.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/UnsignedInt.cs
@@ -76,8 +76,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public int? Value
     {
-      get { return ObjectValue is int or null ? (int?)ObjectValue : throw COVE.FromTypes(typeof(UnsignedInt), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is int or null ? (int?)JsonValue : throw COVE.FromTypes(typeof(UnsignedInt), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/Uuid.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/Uuid.cs
@@ -79,8 +79,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public string? Value
     {
-      get { return ObjectValue is string or null ? (string?)ObjectValue : throw COVE.FromTypes(typeof(Uuid), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is string or null ? (string?)JsonValue : throw COVE.FromTypes(typeof(Uuid), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Generated/XHtml.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/XHtml.cs
@@ -73,8 +73,8 @@ namespace Hl7.Fhir.Model
     [DataMember]
     public string? Value
     {
-      get { return ObjectValue is string or null ? (string?)ObjectValue : throw COVE.FromTypes(typeof(XHtml), ObjectValue); }
-      set { ObjectValue = value; OnPropertyChanged("Value"); }
+      get { return JsonValue is string or null ? (string?)JsonValue : throw COVE.FromTypes(typeof(XHtml), JsonValue); }
+      set { JsonValue = value; OnPropertyChanged("Value"); }
     }
 
     protected internal override Base DeepCopyInternal()

--- a/src/Hl7.Fhir.Base/Model/Id.cs
+++ b/src/Hl7.Fhir.Base/Model/Id.cs
@@ -46,12 +46,12 @@ public partial class Id
     /// Validates the JsonValue and updates the internal cached Date value.
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context) =>
-        ObjectValue switch
+        JsonValue switch
         {
             null => null,
             string unparsed when IsValidValue(unparsed) => null,
             string unparsed => COVE.LITERAL_INVALID(context, unparsed, this.TypeName),
-            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, ObjectValue, this.TypeName)
+            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, JsonValue, this.TypeName)
         };
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/Model/Instant.cs
+++ b/src/Hl7.Fhir.Base/Model/Instant.cs
@@ -60,7 +60,7 @@ public partial class Instant
         set
         {
             _parsedValue = value is null ? null : P.DateTime.FromDateTimeOffset(value.Value);
-            base.ObjectValue = null;
+            base.JsonValue = null;
             OnPropertyChanged("Value");
         }
     }
@@ -89,15 +89,15 @@ public partial class Instant
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context)
     {
-        if (_parsedValue is not null || base.ObjectValue is null) return null;
+        if (_parsedValue is not null || base.JsonValue is null) return null;
 
         _parsedValue = null;
 
-        if (base.ObjectValue is not string unparsed)
-            return COVE.INCORRECT_LITERAL_VALUE_TYPE(context, base.ObjectValue, this.TypeName);
+        if (base.JsonValue is not string unparsed)
+            return COVE.INCORRECT_LITERAL_VALUE_TYPE(context, base.JsonValue, this.TypeName);
 
         _parsedValue = doParse(unparsed);
-        return _parsedValue is null ? COVE.LITERAL_INVALID(context, base.ObjectValue, this.TypeName) : null;
+        return _parsedValue is null ? COVE.LITERAL_INVALID(context, base.JsonValue, this.TypeName) : null;
     }
 
     private static P.DateTime? doParse(string literal) =>
@@ -108,18 +108,18 @@ public partial class Instant
     /// </summary>
     public static bool IsValidValue(string value) => doParse(value) is not null;
 
-    public override object? ObjectValue
+    public override object? JsonValue
     {
         get
         {
-            if (_parsedValue is not null && base.ObjectValue is null)
-                base.ObjectValue = _parsedValue.ToString();
+            if (_parsedValue is not null && base.JsonValue is null)
+                base.JsonValue = _parsedValue.ToString();
 
-            return base.ObjectValue;
+            return base.JsonValue;
         }
         set
         {
-            base.ObjectValue = value;
+            base.JsonValue = value;
             _parsedValue = null;
         }
     }

--- a/src/Hl7.Fhir.Base/Model/Integer.cs
+++ b/src/Hl7.Fhir.Base/Model/Integer.cs
@@ -44,10 +44,10 @@ public partial class Integer
     /// Validates the JsonValue.
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context) =>
-        ObjectValue switch
+        JsonValue switch
         {
             null or int => null,
-            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, ObjectValue, this.TypeName)
+            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, JsonValue, this.TypeName)
         };
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/Model/Integer64.cs
+++ b/src/Hl7.Fhir.Base/Model/Integer64.cs
@@ -62,7 +62,7 @@ public partial class Integer64
         set
         {
             _parsedValue = value;
-            base.ObjectValue = null;
+            base.JsonValue = null;
             OnPropertyChanged("Value");
         }
     }
@@ -75,15 +75,15 @@ public partial class Integer64
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context)
     {
-        if (_parsedValue is not null || base.ObjectValue is null) return null;
+        if (_parsedValue is not null || base.JsonValue is null) return null;
 
         _parsedValue = null;
 
-        if (base.ObjectValue is not string unparsed)
-            return COVE.INCORRECT_LITERAL_VALUE_TYPE(context, base.ObjectValue, this.TypeName);
+        if (base.JsonValue is not string unparsed)
+            return COVE.INCORRECT_LITERAL_VALUE_TYPE(context, base.JsonValue, this.TypeName);
 
         _parsedValue = doParse(unparsed);
-        return _parsedValue is null ? COVE.LITERAL_INVALID(context, base.ObjectValue, this.TypeName) : null;
+        return _parsedValue is null ? COVE.LITERAL_INVALID(context, base.JsonValue, this.TypeName) : null;
     }
 
     private static long? doParse(string literal) =>
@@ -94,18 +94,18 @@ public partial class Integer64
     /// </summary>
     public static bool IsValidValue(string value) => doParse(value) is not null;
 
-    public override object? ObjectValue
+    public override object? JsonValue
     {
         get
         {
-            if (_parsedValue is not null && base.ObjectValue is null)
-                base.ObjectValue = XmlConvert.ToString(_parsedValue.Value);
+            if (_parsedValue is not null && base.JsonValue is null)
+                base.JsonValue = XmlConvert.ToString(_parsedValue.Value);
 
-            return base.ObjectValue;
+            return base.JsonValue;
         }
         set
         {
-            base.ObjectValue = value;
+            base.JsonValue = value;
             _parsedValue = null;
         }
     }

--- a/src/Hl7.Fhir.Base/Model/Markdown.cs
+++ b/src/Hl7.Fhir.Base/Model/Markdown.cs
@@ -44,12 +44,12 @@ public partial class Markdown
     /// Validates the JsonValue.
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context) =>
-        ObjectValue switch
+        JsonValue switch
         {
             null => null,
             string s when IsValidValue(s) => null,
             string s => COVE.LITERAL_INVALID(context, s, this.TypeName),
-            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, ObjectValue, this.TypeName)
+            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, JsonValue, this.TypeName)
         };
 
     public static implicit operator string?(Markdown? md) => md?.Value;

--- a/src/Hl7.Fhir.Base/Model/Oid.cs
+++ b/src/Hl7.Fhir.Base/Model/Oid.cs
@@ -42,12 +42,12 @@ public partial class Oid
 {
     /// Validates the JsonValue.
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context) =>
-        ObjectValue switch
+        JsonValue switch
         {
             null => null,
             string unparsed when IsValidValue(unparsed) => null,
             string unparsed => COVE.LITERAL_INVALID(context, unparsed, this.TypeName),
-            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, ObjectValue, this.TypeName)
+            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, JsonValue, this.TypeName)
         };
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/Model/PositiveInt.cs
+++ b/src/Hl7.Fhir.Base/Model/PositiveInt.cs
@@ -42,12 +42,12 @@ public partial class PositiveInt
 {
     /// Validates the JsonValue.
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context) =>
-        ObjectValue switch
+        JsonValue switch
         {
             null => null,
             > 0 => null,
             int i => COVE.POSITIVE_INT_MUST_BE_POSITIVE(context, i),
-            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, ObjectValue, this.TypeName)
+            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, JsonValue, this.TypeName)
         };
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/Model/PrimitiveType.cs
+++ b/src/Hl7.Fhir.Base/Model/PrimitiveType.cs
@@ -20,31 +20,32 @@ namespace Hl7.Fhir.Model;
 
 public partial class PrimitiveType : P.IToSystemPrimitive
 {
-    /// <summary>
-    /// The value of the primitive, stored as an object. Will generally contain the same value as the
-    /// `Value` property and allows the user to retrieve a primitive value regardless of actual type.
-    /// </summary>
-    /// <remarks>Both <c>Value</c> and <c>ObjectValue</c> may contain invalid values according to the
-    /// primitive's official domain. E.g. <c>Value</c> is a <c>string</c> for <see cref="FhirDateTime"/>,
-    /// and may contain illegally formatted values. Additionally, the deserializers will use this property
-    /// to store the original serialized string form of the value in the wire format when a parsing error is
-    /// encountered.</remarks>
+    /// <inheritdoc cref="JsonValue"/>
+    [Obsolete("The underlying values used by ObjectValue for base64, instant and integer64 have changed, and these will now contain a string instead, to align with the FHIR Json specification for these types. We have renamed this property to JsonValue to reflect this.")]
+    public object? ObjectValue { get => JsonValue; set => JsonValue = value; }
 
-    public virtual object? ObjectValue { get; set; }
+    /// <summary>
+    /// The value of the primitive, as used in Json. This means a string, except for FhirBoolean (bool),
+    /// Integer/PositiveInt/UnsignedInt (int) and FhirDecimal (decimal).
+    /// </summary>
+    /// <remarks>JsonValue may contain incorrect data, as deserializers will use this property to store
+    /// the original serialized value as-is, and parsers will serialize this value as-is to allow for
+    /// roundtripping (as much as possible) of serialized forms.</remarks>
+    public virtual object? JsonValue { get; set; }
 
     /// <inheritdoc/>
     public override string? ToString()
     {
         // The primitive can exist without a value (when there is an extension present)
         // so we need to be able to handle when there is no extension present
-        return ObjectValue is null ? null : PrimitiveTypeConverter.ConvertTo<string>(ObjectValue);
+        return JsonValue is null ? null : PrimitiveTypeConverter.ConvertTo<string>(JsonValue);
     }
 
     /// <summary>
     /// Returns true if the primitive has any child elements (currently in FHIR this can
     /// be only the element id and zero or more extensions).
     /// </summary>
-    public bool HasElements => ElementIdElement?.ObjectValue is not null || Extension?.Any() == true;
+    public bool HasElements => ElementIdElement?.JsonValue is not null || Extension?.Any() == true;
 
     protected internal abstract P.Any? TryConvertToSystemTypeInternal();
 
@@ -84,14 +85,14 @@ public partial class PrimitiveType : P.IToSystemPrimitive
                 Integer64 fint64 => fint64.Value,
                 PositiveInt pint => pint.Value,
                 UnsignedInt unsint => unsint.Value,
-                Base64Binary { ObjectValue: { } b64 } => b64,
-                { } prim => prim.ObjectValue
+                Base64Binary { JsonValue: { } b64 } => b64,
+                { } prim => prim.JsonValue
             };
         }
         catch (FormatException)
         {
             // If it fails, just return the unparsed contents
-            return this.ObjectValue;
+            return this.JsonValue;
         }
     }
 }

--- a/src/Hl7.Fhir.Base/Model/Time.cs
+++ b/src/Hl7.Fhir.Base/Model/Time.cs
@@ -67,15 +67,15 @@ public partial class Time
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context)
     {
-        if (_parsedValue is not null || base.ObjectValue is null) return null;
+        if (_parsedValue is not null || base.JsonValue is null) return null;
 
         _parsedValue = null;
 
-        if (base.ObjectValue is not string unparsed)
-            return COVE.INCORRECT_LITERAL_VALUE_TYPE(context, base.ObjectValue, this.TypeName);
+        if (base.JsonValue is not string unparsed)
+            return COVE.INCORRECT_LITERAL_VALUE_TYPE(context, base.JsonValue, this.TypeName);
 
         _parsedValue = doParse(unparsed);
-        return _parsedValue is null ? COVE.LITERAL_INVALID(context, base.ObjectValue, this.TypeName) : null;
+        return _parsedValue is null ? COVE.LITERAL_INVALID(context, base.JsonValue, this.TypeName) : null;
     }
 
     private static P.Time? doParse(string value) =>
@@ -121,12 +121,12 @@ public partial class Time
 
     protected internal override P.Any? TryConvertToSystemTypeInternal() => TryToSystemTime(out var date) ? date : null;
 
-    public override object? ObjectValue
+    public override object? JsonValue
     {
-        get => base.ObjectValue;
+        get => base.JsonValue;
         set
         {
-            base.ObjectValue = value;
+            base.JsonValue = value;
             _parsedValue = null;
         }
     }

--- a/src/Hl7.Fhir.Base/Model/UnsignedInt.cs
+++ b/src/Hl7.Fhir.Base/Model/UnsignedInt.cs
@@ -44,12 +44,12 @@ public partial class UnsignedInt
     /// Validates the JsonValue.
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context) =>
-        ObjectValue switch
+        JsonValue switch
         {
             null => null,
             >= 0 => null,
             int i => COVE.UNSIGNED_INT_MUST_NOT_BE_NEGATIVE(context, i),
-            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, ObjectValue, this.TypeName)
+            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, JsonValue, this.TypeName)
         };
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/Model/Uuid.cs
+++ b/src/Hl7.Fhir.Base/Model/Uuid.cs
@@ -60,12 +60,12 @@ public partial class Uuid
     /// Validates the JsonValue.
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context) =>
-        ObjectValue switch
+        JsonValue switch
         {
             null => null,
             string unparsed when IsValidValue(unparsed) => null,
             string unparsed => COVE.LITERAL_INVALID(context, unparsed, this.TypeName),
-            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, ObjectValue, this.TypeName)
+            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, JsonValue, this.TypeName)
         };
 
 

--- a/src/Hl7.Fhir.Base/Model/XHtml.cs
+++ b/src/Hl7.Fhir.Base/Model/XHtml.cs
@@ -49,11 +49,11 @@ public partial class XHtml
     /// Validates the JsonValue.
     /// </summary>
     protected internal override COVE? ValidateObjectValue(PocoValidationContext? context) =>
-        ObjectValue switch
+        JsonValue switch
         {
             null => null,
             string xml => ValidateXmlLiteral(xml, context),
-            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, ObjectValue, this.TypeName)
+            _ => COVE.INCORRECT_LITERAL_VALUE_TYPE(context, JsonValue, this.TypeName)
         };
 
     internal static COVE? ValidateXmlLiteral(string xml, PocoValidationContext? context)

--- a/src/Hl7.Fhir.Base/Rest/BaseFhirClient.cs
+++ b/src/Hl7.Fhir.Base/Rest/BaseFhirClient.cs
@@ -1024,7 +1024,7 @@ public partial class BaseFhirClient : IDisposable
         if (capabilityStatement is null) return null;
 
         return capabilityStatement.TryGetValue("fhirVersion", out var value) &&
-               value is PrimitiveType { ObjectValue: string version }
+               value is PrimitiveType { JsonValue: string version }
             ? version
             : null;
     }

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonDeserializer.cs
@@ -414,7 +414,7 @@ public class BaseFhirJsonDeserializer
                 bool b => new FhirBoolean(b),
                 decimal d => new FhirDecimal(d),
                 string s => new FhirString(s),
-                _ => new DynamicPrimitive { ObjectValue = value }
+                _ => new DynamicPrimitive { JsonValue = value }
             };
 
             return (primitive, null);
@@ -683,11 +683,11 @@ public class BaseFhirJsonDeserializer
                 var (result, error) = DeserializePrimitiveValue(ref reader, primitiveImplementingType, state.Path);
                 state.Errors.Add(error);
 
-                if (targetPrimitive.ObjectValue is not null)
+                if (targetPrimitive.JsonValue is not null)
                     state.Errors.Add(ERR.DUPLICATE_PROPERTY(ref reader, state.Path.GetInstancePath(), propertyName));
                 else
                     // Set the value, validation is done in the ObjectValidation of the PrimitiveType's.
-                    targetPrimitive.ObjectValue = result;
+                    targetPrimitive.JsonValue = result;
             }
             finally
             {

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonSerializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonSerializer.cs
@@ -166,7 +166,7 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
 
         foreach (var value in values)
         {
-            if (value?.ObjectValue is not null)
+            if (value?.JsonValue is not null)
             {
                 if (!wroteStartArray)
                 {
@@ -174,7 +174,7 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
                     writeStartArray(elementName, numNullsMissed, writer);
                 }
 
-                SerializePrimitiveValue(value.ObjectValue, writer, requiredType);
+                SerializePrimitiveValue(value.JsonValue, writer, requiredType);
             }
             else
             {
@@ -236,11 +236,11 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
     {
         if (value is null) throw new ArgumentNullException(nameof(value));
 
-        if (value.ObjectValue is not null)
+        if (value.JsonValue is not null)
         {
             // Write a property with 'elementName'
             writer.WritePropertyName(elementName);
-            SerializePrimitiveValue(value.ObjectValue, writer, requiredType);
+            SerializePrimitiveValue(value.JsonValue, writer, requiredType);
         }
 
         if (!value.EnumerateElements().Any()) return;

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
@@ -470,7 +470,7 @@ public class BaseFhirXmlDeserializer
 
         if (target is PrimitiveType primitive && attributeName == "value")
         {
-            primitive.ObjectValue = parsedValue;
+            primitive.JsonValue = parsedValue;
 
             // Validator should not be called on the primitive values, this will
             // be handled by the Primitive's ValidateInstance.
@@ -495,7 +495,7 @@ public class BaseFhirXmlDeserializer
             if(propMapping is null)
                 targetElement.AddAnnotation(new XmlRepresentationAnnotation(XmlRepresentation.XmlAttr));
 
-            targetElement.ObjectValue = parsedValue;
+            targetElement.JsonValue = parsedValue;
 
             // Handle atomic-types-as-primitives, Element.id, Extension.url etc.
             var newPropValue = setPropertyWithRepeating(target, attributeName, targetElementMapping, targetElement, state, reader);

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlSerializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlSerializer.cs
@@ -102,7 +102,7 @@ public class BaseFhirXmlSerializer(ModelInspector inspector)
         // Add the special "value" attribute if this is a FhirPrimitive.
         var orderedMembers = element
             .EnumerateElements()
-            .Concat(element is PrimitiveType { ObjectValue: {} ptValue } ? [KeyValuePair.Create("value", ptValue)] : [])
+            .Concat(element is PrimitiveType { JsonValue: {} ptValue } ? [KeyValuePair.Create("value", ptValue)] : [])
             .Select(m => (m, mapping: mapping?.FindMappedElementByName(m.Key)))
             .OrderBy(p => attributeSorter(p.mapping, p.m.Value as Base));
 
@@ -118,7 +118,7 @@ public class BaseFhirXmlSerializer(ModelInspector inspector)
             {
                 // If this is a FHIR primitive element marked as XmlAttr,
                 // take the primitive's value (e.g. Extension.url, Element.id)
-                serializeValue = primitive.ObjectValue!;
+                serializeValue = primitive.JsonValue!;
             }
 
             var elementName = propertyMapping?.Choice == ChoiceType.DatatypeChoice ?

--- a/src/Hl7.Fhir.Base/Utility/NullExtensions.cs
+++ b/src/Hl7.Fhir.Base/Utility/NullExtensions.cs
@@ -28,7 +28,7 @@ namespace Hl7.Fhir.Utility
             if (element == null) { return true; }
 
             var isEmpty = element is IValue<string> ss ? string.IsNullOrEmpty(ss.Value)
-                : element is not PrimitiveType pp || pp.ObjectValue == null;
+                : element is not PrimitiveType pp || pp.JsonValue == null;
 
             // Note: Children collection includes extensions
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Hl7.Fhir.Base/Utility/TemporarilyChangedAttribute.cs
+++ b/src/Hl7.Fhir.Base/Utility/TemporarilyChangedAttribute.cs
@@ -1,4 +1,0 @@
-namespace System.Runtime.CompilerServices;
-
-[AttributeUsage(AttributeTargets.All, Inherited = false)]
-public class TemporarilyChangedAttribute : Attribute;

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/ElementDefnMerger.cs
@@ -648,13 +648,13 @@ namespace Hl7.Fhir.Specification.Snapshot
                     {
                         result = (T)snap?.DeepCopy();
 
-                        var diffValue = diff.ObjectValue;
+                        var diffValue = diff.JsonValue;
                         if (allowAppend && diffValue is string diffText)
                         {
                             if (diffText.StartsWith("..."))
                             {
                                 //var prefix = snap != null ? snap.ObjectValue as string : null;
-                                var prefix = snap?.ObjectValue as string;
+                                var prefix = snap?.JsonValue as string;
                                 if (string.IsNullOrEmpty(prefix))
                                 {
                                     diffText = diffText.Substring(3);
@@ -665,11 +665,11 @@ namespace Hl7.Fhir.Specification.Snapshot
                                 }
                             }
 
-                            result.ObjectValue = diffText;
+                            result.JsonValue = diffText;
                         }
                         else
                         {
-                            result.ObjectValue = diffValue;
+                            result.JsonValue = diffValue;
                         }
                         // Also merge element id and extensions on primitives
                         result.ElementId = mergeString(snap.ElementId, diff.ElementId);

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
@@ -2127,7 +2127,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             // Otherwise, or if the custom type profile is missing, then try to resolve the core type profile
             // [MV 20191217] stop when it is a special type (System.*). Introduced in the technical correction 4.0.1
             var typeCodeElem = typeRef.CodeElement;
-            if (!isValidProfile && typeCodeElem != null && typeCodeElem.ObjectValue is string typeName && !typeName.StartsWith("http://hl7.org/fhirpath/System."))
+            if (!isValidProfile && typeCodeElem != null && typeCodeElem.JsonValue is string typeName && !typeName.StartsWith("http://hl7.org/fhirpath/System."))
             {
                 baseStructure = await getStructureDefinitionForTypeCode(AsyncResolver, typeCodeElem).ConfigureAwait(false);
                 // [WMR 20160906] Check if element type equals path (e.g. Resource root element), prevent infinite recursion
@@ -2158,7 +2158,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             else
             {
                 // Unknown/custom core type; try to resolve from raw object value
-                var typeName = typeCodeElement.ObjectValue as string;
+                var typeName = typeCodeElement.JsonValue as string;
                 if (!string.IsNullOrEmpty(typeName))
                 {
                     sd = await resolver.FindStructureDefinitionForCoreTypeAsync(typeName).ConfigureAwait(false);

--- a/src/Hl7.Fhir.R4.Tests/Serialization/SerializationTests.cs
+++ b/src/Hl7.Fhir.R4.Tests/Serialization/SerializationTests.cs
@@ -36,7 +36,7 @@ namespace Hl7.Fhir.Tests.Serialization
             string json = FhirJsonSerializer.SerializeToString(es);
             var c2 = new FhirJsonDeserializer().Deserialize<ExampleScenario>(json);
             Assert.AreEqual("brian", c2.Instance[0].Name);
-            Assert.AreEqual("ExampleScenario", c2.Instance[0].ResourceTypeElement.ObjectValue as string);
+            Assert.AreEqual("ExampleScenario", c2.Instance[0].ResourceTypeElement.JsonValue as string);
         }
     }
 }

--- a/src/Hl7.Fhir.R4B.Tests/Serialization/SerializationTests.cs
+++ b/src/Hl7.Fhir.R4B.Tests/Serialization/SerializationTests.cs
@@ -32,7 +32,7 @@ namespace Hl7.Fhir.Tests.Serialization
             string json = FhirJsonSerializer.SerializeToString(es);
             var c2 = new FhirJsonDeserializer().Deserialize<ExampleScenario>(json);
             Assert.AreEqual("brian", c2.Instance[0].Name);
-            Assert.AreEqual("ExampleScenario", c2.Instance[0].ResourceTypeElement.ObjectValue as string);
+            Assert.AreEqual("ExampleScenario", c2.Instance[0].ResourceTypeElement.JsonValue as string);
         }
     }
 }

--- a/src/Hl7.Fhir.STU3.Tests/Serialization/ResourceParsingTests.cs
+++ b/src/Hl7.Fhir.STU3.Tests/Serialization/ResourceParsingTests.cs
@@ -217,7 +217,7 @@ namespace Hl7.Fhir.Tests.Serialization
             // Assume that we can happily read the patient gender when enums are enforced
             var p = pser.Deserialize<Patient>(json);
             Assert.IsNotNull(p.Gender);
-            Assert.AreEqual("male", p.GenderElement.ObjectValue);
+            Assert.AreEqual("male", p.GenderElement.JsonValue);
             Assert.AreEqual(AdministrativeGender.Male, p.Gender.Value);
 
             // Verify that if we relax the restriction that everything still works
@@ -225,7 +225,7 @@ namespace Hl7.Fhir.Tests.Serialization
             p = pser.Deserialize<Patient>(json);
 
             Assert.IsNotNull(p.Gender);
-            Assert.AreEqual("male", p.GenderElement.ObjectValue);
+            Assert.AreEqual("male", p.GenderElement.JsonValue);
             Assert.AreEqual(AdministrativeGender.Male, p.Gender.Value);
 
 
@@ -248,7 +248,7 @@ namespace Hl7.Fhir.Tests.Serialization
             pser.Settings = pser.Settings with { AllowUnrecognizedEnums = true };
             p = pser.Deserialize<Patient>(xml2);
             Assert.ThrowsException<CodedValidationException>(() => p.Gender);
-            Assert.AreEqual("superman", p.GenderElement.ObjectValue);
+            Assert.AreEqual("superman", p.GenderElement.JsonValue);
         }
 
         // This test doesn't work on netcore due to the

--- a/src/Hl7.Fhir.STU3.Tests/Serialization/SerializationTests.cs
+++ b/src/Hl7.Fhir.STU3.Tests/Serialization/SerializationTests.cs
@@ -286,7 +286,7 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.IsTrue(outp.Contains("\"male\""));
 
             // Pollute the data with an incorrect administrative gender
-            p.GenderElement.ObjectValue = "superman";
+            p.GenderElement.JsonValue = "superman";
 
             outp = FhirXmlSerializer.SerializeToString(p);
             Assert.IsFalse(outp.Contains("\"male\""));

--- a/src/Hl7.Fhir.STU3/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Snapshot/ElementDefnMerger.cs
@@ -230,21 +230,21 @@ namespace Hl7.Fhir.Specification.Snapshot
                 {
                     var result = (T)diff.DeepCopy();
 
-                    if (allowAppend && diff.ObjectValue is string)
+                    if (allowAppend && diff.JsonValue is string)
                     {
-                        var diffText = diff.ObjectValue as string;
+                        var diffText = diff.JsonValue as string;
 
                         if (diffText.StartsWith("..."))
                         {
                             // [WMR 20160719] Handle snap == null
                             // diffText = (snap.ObjectValue as string) + "\r\n" + diffText.Substring(3);
-                            var prefix = snap != null ? snap.ObjectValue as string : null;
+                            var prefix = snap != null ? snap.JsonValue as string : null;
                             diffText = string.IsNullOrEmpty(prefix) ?
                                 diffText.Substring(3)
                                 : prefix + "\r\n" + diffText.Substring(3);
                         }
 
-                        result.ObjectValue = diffText;
+                        result.JsonValue = diffText;
                     }
                     // Also merge element id and extensions on primitives
                     // [Backported from R4] 

--- a/src/Hl7.Fhir.STU3/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Snapshot/SnapshotGenerator.cs
@@ -1846,7 +1846,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
             // Otherwise, or if the custom type profile is missing, then try to resolve the core type profile
             var typeCodeElem = typeRef.CodeElement;
-            if (!isValidProfile && typeCodeElem != null && typeCodeElem.ObjectValue is string typeName)
+            if (!isValidProfile && typeCodeElem != null && typeCodeElem.JsonValue is string typeName)
             {
                 baseStructure = await getStructureDefinitionForTypeCode(AsyncResolver, typeCodeElem).ConfigureAwait(false);
                 // [WMR 20160906] Check if element type equals path (e.g. Resource root element), prevent infinite recursion
@@ -1877,7 +1877,7 @@ namespace Hl7.Fhir.Specification.Snapshot
             else
             {
                 // Unknown/custom core type; try to resolve from raw object value
-                var typeName = typeCodeElement.ObjectValue as string;
+                var typeName = typeCodeElement.JsonValue as string;
                 if (!string.IsNullOrEmpty(typeName))
                 {
                     sd = await resolver.FindStructureDefinitionForCoreTypeAsync(typeName).ConfigureAwait(false);

--- a/src/Hl7.Fhir.Shared.Tests/Serialization/ResourceParsingTests.cs
+++ b/src/Hl7.Fhir.Shared.Tests/Serialization/ResourceParsingTests.cs
@@ -216,7 +216,7 @@ namespace Hl7.Fhir.Tests.Serialization
             // Assume that we can happily read the patient gender when enums are enforced
             var p = pser.Deserialize<Patient>(json);
             Assert.IsNotNull(p.Gender);
-            Assert.AreEqual("male", p.GenderElement.ObjectValue);
+            Assert.AreEqual("male", p.GenderElement.JsonValue);
             Assert.AreEqual(AdministrativeGender.Male, p.Gender.Value);
 
             // Verify that if we relax the restriction that everything still works
@@ -224,7 +224,7 @@ namespace Hl7.Fhir.Tests.Serialization
             p = pser.Deserialize<Patient>(json);
 
             Assert.IsNotNull(p.Gender);
-            Assert.AreEqual("male", p.GenderElement.ObjectValue);
+            Assert.AreEqual("male", p.GenderElement.JsonValue);
             Assert.AreEqual(AdministrativeGender.Male, p.Gender.Value);
 
 
@@ -247,7 +247,7 @@ namespace Hl7.Fhir.Tests.Serialization
             pser.Settings = pser.Settings with { AllowUnrecognizedEnums = true };
             p = pser.Deserialize<Patient>(xml2);
             Assert.ThrowsException<CodedValidationException>(() => p.Gender);
-            Assert.AreEqual("superman", p.GenderElement.ObjectValue);
+            Assert.AreEqual("superman", p.GenderElement.JsonValue);
         }
 
         // This test doesn't work on netcore due to the

--- a/src/Hl7.Fhir.Shared.Tests/Serialization/SerializationTests.cs
+++ b/src/Hl7.Fhir.Shared.Tests/Serialization/SerializationTests.cs
@@ -281,7 +281,7 @@ namespace Hl7.Fhir.Tests.Serialization
             Assert.IsTrue(outp.Contains("\"male\""));
 
             // Pollute the data with an incorrect administrative gender
-            p.GenderElement.ObjectValue = "superman";
+            p.GenderElement.JsonValue = "superman";
 
             outp = FhirXmlSerializer.SerializeToString(p);
             Assert.IsFalse(outp.Contains("\"male\""));

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/Base64Tests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/Base64Tests.cs
@@ -22,40 +22,40 @@ public class Base64Tests
     public void SetValueUpdatesRawValue()
     {
         var c = new Base64Binary();
-        Assert.IsNull(c.ObjectValue);
+        Assert.IsNull(c.JsonValue);
         Assert.IsNull(c.Value);
 
         var bytes = "Hi!"u8.ToArray();
         c.Value = bytes;
-        c.ObjectValue.Should().Be("SGkh");
+        c.JsonValue.Should().Be("SGkh");
 
         c.Value = null;
-        c.ObjectValue.Should().BeNull();
+        c.JsonValue.Should().BeNull();
     }
 
 
     [TestMethod]
     public void SetRawValueUpdatesValue()
     {
-        var c = new Base64Binary { ObjectValue = "SGkh" };
+        var c = new Base64Binary { JsonValue = "SGkh" };
         Encoding.UTF8.GetString(c.Value).Should().Be("Hi!");
 
         // Value gets recomputed when we change it.
         // Since base64binary will only keep the parsed value or the original value,
         // try to see if both remain in sync.
-        c.ObjectValue = "dGhlcmU=";
+        c.JsonValue = "dGhlcmU=";
         Encoding.UTF8.GetString(c.Value).Should().Be("there");
-        c.ObjectValue.Should().Be("dGhlcmU=");
+        c.JsonValue.Should().Be("dGhlcmU=");
         Encoding.UTF8.GetString(c.Value).Should().Be("there");
 
-        c.ObjectValue = null;
+        c.JsonValue = null;
         c.Value.Should().BeNull();
 
-        c.ObjectValue = "Hoi";
+        c.JsonValue = "Hoi";
         Assert.ThrowsException<CodedValidationException>(() => c.Value);
         c.HasValidValue().Should().BeFalse();
 
-        c.ObjectValue = 314;
+        c.JsonValue = 314;
         Assert.ThrowsException<CodedValidationException>(() => c.Value);
         c.HasValidValue().Should().BeFalse();
     }

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/CodeEnumTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/CodeEnumTests.cs
@@ -22,15 +22,15 @@ public class CodeEnumTests
     public void SetValueUpdatesRawValue()
     {
         var c = new Code<AdministrativeGender>();
-        Assert.IsNull(c.ObjectValue);
+        Assert.IsNull(c.JsonValue);
         Assert.IsNull(c.Value);
 
         c = new Code<AdministrativeGender>(AdministrativeGender.Female);
-        Assert.AreEqual("female", c.ObjectValue);
+        Assert.AreEqual("female", c.JsonValue);
         Assert.AreEqual(AdministrativeGender.Female, c.Value);
 
         c.Value = AdministrativeGender.Unknown;
-        Assert.AreEqual("unknown", c.ObjectValue);
+        Assert.AreEqual("unknown", c.JsonValue);
         Assert.AreEqual(AdministrativeGender.Unknown, c.Value);
     }
 
@@ -38,20 +38,20 @@ public class CodeEnumTests
     [TestMethod]
     public void SetRawValueUpdatesValue()
     {
-        var c = new Code<AdministrativeGender>(AdministrativeGender.Female) { ObjectValue = "male" };
+        var c = new Code<AdministrativeGender>(AdministrativeGender.Female) { JsonValue = "male" };
         Assert.AreEqual(AdministrativeGender.Male, c.Value);
 
-        c.ObjectValue = "other";
+        c.JsonValue = "other";
         Assert.AreEqual(AdministrativeGender.Other, c.Value);
 
-        c.ObjectValue = null;
+        c.JsonValue = null;
         Assert.IsNull(c.Value);
 
-        c.ObjectValue = "maleX";
+        c.JsonValue = "maleX";
         Assert.ThrowsException<COVE>(() => c.Value);
         c.HasValidValue().Should().BeFalse();
 
-        c.ObjectValue = 314;
+        c.JsonValue = 314;
         Assert.ThrowsException<COVE>(() => c.Value).Message.Should().Contain("integer 314 is not the right type of literal for a code.");
         c.HasValidValue().Should().BeFalse();
     }

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/DateTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/DateTests.cs
@@ -75,7 +75,7 @@ namespace Hl7.Fhir.Tests.Model
             dft.TryToDateTimeOffset(out dto2).Should().BeTrue();
             dto.Equals(dto2).Should().BeTrue();
 
-            dft.ObjectValue = "2023-07-11";
+            dft.JsonValue = "2023-07-11";
             dft.TryToDateTimeOffset(out dto).Should().BeTrue();
             dto.Month.Should().Be(7);
             dft.TryToDateTimeOffset(out dto2).Should().BeTrue();

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/DateTimeTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/DateTimeTests.cs
@@ -99,7 +99,7 @@ namespace Hl7.Fhir.Tests.Model
             dft.TryToDateTimeOffset(out dto2).Should().BeTrue();
             dto.Equals(dto2).Should().BeTrue();
 
-            dft.ObjectValue = "2023-07-11T15:00:00Z";
+            dft.JsonValue = "2023-07-11T15:00:00Z";
             dft.TryToDateTimeOffset(out dto).Should().BeTrue();
             dto.Hour.Should().Be(15);
             dft.TryToDateTimeOffset(out dto2).Should().BeTrue();

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/InstantTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/InstantTests.cs
@@ -21,16 +21,16 @@ public class InstantTests
     public void SetValueUpdatesRawValue()
     {
         var c = new Instant();
-        Assert.IsNull(c.ObjectValue);
+        Assert.IsNull(c.JsonValue);
         Assert.IsNull(c.Value);
 
         c = new Instant(DateTimeOffset.UnixEpoch);
-        Assert.AreEqual(ElementModel.Types.DateTime.FormatDateTimeOffset(DateTimeOffset.UnixEpoch), c.ObjectValue);
+        Assert.AreEqual(ElementModel.Types.DateTime.FormatDateTimeOffset(DateTimeOffset.UnixEpoch), c.JsonValue);
         Assert.AreEqual(DateTimeOffset.UnixEpoch, c.Value);
 
         var now = DateTimeOffset.Now;
         c.Value = now;
-        Assert.AreEqual(ElementModel.Types.DateTime.FormatDateTimeOffset(now), c.ObjectValue);
+        Assert.AreEqual(ElementModel.Types.DateTime.FormatDateTimeOffset(now), c.JsonValue);
         Assert.AreEqual(now, c.Value);
     }
 
@@ -38,17 +38,17 @@ public class InstantTests
     [TestMethod]
     public void SetRawValueUpdatesValue()
     {
-        var c = new Instant { ObjectValue = ElementModel.Types.DateTime.FormatDateTimeOffset(DateTimeOffset.UnixEpoch) };
+        var c = new Instant { JsonValue = ElementModel.Types.DateTime.FormatDateTimeOffset(DateTimeOffset.UnixEpoch) };
         Assert.AreEqual(DateTimeOffset.UnixEpoch, c.Value);
 
-        c.ObjectValue = null;
+        c.JsonValue = null;
         Assert.IsNull(c.Value);
 
-        c.ObjectValue = "nonsense";
+        c.JsonValue = "nonsense";
         Assert.ThrowsException<CodedValidationException>(() => c.Value);
         c.HasValidValue().Should().BeFalse();
 
-        c.ObjectValue = 314;
+        c.JsonValue = 314;
         Assert.ThrowsException<CodedValidationException>(() => c.Value);
         c.HasValidValue().Should().BeFalse();
     }

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/Integer64Tests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/Integer64Tests.cs
@@ -21,15 +21,15 @@ public class Integer64Tests
     public void SetValueUpdatesRawValue()
     {
         var c = new Integer64();
-        Assert.IsNull(c.ObjectValue);
+        Assert.IsNull(c.JsonValue);
         Assert.IsNull(c.Value);
 
         c = new Integer64(3);
-        Assert.AreEqual("3", c.ObjectValue);
+        Assert.AreEqual("3", c.JsonValue);
         Assert.AreEqual(3, c.Value);
 
         c.Value = 5;
-        Assert.AreEqual("5", c.ObjectValue);
+        Assert.AreEqual("5", c.JsonValue);
         Assert.AreEqual(5, c.Value);
     }
 
@@ -37,17 +37,17 @@ public class Integer64Tests
     [TestMethod]
     public void SetRawValueUpdatesValue()
     {
-        var c = new Integer64 { ObjectValue = "7" };
+        var c = new Integer64 { JsonValue = "7" };
         Assert.AreEqual(7, c.Value);
 
-        c.ObjectValue = null;
+        c.JsonValue = null;
         Assert.IsNull(c.Value);
 
-        c.ObjectValue = "nonsense";
+        c.JsonValue = "nonsense";
         Assert.ThrowsException<CodedValidationException>(() => c.Value);
         c.HasValidValue().Should().BeFalse();
 
-        c.ObjectValue = 314;
+        c.JsonValue = 314;
         Assert.ThrowsException<CodedValidationException>(() => c.Value);
         c.HasValidValue().Should().BeFalse();
     }

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/PocoDictionaryTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/PocoDictionaryTests.cs
@@ -76,17 +76,17 @@ public class PocoDictionaryTests
         patient.AddExtension("http://nu.nl", new FhirBoolean(true));
 
         patient["active"].Should().BeOfType<FhirBoolean>().
-            Which.ObjectValue.Should().Be(true);
+            Which.JsonValue.Should().Be(true);
         patient["text"].Should().BeOfType<Narrative>()
             .Which["div"].Should().BeOfType<XHtml>()
-            .Which.ObjectValue.Should().Be("<div>hello</div>");
+            .Which.JsonValue.Should().Be("<div>hello</div>");
         patient["meta"].Should().BeOfType<Meta>()
             .Which["id"].Should().BeOfType<FhirString>()
-            .Which.ObjectValue.Should().Be("4");
+            .Which.JsonValue.Should().Be("4");
         var extension = patient["extension"].Should().BeOfType<List<Extension>>().Which.Should().ContainSingle().Subject;
         extension.Should().BeAssignableTo<Base>()
             .Which["url"].Should().BeOfType<FhirUri>()
-            .Which.ObjectValue.Should().Be("http://nu.nl");
+            .Which.JsonValue.Should().Be("http://nu.nl");
     }
 
     /// <summary>
@@ -98,11 +98,11 @@ public class PocoDictionaryTests
         var name = new HumanName();
         
         name["given"] = new FhirString("John");
-        name["given"].Should().BeOfType<FhirString>().Which.ObjectValue.Should().Be("John");
+        name["given"].Should().BeOfType<FhirString>().Which.JsonValue.Should().Be("John");
         name["given"] = new List<HumanName>([new HumanName()]);
         name["given"].Should().BeOfType<List<HumanName>>().Which.Should().ContainSingle().Which.Should().NotBeNull();
         name["given"] = new List<FhirString>([new FhirString("ji")]);
-        name["given"].Should().BeOfType<List<FhirString>>().Which.Should().ContainSingle().Which.ObjectValue.Should().Be("ji");
+        name["given"].Should().BeOfType<List<FhirString>>().Which.Should().ContainSingle().Which.JsonValue.Should().Be("ji");
         name["given"] = null!;
         var act = () => name["given"];
         act.Should().Throw<KeyNotFoundException>();

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/TimeTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/TimeTests.cs
@@ -68,7 +68,7 @@ namespace Hl7.Fhir.Tests.Model
             dft.TryToTimeSpan(out dto2).Should().BeTrue();
             dto.Equals(dto2).Should().BeTrue();
 
-            dft.ObjectValue = "18:23:34";
+            dft.JsonValue = "18:23:34";
             dft.TryToTimeSpan(out dto).Should().BeTrue();
             dto.Minutes.Should().Be(23);
             dft.TryToTimeSpan(out dto2).Should().BeTrue();

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/TypedElementToPocoTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/TypedElementToPocoTests.cs
@@ -63,10 +63,10 @@ public class TypedElementToPocoTests
     [DynamicData(nameof(PrimitiveTestData))]
     public void GuessesCorrectPrimitive(Type t, object dynamicValue, string objectValue)
     {
-        ITypedElement subject = PocoNodeOrList.Root(new DynamicPrimitive{ DynamicTypeName = "DoesNotExist", ObjectValue = dynamicValue });
+        ITypedElement subject = PocoNodeOrList.Root(new DynamicPrimitive{ DynamicTypeName = "DoesNotExist", JsonValue = dynamicValue });
         var poco = toPoco(subject);
         poco.Should().BeOfType(t);
-        (poco as PrimitiveType)!.ObjectValue.Should().Be(objectValue ?? dynamicValue);
+        (poco as PrimitiveType)!.JsonValue.Should().Be(objectValue ?? dynamicValue);
     }
 
     [TestMethod]
@@ -134,7 +134,7 @@ public class TypedElementToPocoTests
         var subject = new Patient();
 
         subject.SetValue("newField", new FhirString("hi"));
-        subject.SetValue("newDynamicField", new DynamicPrimitive() { ObjectValue = "hi3" });
+        subject.SetValue("newDynamicField", new DynamicPrimitive() { JsonValue = "hi3" });
         subject.SetValue("newListField", new List<FhirString> { new("hi1"), new("hi2") });
 
         var subjectRt = toPoco(subject);
@@ -142,7 +142,7 @@ public class TypedElementToPocoTests
         newField.Should().BeOfType<FhirString>().Which.Value.Should().Be("hi");
 
         subjectRt.TryGetValue("newDynamicField", out var newDynamicField).Should().BeTrue();
-        newDynamicField.Should().BeOfType<DynamicPrimitive>().Which.ObjectValue.Should().Be("hi3");
+        newDynamicField.Should().BeOfType<DynamicPrimitive>().Which.JsonValue.Should().Be("hi3");
 
         subjectRt.TryGetValue("newListField", out var newListField).Should().BeTrue();
         newListField.Should().BeOfType<List<FhirString>>().Which

--- a/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirJsonDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirJsonDeserializationTests.cs
@@ -118,7 +118,7 @@ public class FhirJsonDeserializationTests
         }
 
         if (expectedObjectValue is not null)
-            result.ObjectValue.Should().BeEquivalentTo(expectedObjectValue);
+            result.JsonValue.Should().BeEquivalentTo(expectedObjectValue);
     }
 
     private static (Base?, IReadOnlyCollection<CodedException>) deserializeComplex(Type objectType,
@@ -534,7 +534,7 @@ public class FhirJsonDeserializationTests
         var attachment = deserializeAttachment(new FhirJsonConverterOptions());
 
         // After parsing, the ObjectValue is supposed to be the base64 string
-        attachment.DataElement!.ObjectValue.Should().BeOfType<string>().And.Subject.Should().Be("SGkh");
+        attachment.DataElement!.JsonValue.Should().BeOfType<string>().And.Subject.Should().Be("SGkh");
 
         // Getting the Value should decode and return a byte[]
         Encoding.UTF8.GetString(attachment.Data!).Should().Be("Hi!");
@@ -593,9 +593,9 @@ public class FhirJsonDeserializationTests
         // array where primitive
         obj["active"].Should().BeEquivalentTo(new[]{new FhirBoolean(true), new FhirBoolean(false)});
         // primitive where array
-        obj["communication"].Should().BeEquivalentTo(new FhirString{ ObjectValue = "en" });
+        obj["communication"].Should().BeEquivalentTo(new FhirString{ JsonValue = "en" });
         // primitive when complex
-        obj["name"].Should().BeEquivalentTo(new FhirString{ ObjectValue = "Test"});
+        obj["name"].Should().BeEquivalentTo(new FhirString{ JsonValue = "Test"});
     }
     
     [TestMethod]
@@ -657,7 +657,7 @@ public class FhirJsonDeserializationTests
             if (instance is FhirDateTime fdt)
             {
                 DateTimeSeenByInstanceValidator = fdt;
-                fdt.ObjectValue = "1972-11-30T12:00:00Z";
+                fdt.JsonValue = "1972-11-30T12:00:00Z";
             }
 
             return base.ValidateObject(instance, classMapping, context);

--- a/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirJsonSerializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirJsonSerializationTests.cs
@@ -60,7 +60,7 @@ namespace Hl7.Fhir.Support.Poco.Tests
         {
             var options = new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly);
 
-            var b = new FhirBoolean() { ObjectValue = "treu" };
+            var b = new FhirBoolean() { JsonValue = "treu" };
             var pInvalid = new Patient { ActiveElement = b };
 
             var jdoc = JsonDocument.Parse(JsonSerializer.Serialize(pInvalid, options));

--- a/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirXmlDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirXmlDeserializationTests.cs
@@ -80,7 +80,7 @@ namespace Hl7.Fhir.Support.Poco.Tests
             var datatype = deserializer.DeserializeElement(expectedFhirType, reader);
 
             datatype.Should().BeOfType(expectedFhirType);
-            datatype.As<PrimitiveType>().ObjectValue.Should().Be(expectedValue);
+            datatype.As<PrimitiveType>().JsonValue.Should().Be(expectedValue);
         }
 
         [DataTestMethod]
@@ -121,7 +121,7 @@ namespace Hl7.Fhir.Support.Poco.Tests
             }
             else
             {
-                target.ObjectValue.Should().Be(expectedValue);
+                target.JsonValue.Should().Be(expectedValue);
             }
         }
 

--- a/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirXmlSerializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirXmlSerializationTests.cs
@@ -42,7 +42,7 @@ namespace Hl7.Fhir.Support.Poco.Tests
         public void SerializesInvalidData()
         {
             var serializer = new BaseFhirXmlSerializer(ModelInfo.ModelInspector);
-            FhirBoolean b = new() { ObjectValue = "treu" };
+            FhirBoolean b = new() { JsonValue = "treu" };
             var xdoc = XDocument.Parse(SerializationUtil.WriteXmlToString(w => serializer.Serialize(b, w)));
             Assert.AreEqual("treu", xdoc.Root.Attribute(XName.Get("value")).Value);
 
@@ -57,7 +57,7 @@ namespace Hl7.Fhir.Support.Poco.Tests
         public void SerializesSubtree()
         {
             var serializer = new BaseFhirXmlSerializer(ModelInfo.ModelInspector);
-            FhirBoolean b = new() { ObjectValue = "treu" };
+            FhirBoolean b = new() { JsonValue = "treu" };
 
             serializer.SerializeToString(b).Should().StartWith("<boolean");
             serializer.SerializeToString(b, rootName: "active").Should().StartWith("<active");

--- a/src/Hl7.Fhir.Support.Poco.Tests/PocoValidationTests/ValidatableObjectTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/PocoValidationTests/ValidatableObjectTests.cs
@@ -27,19 +27,19 @@ public class ValidatableObjectTests
         assertValid(c);
         c.Value.Should().Be(FilterOperator.DescendentOf);
 
-        c.ObjectValue = null;
+        c.JsonValue = null;
         assertValid(c);
         c.Value.Should().BeNull();
 
-        c.ObjectValue = FilterOperator.ChildOf.GetLiteral();
+        c.JsonValue = FilterOperator.ChildOf.GetLiteral();
         assertValid(c);
         c.Value.Should().Be(FilterOperator.ChildOf);
 
-        c.ObjectValue = "wrong";
+        c.JsonValue = "wrong";
         assertValid(c, errorCode: COVE.INVALID_CODED_VALUE_CODE);
         Assert.ThrowsExactly<COVE>(() => _ = c.Value);
 
-        c.ObjectValue = 4;
+        c.JsonValue = 4;
         assertValid(c, errorCode: COVE.INCORRECT_LITERAL_VALUE_TYPE_CODE);
         Assert.ThrowsExactly<COVE>(() => _ = c.Value);
     }


### PR DESCRIPTION
## Description
Made ObjectValue obsolete and introduced JsonValue, renaming all occurences in our code of ObjectValue to JsonValue.

⚠️ Also review https://github.com/FirelyTeam/fhir-codegen/pull/59

## Related issues
Fixes #3047.
