### PR TITLE
3087 Prepare for manual ClassMappings

### DIFF
--- a/src/Benchmarks/ModelInspectorBenchmarks.cs
+++ b/src/Benchmarks/ModelInspectorBenchmarks.cs
@@ -30,7 +30,9 @@ namespace Firely.Sdk.Benchmarks
             //ModelInspector.Clear();
             //ClassMapping.Clear();
 
+#pragma warning disable CS0618 // Type or member is obsolete
             _ = ModelInspector.ForAssembly(typeof(ModelInfo).Assembly);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Benchmark]
@@ -40,7 +42,9 @@ namespace Firely.Sdk.Benchmarks
             //ModelInspector.Clear();
             //ClassMapping.Clear();
 
+#pragma warning disable CS0618 // Type or member is obsolete
             var inspector = ModelInspector.ForAssembly(typeof(ModelInfo).Assembly);
+#pragma warning restore CS0618 // Type or member is obsolete
             foreach (var t in PopularResources)
             {
                 var mapping = inspector.FindClassMapping(t);

--- a/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
+++ b/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
@@ -1501,6 +1501,20 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Introspection.EnumMapping.get_CqlTypeSpecifier</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Introspection.ModelInspector.GetClassMappingForType(System.Type)</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Hl7.Fhir.Introspection.PropertyMapping.get_ValidationAttributes</Target>
     <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
     <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
@@ -3735,6 +3749,20 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Hl7.Fhir.Introspection.ClassMapping.set_IsNestedType(System.Boolean)</Target>
+    <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Introspection.EnumMapping.get_CqlTypeSpecifier</Target>
+    <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Introspection.ModelInspector.GetClassMappingForType(System.Type)</Target>
     <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
     <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
+++ b/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
@@ -451,6 +451,18 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute</Target>
+    <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute</Target>
+    <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Hl7.Fhir.ElementModel.ElementNodeExtensions</Target>
     <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
     <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
@@ -1515,7 +1527,35 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Introspection.ModelInspector.set_FhirRelease(Hl7.Fhir.Specification.FhirRelease)</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Hl7.Fhir.Introspection.PropertyMapping.get_ValidationAttributes</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Introspection.PropertyMapping.GetValue(System.Object)</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Introspection.PropertyMapping.SetValue(System.Object,System.Object)</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Introspection.PropertyMapping.TryCreate(System.Reflection.PropertyInfo,Hl7.Fhir.Introspection.PropertyMapping@,Hl7.Fhir.Introspection.ClassMapping,Hl7.Fhir.Specification.FhirRelease)</Target>
     <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
     <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -2888,6 +2928,34 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Hl7.Fhir.Specification.Snapshot.SnapshotGeneratorExtensions.RemoveAllConstrainedByDiffExtensions``1(System.Collections.Generic.IEnumerable{``0})</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Utility.PropertyInfoExtensions.GetValueGetter(System.Reflection.PropertyInfo)</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Utility.PropertyInfoExtensions.GetValueGetter``1(System.Reflection.PropertyInfo)</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Utility.PropertyInfoExtensions.GetValueSetter(System.Reflection.PropertyInfo)</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Utility.PropertyInfoExtensions.GetValueSetter``1(System.Reflection.PropertyInfo)</Target>
     <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
     <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -3769,7 +3837,35 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Introspection.ModelInspector.set_FhirRelease(Hl7.Fhir.Specification.FhirRelease)</Target>
+    <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Hl7.Fhir.Introspection.PropertyMapping.get_ValidationAttributes</Target>
+    <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Introspection.PropertyMapping.GetValue(System.Object)</Target>
+    <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Introspection.PropertyMapping.SetValue(System.Object,System.Object)</Target>
+    <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Introspection.PropertyMapping.TryCreate(System.Reflection.PropertyInfo,Hl7.Fhir.Introspection.PropertyMapping@,Hl7.Fhir.Introspection.ClassMapping,Hl7.Fhir.Specification.FhirRelease)</Target>
     <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
     <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -5142,6 +5238,34 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Hl7.Fhir.Specification.Snapshot.SnapshotGeneratorExtensions.RemoveAllConstrainedByDiffExtensions``1(System.Collections.Generic.IEnumerable{``0})</Target>
+    <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Utility.PropertyInfoExtensions.GetValueGetter(System.Reflection.PropertyInfo)</Target>
+    <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Utility.PropertyInfoExtensions.GetValueGetter``1(System.Reflection.PropertyInfo)</Target>
+    <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Utility.PropertyInfoExtensions.GetValueSetter(System.Reflection.PropertyInfo)</Target>
+    <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Utility.PropertyInfoExtensions.GetValueSetter``1(System.Reflection.PropertyInfo)</Target>
     <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
     <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Hl7.Fhir.Base/ElementModel/TypedElementExtensions.Conversions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/TypedElementExtensions.Conversions.cs
@@ -61,7 +61,9 @@ public static partial class TypedElementExtensions
         if (source is not PocoNode { Poco: Resource resource } node)
             return SerializationUtil.WriteJsonToString(source.WriteTo, pretty);
 
-        var inspector = node.FindInspector() ?? ModelInspector.ForType(resource.GetType());
+#pragma warning disable CS0618 // Type or member is obsolete
+        var inspector = node.FindInspector() ?? ModelInspector.ForAssembly(resource.GetType().Assembly);
+#pragma warning restore CS0618 // Type or member is obsolete
         var ser = new BaseFhirJsonSerializer(inspector);
         return ser.SerializeToString(resource, pretty);
     }

--- a/src/Hl7.Fhir.Base/FhirPath/Functions/EqualityOperators.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Functions/EqualityOperators.cs
@@ -71,11 +71,15 @@ namespace Hl7.FhirPath.Functions
             if (left.InstanceType == "Quantity" && l == null)
                 l = left is PocoNode node 
                     ? Typecasts.ParseQuantity(node) 
+#pragma warning disable CS0618 // Type or member is obsolete
                     : Typecasts.ParseQuantity(left.ToPoco<Quantity>(ModelInspector.ForAssembly(typeof(Quantity).Assembly)).ToPocoNode());
+#pragma warning restore CS0618 // Type or member is obsolete
             if (right.InstanceType == "Quantity" && r == null)
                 r = right is PocoNode node 
                     ? Typecasts.ParseQuantity(node) 
+#pragma warning disable CS0618 // Type or member is obsolete
                     : Typecasts.ParseQuantity(right.ToPoco<Quantity>(ModelInspector.ForAssembly(typeof(Quantity).Assembly)).ToPocoNode());
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // Compare primitives (or extended primitives)
             if (l != null && r != null && P.Any.TryConvert(l, out var lAny) && P.Any.TryConvert(r, out var rAny))
@@ -165,11 +169,15 @@ namespace Hl7.FhirPath.Functions
             if (left.InstanceType == "Quantity" && l == null)
                 l = left is PocoNode node 
                     ? Typecasts.ParseQuantity(node) 
+#pragma warning disable CS0618 // Type or member is obsolete
                     : Typecasts.ParseQuantity(left.ToPoco<Quantity>(ModelInspector.ForAssembly(typeof(Quantity).Assembly)).ToPocoNode());
+#pragma warning restore CS0618 // Type or member is obsolete
             if (right.InstanceType == "Quantity" && r == null)
                 r = right is PocoNode node 
                     ? Typecasts.ParseQuantity(node) 
+#pragma warning disable CS0618 // Type or member is obsolete
                     : Typecasts.ParseQuantity(right.ToPoco<Quantity>(ModelInspector.ForAssembly(typeof(Quantity).Assembly)).ToPocoNode());
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // Compare primitives (or extended primitives)
             if (l != null && r != null && P.Any.TryConvert(l, out var lAny) && P.Any.TryConvert(r, out var rAny))

--- a/src/Hl7.Fhir.Base/FhirPath/Functions/TypeOperators.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Functions/TypeOperators.cs
@@ -24,7 +24,9 @@ namespace Hl7.FhirPath.Functions
         public static bool Is(this PocoNode focus, string type)
         {
             var selfAndBaseClasses = getBaseClasses(focus.Poco.GetType())
-                .Select(t => ModelInspector.ForType(t).GetFhirTypeNameForType(t))
+#pragma warning disable CS0618 // Type or member is obsolete
+                .Select(t => ModelInspector.ForAssembly(t.Assembly).GetFhirTypeNameForType(t))
+#pragma warning restore CS0618 // Type or member is obsolete
                 .Append(((ITypedElement)focus).InstanceType);
             return selfAndBaseClasses.Any(typeString => Is(typeString, type));
             

--- a/src/Hl7.Fhir.Base/Introspection/Attributes/FhirElementAttribute.cs
+++ b/src/Hl7.Fhir.Base/Introspection/Attributes/FhirElementAttribute.cs
@@ -88,5 +88,5 @@ public sealed class FhirElementAttribute : FhirModelAttribute
     /// </summary>
     public bool IsModifier { get; set; }
 
-    public string FiveWs { get; set; } = string.Empty;
+    public string? FiveWs { get; set; }
 }

--- a/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
@@ -21,359 +21,387 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 
-namespace Hl7.Fhir.Introspection
+namespace Hl7.Fhir.Introspection;
+
+/// <summary>
+/// A container for the metadata of a FHIR datatype as present on the (generated) .NET POCO class.
+/// </summary>
+public record ClassMapping : IStructureDefinitionSummary
 {
-    /// <summary>
-    /// A container for the metadata of a FHIR datatype as present on the (generated) .NET POCO class.
-    /// </summary>
-    public class ClassMapping : IStructureDefinitionSummary
+    public delegate IEnumerable<PropertyMapping> PropertyMapper(ClassMapping parent, Type nativeType);
+
+    public ClassMapping(string name, Type nativeType, FhirRelease release,
+        PropertyMapper propertyMapper)
     {
-        private static readonly ConcurrentDictionary<(Type, FhirRelease), ClassMapping?> _mappedClasses = new();
+        Name = name;
+        NativeType = nativeType;
+        Release = release;
+        _propertyMapper = propertyMapper;
+    }
 
-        public static void Clear() => _mappedClasses.Clear();
+    public ClassMapping(string name, Type nativeType, FhirRelease release,
+        IEnumerable<PropertyMapping> properties) : this(name, nativeType, release, (_,_) => properties)
+    {
+        // Nothing
+    }
 
-        /// <summary>
-        /// Gets the <see cref="ClassMapping"/> for the given <see cref="Type"/>. Calling this function multiple
-        /// times for the same type and release will return the same ClassMapping.
-        /// </summary>
-        /// <returns>true if the mapping was found or false if it was not one of the supported and reflectable types.</returns>
-        /// <remarks>For classes shared across FHIR versions, there may be metadata present for different versions
-        /// of FHIR, the <paramref name="release"/> is used to select which subset of metadata to extract. </remarks>
-        /// <seealso cref="TryCreate(Type, out ClassMapping?, FhirRelease)"/>
-        public static bool TryGetMappingForType(Type t, FhirRelease release, [NotNullWhen(true)] out ClassMapping? mapping)
+    public ClassMapping(string name, Type nativeType, FhirRelease release)
+         : this(name, nativeType, release, defaultPropertyMapper)
+    {
+        // Nothing
+    }
+
+    /// <summary>
+    /// The FHIR release which this mapping reflects.
+    /// </summary>
+    /// <remarks>The mapping will contain the metadata that applies to this version (or older), using the
+    /// newest metadata when multiple exist.</remarks>
+    public FhirRelease Release { get; }
+
+    /// <summary>
+    /// Name of the mapping.
+    /// </summary>
+    /// <remarks>
+    /// This is the FHIR name for the type as specified in <see cref="FhirTypeAttribute.Name"/> but not always:
+    /// <list type="bullet">
+    /// <item>FHIR <c>code</c> types with required bindings are modelled in the POCO as a <see cref="Code{T}"/>,
+    /// the mapping name for these will be <c>code&lt;name of enum&gt;</c></item>
+    /// <item>The System/CQL primitives from <see cref="Hl7.Fhir.ElementModel.Types"/> all have their names
+    /// prepended with "System.", e.g. <c>System.Integer</c>.</item>
+    /// <item>.NET primitive types have their <see cref="Type.FullName"/> name prepended with "Net.", e.g. <c>Net.System.Int32</c>.</item>
+    /// </list>
+    /// </remarks>
+    public string Name { get; }
+
+    /// <summary>
+    /// The .NET class that implements the FHIR datatype/resource
+    /// </summary>
+    public Type NativeType { get; }
+
+    /// <summary>
+    /// The element is of an atomic .NET type, not a FHIR generated POCO.
+    /// </summary>
+    public bool IsPrimitive { get; init; } = false;
+
+    /// <summary>
+    /// If this mapping represents a <c>Code&lt;T&gt;</c>, this property will hold the enum type T.
+    /// </summary>
+    public Type? EnumType { get; init; }
+
+    /// <summary>
+    /// Indicates whether this class represents the nested complex type for a backbone element.
+    /// </summary>
+    public bool IsBackboneType { get; init; } = false;
+
+    /// <summary>
+    /// The canonical for the StructureDefinition defining this type
+    /// </summary>
+    /// <remarks>Will be null for backbone types.</remarks>
+    public string? Canonical { get; init; }
+
+    /// <summary>
+    /// The collection of zero or more <see cref="ValidationAttribute"/> (or subclasses) declared
+    /// on this class.
+    /// </summary>
+    public ValidatingFhirModelAttribute[] ValidationAttributes { get; private set; } = [];
+
+    private static readonly ConcurrentDictionary<(Type, FhirRelease), ClassMapping?> _mappedClasses = new();
+
+    public static void Clear() => _mappedClasses.Clear();
+
+    /// <summary>
+    /// Gets the <see cref="ClassMapping"/> for the given <see cref="Type"/>. Calling this function multiple
+    /// times for the same type and release will return the same ClassMapping.
+    /// </summary>
+    /// <returns>true if the mapping was found or false if it was not one of the supported and reflectable types.</returns>
+    /// <remarks>For classes shared across FHIR versions, there may be metadata present for different versions
+    /// of FHIR, the <paramref name="release"/> is used to select which subset of metadata to extract. </remarks>
+    /// <seealso cref="TryCreate(Type, out ClassMapping?, FhirRelease)"/>
+    public static bool TryGetMappingForType(Type t, FhirRelease release, [NotNullWhen(true)] out ClassMapping? mapping)
+    {
+        mapping = _mappedClasses.GetOrAdd((t, release), createMapping);
+        return mapping is not null;
+
+        static ClassMapping? createMapping((Type, FhirRelease) typeAndRelease) =>
+            TryCreate(typeAndRelease.Item1, out var m, typeAndRelease.Item2) ? m : null;
+    }
+
+    /// <summary>
+    /// Inspects the given type, extracting metadata from its attributes and creating a new <see cref="ClassMapping"/>.
+    /// </summary>
+    /// <remarks>For classes shared across FHIR versions, there may be metadata present for different versions
+    /// of FHIR, the <paramref name="release"/> is used to select which subset of metadata to extract.</remarks>
+    public static bool TryCreate(Type type, [NotNullWhen(true)]out ClassMapping? result, FhirRelease release = (FhirRelease)int.MaxValue)
+    {
+        // Simulate reading the ClassMappings from the primitive types (from http://hl7.org/fhirpath namespace).
+        // These are in fact defined as POCOs in Hl7.Fhir.ElementModel.Types,
+        // but we cannot reflect on them, mainly because the current organization of our assemblies and
+        // namespaces make it impossible to include them under Introspection. This is not a showstopper,
+        // since these basic primitives have hardly any additional metadata apart from their names.
+        if (typeof(ElementModel.Types.Any).GetTypeInfo().IsAssignableFrom(type))
         {
-            mapping = _mappedClasses.GetOrAdd((t, release), createMapping);
-            return mapping is not null;
-
-            static ClassMapping? createMapping((Type, FhirRelease) typeAndRelease) =>
-                TryCreate(typeAndRelease.Item1, out var m, typeAndRelease.Item2) ? m : null;
-        }
-
-        /// <summary>
-        /// Inspects the given type, extracting metadata from its attributes and creating a new <see cref="ClassMapping"/>.
-        /// </summary>
-        /// <remarks>For classes shared across FHIR versions, there may be metadata present for different versions
-        /// of FHIR, the <paramref name="release"/> is used to select which subset of metadata to extract.</remarks>
-        public static bool TryCreate(Type type, [NotNullWhen(true)]out ClassMapping? result, FhirRelease release = (FhirRelease)int.MaxValue)
-        {
-            // Simulate reading the ClassMappings from the primitive types (from http://hl7.org/fhirpath namespace).
-            // These are in fact defined as POCOs in Hl7.Fhir.ElementModel.Types,
-            // but we cannot reflect on them, mainly because the current organization of our assemblies and
-            // namespaces make it impossible to include them under Introspection. This is not a showstopper,
-            // since these basic primitives have hardly any additional metadata apart from their names.
-            if (typeof(ElementModel.Types.Any).GetTypeInfo().IsAssignableFrom(type))
-            {
-                result = buildCqlClassMapping(type, release);
-                return true;
-            }
-
-            // We could (and maybe should) be able to reflect on any type - turning these mappings into general
-            // System.Reflection caching classes. I have not done that, but we do need the mappings for the
-            // primitive .NET types used in the POCOs (for Element.id etc) too to make the code using the
-            // classmappings more consistent in handling both FHIR and .NET datatypes.
-            if (SupportedDotNetPrimitiveTypes.Contains(type))
-            {
-                result = buildNetPrimitiveClassMapping(type, release);
-                return true;
-            }
-
-            result = null;
-
-            if (type.IsGenericTypeDefinition)
-            {
-                Message.Info("Type {0} is marked as a FhirType and is an open generic type, which cannot be used directly to represent a FHIR datatype", type.Name);
-                return false;
-            }
-
-            // Now continue with the normal algorithm, types adorned with the [FhirTypeAttribute]
-            if (type.GetCustomAttribute<FhirTypeAttribute>() is not { } typeAttribute) return false;
-
-            result = new ClassMapping(collectTypeName(typeAttribute, type), type, release)
-            {
-                EnumType = type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Code<>) ?
-                            type.GenericTypeArguments[0] : null,
-                IsBackboneType = typeAttribute.IsBackboneType,
-                IsBindable = typeof(ICoded).IsAssignableFrom(type),
-                Canonical = typeAttribute.Canonical,
-                ValidationAttributes = type.GetFhirModelAttributes<ValidatingFhirModelAttribute>(release).ToArray(),
-            };
-
+            result = buildCqlClassMapping(type, release);
             return true;
         }
 
-        private ClassMapping(string name, Type nativeType, FhirRelease release)
+        // We could (and maybe should) be able to reflect on any type - turning these mappings into general
+        // System.Reflection caching classes. I have not done that, but we do need the mappings for the
+        // primitive .NET types used in the POCOs (for Element.id etc) too to make the code using the
+        // classmappings more consistent in handling both FHIR and .NET datatypes.
+        if (SupportedDotNetPrimitiveTypes.Contains(type))
         {
-            Name = name;
-            NativeType = nativeType;
-            Release = release;
+            result = buildNetPrimitiveClassMapping(type, release);
+            return true;
         }
 
-        /// <summary>
-        /// The FHIR release which this mapping reflects.
-        /// </summary>
-        /// <remarks>The mapping will contain the metadata that applies to this version (or older), using the
-        /// newest metadata when multiple exist.</remarks>
-        public FhirRelease Release { get; }
+        result = null;
 
-        /// <summary>
-        /// Name of the mapping.
-        /// </summary>
-        /// <remarks>
-        /// This is the FHIR name for the type as specified in <see cref="FhirTypeAttribute.Name"/> but not always:
-        /// <list type="bullet">
-        /// <item>FHIR <c>code</c> types with required bindings are modelled in the POCO as a <see cref="Code{T}"/>,
-        /// the mapping name for these will be <c>code&lt;name of enum&gt;</c></item>
-        /// <item>The System/CQL primitives from <see cref="Hl7.Fhir.ElementModel.Types"/> all have their names
-        /// prepended with "System.", e.g. "System.Integer".</item>
-        /// <item>.NET primitive types have their <see cref="Type.FullName"/> name prepended with "Net.", e.g. "Net.System.Int32".</item>
-        /// </list>
-        /// </remarks>
-        public string Name { get; private set; }
-
-        /// <summary>
-        /// The .NET class that implements the FHIR datatype/resource
-        /// </summary>
-        public Type NativeType { get; private set; }
-
-        /// <summary>
-        /// Is <c>true</c> when this class represents a Resource datatype.
-        /// </summary>
-        public bool IsResource => typeof(Resource).IsAssignableFrom(NativeType);
-
-        /// <summary>
-        /// Is <c>true</c> when this class represents a FHIR primitive
-        /// </summary>
-        /// <remarks>This is different from a .NET primitive, as FHIR primitives are complex types with a primitive value.</remarks>
-        public bool IsFhirPrimitive => typeof(PrimitiveType).IsAssignableFrom(NativeType);
-
-        /// <summary>
-        /// The element is of an atomic .NET type, not a FHIR generated POCO.
-        /// </summary>
-        public bool IsPrimitive { get; private set; } = false;
-
-        /// <summary>
-        /// Is <c>true</c> when this class represents a code with a required binding.
-        /// </summary>
-        /// <remarks>See <see cref="Name"></see>.</remarks>
-        public bool IsCodeOfT => EnumType is not null;
-
-        /// <summary>
-        /// If this mapping represents a <c>Code&lt;T&gt;</c>, this property will hold the enum type T.
-        /// </summary>
-        public Type? EnumType { get; private init; }
-
-        /// <summary>
-        /// Indicates whether this class represents the nested complex type for a backbone element.
-        /// </summary>
-        public bool IsBackboneType { get; private set; } = false;
-
-        /// <summary>
-        /// Indicates whether this class can be used for binding.
-        /// </summary>
-        public bool IsBindable { get; private set; }
-
-        /// <summary>
-        /// The canonical for the StructureDefinition defining this type
-        /// </summary>
-        /// <remarks>Will be null for backbone types.</remarks>
-        public string? Canonical { get; private set; }
-
-        // This list is created lazily. This not only improves initial startup time of 
-        // applications but also ensures circular references between types will not cause loops.
-        private PropertyMappingCollection? _mappings;
-        private PropertyMappingCollection propertyMappings
+        if (type.IsGenericTypeDefinition)
         {
-            get
+            Message.Info("Type {0} is marked as a FhirType and is an open generic type, which cannot be used directly to represent a FHIR datatype", type.Name);
+            return false;
+        }
+
+        // Now continue with the normal algorithm, types adorned with the [FhirTypeAttribute]
+        if (type.GetCustomAttribute<FhirTypeAttribute>() is not { } typeAttribute) return false;
+
+        result = new ClassMapping(collectTypeName(typeAttribute, type), type, release)
+        {
+            EnumType = type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Code<>) ?
+                type.GenericTypeArguments[0] : null,
+            IsBackboneType = typeAttribute.IsBackboneType,
+            Canonical = typeAttribute.Canonical,
+            ValidationAttributes = type.GetFhirModelAttributes<ValidatingFhirModelAttribute>(release).ToArray(),
+        };
+
+        return true;
+    }
+
+    /// <summary>
+    /// Is <c>true</c> when this class represents a Resource datatype.
+    /// </summary>
+    public bool IsResource => typeof(Resource).IsAssignableFrom(NativeType);
+
+    /// <summary>
+    /// Is <c>true</c> when this class represents a FHIR primitive
+    /// </summary>
+    /// <remarks>This is different from a .NET primitive, as FHIR primitives are complex types with a primitive value.</remarks>
+    public bool IsFhirPrimitive => typeof(PrimitiveType).IsAssignableFrom(NativeType);
+
+    /// <summary>
+    /// Indicates whether this class can be used for binding.
+    /// </summary>
+    public bool IsBindable => typeof(ICoded).IsAssignableFrom(NativeType);
+
+    /// <summary>
+    /// Is <c>true</c> when this class represents a code with a required binding.
+    /// </summary>
+    /// <remarks>See <see cref="Name"></see>.</remarks>
+    public bool IsCodeOfT => EnumType is not null;
+
+
+    // This list is created lazily. This not only improves initial startup time of
+    // applications but also ensures circular references between types will not cause loops.
+    private PropertyMappingCollection? _mappings;
+
+    private PropertyMappingCollection propertyMappings
+    {
+        get
+        {
+            return LazyInitializer.EnsureInitialized(ref _mappings, createCollection)!;
+
+            PropertyMappingCollection createCollection()
             {
-                LazyInitializer.EnsureInitialized(ref _mappings, inspectProperties);
-                return _mappings!;
+                var properties = _propertyMapper(this, NativeType).ToList();
+                if(properties.FirstOrDefault(m => m.DeclaringClass != this) is {} errorMapping)
+                    throw new InvalidOperationException($"PropertyMapping '{errorMapping}' is already used for another ClassMapping '{errorMapping.DeclaringClass.Name}'.");
+
+                return new PropertyMappingCollection(properties);
             }
         }
+    }
 
-        /// <summary>
-        /// List of PropertyMappings for this class, in the order of listing in the FHIR specification.
-        /// </summary>
-        public IReadOnlyList<PropertyMapping> PropertyMappings => propertyMappings.ByOrder;
+    /// <summary>
+    /// List of PropertyMappings for this class, in the order of listing in the FHIR specification.
+    /// </summary>
+    public IReadOnlyList<PropertyMapping> PropertyMappings => propertyMappings.ByOrder;
 
-        /// <summary>
-        /// The collection of zero or more <see cref="ValidationAttribute"/> (or subclasses) declared
-        /// on this class.
-        /// </summary>
-        public ValidatingFhirModelAttribute[] ValidationAttributes { get; private set; } = [];
+    private readonly PropertyMapper _propertyMapper;
 
-        /// <summary>
-        /// Holds a reference to a property that represents the value of a FHIR Primitive. This
-        /// property will also be present in the PropertyMappings collection. If this class has 
-        /// no such property, it is null. 
-        /// </summary>
-        public PropertyMapping? PrimitiveValueProperty => PropertyMappings.SingleOrDefault(pm => pm.RepresentsValueElement);
+    /// <summary>
+    /// Holds a reference to a property that represents the value of a FHIR Primitive. This
+    /// property will also be present in the PropertyMappings collection. If this class has
+    /// no such property, it is null.
+    /// </summary>
+    public PropertyMapping? PrimitiveValueProperty => PropertyMappings.SingleOrDefault(pm => pm.RepresentsValueElement);
 
-        /// <summary>
-        /// This indicates that this class is representing the Patient data (and implements <see cref="IPatient"/>).
-        /// </summary>
-        public bool IsPatientClass => typeof(IPatient).IsAssignableFrom(NativeType);
+    /// <summary>
+    /// This indicates that this class is representing the Patient data (and implements <see cref="IPatient"/>).
+    /// </summary>
+    public bool IsPatientClass => typeof(IPatient).IsAssignableFrom(NativeType);
 
-        /// <summary>
-        /// Whether the reflected type has a member that represent a primitive value.
-        /// </summary>
-        public bool HasPrimitiveValueMember => PropertyMappings.Any(pm => pm.RepresentsValueElement);
+    /// <summary>
+    /// Whether the reflected type has a member that represent a primitive value.
+    /// </summary>
+    public bool HasPrimitiveValueMember => PropertyMappings.Any(pm => pm.RepresentsValueElement);
 
-        /// <summary>
-        /// Returns the mapping for an element of this class by its name.
-        /// </summary>
-        public PropertyMapping? FindMappedElementByName(string name) =>
-            name != null
-                ? propertyMappings.ByName.TryGetValue(name, out var mapping) ? mapping : null
-                : throw Error.ArgumentNull(nameof(name));
+    /// <summary>
+    /// Returns the mapping for an element of this class by its name.
+    /// </summary>
+    public PropertyMapping? FindMappedElementByName(string name) =>
+        name != null
+            ? propertyMappings.ByName.GetValueOrDefault(name)
+            : throw Error.ArgumentNull(nameof(name));
 
-        /// <summary>
-        /// Returns the mapping for an element of this class by a name that
-        /// might be suffixed by a type name (e.g. for choice elements).
-        /// </summary>
-        /// <remarks>Will also return properties for which the name is exactly the same,
-        /// so for where there is no suffix. In this case, however, <see cref="FindMappedElementByName(string)"/>
-        /// is faster.
-        /// </remarks>
-        public PropertyMapping? FindMappedElementByChoiceName(string name)
+    /// <summary>
+    /// Returns the mapping for an element of this class by a name that
+    /// might be suffixed by a type name (e.g. for choice elements).
+    /// </summary>
+    /// <remarks>Will also return properties for which the name is exactly the same,
+    /// so for where there is no suffix. In this case, however, <see cref="FindMappedElementByName(string)"/>
+    /// is faster.
+    /// </remarks>
+    public PropertyMapping? FindMappedElementByChoiceName(string name)
+    {
+        if (name == null) throw Error.ArgumentNull(nameof(name));
+
+        // Returns correct mapping for unsuffixed names.
+        if (FindMappedElementByName(name) is { } pm) return pm;
+
+        // Now, check the choice elements for a match.
+        var matches = propertyMappings.ChoiceProperties
+            .Where(m => name.StartsWith(m.Name)).ToList();
+
+        // Loop through possible matches and return the longest match.
+        if (matches.Any())
         {
-            if (name == null) throw Error.ArgumentNull(nameof(name));
-
-            // Returns correct mapping for unsuffixed names.
-            if (FindMappedElementByName(name) is { } pm) return pm;
-
-            // Now, check the choice elements for a match.
-            var matches = propertyMappings.ChoiceProperties
-                .Where(m => name.StartsWith(m.Name)).ToList();
-
-            // Loop through possible matches and return the longest match.
-            if (matches.Any())
-            {
-                return (matches.Count == 1)
-                        ? matches[0]
-                        : matches.Aggregate((l, r) => l.Name.Length > r.Name.Length ? l : r);
-            }
-            else
-            {
-                return null;
-            }
+            return (matches.Count == 1)
+                ? matches[0]
+                : matches.Aggregate((l, r) => l.Name.Length > r.Name.Length ? l : r);
         }
-
-        #region IStructureDefinitionSummary members
-        /// <inheritdoc />
-        string IStructureDefinitionSummary.TypeName =>
-            this switch
-            {
-                { IsCodeOfT: true } => "code",
-                { IsBackboneType: true } => NativeType.CanBeTreatedAsType(typeof(BackboneElement)) ?
-                            "BackboneElement"
-                            : "Element",
-                _ => Name
-            };
-
-        /// <inheritdoc />
-        bool IStructureDefinitionSummary.IsAbstract =>
-           ((IStructureDefinitionSummary)this).TypeName == "BackboneElement" || NativeType.GetTypeInfo().IsAbstract;
-
-        /// <inheritdoc />
-        bool IStructureDefinitionSummary.IsResource => IsResource;
-
-        /// <inheritdoc />
-        IReadOnlyCollection<IElementDefinitionSummary> IStructureDefinitionSummary.GetElements() =>
-            PropertyMappings.Where(pm => !pm.RepresentsValueElement).ToList();
-
-        #endregion
-
-        /// <summary>
-        /// Gets a delegate that, when called, creates an instance for the <see cref="NativeType"/> represented by this mapping.
-        /// </summary>
-        public Func<object> Factory => LazyInitializer.EnsureInitialized(ref _factory, NativeType.BuildFactoryMethod)!;
-
-        private Func<object>? _factory;
-
-
-        /// <summary>
-        /// Gets a delegate that, when called, creates an instance of a List of the <see cref="NativeType"/> represented by this mapping.
-        /// </summary>
-        public Func<IList> ListFactory => LazyInitializer.EnsureInitialized(ref _listFactory, NativeType.BuildListFactoryMethod)!;
-
-        private Func<IList>? _listFactory;
-
-        // Enumerate this class' properties using reflection, create PropertyMappings
-        // for them and add them to the PropertyMappings.
-        private PropertyMappingCollection inspectProperties()
+        else
         {
-            return new PropertyMappingCollection(map());
-
-            IEnumerable<PropertyMapping> map()
-            {
-                var properties = selectNearestProperties(ReflectionHelper.FindPublicProperties(NativeType));
-
-                foreach (var property in properties)
-                {
-                    if (!PropertyMapping.TryCreate(property, out var propMapping, this, Release)) continue;
-                    yield return propMapping;
-                }
-            }
+            return null;
         }
+    }
 
-        /// <summary>
-        /// When redefining a property using `new` in a subclass, the property will be present multiple times in the
-        /// list of properties. This method will select the property from the "closest" declaring type in the
-        /// inheritance hierarchy to the type of the class mapping.
-        /// </summary>
-        private static IEnumerable<PropertyInfo> selectNearestProperties(IReadOnlyCollection<PropertyInfo> properties)
+    #region IStructureDefinitionSummary members
+    /// <inheritdoc />
+    string IStructureDefinitionSummary.TypeName =>
+        this switch
         {
-            var hierarchyComparer = Comparer<PropertyInfo>.Create(compareInheritance);
-            var ordered = properties.OrderBy(p => p, hierarchyComparer);
-            return ordered.GroupBy(p => p.Name).Select(g => g.First()).ToList();
-        }
+            { IsCodeOfT: true } => "code",
+            { IsBackboneType: true } => NativeType.CanBeTreatedAsType(typeof(BackboneElement)) ?
+                "BackboneElement"
+                : "Element",
+            _ => Name
+        };
 
-        private static int compareInheritance(PropertyInfo x, PropertyInfo y)
+    /// <inheritdoc />
+    bool IStructureDefinitionSummary.IsAbstract =>
+        ((IStructureDefinitionSummary)this).TypeName == "BackboneElement" || NativeType.IsAbstract;
+
+    /// <inheritdoc />
+    bool IStructureDefinitionSummary.IsResource => IsResource;
+
+    /// <inheritdoc />
+    IReadOnlyCollection<IElementDefinitionSummary> IStructureDefinitionSummary.GetElements() =>
+        PropertyMappings.Where(pm => !pm.RepresentsValueElement).ToList();
+
+    #endregion
+
+    /// <summary>
+    /// Gets or sets a delegate that, when called, creates an instance for the <see cref="NativeType"/> represented by this mapping.
+    /// </summary>
+    /// <remarks>If not set, the default constructor for the <see cref="NativeType"/> will be used.</remarks>
+    public Func<object> Factory
+    {
+        get => LazyInitializer.EnsureInitialized(ref _factory, NativeType.BuildFactoryMethod)!;
+        init => _factory = value;
+    }
+
+    private Func<object>? _factory;
+
+    /// <summary>
+    /// Gets or sets a delegate that, when called, creates an instance of a List of the <see cref="NativeType"/> represented by this mapping.
+    /// </summary>
+    /// <remarks>If not set, the default List constructor for the <see cref="NativeType"/> will be used.</remarks>
+    public Func<IList> ListFactory
+    {
+        get => LazyInitializer.EnsureInitialized(ref _listFactory, NativeType.BuildListFactoryMethod)!;
+        init => _listFactory = value;
+    }
+
+    private Func<IList>? _listFactory;
+
+    // Enumerate this class' properties using reflection and create PropertyMappings.
+    // Is used when no external mapping has been passed to the constructor.
+    private static IEnumerable<PropertyMapping> defaultPropertyMapper(ClassMapping parent, Type nativeType)
+    {
+        var properties = selectNearestProperties(ReflectionHelper.FindPublicProperties(nativeType));
+
+        foreach (var property in properties)
+        {
+            if (!PropertyMapping.TryCreate(property, out var propMapping, parent)) continue;
+            yield return propMapping;
+        }
+    }
+
+    /// <summary>
+    /// When redefining a property using `new` in a subclass, the property will be present multiple times in the
+    /// list of properties. This method will select the property from the "closest" declaring type in the
+    /// inheritance hierarchy to the type of the class mapping.
+    /// </summary>
+    private static IEnumerable<PropertyInfo> selectNearestProperties(IReadOnlyCollection<PropertyInfo> properties)
+    {
+        var hierarchyComparer = Comparer<PropertyInfo>.Create(compareInheritance);
+        var ordered = properties.OrderBy(p => p, hierarchyComparer);
+        return ordered.GroupBy(p => p.Name).Select(g => g.First()).ToList();
+
+        static int compareInheritance(PropertyInfo x, PropertyInfo y)
         {
             if (x.DeclaringType == y.DeclaringType) return 0;
             if (x.DeclaringType!.IsAssignableFrom(y.DeclaringType)) return 1;
             if (y.DeclaringType!.IsAssignableFrom(x.DeclaringType)) return -1;
             return 0;
         }
+    }
 
-        private static string collectTypeName(FhirTypeAttribute attr, Type type)
+    private static string collectTypeName(FhirTypeAttribute attr, Type type)
+    {
+        var name = attr.Name;
+
+        if (ReflectionHelper.IsClosedGenericType(type))
         {
-            var name = attr.Name;
-
-            if (ReflectionHelper.IsClosedGenericType(type))
-            {
-                name += "<";
-                name += string.Join(",", type.GetTypeInfo().GenericTypeArguments.Select(arg => arg.FullName));
-                name += ">";
-            }
-
-            return name;
+            name += "<";
+            name += string.Join(",", type.GetTypeInfo().GenericTypeArguments.Select(arg => arg.FullName));
+            name += ">";
         }
 
-        // This is the list of .NET "primitive" types that can be used in the generated POCOs and that we
-        // can generate ClassMappings for.
-        internal static Type[] SupportedDotNetPrimitiveTypes =
-        [
-            typeof(int), typeof(uint), typeof(long), typeof(ulong),
-            typeof(float), typeof(double), typeof(decimal),
-            typeof(string),
-            typeof(bool),
-            typeof(DateTimeOffset),
-            typeof(byte[]),
-            typeof(Enum),
-            typeof(object)
-        ];
-
-        private static ClassMapping buildCqlClassMapping(Type t, FhirRelease release) =>
-            new("System." + t.Name, t, release);
-
-        private static ClassMapping buildNetPrimitiveClassMapping(Type t, FhirRelease release) =>
-            new("Net." + t.FullName, t, release) { IsPrimitive = true };
-
-        internal static ClassMapping DynamicResource => new(typeof(DynamicResource).FullName!, typeof(DynamicResource), (FhirRelease)int.MaxValue);
-        internal static ClassMapping DynamicPrimitive => new(typeof(DynamicPrimitive).FullName!, typeof(DynamicPrimitive), (FhirRelease)int.MaxValue);
-        internal static ClassMapping DynamicDataType => new(typeof(DynamicDataType).FullName!, typeof(DynamicDataType), (FhirRelease)int.MaxValue);
+        return name;
     }
-}
 
-#nullable restore
+    // This is the list of .NET "primitive" types that can be used in the generated POCOs and that we
+    // can generate ClassMappings for.
+    internal static Type[] SupportedDotNetPrimitiveTypes =
+    [
+        typeof(int), typeof(uint), typeof(long), typeof(ulong),
+        typeof(float), typeof(double), typeof(decimal),
+        typeof(string),
+        typeof(bool),
+        typeof(DateTimeOffset),
+        typeof(byte[]),
+        typeof(Enum),
+        typeof(object)
+    ];
+
+    private static ClassMapping buildCqlClassMapping(Type t, FhirRelease release) =>
+        new("System." + t.Name, t, release);
+
+    private static ClassMapping buildNetPrimitiveClassMapping(Type t, FhirRelease release) =>
+        new("Net." + t.FullName, t, release) { IsPrimitive = true };
+
+    internal static ClassMapping DynamicResource => new(typeof(DynamicResource).FullName!, typeof(DynamicResource), (FhirRelease)int.MaxValue);
+    internal static ClassMapping DynamicPrimitive => new(typeof(DynamicPrimitive).FullName!, typeof(DynamicPrimitive), (FhirRelease)int.MaxValue);
+    internal static ClassMapping DynamicDataType => new(typeof(DynamicDataType).FullName!, typeof(DynamicDataType), (FhirRelease)int.MaxValue);
+}

--- a/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
@@ -95,7 +95,7 @@ namespace Hl7.Fhir.Introspection
                 IsBackboneType = typeAttribute.IsBackboneType,
                 IsBindable = typeof(ICoded).IsAssignableFrom(type),
                 Canonical = typeAttribute.Canonical,
-                ValidationAttributes = GetAttributes<ValidatingFhirModelAttribute>(type, release).ToArray(),
+                ValidationAttributes = type.GetFhirModelAttributes<ValidatingFhirModelAttribute>(release).ToArray(),
             };
 
             return true;
@@ -256,23 +256,6 @@ namespace Hl7.Fhir.Introspection
             {
                 return null;
             }
-        }
-
-        internal static T? GetAttribute<T>(MemberInfo t, FhirRelease version) where T : FhirModelAttribute => GetAttributes<T>(t, version).LastOrDefault();
-
-        internal static IEnumerable<T> GetAttributes<T>(MemberInfo t, FhirRelease version) where T : FhirModelAttribute
-        {
-            return t.GetCustomAttributes<T>().Where(isRelevant).OrderBy(att => att.Since);
-
-            bool isRelevant(FhirModelAttribute a) => a.AppliesToRelease(version);
-        }
-
-        internal static IEnumerable<ValidatingFhirModelAttribute> GetValidatingAttributes(MemberInfo t, FhirRelease version)
-        {
-            return GetAttributes<ValidatingFhirModelAttribute>(t, version)
-                .GroupBy(att => att.GetType())
-                .Select(g => g.LastOrDefault())
-                .OfType<ValidatingFhirModelAttribute>();
         }
 
         #region IStructureDefinitionSummary members

--- a/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
@@ -28,7 +28,7 @@ namespace Hl7.Fhir.Introspection;
 /// </summary>
 public record ClassMapping : IStructureDefinitionSummary
 {
-    public delegate IEnumerable<PropertyMapping> PropertyMapper(ClassMapping parent, Type nativeType);
+    public delegate IEnumerable<PropertyMapping> PropertyMapper(ClassMapping parent);
 
     public ClassMapping(string name, Type nativeType, FhirRelease release,
         PropertyMapper propertyMapper)
@@ -40,13 +40,13 @@ public record ClassMapping : IStructureDefinitionSummary
     }
 
     public ClassMapping(string name, Type nativeType, FhirRelease release,
-        IEnumerable<PropertyMapping> properties) : this(name, nativeType, release, (_,_) => properties)
+        IEnumerable<PropertyMapping> properties) : this(name, nativeType, release, _ => properties)
     {
         // Nothing
     }
 
     public ClassMapping(string name, Type nativeType, FhirRelease release)
-         : this(name, nativeType, release, defaultPropertyMapper)
+         : this(name, nativeType, release, DefaultPropertyMapper)
     {
         // Nothing
     }
@@ -212,7 +212,7 @@ public record ClassMapping : IStructureDefinitionSummary
 
             PropertyMappingCollection createCollection()
             {
-                var properties = _propertyMapper(this, NativeType).ToList();
+                var properties = _propertyMapper(this).ToList();
                 if(properties.FirstOrDefault(m => m.DeclaringClass != this) is {} errorMapping)
                     throw new InvalidOperationException($"PropertyMapping '{errorMapping}' is already used for another ClassMapping '{errorMapping.DeclaringClass.Name}'.");
 
@@ -334,11 +334,13 @@ public record ClassMapping : IStructureDefinitionSummary
 
     private Func<IList>? _listFactory;
 
-    // Enumerate this class' properties using reflection and create PropertyMappings.
-    // Is used when no external mapping has been passed to the constructor.
-    private static IEnumerable<PropertyMapping> defaultPropertyMapper(ClassMapping parent, Type nativeType)
+    /// <summary>
+    /// Enumerate this class' properties using reflection to create PropertyMappings.
+    /// </summary>
+    /// <remarks>This is the mapper used when no other mapper is specified in the constructor.</remarks>
+    public static IEnumerable<PropertyMapping> DefaultPropertyMapper(ClassMapping parent)
     {
-        var properties = selectNearestProperties(ReflectionHelper.FindPublicProperties(nativeType));
+        var properties = selectNearestProperties(ReflectionHelper.FindPublicProperties(parent.NativeType));
 
         foreach (var property in properties)
         {

--- a/src/Hl7.Fhir.Base/Introspection/ClassMappingCollection.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMappingCollection.cs
@@ -9,64 +9,91 @@
 #nullable enable
 
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
-namespace Hl7.Fhir.Introspection
+namespace Hl7.Fhir.Introspection;
+
+internal class ClassMappingCollection : ICollection<ClassMapping>
 {
-    internal class ClassMappingCollection
+    public ClassMappingCollection()
     {
-        public ClassMappingCollection()
-        {
-            // Nothing
-        }
-
-        public ClassMappingCollection(IEnumerable<ClassMapping> mappings)
-        {
-            AddRange(mappings);
-        }
-
-        /// <summary>
-        /// Adds the mapped type to the collection, updating the indexed
-        /// collections. Note: a newer mapping for the same canonical/name will overwrite
-        /// the old one. This way, it is possible to substitute mappings if necessary.
-        /// </summary>
-        public void Add(ClassMapping mapping)
-        {
-            var propKey = mapping.Name;
-            _byName[propKey] = mapping;
-
-            _byType[mapping.NativeType] = mapping;
-
-            var canonical = mapping.Canonical;
-            if (canonical is not null)
-                _byCanonical[canonical] = mapping;
-        }
-
-        public void AddRange(IEnumerable<ClassMapping> mappings)
-        {
-            foreach (var mapping in mappings)
-                Add(mapping);
-        }
-
-        /// <summary>
-        /// List of the class mappings, keyed by name.
-        /// </summary>
-        public IReadOnlyDictionary<string, ClassMapping> ByName => _byName;
-        private readonly ConcurrentDictionary<string, ClassMapping> _byName = new(StringComparer.OrdinalIgnoreCase);
-
-        /// <summary>
-        /// List of the class mappings, keyed by canonical.
-        /// </summary>
-        public IReadOnlyDictionary<string, ClassMapping> ByCanonical => _byCanonical;
-        private readonly ConcurrentDictionary<string, ClassMapping> _byCanonical = new();
-
-        /// <summary>
-        /// List of the class mappings, keyed by canonical.
-        /// </summary>
-        public IReadOnlyDictionary<Type, ClassMapping> ByType => _byType;
-        public readonly ConcurrentDictionary<Type, ClassMapping> _byType = new();
+        // Nothing
     }
-}
 
-#nullable restore
+    public ClassMappingCollection(IEnumerable<ClassMapping> mappings)
+    {
+        AddRange(mappings);
+    }
+
+    /// <summary>
+    /// Adds the mapped type to the collection, updating the indexed
+    /// collections. Note: a newer mapping for the same canonical/name will overwrite
+    /// the old one. This way, it is possible to substitute mappings if necessary.
+    /// </summary>
+    public void Add(ClassMapping mapping)
+    {
+        var propKey = mapping.Name;
+        _byName[propKey] = mapping;
+
+        _byType[mapping.NativeType] = mapping;
+
+        var canonical = mapping.Canonical;
+        if (canonical is not null)
+            _byCanonical[canonical] = mapping;
+    }
+
+    public void Clear()
+    {
+        _byName.Clear();
+        _byCanonical.Clear();
+        _byType.Clear();
+    }
+
+    public bool Contains(ClassMapping item) => _byName.Values.Contains(item);
+
+    public void CopyTo(ClassMapping[] array, int arrayIndex) => _byName.Values.CopyTo(array, arrayIndex);
+
+    public bool Remove(ClassMapping item)
+    {
+        if (!_byName.Values.Remove(item)) return false;
+
+        _byType.Values.Remove(item);
+        _byCanonical.Values.Remove(item);
+
+        return true;
+    }
+
+    public int Count => _byType.Count;
+
+    public bool IsReadOnly => false;
+
+    public void AddRange(IEnumerable<ClassMapping> mappings)
+    {
+        foreach (var mapping in mappings)
+            Add(mapping);
+    }
+
+    /// <summary>
+    /// List of the class mappings, keyed by name.
+    /// </summary>
+    public IReadOnlyDictionary<string, ClassMapping> ByName => _byName;
+    private readonly ConcurrentDictionary<string, ClassMapping> _byName = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// List of the class mappings, keyed by canonical.
+    /// </summary>
+    public IReadOnlyDictionary<string, ClassMapping> ByCanonical => _byCanonical;
+    private readonly ConcurrentDictionary<string, ClassMapping> _byCanonical = new();
+
+    /// <summary>
+    /// List of the class mappings, keyed by canonical.
+    /// </summary>
+    public IReadOnlyDictionary<Type, ClassMapping> ByType => _byType;
+    public readonly ConcurrentDictionary<Type, ClassMapping> _byType = new();
+
+    IEnumerator<ClassMapping> IEnumerable<ClassMapping>.GetEnumerator() => _byName.Values.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_byName.Values).GetEnumerator();
+}

--- a/src/Hl7.Fhir.Base/Introspection/ClassMappingCollection.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMappingCollection.cs
@@ -57,10 +57,10 @@ internal class ClassMappingCollection : ICollection<ClassMapping>
 
     public bool Remove(ClassMapping item)
     {
-        if (!_byName.Values.Remove(item)) return false;
-
-        _byType.Values.Remove(item);
-        _byCanonical.Values.Remove(item);
+        if (!_byName.TryRemove(item.Name, out _)) return false;
+        _byType.TryRemove(item.NativeType, out _);
+        if (item.Canonical is not null)
+            _byCanonical.TryRemove(item.Canonical, out _);
 
         return true;
     }

--- a/src/Hl7.Fhir.Base/Introspection/EnumMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/EnumMapping.cs
@@ -22,13 +22,35 @@ namespace Hl7.Fhir.Introspection;
 /// <summary>
 /// A container for the metadata of a FHIR valueset as present on the .NET Enum.
 /// </summary>
-public class EnumMapping(
-    string name,
-    string? canonical,
-    Type nativeType,
-    FhirRelease release,
-    Func<IReadOnlyDictionary<string, EnumMemberMapping>> memberMapper)
+public record EnumMapping
 {
+    public delegate IReadOnlyDictionary<string, EnumMemberMapping> EnumMemberMapper(Type nativeType, string? defaultCodeSystem);
+
+    public EnumMapping(
+        string name,
+        Type nativeType,
+        FhirRelease release,
+        EnumMemberMapper memberMapper)
+    {
+        Name = name;
+        NativeType = nativeType;
+        Release = release;
+        _memberMapper = memberMapper;
+    }
+
+    public EnumMapping(string name, Type nativeType, FhirRelease release)
+        : this(name, nativeType, release, defaultMappingInitializer)
+    {
+        // Nothing
+    }
+
+    public EnumMapping(string name, Type nativeType, FhirRelease release,
+        IReadOnlyDictionary<string, EnumMemberMapping> mappings)
+        : this(name, nativeType, release, (_,_) => mappings)
+    {
+        // Nothing
+    }
+
     private static readonly ConcurrentDictionary<(Type, FhirRelease), EnumMapping?> _mappedEnums = new();
 
     public static void Clear() => _mappedEnums.Clear();
@@ -56,37 +78,31 @@ public class EnumMapping(
     /// </summary>
     /// <remarks>For classes shared across FHIR versions, there may be metadata present for different versions
     /// of FHIR, the <paramref name="release"/> is used to select which subset of metadata to extract.</remarks>
-    public static bool TryCreate(Type type, [NotNullWhen(true)] out EnumMapping? result, FhirRelease release = (FhirRelease)int.MaxValue)
+    public static bool TryCreate(Type type, [NotNullWhen(true)] out EnumMapping? result,
+        FhirRelease release = (FhirRelease)int.MaxValue)
     {
         result = null;
         if (!type.IsEnum) return false;
 
         if (type.GetTypeInfo().GetFhirModelAttribute<FhirEnumerationAttribute>(release) is not { } typeAttribute) return false;
 
-        result = new EnumMapping(typeAttribute.BindingName, typeAttribute.Valueset, type, release, (typeAttribute.DefaultCodeSystem is not null) ? string.Intern(typeAttribute.DefaultCodeSystem) : null);
+        result = new EnumMapping(typeAttribute.BindingName, type, release)
+        {
+        Canonical = typeAttribute.Valueset,
+        DefaultCodeSystem = typeAttribute.DefaultCodeSystem is not null
+            ? string.Intern(typeAttribute.DefaultCodeSystem)
+            : null
+        };
+
         return true;
     }
-
-    public EnumMapping(string name, string? canonical, Type nativeType, FhirRelease release, string? defaultCodeSystem)
-     : this(name, canonical, nativeType, release, () => defaultMappingInitializer(defaultCodeSystem,nativeType))
-    {
-        // Nothing
-    }
-
-    public EnumMapping(string name, string? canonical, Type nativeType, FhirRelease release,
-        IReadOnlyDictionary<string, EnumMemberMapping> mappings)
-    : this(name, canonical, nativeType, release, () => mappings)
-    {
-        // Nothing
-    }
-
 
     /// <summary>
     /// The FHIR release which this mapping reflects.
     /// </summary>
     /// <remarks>The mapping will contain the metadata that applies to this version (or older), using the
     /// newest metadata when multiple exist.</remarks>
-    public FhirRelease? Release { get; } = release;
+    public FhirRelease? Release { get; }
 
     /// <summary>
     /// Name of the mapping, derived from the valueset's name or id.
@@ -94,12 +110,7 @@ public class EnumMapping(
     /// <remarks>
     /// This is the FHIR name
     /// </remarks>
-    public string Name { get; } = name;
-
-    /// <summary>
-    /// The canonical of the ValueSet where this enum was derived from.
-    /// </summary>
-    public string? Canonical { get; init; } = canonical;
+    public string Name { get; }
 
     /// <summary>
     /// The code system of most of the member of the ValueSet
@@ -108,7 +119,14 @@ public class EnumMapping(
     /// <summary>
     /// The .NET class that implements the FHIR datatype/resource
     /// </summary>
-    public Type NativeType { get; } = nativeType;
+    public Type NativeType { get; }
+
+    /// <summary>
+    /// The canonical of the ValueSet where this enum was derived from.
+    /// </summary>
+    public string? Canonical { get; init; }
+
+    public string? DefaultCodeSystem { get; init; }
 
     /// <summary>
     /// The list of enum members.
@@ -117,11 +135,14 @@ public class EnumMapping(
     /// The list of enum members.
     /// </summary>
     public IReadOnlyDictionary<string, EnumMemberMapping> Members =>
-        LazyInitializer.EnsureInitialized(ref _mappings, memberMapper)!;
+        LazyInitializer.EnsureInitialized(ref _mappings, () => _memberMapper(NativeType, DefaultCodeSystem))!;
+
+    private readonly EnumMemberMapper _memberMapper;
 
     private IReadOnlyDictionary<string, EnumMemberMapping>? _mappings;
 
-    private static Dictionary<string, EnumMemberMapping> defaultMappingInitializer(string? defaultCodeSystem, Type nativeType)
+    private static Dictionary<string, EnumMemberMapping> defaultMappingInitializer(Type nativeType,
+        string? defaultCodeSystem)
     {
         var result = new Dictionary<string, EnumMemberMapping>();
 

--- a/src/Hl7.Fhir.Base/Introspection/EnumMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/EnumMapping.cs
@@ -15,113 +15,123 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Threading;
 
-namespace Hl7.Fhir.Introspection
+namespace Hl7.Fhir.Introspection;
+
+/// <summary>
+/// A container for the metadata of a FHIR valueset as present on the .NET Enum.
+/// </summary>
+public class EnumMapping(
+    string name,
+    string? canonical,
+    Type nativeType,
+    FhirRelease release,
+    Func<IReadOnlyDictionary<string, EnumMemberMapping>> memberMapper)
 {
+    private static readonly ConcurrentDictionary<(Type, FhirRelease), EnumMapping?> _mappedEnums = new();
+
+    public static void Clear() => _mappedEnums.Clear();
+
     /// <summary>
-    /// A container for the metadata of a FHIR valueset as present on the .NET Enum.
+    /// Gets the <see cref="EnumMapping"/> for the given <see cref="Type"/>. Calling this function multiple
+    /// times for the same type and release will return the same <see cref="EnumMapping"/>.
     /// </summary>
-    public class EnumMapping
+    /// <returns>true if the mapping was found or false if the type did not represent a FHIR valueset.</returns>
+    /// <remarks>For enums shared across FHIR versions, there may be metadata present for different versions
+    /// of FHIR, the <paramref name="release"/> is used to select which subset of metadata to extract. </remarks>
+    /// <seealso cref="TryCreate(Type, out EnumMapping?, FhirRelease)"/>
+    public static bool TryGetMappingForEnum(Type t, FhirRelease release, [NotNullWhen(true)] out EnumMapping? mapping)
     {
-        private static readonly ConcurrentDictionary<(Type, FhirRelease), EnumMapping?> _mappedEnums = new();
+        mapping = _mappedEnums.GetOrAdd((t, release), createMapping);
+        return mapping is not null;
 
-        public static void Clear() => _mappedEnums.Clear();
+        static EnumMapping? createMapping((Type, FhirRelease) typeAndRelease) =>
+            TryCreate(typeAndRelease.Item1, out var m, typeAndRelease.Item2) ? m : null;
+    }
 
-        /// <summary>
-        /// Gets the <see cref="EnumMapping"/> for the given <see cref="Type"/>. Calling this function multiple
-        /// times for the same type and release will return the same <see cref="EnumMapping"/>.
-        /// </summary>
-        /// <returns>true if the mapping was found or false if the type did not represent a FHIR valueset.</returns>
-        /// <remarks>For enums shared across FHIR versions, there may be metadata present for different versions
-        /// of FHIR, the <paramref name="release"/> is used to select which subset of metadata to extract. </remarks>
-        /// <seealso cref="TryCreate(Type, out EnumMapping?, FhirRelease)"/>
-        public static bool TryGetMappingForEnum(Type t, FhirRelease release, [NotNullWhen(true)] out EnumMapping? mapping)
+    /// <summary>
+    /// Inspects the given enum type using reflection, extracting metadata from its attributes and
+    /// creating a new <see cref="EnumMapping"/>.
+    /// </summary>
+    /// <remarks>For classes shared across FHIR versions, there may be metadata present for different versions
+    /// of FHIR, the <paramref name="release"/> is used to select which subset of metadata to extract.</remarks>
+    public static bool TryCreate(Type type, [NotNullWhen(true)] out EnumMapping? result, FhirRelease release = (FhirRelease)int.MaxValue)
+    {
+        result = null;
+        if (!type.IsEnum) return false;
+
+        if (type.GetTypeInfo().GetFhirModelAttribute<FhirEnumerationAttribute>(release) is not { } typeAttribute) return false;
+
+        result = new EnumMapping(typeAttribute.BindingName, typeAttribute.Valueset, type, release, (typeAttribute.DefaultCodeSystem is not null) ? string.Intern(typeAttribute.DefaultCodeSystem) : null);
+        return true;
+    }
+
+    public EnumMapping(string name, string? canonical, Type nativeType, FhirRelease release, string? defaultCodeSystem)
+     : this(name, canonical, nativeType, release, () => defaultMappingInitializer(defaultCodeSystem,nativeType))
+    {
+        // Nothing
+    }
+
+    public EnumMapping(string name, string? canonical, Type nativeType, FhirRelease release,
+        IReadOnlyDictionary<string, EnumMemberMapping> mappings)
+    : this(name, canonical, nativeType, release, () => mappings)
+    {
+        // Nothing
+    }
+
+
+    /// <summary>
+    /// The FHIR release which this mapping reflects.
+    /// </summary>
+    /// <remarks>The mapping will contain the metadata that applies to this version (or older), using the
+    /// newest metadata when multiple exist.</remarks>
+    public FhirRelease? Release { get; } = release;
+
+    /// <summary>
+    /// Name of the mapping, derived from the valueset's name or id.
+    /// </summary>
+    /// <remarks>
+    /// This is the FHIR name
+    /// </remarks>
+    public string Name { get; } = name;
+
+    /// <summary>
+    /// The canonical of the ValueSet where this enum was derived from.
+    /// </summary>
+    public string? Canonical { get; init; } = canonical;
+
+    /// <summary>
+    /// The code system of most of the member of the ValueSet
+    /// </summary>
+
+    /// <summary>
+    /// The .NET class that implements the FHIR datatype/resource
+    /// </summary>
+    public Type NativeType { get; } = nativeType;
+
+    /// <summary>
+    /// The list of enum members.
+    /// </summary>
+    /// <summary>
+    /// The list of enum members.
+    /// </summary>
+    public IReadOnlyDictionary<string, EnumMemberMapping> Members =>
+        LazyInitializer.EnsureInitialized(ref _mappings, memberMapper)!;
+
+    private IReadOnlyDictionary<string, EnumMemberMapping>? _mappings;
+
+    private static Dictionary<string, EnumMemberMapping> defaultMappingInitializer(string? defaultCodeSystem, Type nativeType)
+    {
+        var result = new Dictionary<string, EnumMemberMapping>();
+
+        foreach (var member in ReflectionHelper.FindEnumFields(nativeType))
         {
-            mapping = _mappedEnums.GetOrAdd((t, release), createMapping);
-            return mapping is not null;
+            var success = EnumMemberMapping.TryCreate(member, out var mapping, (FhirRelease)int.MaxValue, defaultCodeSystem);
 
-            static EnumMapping? createMapping((Type, FhirRelease) typeAndRelease) =>
-                TryCreate(typeAndRelease.Item1, out var m, typeAndRelease.Item2) ? m : null;
+            if (success) result.Add(mapping!.Code, mapping);
         }
 
-        /// <summary>
-        /// Inspects the given enum type, extracting metadata from its attributes and creating a new <see cref="EnumMapping"/>.
-        /// </summary>
-        /// <remarks>For classes shared across FHIR versions, there may be metadata present for different versions
-        /// of FHIR, the <paramref name="release"/> is used to select which subset of metadata to extract.</remarks>
-        public static bool TryCreate(Type type, [NotNullWhen(true)] out EnumMapping? result, FhirRelease release = (FhirRelease)int.MaxValue)
-        {
-            result = default;
-            if (!type.IsEnum) return false;
-
-            if (ClassMapping.GetAttribute<FhirEnumerationAttribute>(type.GetTypeInfo(), release) is not { } typeAttribute) return false;
-
-            result = new EnumMapping(typeAttribute.BindingName, typeAttribute.Valueset, type, release, (typeAttribute.DefaultCodeSystem is not null) ? string.Intern(typeAttribute.DefaultCodeSystem) : null);
-            return true;
-        }
-
-        private EnumMapping(string name, string? canonical, Type nativeType, FhirRelease release, string? defaultCodeSystem)
-        {
-            Name = name;
-            Canonical = canonical;
-            NativeType = nativeType;
-            Release = release;
-            _mappings = new(valueFactory: () => mappingInitializer(defaultCodeSystem));
-        }
-
-        /// <summary>
-        /// The FHIR release which this mapping reflects.
-        /// </summary>
-        /// <remarks>The mapping will contain the metadata that applies to this version (or older), using the
-        /// newest metadata when multiple exist.</remarks>
-        public FhirRelease? Release { get; }
-
-        /// <summary>
-        /// Name of the mapping, derived from the valueset's name or id.
-        /// </summary>
-        /// <remarks>
-        /// This is the FHIR name 
-        /// </remarks>
-        public string Name { get; private set; }
-
-        /// <summary>
-        /// The canonical of the ValueSet where this enum was derived from.
-        /// </summary>
-        public string? Canonical { get; }
-
-        /// <summary>
-        /// The code system of most of the member of the ValueSet
-        /// </summary>
-
-        /// <summary>
-        /// The .NET class that implements the FHIR datatype/resource
-        /// </summary>
-        public Type NativeType { get; private set; }
-
-        /// <summary>
-        /// The list of enum members.
-        /// </summary>
-        public IReadOnlyDictionary<string, EnumMemberMapping> Members => _mappings.Value;
-
-        private readonly Lazy<IReadOnlyDictionary<string, EnumMemberMapping>> _mappings;
-
-        public string CqlTypeSpecifier => "{http://hl7.org/fhir}" + Name;
-
-
-        private IReadOnlyDictionary<string, EnumMemberMapping> mappingInitializer(string? defaultCS)
-        {
-            var result = new Dictionary<string, EnumMemberMapping>();
-
-            foreach (var member in ReflectionHelper.FindEnumFields(NativeType))
-            {
-                var success = EnumMemberMapping.TryCreate(member, out var mapping, (FhirRelease)int.MaxValue, defaultCS);
-
-                if (success) result.Add(mapping!.Code, mapping);
-            }
-
-            return result;
-        }
+        return result;
     }
 }
-
-#nullable restore

--- a/src/Hl7.Fhir.Base/Introspection/EnumMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/EnumMapping.cs
@@ -24,7 +24,7 @@ namespace Hl7.Fhir.Introspection;
 /// </summary>
 public record EnumMapping
 {
-    public delegate IReadOnlyDictionary<string, EnumMemberMapping> EnumMemberMapper(Type nativeType, string? defaultCodeSystem);
+    public delegate IReadOnlyDictionary<string, EnumMemberMapping> EnumMemberMapper(EnumMapping parent);
 
     public EnumMapping(
         string name,
@@ -39,14 +39,14 @@ public record EnumMapping
     }
 
     public EnumMapping(string name, Type nativeType, FhirRelease release)
-        : this(name, nativeType, release, defaultMappingInitializer)
+        : this(name, nativeType, release, DefaultEnumMemberMapper)
     {
         // Nothing
     }
 
     public EnumMapping(string name, Type nativeType, FhirRelease release,
         IReadOnlyDictionary<string, EnumMemberMapping> mappings)
-        : this(name, nativeType, release, (_,_) => mappings)
+        : this(name, nativeType, release, _ => mappings)
     {
         // Nothing
     }
@@ -135,20 +135,23 @@ public record EnumMapping
     /// The list of enum members.
     /// </summary>
     public IReadOnlyDictionary<string, EnumMemberMapping> Members =>
-        LazyInitializer.EnsureInitialized(ref _mappings, () => _memberMapper(NativeType, DefaultCodeSystem))!;
+        LazyInitializer.EnsureInitialized(ref _mappings, () => _memberMapper(this))!;
 
     private readonly EnumMemberMapper _memberMapper;
 
     private IReadOnlyDictionary<string, EnumMemberMapping>? _mappings;
 
-    private static Dictionary<string, EnumMemberMapping> defaultMappingInitializer(Type nativeType,
-        string? defaultCodeSystem)
+    /// <summary>
+    /// Enumerate this enums fields using reflection to create EnumMemberMappings.
+    /// </summary>
+    /// <remarks>This is the mapper used when no other mapper is specified in the constructor.</remarks>
+    public static Dictionary<string, EnumMemberMapping> DefaultEnumMemberMapper(EnumMapping parent)
     {
         var result = new Dictionary<string, EnumMemberMapping>();
 
-        foreach (var member in ReflectionHelper.FindEnumFields(nativeType))
+        foreach (var member in ReflectionHelper.FindEnumFields(parent.NativeType))
         {
-            var success = EnumMemberMapping.TryCreate(member, out var mapping, (FhirRelease)int.MaxValue, defaultCodeSystem);
+            var success = EnumMemberMapping.TryCreate(member, out var mapping, (FhirRelease)int.MaxValue, parent.DefaultCodeSystem);
 
             if (success) result.Add(mapping!.Code, mapping);
         }

--- a/src/Hl7.Fhir.Base/Introspection/EnumMappingCollection.cs
+++ b/src/Hl7.Fhir.Base/Introspection/EnumMappingCollection.cs
@@ -12,62 +12,59 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
-namespace Hl7.Fhir.Introspection
+namespace Hl7.Fhir.Introspection;
+
+internal class EnumMappingCollection
 {
-    internal class EnumMappingCollection
+    public EnumMappingCollection()
     {
-        public EnumMappingCollection()
-        {
-            // Nothing
-        }
-
-        public EnumMappingCollection(IEnumerable<EnumMapping> mappings)
-        {
-            AddRange(mappings);
-        }
-
-        /// <summary>
-        /// Adds the mapped valueset enum to the collection, updating the indexed
-        /// collections. Note: a newer mapping for the same canonical/name will overwrite
-        /// the old one. This way, it is possible to substitute mappings if necessary.
-        /// </summary>
-        /// <param name="mapping"></param>
-        public void Add(EnumMapping mapping)
-        {
-            var propKey = mapping.Name;
-            _byName[propKey] = mapping;
-
-            _byType[mapping.NativeType] = mapping;
-
-            var canonical = mapping.Canonical;
-            if (canonical is not null)
-                _byCanonical[canonical] = mapping;
-        }
-
-        public void AddRange(IEnumerable<EnumMapping> mappings)
-        {
-            foreach (var mapping in mappings)
-                Add(mapping);
-        }
-
-        /// <summary>
-        /// List of the enumerations, keyed by name.
-        /// </summary>
-        public IReadOnlyDictionary<string, EnumMapping> ByName => _byName;
-        private readonly ConcurrentDictionary<string, EnumMapping> _byName = new(StringComparer.OrdinalIgnoreCase);
-
-        /// <summary>
-        /// List of the enums, keyed by canonical.
-        /// </summary>
-        public IReadOnlyDictionary<string, EnumMapping> ByCanonical => _byCanonical;
-        private readonly ConcurrentDictionary<string, EnumMapping> _byCanonical = new();
-
-        /// <summary>
-        /// List of the enums, keyed by canonical.
-        /// </summary>
-        public IReadOnlyDictionary<Type, EnumMapping> ByType => _byType;
-        public readonly ConcurrentDictionary<Type, EnumMapping> _byType = new();
+        // Nothing
     }
-}
 
-#nullable restore
+    public EnumMappingCollection(IEnumerable<EnumMapping> mappings)
+    {
+        AddRange(mappings);
+    }
+
+    /// <summary>
+    /// Adds the mapped valueset enum to the collection, updating the indexed
+    /// collections. Note: a newer mapping for the same canonical/name will overwrite
+    /// the old one. This way, it is possible to substitute mappings if necessary.
+    /// </summary>
+    /// <param name="mapping"></param>
+    public void Add(EnumMapping mapping)
+    {
+        var propKey = mapping.Name;
+        _byName[propKey] = mapping;
+
+        _byType[mapping.NativeType] = mapping;
+
+        var canonical = mapping.Canonical;
+        if (canonical is not null)
+            _byCanonical[canonical] = mapping;
+    }
+
+    public void AddRange(IEnumerable<EnumMapping> mappings)
+    {
+        foreach (var mapping in mappings)
+            Add(mapping);
+    }
+
+    /// <summary>
+    /// List of the enumerations, keyed by name.
+    /// </summary>
+    public IReadOnlyDictionary<string, EnumMapping> ByName => _byName;
+    private readonly ConcurrentDictionary<string, EnumMapping> _byName = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// List of the enums, keyed by canonical.
+    /// </summary>
+    public IReadOnlyDictionary<string, EnumMapping> ByCanonical => _byCanonical;
+    private readonly ConcurrentDictionary<string, EnumMapping> _byCanonical = new();
+
+    /// <summary>
+    /// List of the enums, keyed by canonical.
+    /// </summary>
+    public IReadOnlyDictionary<Type, EnumMapping> ByType => _byType;
+    public readonly ConcurrentDictionary<Type, EnumMapping> _byType = new();
+}

--- a/src/Hl7.Fhir.Base/Introspection/EnumMemberMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/EnumMemberMapping.cs
@@ -14,63 +14,60 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
-namespace Hl7.Fhir.Introspection
+namespace Hl7.Fhir.Introspection;
+
+/// <summary>
+/// A container for the metadata of a FHIR code from a valueset as present on the .NET Enum member.
+/// </summary>
+public class EnumMemberMapping
 {
-    /// <summary>
-    /// A container for the metadata of a FHIR code from a valueset as present on the .NET Enum member.
-    /// </summary>
-    public class EnumMemberMapping
+    private EnumMemberMapping(FieldInfo fieldInfo, string code, string? system, object value, string? description, string? defaultSystem)
     {
-        private EnumMemberMapping(FieldInfo fieldInfo, string code, string? system, object value, string? description, string? defaultSystem)
-        {
-            Code = code;
-            System = system ?? defaultSystem;
-            Description = description;
-            Value = value;
-            NativeField = fieldInfo;
-        }
+        Code = code;
+        System = system ?? defaultSystem;
+        Description = description;
+        Value = value;
+        NativeField = fieldInfo;
+    }
 
-        /// <summary>
-        /// The code that is represented by this member.
-        /// </summary>
-        public string Code { get; }
+    /// <summary>
+    /// The code that is represented by this member.
+    /// </summary>
+    public string Code { get; }
 
-        /// <summary>
-        /// The coding system that is associated with the code.
-        /// </summary>
-        public string? System { get; }
+    /// <summary>
+    /// The coding system that is associated with the code.
+    /// </summary>
+    public string? System { get; }
 
-        /// <summary>
-        /// A description of the concept.
-        /// </summary>
-        public string? Description { get; }
+    /// <summary>
+    /// A description of the concept.
+    /// </summary>
+    public string? Description { get; }
 
-        /// <summary>
-        /// The .NET enum value for this enum member.
-        /// </summary>
-        public object Value { get; }
+    /// <summary>
+    /// The .NET enum value for this enum member.
+    /// </summary>
+    public object Value { get; }
 
-        /// <summary>
-        /// The original <see cref="FieldInfo"/> the metadata was extracted from.
-        /// </summary>
-        public FieldInfo NativeField { get; }
+    /// <summary>
+    /// The original <see cref="FieldInfo"/> the metadata was extracted from.
+    /// </summary>
+    public FieldInfo NativeField { get; }
 
-        /// <summary>
-        /// Inspects the given enum member, extracting metadata from its attributes and creating a new <see cref="EnumMemberMapping"/>.
-        /// </summary>
-        public static bool TryCreate(FieldInfo member, [NotNullWhen(true)] out EnumMemberMapping? result, FhirRelease release = (FhirRelease)int.MaxValue, string? defaultSystem = null)
-        {
-            result = null;
-            if (ClassMapping.GetAttribute<EnumLiteralAttribute>(member, release) is not { } ela) return false;
+    /// <summary>
+    /// Inspects the given enum member, extracting metadata from its attributes and creating a new <see cref="EnumMemberMapping"/>.
+    /// </summary>
+    public static bool TryCreate(FieldInfo member, [NotNullWhen(true)] out EnumMemberMapping? result, FhirRelease release = (FhirRelease)int.MaxValue, string? defaultSystem = null)
+    {
+        result = null;
+        if (member.GetFhirModelAttribute<EnumLiteralAttribute>(release) is not { } ela) return false;
 
-            var code = ela.Literal ?? member.Name;
-            var value = (Enum)member.GetValue(null)!;
-            var desc = ClassMapping.GetAttribute<DescriptionAttribute>(member, release)?.Description;
+        var code = ela.Literal;
+        var value = (Enum)member.GetValue(null)!;
+        var desc = member.GetFhirModelAttribute<DescriptionAttribute>(release)?.Description;
 
-            result = new EnumMemberMapping(member, code, ela.System, value, desc, defaultSystem);
-            return true;
-        }
+        result = new EnumMemberMapping(member, code, ela.System, value, desc, defaultSystem);
+        return true;
     }
 }
-
-#nullable restore

--- a/src/Hl7.Fhir.Base/Introspection/EnumMemberMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/EnumMemberMapping.cs
@@ -19,36 +19,14 @@ namespace Hl7.Fhir.Introspection;
 /// <summary>
 /// A container for the metadata of a FHIR code from a valueset as present on the .NET Enum member.
 /// </summary>
-public class EnumMemberMapping
+public record EnumMemberMapping
 {
-    private EnumMemberMapping(FieldInfo fieldInfo, string code, string? system, object value, string? description, string? defaultSystem)
+    public EnumMemberMapping(FieldInfo fieldInfo, string code, object value)
     {
-        Code = code;
-        System = system ?? defaultSystem;
-        Description = description;
-        Value = value;
         NativeField = fieldInfo;
+        Code = code;
+        Value = value;
     }
-
-    /// <summary>
-    /// The code that is represented by this member.
-    /// </summary>
-    public string Code { get; }
-
-    /// <summary>
-    /// The coding system that is associated with the code.
-    /// </summary>
-    public string? System { get; }
-
-    /// <summary>
-    /// A description of the concept.
-    /// </summary>
-    public string? Description { get; }
-
-    /// <summary>
-    /// The .NET enum value for this enum member.
-    /// </summary>
-    public object Value { get; }
 
     /// <summary>
     /// The original <see cref="FieldInfo"/> the metadata was extracted from.
@@ -56,9 +34,31 @@ public class EnumMemberMapping
     public FieldInfo NativeField { get; }
 
     /// <summary>
+    /// The code that is represented by this member.
+    /// </summary>
+    public string Code { get; }
+
+    /// <summary>
+    /// The .NET enum value for this enum member.
+    /// </summary>
+    public object Value { get; }
+
+    /// <summary>
+    /// The coding system that is associated with the code.
+    /// </summary>
+    public string? System { get; init; }
+
+    /// <summary>
+    /// A description of the concept.
+    /// </summary>
+    public string? Description { get; init; }
+
+
+    /// <summary>
     /// Inspects the given enum member, extracting metadata from its attributes and creating a new <see cref="EnumMemberMapping"/>.
     /// </summary>
-    public static bool TryCreate(FieldInfo member, [NotNullWhen(true)] out EnumMemberMapping? result, FhirRelease release = (FhirRelease)int.MaxValue, string? defaultSystem = null)
+    public static bool TryCreate(FieldInfo member, [NotNullWhen(true)] out EnumMemberMapping? result,
+        FhirRelease release = (FhirRelease)int.MaxValue, string? defaultSystem = null)
     {
         result = null;
         if (member.GetFhirModelAttribute<EnumLiteralAttribute>(release) is not { } ela) return false;
@@ -67,7 +67,12 @@ public class EnumMemberMapping
         var value = (Enum)member.GetValue(null)!;
         var desc = member.GetFhirModelAttribute<DescriptionAttribute>(release)?.Description;
 
-        result = new EnumMemberMapping(member, code, ela.System, value, desc, defaultSystem);
+        result = new EnumMemberMapping(member, code, value)
+        {
+            System = ela.System ?? defaultSystem,
+            Description = desc
+        };
+
         return true;
     }
 }

--- a/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
@@ -37,16 +37,6 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
     public static void Clear() => _inspectedAssemblies.Clear();
 
     /// <summary>
-    /// Finds or creates the <see cref="ClassMapping"/> for a given type.
-    /// Calling this function repeatedly for the same type will return the same ClassMapping.
-    /// </summary>
-    /// <remarks>If the type given is FHIR Release specific, the returned mapping will contain
-    /// metadata for that release only. If the type is from the base assembly, it will contain
-    /// metadata for that type from the most recent release of the base assembly.</remarks>
-    public static ClassMapping? GetClassMappingForType(Type t) =>
-        ForAssembly(t.Assembly).FindOrImportClassMapping(t);
-
-    /// <summary>
     /// Returns a fully configured <see cref="ModelInspector"/> with the
     /// FHIR metadata contents of the given assembly, plus all the assemblies it depends upon.
     /// Calling this function repeatedly for the same assembly will return the same inspector.
@@ -54,6 +44,7 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
     /// <remarks>If the assembly given is FHIR Release specific, the returned inspector will contain
     /// metadata for that release only. If the assembly is the base assembly, it will contain
     /// metadata for the most recent release for those base classes.</remarks>
+    [Obsolete("ModelInspectors should be retrieved from the ModelInfo, or while using Base only, from ModelInspector.Base.")]
     public static ModelInspector ForAssembly(Assembly a)
     {
         return _inspectedAssemblies.GetOrAdd(a.FullName ?? throw Error.ArgumentNull(nameof(a.FullName)),
@@ -109,6 +100,7 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
     /// repeatedly for the same type will return the same inspector.
     /// </summary>
     /// <param name="type"></param>
+    [Obsolete("ModelInspectors should be retrieved from the ModelInfo, or while using Base only, from ModelInspector.Base.")]
     public static ModelInspector ForType(Type type) => ForAssembly(type.Assembly);
 
     /// <summary>
@@ -117,13 +109,16 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
     /// repeatedly for the same type will return the same inspector.
     /// </summary>
     /// <typeparam name="T"></typeparam>
+    [Obsolete("ModelInspectors should be retrieved from the ModelInfo, or while using Base only, from ModelInspector.Base.")]
     public static ModelInspector ForType<T>() where T : Resource => ForType(typeof(T));
 
     /// <summary>
     /// Returns a fully configured <see cref="ModelInspector"/> with the
     /// FHIR metadata contents of the base assembly
     /// </summary>
-    public static ModelInspector Base => ForType(typeof(ModelInspector));
+#pragma warning disable CS0618 // Type or member is obsolete
+    public static ModelInspector Base => ForAssembly(typeof(ModelInspector).Assembly);
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     /// Constructs a ModelInspector that will reflect the FHIR metadata for the given FHIR release
@@ -175,7 +170,7 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
         extractEnums(exportedEnums);
 
         // Find and extract all ClassMappings
-        var exportedClasses = exportedTypes.Where(et => et.IsClass && !et.IsEnum);
+        var exportedClasses = exportedTypes.Where(et => et is { IsClass: true, IsEnum: false });
         return exportedClasses.Select(ImportType)
             .Where(cm => cm is not null)
             .ToList()!;

--- a/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
@@ -121,26 +121,22 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
 #pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
-    /// Constructs a ModelInspector that will reflect the FHIR metadata for the given FHIR release
+    /// Constructs an empty <see cref="ModelInspector"/> with the given FHIR release.
     /// </summary>
     public ModelInspector(FhirRelease fhirRelease)
     {
         FhirRelease = fhirRelease;
     }
 
-    private ModelInspector(FhirRelease fhirRelease, IEnumerable<ClassMapping> classMappings,
+    /// <summary>
+    /// Constructs a <see cref="ModelInspector"/> with the given predefined mappings.
+    /// </summary>
+    public ModelInspector(FhirRelease fhirRelease, IEnumerable<ClassMapping> classMappings,
         IEnumerable<EnumMapping> enumMappings) : this(fhirRelease)
     {
         _classMappings = new ClassMappingCollection(classMappings);
         _enumMappings = new EnumMappingCollection(enumMappings);
     }
-
-    /// <summary>
-    /// Returns a configured <see cref="ModelInspector"/> with the given predefined mappings.
-    /// </summary>
-    public static ModelInspector ForPredefinedMappings(FhirRelease version,
-        IEnumerable<ClassMapping> classMappings,
-        IEnumerable<EnumMapping> enumMappings) => new(version, classMappings, enumMappings);
 
     /// <summary>
     /// The release of FHIR (i.e. STU3, R4) that this metadata is constructor for.
@@ -282,9 +278,9 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
     /// <summary>
     /// List of ClassMappings registered with the inspector.
     /// </summary>
-    public ICollection<ClassMapping> ClassMappings => _classMappings.ByName.Values.ToList();
+    public ICollection<ClassMapping> ClassMappings => _classMappings;
 
-    private readonly ClassMappingCollection _classMappings = new();
+    private readonly ClassMappingCollection _classMappings = [];
 
     /// <summary>
     /// List of EnumMappings registered with the inspector.

--- a/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
@@ -74,14 +74,14 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
                     Where(typ => typeof(ElementModel.Types.Any).IsAssignableFrom(typ));
             }
 
-            void importRecursively(Assembly a)
+            void importRecursively(Assembly assembly)
             {
-                if (imported.Contains(a)) return;
+                if (imported.Contains(assembly)) return;
 
-                newInspector.Import(a);
-                imported.Add(a);
+                newInspector.Import(assembly);
+                imported.Add(assembly);
 
-                var referencedFhirAssemblies = a.GetReferencedAssemblies()
+                var referencedFhirAssemblies = assembly.GetReferencedAssemblies()
                     .Select(Assembly.Load)
                     .Where(isFhirModelAssembly);
 
@@ -128,12 +128,26 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
         FhirRelease = fhirRelease;
     }
 
+    private ModelInspector(FhirRelease fhirRelease, IEnumerable<ClassMapping> classMappings,
+        IEnumerable<EnumMapping> enumMappings) : this(fhirRelease)
+    {
+        _classMappings = new ClassMappingCollection(classMappings);
+        _enumMappings = new EnumMappingCollection(enumMappings);
+    }
+
+    /// <summary>
+    /// Returns a configured <see cref="ModelInspector"/> with the given predefined mappings.
+    /// </summary>
+    public static ModelInspector ForPredefinedMappings(FhirRelease version,
+        IEnumerable<ClassMapping> classMappings,
+        IEnumerable<EnumMapping> enumMappings) => new(version, classMappings, enumMappings);
+
     /// <summary>
     /// The release of FHIR (i.e. STU3, R4) that this metadata is constructor for.
     /// </summary>
     /// <remarks>This is taken in consideration when encountering versioned FHIR attributes, to be able to
     /// use a single POCO class to reflect the members for different FHIR releases.</remarks>
-    public FhirRelease FhirRelease { get; init; }
+    public FhirRelease FhirRelease { get; }
 
     /// <summary>
     /// The detected version of FHIR (i.e. 4.0.2) on the loaded assembly.
@@ -186,7 +200,7 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
         if (!ClassMapping.TryGetMappingForType(type, FhirRelease, out var mapping))
             return null;
 
-        _classMappings.Add(mapping!);
+        _classMappings.Add(mapping);
 
         var nestedTypes = type.GetNestedTypes(BindingFlags.Public);
         var nestedEnums = nestedTypes.Where(t => t.IsEnum);
@@ -285,13 +299,13 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
 
     #region IModelInfo
 
-    public Canonical? CanonicalUriForFhirCoreType(string typeName) => Canonical.ForCoreType(typeName);
+    public Canonical CanonicalUriForFhirCoreType(string typeName) => Canonical.ForCoreType(typeName);
 
     public Canonical? CanonicalUriForFhirCoreType(Type type) => GetFhirTypeNameForType(type) is { } name ? CanonicalUriForFhirCoreType(name) : null;
 
     public Type? GetTypeForFhirType(string name) => FindClassMapping(name) is { } mapping ? mapping.NativeType : null;
 
-    public bool IsBindable(string type) => FindClassMapping(type) is { } mapping && mapping.IsBindable;
+    public bool IsBindable(string type) => FindClassMapping(type) is { IsBindable: true };
 
     public bool IsConformanceResource(string name) => GetTypeForFhirType(name) is { } type && IsConformanceResource(type);
 
@@ -301,12 +315,9 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
 
     public bool IsCoreModelType(Type type) => FindClassMapping(type) is not null;
 
-    public bool IsCoreModelTypeUri(Uri uri) => uri is not null
-                                               // [WMR 20181025] Issue #746
-                                               // Note: FhirCoreProfileBaseUri.IsBaseOf(new Uri("Dummy", UriKind.RelativeOrAbsolute)) = true...?!
-                                               && uri.IsAbsoluteUri
-                                               && Canonical.FHIR_CORE_PROFILE_BASE_URI.IsBaseOf(uri)
-                                               && IsCoreModelType(Canonical.FHIR_CORE_PROFILE_BASE_URI.MakeRelativeUri(uri).ToString());
+    public bool IsCoreModelTypeUri(Uri uri) =>
+        uri.IsAbsoluteUri && Canonical.FHIR_CORE_PROFILE_BASE_URI.IsBaseOf(uri)
+                          && IsCoreModelType(Canonical.FHIR_CORE_PROFILE_BASE_URI.MakeRelativeUri(uri).ToString());
 
     public bool IsCoreSuperType(string name) => GetTypeForFhirType(name) is { } type && IsCoreSuperType(type);
 
@@ -320,9 +331,9 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
         type == typeof(PrimitiveType) ||
         type == typeof(BackboneType);
 
-    public bool IsDataType(string name) => FindClassMapping(name) is { } mapping && !mapping.IsFhirPrimitive && !mapping.IsResource;
+    public bool IsDataType(string name) => FindClassMapping(name) is { IsFhirPrimitive: false, IsResource: false };
 
-    public bool IsDataType(Type type) => FindClassMapping(type) is { } mapping && !mapping.IsFhirPrimitive && !mapping.IsResource;
+    public bool IsDataType(Type type) => FindClassMapping(type) is { IsFhirPrimitive: false, IsResource: false };
 
     public bool IsInstanceTypeFor(string superclass, string subclass)
     {
@@ -334,9 +345,9 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
 
     public bool IsInstanceTypeFor(Type superclass, Type subclass) => superclass == subclass || superclass.IsAssignableFrom(subclass);
 
-    public bool IsKnownResource(string name) => FindClassMapping(name) is { } mapping && mapping.IsResource;
+    public bool IsKnownResource(string name) => FindClassMapping(name) is { IsResource: true };
 
-    public bool IsKnownResource(Type type) => FindClassMapping(type) is { } mapping && mapping.IsResource;
+    public bool IsKnownResource(Type type) => FindClassMapping(type) is { IsResource: true };
 
     public bool IsPrimitive(string name) => FindClassMapping(name)?.IsFhirPrimitive ?? false;
 

--- a/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
@@ -19,367 +19,341 @@ using P=Hl7.Fhir.ElementModel.Types;
 
 #nullable enable
 
+namespace Hl7.Fhir.Introspection;
 
-namespace Hl7.Fhir.Introspection
+/// <summary>
+/// A container for the metadata of an element of a FHIR datatype as present on a property of a (generated) .NET POCO class.
+/// </summary>
+[System.Diagnostics.DebuggerDisplay(@"\{Name={Name} ElementType={ImplementingType.Name}}")]
+public record PropertyMapping : IElementDefinitionSummary
 {
-    /// <summary>
-    /// A container for the metadata of an element of a FHIR datatype as present on a property of a (generated) .NET POCO class.
-    /// </summary>
-    [System.Diagnostics.DebuggerDisplay(@"\{Name={Name} ElementType={ImplementingType.Name}}")]
-    public class PropertyMapping : IElementDefinitionSummary
+    public PropertyMapping(
+        string name,
+        ClassMapping declaringClass,
+        PropertyInfo pi)
     {
-        // no public constructors
-        private PropertyMapping(
-            string name,
-            ClassMapping declaringClass,
-            PropertyInfo pi,
-            Type implementingType,
-            ClassMapping propertyTypeMapping,
-            Type[] fhirTypes,
-            FhirRelease version)
+        DeclaringClass = declaringClass;
+        Name = name;
+        NativeProperty = pi;
+    }
+
+    /// <summary>
+    /// The name of the element in the FHIR specification.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// The ClassMapping for the type this property is a member of.
+    /// </summary>
+    public ClassMapping DeclaringClass { get; }
+
+    /// <summary>
+    /// The original <see cref="PropertyInfo"/> the metadata was obtained from.
+    /// </summary>
+    public PropertyInfo NativeProperty { get; }
+
+    /// <summary>
+    /// The native type of the element.
+    /// </summary>
+    /// <remarks>If the element is a collection or is nullable, this reflects the
+    /// collection item or the type that is made nullable respectively.
+    /// </remarks>
+    public required Type ImplementingType { get; init; }
+
+    /// <summary>
+    /// The list of possible FHIR types for this element, listed as the representative .NET types.
+    /// For non-choice types this is a single Type, for choices this is either a list of Types or
+    /// just <see cref="Hl7.Fhir.Model.DataType"/>.
+    /// </summary>
+    /// <remark>These are the defined (choice) types for this element as specified in the
+    /// FHIR data definitions. It is derived from the actual property type,
+    /// or, if present, via a list of types in the [AllowedTypes] attribute. Finally,
+    /// it the property type does not represent FHIR metadata, it is overridden using
+    /// the [DeclaredType] attribute.
+    /// </remark>
+    public required Type[] FhirType { get; init; }
+
+    /// <summary>
+    /// The <see cref="ClassMapping" /> that represents the type of this property.
+    /// </summary>
+    /// <remarks>This is effectively the ClassMapping for the <see cref="ImplementingType" /> unless a
+    /// <see cref="AllowedTypesAttribute" /> specifies otherwise.</remarks>
+    public required ClassMapping PropertyTypeMapping { get; init; }
+
+    /// <summary>
+    /// Whether the element can repeat.
+    /// </summary>
+    public bool IsCollection { get; init; }
+
+    /// <summary>
+    /// The element is of an atomic .NET type, not a FHIR generated POCO.
+    /// </summary>
+    public bool IsPrimitive { get; init; }
+
+    /// <summary>
+    /// The element is a primitive (<seealso cref="IsPrimitive"/>) and
+    /// represents the primitive `value` attribute/property in the FHIR serialization.
+    /// </summary>
+    public bool RepresentsValueElement { get; init; }
+
+    /// <summary>
+    /// Whether the element appears in _summary
+    /// (see https://www.hl7.org/fhir/search.html#summary)
+    /// </summary>
+    public bool InSummary { get; init; }
+
+    /// <summary>
+    /// If this modifies the meaning of other elements
+    /// (see https://www.hl7.org/fhir/conformance-rules.html#isModifier)
+    /// </summary>
+    public bool IsModifier { get; init; }
+
+    /// <summary>
+    /// Five W's mappings of the element.
+    /// <remarks>it represents the exact element name of one the elements of the
+    /// <c>FiveWs</c> pattern from http://hl7.org/fhir/fivews.html. Choice elements are spelled with the
+    /// [x] suffix, like <c>done[x]</c>. </remarks>
+    /// </summary>
+    public string? FiveWs { get; init; }
+
+    /// <summary>
+    /// Whether the element has a cardinality higher than 0.
+    /// </summary>
+    public bool IsMandatoryElement { get; init; }
+
+    /// <summary>
+    /// The numeric order of the element (relevant for the XML serialization, which
+    /// needs to be in order).
+    /// </summary>
+    public int Order { get; init; }
+
+    /// <summary>
+    /// How this element is represented in the XML serialization.
+    /// </summary>
+    public XmlRepresentation SerializationHint { get; init; }
+
+    /// <summary>
+    /// Specifies whether this element contains a choice (either a choice element or a
+    /// contained resource).
+    /// </summary>
+    /// <remarks>In the case of a DataChoice, these elements have names ending in [x] in
+    /// the StructureDefinition and allow a (possibly restricted) set of types to be used.
+    /// These are reflected in the <see cref="FhirType"/> property.</remarks>
+    public ChoiceType Choice { get; init; }
+
+    /// <summary>
+    /// The collection of zero or more <see cref="ValidationAttribute"/> (or subclasses) declared
+    /// on this property.
+    /// </summary>
+    public ValidatingFhirModelAttribute[] ValidationAttributes { get; init; } = [];
+
+
+    /// <summary>
+    /// For a bound element, this is the name of the binding.
+    /// </summary>
+    public string? BindingName { get; init; }
+
+    /// <summary>
+    /// The release of FHIR for which the metadata was extracted from the property.
+    /// </summary>
+    public FhirRelease Release => DeclaringClass.Release;
+
+    /// <summary>
+    /// Inspects the given PropertyInfo, extracting metadata from its attributes and creating a new <see cref="PropertyMapping"/>.
+    /// </summary>
+    /// <remarks>There should generally be no reason to call this method, as you can easily get the required PropertyMapping via
+    /// a ClassMapping - which will cache this information as well. This constructor is public for historical reasons only.</remarks>
+    public static bool TryCreate(PropertyInfo prop, [NotNullWhen(true)] out PropertyMapping? result, ClassMapping declaringClass)
+    {
+        if (prop == null) throw Error.ArgumentNull(nameof(prop));
+        result = null;
+        var release = declaringClass.Release;
+
+        // If there is no [FhirElement] on the property, skip it
+        var elementAttr = prop.GetFhirModelAttribute<FhirElementAttribute>(release);
+        if (elementAttr == null) return false;
+
+        // If there is an explicit [NotMapped] on the property, skip it
+        // (in combination with `Since` useful to remove a property from the serialization)
+        var notmappedAttr = prop.GetFhirModelAttribute<NotMappedAttribute>(release);
+        if (notmappedAttr != null) return false;
+
+        // We broadly use .IsArray here - this means arrays in POCOs cannot be used to represent
+        // FHIR repeating elements. If we would allow this, we'd also have stuff like `string` and binary
+        // data as repeating element, and would need to exclude these exceptions on a case by case basis.
+        // This is pretty ugly, so we prefer to not support arrays - you should use lists instead.
+        _ = ReflectionHelper.TryGetRepeatingElementType(prop.PropertyType, out var collectionItemType);
+
+        var cardinalityAttr = prop.GetFhirModelAttribute<CardinalityAttribute>(release);
+
+        // Get to the actual (native) type representing this element
+        var implementingType = prop.PropertyType;
+        if (collectionItemType is not null) implementingType = collectionItemType;
+        if (Nullable.GetUnderlyingType(implementingType) is { } underlyingType) implementingType = underlyingType;
+
+        // The [AllowedTypes] attribute can specify a set of allowed types for this element.
+        // If this is a choice element, then take this list as the declared list of FHIR types,
+        // otherwise assume this is the implementing FHIR type above
+        var overridingTypes = prop.GetFhirModelAttribute<AllowedTypesAttribute>(release)?.Types;
+        Type mappingType = determineMappingType(overridingTypes, implementingType, elementAttr, declaringClass.Name);
+
+        if (!ClassMapping.TryGetMappingForType(mappingType, release, out var propertyTypeMapping))
+            throw new InvalidOperationException($"Property {prop.Name} in class {prop.DeclaringType!.Name} is of type " +
+                                                $"{mappingType}, for which a classmapping cannot be found.");
+
+        // FhirTypes is either the explicitly listed types in the [AllowedTypes] attribute, or the
+        // mappingType we have determined before.
+        var fhirTypes = overridingTypes ?? [mappingType];
+        var isPrimitive = isAllowedNativeTypeForDataTypeValue(implementingType);
+
+        result = new PropertyMapping(elementAttr.Name, declaringClass, prop)
         {
-            Name = name;
-            NativeProperty = pi;
-            Release = version;
-            ImplementingType = implementingType;
-            FhirType = fhirTypes;
-            PropertyTypeMapping = propertyTypeMapping;
-            DeclaringClass = declaringClass;
-            FiveWs = string.Empty;
-            ValidationAttributes = [];
-        }
+            InSummary = elementAttr.InSummary,
+            IsModifier = elementAttr.IsModifier,
+            Choice = elementAttr.Choice,
+            SerializationHint = elementAttr.XmlSerialization,
+            Order = elementAttr.Order,
+            IsCollection = collectionItemType is not null,
+            IsMandatoryElement = cardinalityAttr?.Min > 0,
+            IsPrimitive = isPrimitive,
+            RepresentsValueElement = elementAttr.IsPrimitiveValue,
+            ValidationAttributes = prop.GetValidatingAttributes(release).ToArray(),
+            FiveWs = elementAttr.FiveWs,
+            BindingName = prop.GetFhirModelAttribute<BindingAttribute>(release)?.Name,
+            PropertyTypeMapping = propertyTypeMapping,
+            FhirType = fhirTypes,
+            ImplementingType = implementingType,
+        };
 
-        /// <summary>
-        /// The name of the element in the FHIR specification.
-        /// </summary>
-        public string Name { get; internal set; }
+        return true;
+    }
 
-        /// <summary>
-        /// The ClassMapping for the type this property is a member of.
-        /// </summary>
-        public ClassMapping DeclaringClass { get; internal set; }
+    private static Type determineMappingType(Type[]? overridingTypes, Type implementingType, FhirElementAttribute felem, string parentTypeName)
+    {
+        // There are a few cases where AllowedTypes is used to specify the "correct" concrete FhirType to
+        // use when ImplementingType is not the right type to base the mapping on:
+        // * For elements that use DataType and have a specific AllowedType per version (e.g. Signature.who)
+        // * For the value element of Primitives, that need to be mapped to CQL types.
+        if (overridingTypes?.Length == 1)
+            return overridingTypes[0];
 
-        /// <summary>
-        /// Whether the element can repeat.
-        /// </summary>
-        public bool IsCollection { get; internal set; }
-
-        /// <summary>
-        /// The element is of an atomic .NET type, not a FHIR generated POCO.
-        /// </summary>
-        public bool IsPrimitive { get; private set; }
-
-        /// <summary>
-        /// The element is a primitive (<seealso cref="IsPrimitive"/>) and 
-        /// represents the primitive `value` attribute/property in the FHIR serialization.
-        /// </summary>
-        public bool RepresentsValueElement { get; private set; }
-
-        /// <summary>
-        /// Whether the element appears in _summary 
-        /// (see https://www.hl7.org/fhir/search.html#summary)
-        /// </summary>
-        public bool InSummary { get; private set; }
-
-        /// <summary>
-        /// If this modifies the meaning of other elements
-        /// (see https://www.hl7.org/fhir/conformance-rules.html#isModifier)
-        /// </summary>
-        public bool IsModifier { get; private set; }
-
-        /// <summary>
-        /// Five W's mappings of the element.
-        /// <remarks>it represents the exact element name of one the elements of the 
-        /// <c>FiveWs</c> pattern from http://hl7.org/fhir/fivews.html. Choice elements are spelled with the
-        /// [x] suffix, like <c>done[x]</c>. </remarks>
-        /// </summary>
-        public string? FiveWs { get; private set; }
-
-        /// <summary>
-        /// Whether the element has a cardinality higher than 0.
-        /// </summary>
-        public bool IsMandatoryElement { get; private set; }
-
-        /// <summary>
-        /// The native type of the element.
-        /// </summary>
-        /// <remarks>If the element is a collection or is nullable, this reflects the
-        /// collection item or the type that is made nullable respectively.
-        /// </remarks>
-        public Type ImplementingType { get; private set; }
-
-        /// <summary>
-        /// The numeric order of the element (relevant for the XML serialization, which
-        /// needs to be in order).
-        /// </summary>
-        public int Order { get; private set; }
-
-        /// <summary>
-        /// How this element is represented in the XML serialization.
-        /// </summary>
-        public XmlRepresentation SerializationHint { get; private set; }
-
-        /// <summary>
-        /// Specifies whether this element contains a choice (either a choice element or a
-        /// contained resource).
-        /// </summary>
-        /// <remarks>In the case of a DataChoice, these elements have names ending in [x] in 
-        /// the StructureDefinition and allow a (possibly restricted) set of types to be used. 
-        /// These are reflected in the <see cref="FhirType"/> property.</remarks>
-        public ChoiceType Choice { get; private set; }
-
-        /// <summary>
-        /// The list of possible FHIR types for this element, listed as the representative .NET types. 
-        /// For non-choice types this is a single Type, for choices this is either a list of Types or 
-        /// just <see cref="Hl7.Fhir.Model.DataType"/>.
-        /// </summary>
-        /// <remark>These are the defined (choice) types for this element as specified in the
-        /// FHIR data definitions. It is derived from the actual property type,
-        /// or, if present, via a list of types in the [AllowedTypes] attribute. Finally,
-        /// it the property type does not represent FHIR metadata, it is overridden using
-        /// the [DeclaredType] attribute.
-        /// </remark>
-        public Type[] FhirType { get; }
-
-        /// <summary>
-        /// The <see cref="ClassMapping" /> that represents the type of this property.
-        /// </summary>
-        /// <remarks>This is effectively the ClassMapping for the <see cref="ImplementingType" /> unless a
-        /// <see cref="AllowedTypesAttribute" /> specifies otherwise.</remarks>
-        public ClassMapping PropertyTypeMapping { get; }
-
-        /// <summary>
-        /// The collection of zero or more <see cref="ValidationAttribute"/> (or subclasses) declared
-        /// on this property.
-        /// </summary>
-        public ValidatingFhirModelAttribute[] ValidationAttributes { get; private set; }
-
-        /// <summary>
-        /// The original <see cref="PropertyInfo"/> the metadata was obtained from.
-        /// </summary>
-        public readonly PropertyInfo NativeProperty;
-
-        /// <summary>
-        /// The release of FHIR for which the metadata was extracted from the property.
-        /// </summary>
-        public readonly FhirRelease Release;
-
-        /// <summary>
-        /// For a bound element, this is the name of the binding.
-        /// </summary>
-        public string? BindingName { get; private set; }
-
-        /// <summary>
-        /// Inspects the given PropertyInfo, extracting metadata from its attributes and creating a new <see cref="PropertyMapping"/>.
-        /// </summary>
-        /// <remarks>There should generally be no reason to call this method, as you can easily get the required PropertyMapping via
-        /// a ClassMapping - which will cache this information as well. This constructor is public for historical reasons only.</remarks>
-        public static bool TryCreate(PropertyInfo prop, [NotNullWhen(true)] out PropertyMapping? result, ClassMapping declaringClass, FhirRelease release)
+        // The special "value" properties of primitive types are mapped to the CQL types.
+        if (isAllowedNativeTypeForDataTypeValue(implementingType) && felem.IsPrimitiveValue)
         {
-            if (prop == null) throw Error.ArgumentNull(nameof(prop));
-            result = default;
-
-            // If there is no [FhirElement] on the property, skip it
-            var elementAttr = prop.GetFhirModelAttribute<FhirElementAttribute>(release);
-            if (elementAttr == null) return false;
-
-            // If there is an explicit [NotMapped] on the property, skip it
-            // (in combination with `Since` useful to remove a property from the serialization)
-            var notmappedAttr = prop.GetFhirModelAttribute<NotMappedAttribute>(release);
-            if (notmappedAttr != null) return false;
-
-            // We broadly use .IsArray here - this means arrays in POCOs cannot be used to represent
-            // FHIR repeating elements. If we would allow this, we'd also have stuff like `string` and binary
-            // data as repeating element, and would need to exclude these exceptions on a case by case basis.
-            // This is pretty ugly, so we prefer to not support arrays - you should use lists instead.
-            _ = ReflectionHelper.TryGetRepeatingElementType(prop.PropertyType, out var collectionItemType);
-
-            var cardinalityAttr = prop.GetFhirModelAttribute<CardinalityAttribute>(release);
-
-            // Get to the actual (native) type representing this element
-            var implementingType = prop.PropertyType;
-            if (collectionItemType is not null) implementingType = collectionItemType!;
-            if (Nullable.GetUnderlyingType(implementingType) is { } underlyingType) implementingType = underlyingType;
-
-            // The [AllowedTypes] attribute can specify a set of allowed types for this element.
-            // If this is a choice element, then take this list as the declared list of FHIR types,
-            // otherwise assume this is the implementing FHIR type above
-            var overridingTypes = prop.GetFhirModelAttribute<AllowedTypesAttribute>(release)?.Types;
-            Type mappingType = determineMappingType(overridingTypes, implementingType, elementAttr, declaringClass.Name);
-
-            if (!ClassMapping.TryGetMappingForType(mappingType, release, out var propertyTypeMapping))
-                throw new InvalidOperationException($"Property {prop.Name} in class {prop.DeclaringType!.Name} is of type " +
-                                                    $"{mappingType}, for which a classmapping cannot be found.");
-
-            // FhirTypes is either the explicitly listed types in the [AllowedTypes] attribute, or the
-            // mappingType we have determined before.
-            var fhirTypes = overridingTypes ?? [mappingType];
-            var isPrimitive = isAllowedNativeTypeForDataTypeValue(implementingType);
-
-            result = new PropertyMapping(elementAttr.Name, declaringClass, prop, implementingType, propertyTypeMapping, fhirTypes, release)
+            return parentTypeName switch
             {
-                InSummary = elementAttr.InSummary,
-                IsModifier = elementAttr.IsModifier,
-                Choice = elementAttr.Choice,
-                SerializationHint = elementAttr.XmlSerialization,
-                Order = elementAttr.Order,
-                IsCollection = collectionItemType is not null,
-                IsMandatoryElement = cardinalityAttr?.Min > 0,
-                IsPrimitive = isPrimitive,
-                RepresentsValueElement = elementAttr.IsPrimitiveValue,
-                ValidationAttributes = prop.GetValidatingAttributes(release).ToArray(),
-                FiveWs = elementAttr.FiveWs,
-                BindingName = prop.GetFhirModelAttribute<BindingAttribute>(release)?.Name
+                "boolean" => typeof(P.Boolean),
+                "integer" or "unsignedInt" or "positiveInt" => typeof(P.Integer),
+                "integer64" => typeof(P.Long),
+                "time" => typeof(P.Time),
+                "date" => typeof(P.Date),
+                "instant" or "datetime" => typeof(P.DateTime),
+                "decimal" => typeof(P.Decimal),
+                _ => typeof(P.String)
             };
-
-            return true;
         }
 
-        private static Type determineMappingType(Type[]? overridingTypes, Type implementingType, FhirElementAttribute felem, string parentTypeName)
-        {
-            // There are a few cases where AllowedTypes is used to specify the "correct" concrete FhirType to
-            // use when ImplementingType is not the right type to base the mapping on:
-            // * For elements that use DataType and have a specific AllowedType per version (e.g. Signature.who)
-            // * For the value element of Primitives, that need to be mapped to CQL types.
-            if (overridingTypes?.Length == 1)
-                return overridingTypes[0];
+        // For all enums, we use the single mapping for Enum
+        if (typeof(Enum).IsAssignableFrom(implementingType))
+            return typeof(Enum);
 
-            // The special "value" properties of primitive types are mapped to the CQL types.
-            if (isAllowedNativeTypeForDataTypeValue(implementingType) && felem.IsPrimitiveValue)
-            {
-                return parentTypeName switch
-                {
-                    "boolean" => typeof(P.Boolean),
-                    "integer" or "unsignedInt" or "positiveInt" => typeof(P.Integer),
-                    "integer64" => typeof(P.Long),
-                    "time" => typeof(P.Time),
-                    "date" => typeof(P.Date),
-                    "instant" or "datetime" => typeof(P.DateTime),
-                    "decimal" => typeof(P.Decimal),
-                    _ => typeof(P.String)
-                };
-            }
+        // For all Code<T>, we use the mapping for Coding
+        if (implementingType.IsConstructedGenericType && implementingType.GetGenericTypeDefinition() == typeof(Code<>))
+            return typeof(Code);
 
-            // For all enums, we use the single mapping for Enum
-            if (typeof(Enum).IsAssignableFrom(implementingType))
-                return typeof(Enum);
+        // Otherwise, we simply use the mapping for the actual implementing type.
+        return implementingType;
+    }
 
-            // For all Code<T>, we use the mapping for Coding
-            if (implementingType.IsConstructedGenericType && implementingType.GetGenericTypeDefinition() == typeof(Code<>))
-                return typeof(Code);
-
-            // Otherwise, we simply use the mapping for the actual implementing type.
-            return implementingType;
-        }
-
-        /// <summary>
-        /// This function tried to figure out a concrete type for the element represented by this property.
-        /// If it cannot derive a concrete type, it will just return <see cref="ImplementingType"/>.
-        /// </summary>
-        internal Type GetInstantiableType()
-        {
-            if (!ImplementingType.IsAbstract)
-                return ImplementingType;
-
-            // Ok, so we're in abstract type land, maybe FhirType can help us
-            if (FhirType.Length == 1)
-                return FhirType[0];
-
-            // No, just return ImplementingType then.
+    /// <summary>
+    /// This function tried to figure out a concrete type for the element represented by this property.
+    /// If it cannot derive a concrete type, it will just return <see cref="ImplementingType"/>.
+    /// </summary>
+    internal Type GetInstantiableType()
+    {
+        if (!ImplementingType.IsAbstract)
             return ImplementingType;
-        }
 
-        private static string buildQualifiedPropName(PropertyInfo p)
-            => $"{p.DeclaringType?.Name ?? throw Error.ArgumentNull(nameof(p.DeclaringType))}.{p.Name}";
+        // Ok, so we're in abstract type land, maybe FhirType can help us
+        if (FhirType.Length == 1)
+            return FhirType[0];
 
-        private static bool isAllowedNativeTypeForDataTypeValue(Type type) =>
-            type.IsEnum || ClassMapping.SupportedDotNetPrimitiveTypes.Contains(type);
+        // No, just return ImplementingType then.
+        return ImplementingType;
+    }
 
-        /// <summary>
-        /// Given an instance of the parent class, gets the value for this property.
-        /// </summary>
-        public object? GetValue(object instance) => LazyInitializer.EnsureInitialized(ref _getter, NativeProperty.GetValueGetter)!(instance);
+    internal string QualifiedPropName => $"{DeclaringClass.Name}.{Name}";
 
-        private Func<object, object?>? _getter;
+    private static bool isAllowedNativeTypeForDataTypeValue(Type type) =>
+        type.IsEnum || ClassMapping.SupportedDotNetPrimitiveTypes.Contains(type);
 
-        /// <summary>
-        /// Given an instance of the parent class, sets the value for this property.
-        /// </summary>
-        public void SetValue(object instance, object? value) =>
-            LazyInitializer.EnsureInitialized(ref _setter, NativeProperty.GetValueSetter)!(instance, value);
+    #region IElementDefinitionSummary members
+    string IElementDefinitionSummary.ElementName => this.Name;
 
-        private Action<object, object?>? _setter;
+    bool IElementDefinitionSummary.IsCollection => this.IsCollection;
 
-        #region IElementDefinitionSummary members
-        string IElementDefinitionSummary.ElementName => this.Name;
+    bool IElementDefinitionSummary.IsRequired => this.IsMandatoryElement;
 
-        bool IElementDefinitionSummary.IsCollection => this.IsCollection;
+    bool IElementDefinitionSummary.InSummary => this.InSummary;
 
-        bool IElementDefinitionSummary.IsRequired => this.IsMandatoryElement;
+    /// <inheritdoc/>
+    bool IElementDefinitionSummary.IsModifier => this.IsModifier;
 
-        bool IElementDefinitionSummary.InSummary => this.InSummary;
+    bool IElementDefinitionSummary.IsChoiceElement => this.Choice == ChoiceType.DatatypeChoice;
 
-        /// <inheritdoc/>
-        bool IElementDefinitionSummary.IsModifier => this.IsModifier;
+    bool IElementDefinitionSummary.IsResource => this.Choice == ChoiceType.ResourceChoice;
 
-        bool IElementDefinitionSummary.IsChoiceElement => this.Choice == ChoiceType.DatatypeChoice;
+    string? IElementDefinitionSummary.DefaultTypeName => null;
 
-        bool IElementDefinitionSummary.IsResource => this.Choice == ChoiceType.ResourceChoice;
-
-        string? IElementDefinitionSummary.DefaultTypeName => null;
-
-        ITypeSerializationInfo[] IElementDefinitionSummary.Type
+    ITypeSerializationInfo[] IElementDefinitionSummary.Type
+    {
+        get
         {
-            get
-            {
-                LazyInitializer.EnsureInitialized(ref _types, buildTypes);
-                return _types!;
-            }
+            LazyInitializer.EnsureInitialized(ref _types, buildTypes);
+            return _types!;
         }
+    }
 
-        private ITypeSerializationInfo[]? _types;
+    private ITypeSerializationInfo[]? _types;
 
-        string? IElementDefinitionSummary.NonDefaultNamespace => null;
+    string? IElementDefinitionSummary.NonDefaultNamespace => null;
 
-        XmlRepresentation IElementDefinitionSummary.Representation =>
-            SerializationHint != XmlRepresentation.None ?
+    XmlRepresentation IElementDefinitionSummary.Representation =>
+        SerializationHint != XmlRepresentation.None ?
             SerializationHint : XmlRepresentation.XmlElement;
 
-        int IElementDefinitionSummary.Order => Order;
+    int IElementDefinitionSummary.Order => Order;
 
-        private ITypeSerializationInfo[] buildTypes()
+    private ITypeSerializationInfo[] buildTypes()
+    {
+        if (PropertyTypeMapping.IsBackboneType)
+            return [PropertyTypeMapping];
+
+        if (IsPrimitive)
         {
-            if (PropertyTypeMapping!.IsBackboneType)
-                return [PropertyTypeMapping];
-
-            if (IsPrimitive)
-            {
-                throw new NotSupportedException(
-                    $"Encountered unexpected primitive type {Name} for ITypedElement.InstanceType.");
-            }
-
-            var names = FhirType.Select(getFhirTypeName);
-            return names.Select(n => (ITypeSerializationInfo)new PocoTypeReferenceInfo(n)).ToArray();
-
-            string getFhirTypeName(Type ft)
-            {
-                // The special case where the mapping name is a backbone element name can safely
-                // be ignored here, since that is handled by the first case in the if statement above.
-                return ClassMapping.TryGetMappingForType(ft, Release, out var tm)
-                    ? ((IStructureDefinitionSummary)tm).TypeName
-                    : throw new NotSupportedException($"Type '{ft.Name}' is listed as an allowed type for property " +
-                        $"'{buildQualifiedPropName(NativeProperty)}', but it does not seem to" +
-                        $"be a valid FHIR type POCO.");
-            }
+            throw new NotSupportedException(
+                $"Encountered unexpected primitive type {Name} for ITypedElement.InstanceType.");
         }
 
-        private readonly struct PocoTypeReferenceInfo(string canonical) : IStructureDefinitionReference
-        {
-            public string ReferredType { get; } = canonical;
-        }
+        var names = FhirType.Select(getFhirTypeName);
+        return names.Select(n => (ITypeSerializationInfo)new PocoTypeReferenceInfo(n)).ToArray();
 
-        #endregion
+        string getFhirTypeName(Type ft)
+        {
+            // The special case where the mapping name is a backbone element name can safely
+            // be ignored here, since that is handled by the first case in the if statement above.
+            return ClassMapping.TryGetMappingForType(ft, DeclaringClass.Release, out var tm)
+                ? ((IStructureDefinitionSummary)tm).TypeName
+                : throw new NotSupportedException($"Type '{ft.Name}' is listed as an allowed type for property " +
+                                                  $"'{QualifiedPropName}', but it does not seem to" +
+                                                  $"be a valid FHIR type POCO.");
+        }
     }
-}
 
-#nullable restore
+    private readonly struct PocoTypeReferenceInfo(string canonical) : IStructureDefinitionReference
+    {
+        public string ReferredType { get; } = canonical;
+    }
+
+    #endregion
+}

--- a/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
@@ -93,7 +93,7 @@ namespace Hl7.Fhir.Introspection
         /// <c>FiveWs</c> pattern from http://hl7.org/fhir/fivews.html. Choice elements are spelled with the
         /// [x] suffix, like <c>done[x]</c>. </remarks>
         /// </summary>
-        public string FiveWs { get; private set; }
+        public string? FiveWs { get; private set; }
 
         /// <summary>
         /// Whether the element has a cardinality higher than 0.
@@ -180,12 +180,12 @@ namespace Hl7.Fhir.Introspection
             result = default;
 
             // If there is no [FhirElement] on the property, skip it
-            var elementAttr = ClassMapping.GetAttribute<FhirElementAttribute>(prop, release);
+            var elementAttr = prop.GetFhirModelAttribute<FhirElementAttribute>(release);
             if (elementAttr == null) return false;
 
             // If there is an explicit [NotMapped] on the property, skip it
             // (in combination with `Since` useful to remove a property from the serialization)
-            var notmappedAttr = ClassMapping.GetAttribute<NotMappedAttribute>(prop, release);
+            var notmappedAttr = prop.GetFhirModelAttribute<NotMappedAttribute>(release);
             if (notmappedAttr != null) return false;
 
             // We broadly use .IsArray here - this means arrays in POCOs cannot be used to represent
@@ -194,7 +194,7 @@ namespace Hl7.Fhir.Introspection
             // This is pretty ugly, so we prefer to not support arrays - you should use lists instead.
             _ = ReflectionHelper.TryGetRepeatingElementType(prop.PropertyType, out var collectionItemType);
 
-            var cardinalityAttr = ClassMapping.GetAttribute<CardinalityAttribute>(prop, release);
+            var cardinalityAttr = prop.GetFhirModelAttribute<CardinalityAttribute>(release);
 
             // Get to the actual (native) type representing this element
             var implementingType = prop.PropertyType;
@@ -204,7 +204,7 @@ namespace Hl7.Fhir.Introspection
             // The [AllowedTypes] attribute can specify a set of allowed types for this element.
             // If this is a choice element, then take this list as the declared list of FHIR types,
             // otherwise assume this is the implementing FHIR type above
-            var overridingTypes = ClassMapping.GetAttribute<AllowedTypesAttribute>(prop, release)?.Types;
+            var overridingTypes = prop.GetFhirModelAttribute<AllowedTypesAttribute>(release)?.Types;
             Type mappingType = determineMappingType(overridingTypes, implementingType, elementAttr, declaringClass.Name);
 
             if (!ClassMapping.TryGetMappingForType(mappingType, release, out var propertyTypeMapping))
@@ -227,9 +227,9 @@ namespace Hl7.Fhir.Introspection
                 IsMandatoryElement = cardinalityAttr?.Min > 0,
                 IsPrimitive = isPrimitive,
                 RepresentsValueElement = elementAttr.IsPrimitiveValue,
-                ValidationAttributes = ClassMapping.GetValidatingAttributes(prop, release).ToArray(),
+                ValidationAttributes = prop.GetValidatingAttributes(release).ToArray(),
                 FiveWs = elementAttr.FiveWs,
-                BindingName = ClassMapping.GetAttribute<BindingAttribute>(prop, release)?.Name
+                BindingName = prop.GetFhirModelAttribute<BindingAttribute>(release)?.Name
             };
 
             return true;

--- a/src/Hl7.Fhir.Base/Introspection/PropertyMappingCollection.cs
+++ b/src/Hl7.Fhir.Base/Introspection/PropertyMappingCollection.cs
@@ -8,50 +8,36 @@
 
 #nullable enable
 
-using Hl7.Fhir.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Hl7.Fhir.Introspection
+namespace Hl7.Fhir.Introspection;
+
+/// <summary>
+/// A list of <see cref="PropertyMapping"/>s, indexed by name and order and choice.
+/// </summary>
+internal class PropertyMappingCollection
 {
-    internal class PropertyMappingCollection
+    internal PropertyMappingCollection(IEnumerable<PropertyMapping> mappings)
     {
-        public PropertyMappingCollection(IEnumerable<PropertyMapping> mappings)
-        {
-            var byName = new Dictionary<string, PropertyMapping>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var mapping in mappings)
-            {
-                var propKey = mapping.Name;
-                if (!byName.TryAdd(propKey, mapping))
-                {
-                    throw Error.InvalidOperation(
-                        $"Class has multiple properties that are named '{propKey}'. The property name must be unique.");
-                }
-            }
-
-            ByName = byName;
-            ByOrder = ByName.Values.OrderBy(pm => pm.Order).ToList();
-
-            ChoiceProperties = ByOrder.Where(pm => pm.Choice == ChoiceType.DatatypeChoice).ToList();
-        }
-
-        /// <summary>
-        /// List of the properties, in the order of appearance.
-        /// </summary>
-        public readonly IReadOnlyList<PropertyMapping> ByOrder;
-
-        /// <summary>
-        /// The list of properties that represent choice elements.
-        /// </summary>
-        public readonly IReadOnlyList<PropertyMapping> ChoiceProperties;
-
-        /// <summary>
-        /// List of the properties, keyed by name.
-        /// </summary>
-        public readonly IReadOnlyDictionary<string, PropertyMapping> ByName;
+        ByName = mappings.ToDictionary(m => m.Name, StringComparer.OrdinalIgnoreCase);
+        ByOrder = ByName.Values.OrderBy(pm => pm.Order).ToList();
+        ChoiceProperties = ByOrder.Where(pm => pm.Choice == ChoiceType.DatatypeChoice).ToList();
     }
-}
 
-#nullable restore
+    /// <summary>
+    /// List of the properties, in the order of appearance.
+    /// </summary>
+    public readonly IReadOnlyList<PropertyMapping> ByOrder;
+
+    /// <summary>
+    /// The list of properties that represent choice elements.
+    /// </summary>
+    public readonly IReadOnlyList<PropertyMapping> ChoiceProperties;
+
+    /// <summary>
+    /// List of the properties, keyed by name.
+    /// </summary>
+    public readonly IReadOnlyDictionary<string, PropertyMapping> ByName;
+}

--- a/src/Hl7.Fhir.Base/Model/FhirTypeNames.cs
+++ b/src/Hl7.Fhir.Base/Model/FhirTypeNames.cs
@@ -49,5 +49,6 @@ internal static class FhirTypeNames
     public const string ELEMENT_NAME = "Element";
     public const string STRING_NAME = "string";
     public const string MARKDOWN_NAME = "markdown";
+    public const string VALUESET_NAME = "ValueSet";
 
 }

--- a/src/Hl7.Fhir.Base/Model/PocoNodeExtensions.cs
+++ b/src/Hl7.Fhir.Base/Model/PocoNodeExtensions.cs
@@ -311,7 +311,9 @@ public static class PocoNodeExtensions
     
     internal static string SerializeToString(this PocoNode pn, bool pretty)
     {
-        var serializer = new BaseFhirXmlSerializer(pn.FindInspector() ?? ModelInspector.ForType(pn.Poco.GetType()));
+#pragma warning disable CS0618 // Type or member is obsolete
+        var serializer = new BaseFhirXmlSerializer(pn.FindInspector() ?? ModelInspector.ForAssembly(pn.Poco.GetType().Assembly));
+#pragma warning restore CS0618 // Type or member is obsolete
 
         // If we are serializing a subtree of a resource, then if the current node is a datatype or a nested resource,
         // we need to pick a name for this root element.

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonPocoDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonPocoDeserializer.cs
@@ -20,8 +20,6 @@ public class BaseFhirJsonPocoDeserializer : BaseFhirJsonDeserializer
     /// Initializes an instance of the deserializer.
     /// </summary>
     /// <param name="assembly">Assembly containing the POCO classes to be used for deserialization.</param>
-    [Obsolete("Use the constructor that takes a ModelInspector instead. " +
-              "You can find the right ModelInspector for an assembly by calling ModelInspector.ForAssembly(assembly).")]
     public BaseFhirJsonPocoDeserializer(Assembly assembly) : this(ModelInspector.ForAssembly(assembly),
         new FhirJsonConverterOptions())
     {

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonConverterOptionsExtensions.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonConverterOptionsExtensions.cs
@@ -39,17 +39,6 @@ public static class FhirJsonConverterOptionsExtensions
         FhirJsonConverterOptions? deserializerSettings = null) =>
         options.ForFhir(inspector, deserializerSettings ?? new FhirJsonConverterOptions()).addCdsHooks();
 
-
-#if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
-#else
-        [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
-#endif
-    public static JsonSerializerOptions ForCdsHooks(this JsonSerializerOptions options, Assembly modelAssembly,
-        FhirJsonConverterOptions? deserializerSettings = null) =>
-        options.ForFhir(modelAssembly, deserializerSettings ?? new FhirJsonConverterOptions())
-            .addCdsHooks();
-
     private static JsonSerializerOptions addCdsHooks(this JsonSerializerOptions options)
     {
         options.TypeInfoResolver = (options.TypeInfoResolver ?? new DefaultJsonTypeInfoResolver()).WithAddedModifier(changeCdsHookPropertyNames);
@@ -68,9 +57,13 @@ public static class FhirJsonConverterOptionsExtensions
     /// <summary>
     /// Initialize the options to serialize using the JsonFhirConverter, producing compact output without whitespace.
     /// </summary>
+    [Obsolete("Use the overload that takes a ModelInspector instead. " +
+              "You can find the right ModelInspector for an assembly by calling ModelInspector.ForAssembly(assembly).")]
     public static JsonSerializerOptions ForFhir(this JsonSerializerOptions options, Assembly modelAssembly) =>
         options.ForFhir(modelAssembly, new FhirJsonConverterOptions());
 
+    [Obsolete("Use the overload that takes a ModelInspector instead. " +
+              "You can find the right ModelInspector for an assembly by calling ModelInspector.ForAssembly(assembly).")]
     public static JsonSerializerOptions ForFhir(
         this JsonSerializerOptions options,
         Assembly modelAssembly,

--- a/src/Hl7.Fhir.Base/Utility/CompilerFeatureRequiredAttribute.cs
+++ b/src/Hl7.Fhir.Base/Utility/CompilerFeatureRequiredAttribute.cs
@@ -1,0 +1,40 @@
+#if NETSTANDARD2_1
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Indicates that compiler support for a particular feature is required for the location where this attribute is applied.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+    public sealed class CompilerFeatureRequiredAttribute : Attribute
+    {
+        public CompilerFeatureRequiredAttribute(string featureName)
+        {
+            FeatureName = featureName;
+        }
+
+        /// <summary>
+        /// The name of the compiler feature.
+        /// </summary>
+        public string FeatureName { get; }
+
+        /// <summary>
+        /// If true, the compiler can choose to allow access to the location where this attribute is applied if it does not understand <see cref="FeatureName"/>.
+        /// </summary>
+        public bool IsOptional { get; init; }
+
+        /// <summary>
+        /// The <see cref="FeatureName"/> used for the ref structs C# feature.
+        /// </summary>
+        public const string RefStructs = nameof(RefStructs);
+
+        /// <summary>
+        /// The <see cref="FeatureName"/> used for the required members C# feature.
+        /// </summary>
+        public const string RequiredMembers = nameof(RequiredMembers);
+    }
+}
+
+#endif

--- a/src/Hl7.Fhir.Base/Utility/EnumUtility.cs
+++ b/src/Hl7.Fhir.Base/Utility/EnumUtility.cs
@@ -13,193 +13,190 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace Hl7.Fhir.Utility
+namespace Hl7.Fhir.Utility;
+
+/// <summary>
+/// A set of utility methods to work with serialized enumeration values.
+/// </summary>
+public static class EnumUtility
 {
     /// <summary>
-    /// A set of utility methods to work with serialized enumeration values.
+    /// Retrieves the literal value for the code represented by this enum value, or the member name itself if there
+    /// is no literal value defined.
     /// </summary>
-    public static class EnumUtility
+    public static string GetLiteral(this Enum e) =>   getEnumMapping(e.GetType()).GetLiteral(e);
+
+    /// <summary>
+    /// Retrieves the literal value for the code represented by this enum <typeparamref name="T"/>, or the member name itself if there
+    /// is no literal value defined.
+    /// </summary>
+    public static string GetLiteral<T>(this T e) where T : struct, Enum => EnumMappingCache<T>.GetLiteral(e);
+
+    /// <summary>
+    /// Retrieves the literal value for the code represented by this nullable enum <typeparamref name="T"/>, or the member name itself if there
+    /// is no literal value defined, or null if the enum does not have a value.
+    /// </summary>
+    public static string? GetLiteral<T>(this T? e) where T : struct, Enum => e?.GetLiteral();
+
+    /// <summary>
+    /// Retrieves the system canonical for the code represented by this enum value, or <c>null</c> if there is no system defined.
+    /// </summary>
+    public static string? GetSystem(this Enum e) => e.GetAttributeOnEnum<EnumLiteralAttribute>()?.System ?? e.GetType().GetCustomAttribute<FhirEnumerationAttribute>()?.DefaultCodeSystem;
+
+    /// <summary>
+    /// Retrieves the system canonical for the code represented by this enum <typeparamref name="T"/>, or <c>null</c> if there is no system defined.
+    /// </summary>
+    public static string? GetSystem<T>(this T e) where T : struct, Enum => EnumMappingCache<T>.GetSystem(e);
+
+    /// <summary>
+    /// Retrieves the description for this enum value or the enumeration value itself if there is no description defined.
+    /// </summary>
+    public static string GetDocumentation(this Enum e) =>
+        e.GetAttributeOnEnum<DescriptionAttribute>()?.Description ?? e.ToString();
+
+    private static readonly ConcurrentDictionary<Type, EnumMapping> CACHE = new();
+
+    /// <summary>
+    /// Finds an enumeration value from <paramref name="enumType"/> where the literal is the same as <paramref name="rawValue"/>.
+    /// </summary>
+    public static Enum? ParseLiteral(string? rawValue, Type enumType, bool ignoreCase = false)
+        => getEnumMapping(enumType).ParseLiteral(rawValue, ignoreCase);
+
+    /// <summary>
+    /// Finds an enumeration value from enum <typeparamref name="T"/> where the literal is the same as <paramref name="rawValue"/>.
+    /// </summary>
+    public static T? ParseLiteral<T>(string? rawValue, bool ignoreCase = false) where T : struct, Enum
+        => EnumMappingCache<T>.ParseLiteral(rawValue, ignoreCase);
+
+    /// <summary>
+    /// Gets the human readable name defined for the enumeration <paramref name="enumType"/>.
+    /// </summary>
+    public static string GetName(Type enumType) => getEnumMapping(enumType).Name;
+
+    /// <summary>
+    /// Gets the human readable name defined for the enumeration <typeparamref name="T"/>.
+    /// </summary>
+    public static string GetName<T>() where T : struct, Enum => EnumMappingCache<T>.Name;
+
+    private static EnumMapping getEnumMapping(Type enumType)
+        => CACHE.GetOrAdd(enumType, EnumMapping.Create);
+
+    private static class EnumMappingCache<TEnum>
+        where TEnum : struct, Enum
     {
-        /// <summary>
-        /// Retrieves the literal value for the code represented by this enum value, or the member name itself if there
-        /// is no literal value defined.
-        /// </summary>
-        public static string GetLiteral(this Enum e) => getEnumMapping(e.GetType()).GetLiteral(e);
-
-        /// <summary>
-        /// Retrieves the literal value for the code represented by this enum <typeparamref name="T"/>, or the member name itself if there
-        /// is no literal value defined.
-        /// </summary>
-        public static string GetLiteral<T>(this T e) where T : struct, Enum => EnumMappingCache<T>.GetLiteral(e);
-
-        /// <summary>
-        /// Retrieves the literal value for the code represented by this nullable enum <typeparamref name="T"/>, or the member name itself if there
-        /// is no literal value defined, or null if the enum does not have a value.
-        /// </summary>
-        public static string? GetLiteral<T>(this T? e) where T : struct, Enum => e.HasValue ? e.Value.GetLiteral() : null;
-
-        /// <summary>
-        /// Retrieves the system canonical for the code represented by this enum value, or <c>null</c> if there is no system defined.
-        /// </summary>
-        public static string? GetSystem(this Enum e) => e.GetAttributeOnEnum<EnumLiteralAttribute>()?.System ?? e.GetType().GetCustomAttribute<FhirEnumerationAttribute>()?.DefaultCodeSystem;
-
-        /// <summary>
-        /// Retrieves the system canonical for the code represented by this enum <typeparamref name="T"/>, or <c>null</c> if there is no system defined.
-        /// </summary>
-        public static string? GetSystem<T>(this T e) where T : struct, Enum => EnumMappingCache<T>.GetSystem(e);
-
-        /// <summary>
-        /// Retrieves the description for this enum value or the enumeration value itself if there is no description defined.
-        /// </summary>
-        public static string GetDocumentation(this Enum e) =>
-            e.GetAttributeOnEnum<DescriptionAttribute>()?.Description ?? e.ToString();
-
-        private static readonly ConcurrentDictionary<Type, EnumMapping> CACHE = new();
-
-        /// <summary>
-        /// Finds an enumeration value from <paramref name="enumType"/> where the literal is the same as <paramref name="rawValue"/>.
-        /// </summary>
-        public static Enum? ParseLiteral(string? rawValue, Type enumType, bool ignoreCase = false)
-            => getEnumMapping(enumType).ParseLiteral(rawValue, ignoreCase);
-
-        /// <summary>
-        /// Finds an enumeration value from enum <typeparamref name="T"/> where the literal is the same as <paramref name="rawValue"/>.
-        /// </summary>
-        public static T? ParseLiteral<T>(string? rawValue, bool ignoreCase = false) where T : struct, Enum
-            => EnumMappingCache<T>.ParseLiteral(rawValue, ignoreCase);
-
-        /// <summary>
-        /// Gets the human readable name defined for the enumeration <paramref name="enumType"/>.
-        /// </summary>
-        public static string GetName(Type enumType) => getEnumMapping(enumType).Name;
-
-        /// <summary>
-        /// Gets the human readable name defined for the enumeration <typeparamref name="T"/>.
-        /// </summary>
-        public static string GetName<T>() where T : struct, Enum => EnumMappingCache<T>.Name;
-
-        private static EnumMapping getEnumMapping(Type enumType)
-            => CACHE.GetOrAdd(enumType, t => EnumMapping.Create(t));
-
-        private static class EnumMappingCache<TEnum>
-            where TEnum : struct, Enum
+        static EnumMappingCache()
         {
-            static EnumMappingCache()
+            var t = typeof(TEnum);
+            var enumAttr = t.GetTypeInfo().GetCustomAttribute<FhirEnumerationAttribute>();
+            Name = enumAttr?.BindingName ?? t.Name;
+            DefaultCodeSystem = enumAttr?.DefaultCodeSystem;
+            foreach (var enumValue in ReflectionHelper.FindEnumFields(t))
             {
-                var t = typeof(TEnum);
-                var enumAttr = t.GetTypeInfo().GetCustomAttribute<FhirEnumerationAttribute>();
-                Name = enumAttr?.BindingName ?? t.Name;
-                DefaultCodeSystem = enumAttr?.DefaultCodeSystem;
-                foreach (var enumValue in ReflectionHelper.FindEnumFields(t))
+                var attr = enumValue.GetCustomAttribute<EnumLiteralAttribute>();
+                string literal = attr?.Literal ?? enumValue.Name;
+
+                var value = (TEnum)enumValue.GetValue(null)!;
+
+                _enumToLiteral.Add(value, literal);
+                _literalToEnum.Add(literal, value);
+                _caseInsensitiveLiteralToEnum.Add(literal, value);
+                if (attr?.System is { } systemVal)
                 {
-                    var attr = enumValue.GetCustomAttribute<EnumLiteralAttribute>();
-                    string literal = attr?.Literal ?? enumValue.Name;
-
-                    var value = (TEnum)enumValue.GetValue(null)!;
-
-                    _enumToLiteral.Add(value, literal);
-                    _literalToEnum.Add(literal, value);
-                    _caseInsensitiveLiteralToEnum.Add(literal, value);
-                    if (attr?.System is { } systemVal)
-                    {
-                        _enumToSystem.Add(value, systemVal);
-                    }
+                    _enumToSystem.Add(value, systemVal);
                 }
-            }
-
-            public static string Name { get; }
-
-            public static string? DefaultCodeSystem { get; }
-
-            private static readonly Dictionary<string, TEnum> _literalToEnum = new();
-            private static readonly Dictionary<string, TEnum> _caseInsensitiveLiteralToEnum = new(StringComparer.OrdinalIgnoreCase);
-            private static readonly Dictionary<TEnum, string> _enumToLiteral = new();
-            private static readonly Dictionary<TEnum, string> _enumToSystem = new();
-
-            public static string? GetSystem(TEnum value) =>
-                !_enumToSystem.TryGetValue(value, out string? result)
-                    ? DefaultCodeSystem
-                    : result;
-
-            public static string GetLiteral(TEnum value) =>
-                !_enumToLiteral.TryGetValue(value, out string? result)
-                    ? throw new InvalidOperationException($"Should only pass enum values that are member of the given enum: {value} is not a member of {Name}.")
-                    : result;
-
-            public static TEnum? ParseLiteral(string? literal, bool ignoreCase)
-            {
-                if (literal is null) return null;
-
-                var success = ignoreCase
-                    ? _caseInsensitiveLiteralToEnum.TryGetValue(literal, out TEnum result)
-                    : _literalToEnum.TryGetValue(literal, out result);
-
-                return success ? result : null;
             }
         }
 
-        internal class EnumMapping
+        public static string Name { get; }
+
+        public static string? DefaultCodeSystem { get; }
+
+        private static readonly Dictionary<string, TEnum> _literalToEnum = new();
+        private static readonly Dictionary<string, TEnum> _caseInsensitiveLiteralToEnum = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<TEnum, string> _enumToLiteral = new();
+        private static readonly Dictionary<TEnum, string> _enumToSystem = new();
+
+        public static string? GetSystem(TEnum value) =>
+            !_enumToSystem.TryGetValue(value, out string? result)
+                ? DefaultCodeSystem
+                : result;
+
+        public static string GetLiteral(TEnum value) =>
+            !_enumToLiteral.TryGetValue(value, out string? result)
+                ? throw new InvalidOperationException($"Should only pass enum values that are member of the given enum: {value} is not a member of {Name}.")
+                : result;
+
+        public static TEnum? ParseLiteral(string? literal, bool ignoreCase)
         {
-            internal EnumMapping(string name, Type enumType)
+            if (literal is null) return null;
+
+            var success = ignoreCase
+                ? _caseInsensitiveLiteralToEnum.TryGetValue(literal, out TEnum result)
+                : _literalToEnum.TryGetValue(literal, out result);
+
+            return success ? result : null;
+        }
+    }
+
+    internal class EnumMapping
+    {
+        internal EnumMapping(string name, Type enumType)
+        {
+            Name = name;
+            EnumType = enumType;
+        }
+
+        // Symbolic name of the enumeration
+        public string Name { get; }
+
+        // .NET enumeration type
+        public Type EnumType { get; private set; }
+
+        private readonly Dictionary<string, Enum> _literalToEnum = new();
+        private readonly Dictionary<string, Enum> _caseInsensitiveLiteralToEnum = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<Enum, string> _enumToLiteral = new();
+
+        public string GetLiteral(Enum value) =>
+            !_enumToLiteral.TryGetValue(value, out string? result)
+                ? throw new InvalidOperationException($"Should only pass enum values that are member of the given enum: {value} is not a member of {Name}.")
+                : result;
+
+        public Enum? ParseLiteral(string? literal, bool ignoreCase)
+        {
+            if (literal is null) return null;
+
+            var success = ignoreCase
+                ? _caseInsensitiveLiteralToEnum.TryGetValue(literal, out Enum? result)
+                : _literalToEnum.TryGetValue(literal, out result);
+
+            return success ? result : null;
+        }
+
+        public static EnumMapping Create(Type enumType)
+        {
+            if (enumType is null) throw new ArgumentNullException(nameof(enumType));
+            if (!enumType.IsEnum) throw new ArgumentException($"Type {enumType.Name} is not an enumerated type", nameof(enumType));
+
+            var result = new EnumMapping(getEnumName(enumType), enumType);
+
+            foreach (var enumValue in ReflectionHelper.FindEnumFields(enumType))
             {
-                Name = name;
-                EnumType = enumType;
+                var attr = enumValue.GetCustomAttribute<EnumLiteralAttribute>();
+                string literal = attr?.Literal ?? enumValue.Name;
+                var value = (Enum)enumValue.GetValue(null)!;
+
+                result._enumToLiteral.Add(value, literal);
+                result._literalToEnum.Add(literal, value);
+                result._caseInsensitiveLiteralToEnum.Add(literal, value);
             }
 
-            // Symbolic name of the enumeration
-            public string Name { get; private set; }
+            return result;
 
-            // .NET enumeration type
-            public Type EnumType { get; private set; }
-
-            private readonly Dictionary<string, Enum> _literalToEnum = new();
-            private readonly Dictionary<string, Enum> _caseInsensitiveLiteralToEnum = new(StringComparer.OrdinalIgnoreCase);
-            private readonly Dictionary<Enum, string> _enumToLiteral = new();
-
-            public string GetLiteral(Enum value) =>
-                !_enumToLiteral.TryGetValue(value, out string? result)
-                    ? throw new InvalidOperationException($"Should only pass enum values that are member of the given enum: {value} is not a member of {Name}.")
-                    : result;
-
-            public Enum? ParseLiteral(string? literal, bool ignoreCase)
+            static string getEnumName(Type t)
             {
-                if (literal is null) return null;
-
-                var success = ignoreCase
-                    ? _caseInsensitiveLiteralToEnum.TryGetValue(literal, out Enum? result)
-                    : _literalToEnum.TryGetValue(literal, out result);
-
-                return success ? result : null;
-            }
-
-            public static EnumMapping Create(Type enumType)
-            {
-                if (enumType is null) throw new ArgumentNullException(nameof(enumType));
-                if (!enumType.IsEnum) throw new ArgumentException($"Type {enumType.Name} is not an enumerated type", nameof(enumType));
-
-                var result = new EnumMapping(getEnumName(enumType), enumType);
-
-                foreach (var enumValue in ReflectionHelper.FindEnumFields(enumType))
-                {
-                    var attr = enumValue.GetCustomAttribute<EnumLiteralAttribute>();
-                    string literal = attr?.Literal ?? enumValue.Name;
-                    var value = (Enum)enumValue.GetValue(null)!;
-
-                    result._enumToLiteral.Add(value, literal);
-                    result._literalToEnum.Add(literal, value);
-                    result._caseInsensitiveLiteralToEnum.Add(literal, value);
-                }
-
-                return result;
-
-                static string getEnumName(Type t)
-                {
-                    var attr = t.GetTypeInfo().GetCustomAttribute<FhirEnumerationAttribute>();
-                    return attr != null ? attr.BindingName : t.Name;
-                }
+                var attr = t.GetTypeInfo().GetCustomAttribute<FhirEnumerationAttribute>();
+                return attr != null ? attr.BindingName : t.Name;
             }
         }
     }
 }
-
-#nullable restore   

--- a/src/Hl7.Fhir.Base/Utility/FhirEnumerationAttribute.cs
+++ b/src/Hl7.Fhir.Base/Utility/FhirEnumerationAttribute.cs
@@ -33,35 +33,37 @@
 using Hl7.Fhir.Introspection;
 using System;
 
-namespace Hl7.Fhir.Utility
+namespace Hl7.Fhir.Utility;
+
+/// <summary>
+/// Specifies FHIR metadata for the ValueSet that this enum represents.
+/// </summary>
+[AttributeUsage(AttributeTargets.Enum)]
+public sealed class FhirEnumerationAttribute(
+    string bindingName,
+    string? canonical = null,
+    string? defaultCodeSystem = null)
+    : FhirModelAttribute
 {
-    [AttributeUsage(AttributeTargets.Enum, Inherited = false, AllowMultiple = false)]
-    public sealed class FhirEnumerationAttribute : FhirModelAttribute
+    public FhirEnumerationAttribute(string bindingName) : this(bindingName, null, null)
     {
-        private readonly string _bindingName;
-
-        // This is a positional argument
-        public FhirEnumerationAttribute(string bindingName, string? canonical = null, string? defaultCodeSystem = null)
-        {
-            this._bindingName = bindingName;
-            Valueset = canonical;
-            DefaultCodeSystem = defaultCodeSystem;
-        }
-
-        public FhirEnumerationAttribute(string bindingName) : this(bindingName, null, null)
-        {
-            // Nothing
-        }
-
-        public string BindingName
-        {
-            get { return _bindingName; }
-        }
-
-        public string? Valueset { get; }
-
-        public string? DefaultCodeSystem { get; }
+        // Nothing
     }
-}
 
-#nullable restore
+    /// <summary>
+    /// The binding name as used for this valueset in CQL.
+    /// </summary>
+    /// <remarks>This seems to be a mistake, since there is a one-to-many relationship between valueset
+    /// and binding, so this will probably be changed in the future.</remarks>
+    public string BindingName => bindingName;
+
+    /// <summary>
+    /// The canonical uri for the valueset that this enum represents.
+    /// </summary>
+    public string? Valueset { get; } = canonical;
+
+    /// <summary>
+    /// The default codesystem to use for members of this enumeration that do not have a codesystem specified.
+    /// </summary>
+    public string? DefaultCodeSystem { get; } = defaultCodeSystem;
+}

--- a/src/Hl7.Fhir.Base/Utility/PropertyInfoExtensions.cs
+++ b/src/Hl7.Fhir.Base/Utility/PropertyInfoExtensions.cs
@@ -14,210 +14,111 @@ using System.Reflection.Emit;
 
 #nullable enable
 
-namespace Hl7.Fhir.Utility
+namespace Hl7.Fhir.Utility;
+
+/// <summary>
+/// Utility methods for generating delegates to support the deserializer.
+/// </summary>
+public static class PropertyInfoExtensions
 {
+    // Will be set to true when we detect the platform has no codegen support.
+    // This happens the first time we catch a PlatformNotSupportedException.
+    public static bool NoCodeGenSupport { get; set; } = false;
+
     /// <summary>
-    /// Utility methods for generating delegates to support the deserializer.
+    /// Generates a function that creates an instance of the given type.
     /// </summary>
-    public static class PropertyInfoExtensions
+    public static Func<object> BuildFactoryMethod(this Type type)
     {
-        // Will be set to true when we detect the platform has no codegen support.
-        // This happens the first time we catch a PlatformNotSupportedException.
-        public static bool NoCodeGenSupport { get; set; } = false;
+        var ti = type.GetTypeInfo();
 
-        /// <summary>
-        /// Generates a function that creates an instance of the given type.
-        /// </summary>
-        public static Func<object> BuildFactoryMethod(this Type type)
+        if (!ti.IsClass) throw new NotSupportedException($"Can only create factory methods for classes (which {type} is not).");
+
+        var constructor = ti.GetConstructor(Type.EmptyTypes);
+        if (constructor is null) throw new NotSupportedException($"Cannot generate factory method for type {type}: there is no default constructor.");
+
+        try
         {
-            var ti = type.GetTypeInfo();
+            if (NoCodeGenSupport) return createInstance;
 
-            if (!ti.IsClass) throw new NotSupportedException($"Can only create factory methods for classes (which {type} is not).");
+            DynamicMethod getter = new($"{type.Name}_new", typeof(object), Type.EmptyTypes);
+            ILGenerator il = getter.GetILGenerator();
 
-            var constructor = ti.GetConstructor(Type.EmptyTypes);
-            if (constructor is null) throw new NotSupportedException($"Cannot generate factory method for type {type}: there is no default constructor.");
+            il.Emit(OpCodes.Newobj, constructor);
+            if (ti.IsValueType)
+                il.Emit(OpCodes.Box, type);
 
-            try
-            {
-                if (NoCodeGenSupport) return createInstance;
+            il.Emit(OpCodes.Ret);
 
-                DynamicMethod getter = new($"{type.Name}_new", typeof(object), Type.EmptyTypes);
-                ILGenerator il = getter.GetILGenerator();
-
-                il.Emit(OpCodes.Newobj, constructor);
-                if (ti.IsValueType)
-                    il.Emit(OpCodes.Box, type);
-
-                il.Emit(OpCodes.Ret);
-
-                return (Func<object>)getter.CreateDelegate(typeof(Func<object>));
-            }
-            catch (PlatformNotSupportedException)
-            {
-                NoCodeGenSupport = true;
-                return createInstance;
-            }
-
-            object createInstance() => Activator.CreateInstance(type)!;
+            return (Func<object>)getter.CreateDelegate(typeof(Func<object>));
+        }
+        catch (PlatformNotSupportedException)
+        {
+            NoCodeGenSupport = true;
+            return createInstance;
         }
 
-        /// <summary>
-        /// Generates a function that creates an instance of a list of the given type.
-        /// </summary>
-        /// <remarks>The returned instance will actually be of type <see cref="List{T}"/> where T is the given type.</remarks>
-        public static Func<IList> BuildListFactoryMethod(this Type type)
+        object createInstance() => Activator.CreateInstance(type)!;
+    }
+
+    /// <summary>
+    /// Generates a function that creates an instance of a list of the given type.
+    /// </summary>
+    /// <remarks>The returned instance will actually be of type <see cref="List{T}"/> where T is the given type.</remarks>
+    public static Func<IList> BuildListFactoryMethod(this Type type)
+    {
+        // Note that MakeGenericType() will return the same Type instance for the same List<T> type instantiations,
+        // so we don't have to cache the result.
+        var listType = typeof(List<>).MakeGenericType(type);
+        var constructor = listType.GetTypeInfo().GetConstructor(Type.EmptyTypes)
+                          ?? throw new ArgumentException($"Type {type.Name} does not have a parameterless constructor.");
+
+        try
         {
-            // Note that MakeGenericType() will return the same Type instance for the same List<T> type instantiations,
-            // so we don't have to cache the result.
-            var listType = typeof(List<>).MakeGenericType(type);
-            var constructor = listType.GetTypeInfo().GetConstructor(Type.EmptyTypes)
-                ?? throw new ArgumentException($"Type {type.Name} does not have a parameterless constructor.");
+            if (NoCodeGenSupport) return createList;
 
-            try
-            {
-                if (NoCodeGenSupport) return createList;
+            DynamicMethod getter = new($"new_list_of_{type.Name}", typeof(IList), Type.EmptyTypes);
+            ILGenerator il = getter.GetILGenerator();
 
-                DynamicMethod getter = new($"new_list_of_{type.Name}", typeof(IList), Type.EmptyTypes);
-                ILGenerator il = getter.GetILGenerator();
+            il.Emit(OpCodes.Newobj, constructor);
+            il.Emit(OpCodes.Ret);
 
-                il.Emit(OpCodes.Newobj, constructor);
-                il.Emit(OpCodes.Ret);
-
-                return (Func<IList>)getter.CreateDelegate(typeof(Func<IList>));
-            }
-            catch (PlatformNotSupportedException)
-            {
-                NoCodeGenSupport = true;
-                return createList;
-            }
-
-            IList createList() => (IList)Activator.CreateInstance(listType)!;
+            return (Func<IList>)getter.CreateDelegate(typeof(Func<IList>));
+        }
+        catch (PlatformNotSupportedException)
+        {
+            NoCodeGenSupport = true;
+            return createList;
         }
 
-        /// <summary>
-        /// Generates a function that, when passed an instance, gets the value of the given property.
-        /// </summary>
-        public static Func<T, object> GetValueGetter<T>(this PropertyInfo propertyInfo)
+        IList createList() => (IList)Activator.CreateInstance(listType)!;
+    }
+
+    public static Func<C, T> GetField<C, T>(string fieldName)
+    {
+        FieldInfo? field = typeof(C).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+        if (field is null) throw new ArgumentException($"Cannot find field {fieldName} in type {typeof(C).Name}.", nameof(fieldName));
+
+        try
         {
-            MethodInfo getMethod = propertyInfo.GetMethod ?? throw new InvalidOperationException($"Property {propertyInfo.Name} does not have a getter.");
+            if (NoCodeGenSupport) return getField;
 
-            if (typeof(T) != propertyInfo.DeclaringType && typeof(T) != typeof(object))
-                throw new ArgumentException("Generic param T should be the type of property's declaring class.", nameof(propertyInfo));
+            Type[] arguments = [typeof(C)];
+            DynamicMethod setter = new($"getField_{fieldName}", typeof(T), arguments, typeof(C), true);
+            ILGenerator il = setter.GetILGenerator();
 
-            try
-            {
-                if (NoCodeGenSupport) return getValue;
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, field);
+            il.Emit(OpCodes.Ret);
 
-                DynamicMethod getter = new($"{propertyInfo.Name}_get", typeof(object), new Type[] { typeof(object) },
-                    propertyInfo.DeclaringType!);
-
-                ILGenerator il = getter.GetILGenerator();
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Castclass, propertyInfo.DeclaringType!);
-                il.EmitCall(OpCodes.Callvirt, getMethod, null);
-
-                if (propertyInfo.PropertyType.GetTypeInfo().IsValueType)
-                    il.Emit(OpCodes.Box, propertyInfo.PropertyType);
-
-                il.Emit(OpCodes.Ret);
-
-                return (Func<T, object>)getter.CreateDelegate(typeof(Func<T, object>));
-            }
-            catch (PlatformNotSupportedException)
-            {
-                NoCodeGenSupport = true;
-                return getValue;
-            }
-
-            object getValue(T instance) => propertyInfo.GetValue(instance, null)!;
+            return (Func<C, T>)setter.CreateDelegate(typeof(Func<C, T>));
+        }
+        catch (PlatformNotSupportedException)
+        {
+            NoCodeGenSupport = true;
+            return getField;
         }
 
-        /// <summary>
-        /// Generates a function that, when passed an object instance, gets the value of the given property.
-        /// </summary>   
-        public static Func<object, object?> GetValueGetter(this PropertyInfo propertyInfo) =>
-            GetValueGetter<object?>(propertyInfo);
-
-        /// <summary>
-        /// Generates a function that, when passed an instance and a value, sets the value of the given property.
-        /// </summary>
-        public static Action<T, object?> GetValueSetter<T>(this PropertyInfo propertyInfo)
-        {
-            MethodInfo setMethod = propertyInfo.SetMethod ?? throw new InvalidOperationException($"Property {propertyInfo.Name} does not have a setter."); ;
-
-            if (typeof(T) != propertyInfo.DeclaringType && typeof(T) != typeof(object))
-                throw new ArgumentException("Generic param T should be the type of property's declaring class.", nameof(propertyInfo));
-
-            try
-            {
-                if (NoCodeGenSupport) return setValue;
-
-                Type[] arguments = new Type[] { typeof(object), typeof(object) };
-                DynamicMethod setter = new($"{propertyInfo.Name}_set", typeof(object), arguments, propertyInfo.DeclaringType!, true);
-                ILGenerator il = setter.GetILGenerator();
-
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Castclass, propertyInfo.DeclaringType!);
-                il.Emit(OpCodes.Ldarg_1);
-
-                if (propertyInfo.PropertyType.GetTypeInfo().IsClass)
-                    il.Emit(OpCodes.Castclass, propertyInfo.PropertyType);
-                else
-                    il.Emit(OpCodes.Unbox_Any, propertyInfo.PropertyType);
-
-                il.EmitCall(OpCodes.Callvirt, setMethod, null);
-                il.Emit(OpCodes.Ldarg_0);
-
-                il.Emit(OpCodes.Ret);
-
-                var del = (Func<T, object?, object>)setter.CreateDelegate(typeof(Func<T, object?, object>));
-                void actionDelegate(T obj, object? val) => del(obj, val);
-
-                return actionDelegate;
-            }
-            catch (PlatformNotSupportedException)
-            {
-                NoCodeGenSupport = true;
-                return setValue;
-            }
-
-            void setValue(T instance, object? value) => propertyInfo.SetValue(instance, value, null);
-        }
-
-        /// <summary>
-        /// Generates a function that, when passed an object instance and a value, sets the value of the given property.
-        /// </summary>
-        public static Action<object, object?> GetValueSetter(this PropertyInfo propertyInfo) => GetValueSetter<object>(propertyInfo);
-
-
-        public static Func<C, T> GetField<C, T>(string fieldName)
-        {
-            FieldInfo? field = typeof(C).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
-            if (field is null) throw new ArgumentException($"Cannot find field {fieldName} in type {typeof(C).Name}.", nameof(fieldName));
-
-            try
-            {
-                if (NoCodeGenSupport) return getField;
-
-                Type[] arguments = new Type[] { typeof(C) };
-                DynamicMethod setter = new($"getField_{fieldName}", typeof(T), arguments, typeof(C), true);
-                ILGenerator il = setter.GetILGenerator();
-
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldfld, field);
-                il.Emit(OpCodes.Ret);
-
-                return (Func<C, T>)setter.CreateDelegate(typeof(Func<C, T>));
-            }
-            catch (PlatformNotSupportedException)
-            {
-                NoCodeGenSupport = true;
-                return getField;
-            }
-
-            T getField(C instance) => (T)field.GetValue(instance)!;
-        }
+        T getField(C instance) => (T)field.GetValue(instance)!;
     }
 }
-
-#nullable restore

--- a/src/Hl7.Fhir.Base/Utility/ReflectionHelper.cs
+++ b/src/Hl7.Fhir.Base/Utility/ReflectionHelper.cs
@@ -8,6 +8,8 @@
 
 #nullable enable
 
+using Hl7.Fhir.Introspection;
+using Hl7.Fhir.Specification;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -17,17 +19,18 @@ using System.Reflection;
 
 namespace Hl7.Fhir.Utility;
 
+/// <summary>
+/// A set of helper methods to make working with the FHIR reflection model metadata easier.
+/// </summary>
 internal static class ReflectionHelper
 {
-    public static bool CanBeTreatedAsType(this Type? currentType, Type? typeToCompareWith)
-    {
-        // Always return false if either Type is null
-        if (currentType == null || typeToCompareWith == null)
-            return false;
-
-        // Return the result of the assignability test
-        return typeToCompareWith.IsAssignableFrom(currentType);
-    }
+    /// <summary>
+    /// Determines whether the specified type is a subclass of the type in <paramref name="typeToCompareWith"/>.
+    /// </summary>
+    /// <remarks>This function simply inverts the arguments for <see cref="Type.IsAssignableFrom(Type)"/>
+    /// for better readability.</remarks>
+    public static bool CanBeTreatedAsType(this Type currentType, Type typeToCompareWith) =>
+        typeToCompareWith.IsAssignableFrom(currentType);
 
     /// <summary>
     /// Gets an attribute on an enum field value
@@ -65,7 +68,7 @@ internal static class ReflectionHelper
     /// <returns>The type of the typed collection's items.</returns>
     public static Type GetRepeatingElementType(Type type) =>
         TryGetRepeatingElementType(type, out var itemType) ? itemType :
-            throw Error.Argument("type", "Type {0} is not a typed collection.".FormatWith(type.Name));
+            throw Error.Argument("type", $"Type {type.Name} is not a typed collection.");
 
     public static bool TryGetRepeatingElementType(Type type, [NotNullWhen(true)] out Type? itemType)
     {
@@ -101,4 +104,32 @@ internal static class ReflectionHelper
 
         return cleanedInformationalVersion;
     }
+
+    /// <summary>
+    /// Gets an attribute of <typeparamref name="T"/> or subclasses on a given member that is relevant for the
+    /// given <paramref name="version" />. Returns the last one if there are multiple matching attributes.
+    /// </summary>
+    public static T? GetFhirModelAttribute<T>(this MemberInfo t, FhirRelease version) where T : FhirModelAttribute =>
+        t.GetFhirModelAttributes<T>(version).LastOrDefault();
+
+    /// <summary>
+    /// Gets all attribute of <typeparamref name="T"/> or subclasses on a given member that is relevant for the
+    /// given <paramref name="version" />.
+    /// </summary>
+    public static IEnumerable<T> GetFhirModelAttributes<T>(this MemberInfo t, FhirRelease version) where T : FhirModelAttribute
+    {
+        return t.GetCustomAttributes<T>().Where(isRelevant).OrderBy(att => att.Since);
+
+        bool isRelevant(FhirModelAttribute a) => a.AppliesToRelease(version);
+    }
+
+    /// <summary>
+    /// Gets all <see cref="ValidatingFhirModelAttribute"/> attributes (including) subclasses on a given member
+    /// that is relevant for the given <paramref name="version" />. Will return at most one result per type of the attribute.
+    /// </summary>
+    public static IEnumerable<ValidatingFhirModelAttribute> GetValidatingAttributes(this MemberInfo t, FhirRelease version) =>
+        GetFhirModelAttributes<ValidatingFhirModelAttribute>(t, version)
+            .GroupBy(att => att.GetType())
+            .Select(g => g.LastOrDefault())
+            .OfType<ValidatingFhirModelAttribute>();
 }

--- a/src/Hl7.Fhir.Base/Utility/RequiredMemberAttribute.cs
+++ b/src/Hl7.Fhir.Base/Utility/RequiredMemberAttribute.cs
@@ -1,0 +1,21 @@
+#if NETSTANDARD2_1
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>Specifies that a type has required members or that a member is required.</summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class RequiredMemberAttribute : Attribute
+    { }
+}
+
+#endif

--- a/src/Hl7.Fhir.Base/Utility/SetsRequiredMembersAttribute.cs
+++ b/src/Hl7.Fhir.Base/Utility/SetsRequiredMembersAttribute.cs
@@ -1,0 +1,11 @@
+#if NETSTANDARD2_1
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis;
+
+/// <summary>Specifies that this constructor sets all required members for the current type, and callers do not need to set any required members themselves.</summary>
+[AttributeUsage(AttributeTargets.Constructor)]
+public sealed class SetsRequiredMembersAttribute : Attribute;
+
+#endif

--- a/src/Hl7.Fhir.Base/Validation/PocoValidationExtensions.cs
+++ b/src/Hl7.Fhir.Base/Validation/PocoValidationExtensions.cs
@@ -33,10 +33,10 @@ public static class PocoValidationExtensions
     /// <param name="validator"></param>
     public static IReadOnlyCollection<CodedValidationException> Validate(
         this Base poco,
+        ModelInspector inspector,
         NarrativeValidationKind narrativeValidation = NarrativeValidationKind.FhirXhtml,
-        ModelInspector? inspector = null, IPocoValidator? validator = null)
+        IPocoValidator? validator = null)
     {
-        inspector ??= ModelInspector.ForType(poco.GetType());
         validator ??= new FhirAttributeValidator();
         var validationContext = buildContext(poco, inspector, narrativeValidation);
 

--- a/src/Hl7.Fhir.Conformance/Specification/Source/Summary/ArtifactSummary.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Source/Summary/ArtifactSummary.cs
@@ -42,7 +42,7 @@ namespace Hl7.Fhir.Specification.Source
     public class ArtifactSummary : IArtifactSummaryPropertyBag
     {
         /// <summary>Returns an empty <see cref="ArtifactSummary"/> instance.</summary>
-        public static ArtifactSummary Empty => new ArtifactSummary(ArtifactSummaryPropertyBag.Empty, ModelInspector.ForAssembly(typeof(IModelInfo).Assembly));
+        public static ArtifactSummary Empty => new(ArtifactSummaryPropertyBag.Empty, ModelInspector.Base);
 
         // Note: omit leading underscore to be CLS compliant
         protected readonly IArtifactSummaryPropertyBag properties;

--- a/src/Hl7.Fhir.ElementModel.Shared.Tests/TypedElementToSourceNodeAdapterTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Shared.Tests/TypedElementToSourceNodeAdapterTests.cs
@@ -110,7 +110,7 @@ namespace Hl7.Fhir.ElementModel.Tests
             var poco = new Patient();
             poco.Extension.Add(new Extension("http://hl7.org/fhir/StructureDefinition/patient-birthTime", new FhirDateTime("2021-01-01T00:00:00Z")));
 
-            var result = poco.ToSourceNode(ModelInspector.ForType<Patient>());
+            var result = poco.ToSourceNode(ModelInfo.ModelInspector);
             result.Children("extension").First().Children("valueDateTime").First().Location.Should()
                 .Be(extensionValueSourceLocation,
                     "On a SourceNode from a TypedElement, a choice type should again have the same Location as if it was constructed as SourceNode");

--- a/src/Hl7.Fhir.Shared.Tests/ElementModel/PocoTypedElementTests.cs
+++ b/src/Hl7.Fhir.Shared.Tests/ElementModel/PocoTypedElementTests.cs
@@ -188,8 +188,7 @@ namespace Hl7.Fhir.Core.Tests.ElementModel
             var fiveWsProp = aResourceMapping.PropertyMappings.Where(p => p.FiveWs != null && p.FiveWs.StartsWith("FiveWs.subject")).FirstOrDefault();
             fiveWsProp.Should().NotBeNull("There should be a fiveW mapping for subject");
 
-            var subjectProp = fiveWsProp.GetValue(poco) as ResourceReference;
-
+            var subjectProp = poco[fiveWsProp.Name];
             Assert.AreEqual(poco.Subject, subjectProp);
         }
 

--- a/src/Hl7.Fhir.Shared.Tests/Introspection/FhirClassMappingTests.cs
+++ b/src/Hl7.Fhir.Shared.Tests/Introspection/FhirClassMappingTests.cs
@@ -84,7 +84,9 @@ namespace Hl7.Fhir.Tests.Introspection
         public void LoadsDependentSatelliteAssemblies()
         {
             var satellite = typeof(ModelInfo).Assembly;
+#pragma warning disable CS0618 // Type or member is obsolete
             var inspector = ModelInspector.ForAssembly(satellite);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             inspector.FindClassMapping(typeof(Patient)).Should().NotBeNull();
             inspector.FindClassMapping(typeof(StructureDefinition)).Should().NotBeNull();
@@ -98,7 +100,9 @@ namespace Hl7.Fhir.Tests.Introspection
         public void LoadsDependentConformanceAssemblies()
         {
             var satellite = typeof(StructureDefinition).Assembly;
+#pragma warning disable CS0618 // Type or member is obsolete
             var inspector = ModelInspector.ForAssembly(satellite);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             inspector.FindClassMapping(typeof(StructureDefinition)).Should().NotBeNull();
             inspector.FindClassMapping(typeof(ValueSet)).Should().NotBeNull();
@@ -110,9 +114,7 @@ namespace Hl7.Fhir.Tests.Introspection
         [TestMethod]
         public void FindsCorrectFhirVersion()
         {
-            var satellite = typeof(ModelInfo).Assembly;
-            IModelInfo mi = ModelInspector.ForAssembly(satellite);  // R5 is arbitrary here
-
+            var mi = ModelInfo.ModelInspector;  // R5 is arbitrary here
             mi.FhirVersion.Should().Be(ModelInfo.Version);
         }
     }

--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/ExternalTerminologyService.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/ExternalTerminologyService.cs
@@ -8,96 +8,92 @@
 
 #nullable enable
 
-using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using System;
 using System.Threading.Tasks;
 
-namespace Hl7.Fhir.Specification.Terminology
+namespace Hl7.Fhir.Specification.Terminology;
+
+/// <summary>
+/// An implementation of <see cref="ITerminologyService"/> that contacts an external terminology service using the <see cref="BaseFhirClient"/>.
+/// </summary>
+public class ExternalTerminologyService : ITerminologyService
 {
     /// <summary>
-    /// An implementation of <see cref="ITerminologyService"/> that contacts an external terminology service using the <see cref="BaseFhirClient"/>.
+    /// Construct an instance that uses the given client.
     /// </summary>
-    public class ExternalTerminologyService : ITerminologyService
+    /// <param name="client"></param>
+    public ExternalTerminologyService(BaseFhirClient client)
     {
-        /// <summary>
-        /// Construct an instance that uses the given client.
-        /// </summary>
-        /// <param name="client"></param>
-        public ExternalTerminologyService(BaseFhirClient client)
-        {
-            Endpoint = client;
-        }
+        Endpoint = client;
+    }
 
-        /// <summary>
-        /// The external service to reach out to.
-        /// </summary>
-        public BaseFhirClient Endpoint { get; set; }
+    /// <summary>
+    /// The external service to reach out to.
+    /// </summary>
+    public BaseFhirClient Endpoint { get; set; }
 
-        ///<inheritdoc />
-        public async Task<Parameters?> ValueSetValidateCode(Parameters parameters, string? id = null, bool useGet = false)
-        {
-            if (string.IsNullOrEmpty(id))
-                return await Endpoint.TypeOperationAsync<ValueSet>(RestOperation.VALIDATE_CODE, parameters, useGet).ConfigureAwait(false) as Parameters;
-            else
-                return await Endpoint.InstanceOperationAsync(constructUri<ValueSet>(id!), RestOperation.VALIDATE_CODE, parameters, useGet).ConfigureAwait(false) as Parameters;
-        }
+    ///<inheritdoc />
+    public async Task<Parameters?> ValueSetValidateCode(Parameters parameters, string? id = null, bool useGet = false)
+    {
+        if (string.IsNullOrEmpty(id))
+            return await Endpoint.TypeOperationAsync<ValueSet>(RestOperation.VALIDATE_CODE, parameters, useGet).ConfigureAwait(false) as Parameters;
+        else
+            return await Endpoint.InstanceOperationAsync(constructUri(FhirTypeNames.VALUESET_NAME,id), RestOperation.VALIDATE_CODE, parameters, useGet).ConfigureAwait(false) as Parameters;
+    }
 
-        ///<inheritdoc />
-        public async Task<Parameters?> CodeSystemValidateCode(Parameters parameters, string? id = null, bool useGet = false)
-        {
-            if (string.IsNullOrEmpty(id))
-                return await Endpoint.TypeOperationAsync<CodeSystem>(RestOperation.VALIDATE_CODE, parameters, useGet).ConfigureAwait(false) as Parameters;
-            else
-                return await Endpoint.InstanceOperationAsync(constructUri<CodeSystem>(id!), RestOperation.VALIDATE_CODE, parameters, useGet).ConfigureAwait(false) as Parameters;
-        }
+    ///<inheritdoc />
+    public async Task<Parameters?> CodeSystemValidateCode(Parameters parameters, string? id = null, bool useGet = false)
+    {
+        if (string.IsNullOrEmpty(id))
+            return await Endpoint.TypeOperationAsync<CodeSystem>(RestOperation.VALIDATE_CODE, parameters, useGet).ConfigureAwait(false) as Parameters;
+        else
+            return await Endpoint.InstanceOperationAsync(constructUri(FhirTypeNames.CODESYSTEM_NAME, id), RestOperation.VALIDATE_CODE, parameters, useGet).ConfigureAwait(false) as Parameters;
+    }
 
-        private static Uri constructUri<T>(string id) where T : Resource =>
-            ResourceIdentity.Build(ModelInspector.ForType<T>().GetFhirTypeNameForType(typeof(T)), id);
+    private static Uri constructUri(string resourceName, string id) =>
+        ResourceIdentity.Build(resourceName, id);
 
-        ///<inheritdoc />
-        public Task<Resource?> Expand(Parameters parameters, string? id = null, bool useGet = false)
-        {
-            if (string.IsNullOrEmpty(id))
-                return Endpoint.TypeOperationAsync<ValueSet>(RestOperation.EXPAND_VALUESET, parameters, useGet);
-            else
-                return Endpoint.InstanceOperationAsync(constructUri<ValueSet>(id!), RestOperation.EXPAND_VALUESET, parameters, useGet);
-        }
+    ///<inheritdoc />
+    public Task<Resource?> Expand(Parameters parameters, string? id = null, bool useGet = false)
+    {
+        if (string.IsNullOrEmpty(id))
+            return Endpoint.TypeOperationAsync<ValueSet>(RestOperation.EXPAND_VALUESET, parameters, useGet);
+        else
+            return Endpoint.InstanceOperationAsync(constructUri(FhirTypeNames.VALUESET_NAME,id), RestOperation.EXPAND_VALUESET, parameters, useGet);
+    }
 
-        ///<inheritdoc />
-        public async Task<Parameters?> Lookup(Parameters parameters, bool useGet = false)
-        {
-            return await Endpoint.TypeOperationAsync<CodeSystem>(RestOperation.CONCEPT_LOOKUP, parameters, useGet).ConfigureAwait(false) as Parameters;
-        }
+    ///<inheritdoc />
+    public async Task<Parameters?> Lookup(Parameters parameters, bool useGet = false)
+    {
+        return await Endpoint.TypeOperationAsync<CodeSystem>(RestOperation.CONCEPT_LOOKUP, parameters, useGet).ConfigureAwait(false) as Parameters;
+    }
 
-        ///<inheritdoc />
-        public async Task<Parameters?> Translate(Parameters parameters, string? id = null, bool useGet = false)
-        {
-            if (string.IsNullOrEmpty(id))
-                return await Endpoint.TypeOperationAsync(RestOperation.TRANSLATE, FhirTypeNames.CONCEPTMAP_NAME, parameters, useGet).ConfigureAwait(false) as Parameters;
-            else
-                return await Endpoint.InstanceOperationAsync(
-                    ResourceIdentity.Build(FhirTypeNames.CONCEPTMAP_NAME, id!),
+    ///<inheritdoc />
+    public async Task<Parameters?> Translate(Parameters parameters, string? id = null, bool useGet = false)
+    {
+        if (string.IsNullOrEmpty(id))
+            return await Endpoint.TypeOperationAsync(RestOperation.TRANSLATE, FhirTypeNames.CONCEPTMAP_NAME, parameters, useGet).ConfigureAwait(false) as Parameters;
+        else
+            return await Endpoint.InstanceOperationAsync(
+                    ResourceIdentity.Build(FhirTypeNames.CONCEPTMAP_NAME, id),
                     RestOperation.TRANSLATE, parameters, useGet)
-                    .ConfigureAwait(false) as Parameters;
-        }
+                .ConfigureAwait(false) as Parameters;
+    }
 
-        ///<inheritdoc />
-        public async Task<Parameters?> Subsumes(Parameters parameters, string? id = null, bool useGet = false)
-        {
-            if (string.IsNullOrEmpty(id))
-                return await Endpoint.TypeOperationAsync<CodeSystem>(RestOperation.SUBSUMES, parameters, useGet).ConfigureAwait(false) as Parameters;
-            else
-                return await Endpoint.InstanceOperationAsync(constructUri<CodeSystem>(id!), RestOperation.SUBSUMES, parameters, useGet).ConfigureAwait(false) as Parameters;
-        }
+    ///<inheritdoc />
+    public async Task<Parameters?> Subsumes(Parameters parameters, string? id = null, bool useGet = false)
+    {
+        if (string.IsNullOrEmpty(id))
+            return await Endpoint.TypeOperationAsync<CodeSystem>(RestOperation.SUBSUMES, parameters, useGet).ConfigureAwait(false) as Parameters;
+        else
+            return await Endpoint.InstanceOperationAsync(constructUri(FhirTypeNames.CODESYSTEM_NAME,id), RestOperation.SUBSUMES, parameters, useGet).ConfigureAwait(false) as Parameters;
+    }
 
-        /// <inheritdoc />
-        public Task<Resource?> Closure(Parameters parameters, bool useGet = false)
-        {
-            return Endpoint.WholeSystemOperationAsync(RestOperation.CLOSURE, parameters, useGet);
-        }
+    /// <inheritdoc />
+    public Task<Resource?> Closure(Parameters parameters, bool useGet = false)
+    {
+        return Endpoint.WholeSystemOperationAsync(RestOperation.CLOSURE, parameters, useGet);
     }
 }
-
-#nullable restore

--- a/src/Hl7.Fhir.Shims.STU3AndUp/Hl7.Fhir.Shims.STU3AndUp.projitems
+++ b/src/Hl7.Fhir.Shims.STU3AndUp/Hl7.Fhir.Shims.STU3AndUp.projitems
@@ -27,5 +27,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\PocoSerializationExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\FhirXmlPocoSerializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Specification\PocoStructureDefinitionSummaryProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Validation\PocoValidationExtensions.cs" />
   </ItemGroup>
 </Project>

--- a/src/Hl7.Fhir.Shims.STU3AndUp/Model/ModelInfo.cs
+++ b/src/Hl7.Fhir.Shims.STU3AndUp/Model/ModelInfo.cs
@@ -205,7 +205,9 @@ namespace Hl7.Fhir.Model
         {
             get
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 var inspector = ModelInspector.ForAssembly(typeof(ModelInfo).GetTypeInfo().Assembly);
+#pragma warning restore CS0618 // Type or member is obsolete
                 if (inspector.FhirRelease != Specification.FhirRelease.STU3)
                 {
                     // In case of release 4 or higher, also load the assembly with common conformance resources, like StructureDefinition

--- a/src/Hl7.Fhir.Shims.STU3AndUp/Validation/PocoValidationExtensions.cs
+++ b/src/Hl7.Fhir.Shims.STU3AndUp/Validation/PocoValidationExtensions.cs
@@ -1,0 +1,37 @@
+﻿/* 
+ * Copyright (c) 2014, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+using Hl7.Fhir.Introspection;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Utility;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
+#nullable enable
+
+namespace Hl7.Fhir.Validation;
+
+/// <summary>
+/// Extension methods on POCOs to invoke validation.
+/// </summary>
+public static class PocoValidationExtensions
+{
+    /// <summary>
+    /// Validate an object and its members against any <see cref="ValidationAttribute" />s present.
+    /// </summary>
+    /// <param name="poco">The POCO to validate</param>
+    /// <param name="narrativeValidation">The kind of narrative validation to perform when validating <see cref="XHtml"/>.</param>
+    /// <param name="validator"></param>
+    public static IReadOnlyCollection<CodedValidationException> Validate(
+        this Base poco,
+        NarrativeValidationKind narrativeValidation = NarrativeValidationKind.FhirXhtml,
+        IPocoValidator? validator = null) => poco.Validate(ModelInfo.ModelInspector, narrativeValidation, validator);
+}

--- a/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirJsonDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirJsonDeserializationTests.cs
@@ -44,7 +44,7 @@ public class FhirJsonDeserializationTests
 
         static (ClassMapping?, CodedException?) test(object? typename)
         {
-            var inspector = ModelInspector.ForAssembly(typeof(Resource).Assembly);
+            var inspector = ModelInspector.Base;
 
             var jsonBytes = typename != null
                 ? JsonSerializer.SerializeToUtf8Bytes(new { resourceType = typename })
@@ -93,7 +93,7 @@ public class FhirJsonDeserializationTests
 
         PrimitiveType test()
         {
-            var inspector = ModelInspector.ForType(typeof(Patient));
+            var inspector = ModelInfo.ModelInspector;
             var deserializer = new BaseFhirJsonDeserializer(inspector);
             var mapping = new ClassMappingDynamic(inspector.ImportType(targetType)!, null);
 
@@ -126,7 +126,7 @@ public class FhirJsonDeserializationTests
         FhirJsonConverterOptions settings)
     {
         // For the tests, enable full XHML validation so we can test it when necessary.
-        var deserializer = new BaseFhirJsonDeserializer(ModelInspector.ForType<Patient>(), settings);
+        var deserializer = new FhirJsonDeserializer(settings);
         Utf8JsonReader reader = constructReader(testObject);
         reader.Read();
 
@@ -161,7 +161,7 @@ public class FhirJsonDeserializationTests
         var reader = constructReader(testObject);
         reader.Read();
 
-        var deserializer = new BaseFhirJsonDeserializer(ModelInspector.ForType<Patient>());
+        var deserializer = new FhirJsonDeserializer();
         var state = new PocoDeserializerState();
         _ = deserializer.DeserializeResourceInternal(ref reader, state, stayOnLastToken: false);
         state.Errors.Select(err => err.ErrorCode).Should().BeEquivalentTo(errors);
@@ -474,7 +474,7 @@ public class FhirJsonDeserializationTests
         var errorsFileName = Path.Combine(fileDir, "fp-test-patient-errors-expected-json.txt");
         var jsonInput = File.ReadAllText(patientFileName);
 
-        var options = new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly);
+        var options = new JsonSerializerOptions().ForFhir();
         if (overwrite)
             options = options.Pretty();
 
@@ -572,7 +572,7 @@ public class FhirJsonDeserializationTests
     [TestMethod]
     public void JsonDeserializerSupportsUnknownPropertiesOnKnownTypes()
     {
-        var parser = new BaseFhirJsonDeserializer(ModelInspector.ForType<Patient>());
+        var parser = new FhirJsonDeserializer();
 
         var dt = DateTimeOffset.UtcNow;
         
@@ -601,7 +601,7 @@ public class FhirJsonDeserializationTests
     [TestMethod]
     public void JsonDeserializerHandleUnexpectedObject()
     {
-        var parser = new BaseFhirJsonDeserializer(ModelInspector.ForType<Patient>());
+        var parser = new FhirJsonDeserializer();
 
         var test = new
         {
@@ -625,7 +625,7 @@ public class FhirJsonDeserializationTests
     [TestMethod]
     public void JsonDeserializerHandleContainedStuff()
     {
-        var parser = new BaseFhirJsonDeserializer(ModelInspector.ForType<Patient>());
+        var parser = new FhirJsonDeserializer();
 
         var test = new
         {
@@ -712,7 +712,7 @@ public class FhirJsonDeserializationTests
     {
         var reader = constructReader(new { system = "http://nu.nl", value = "bla" });
 
-        var options = new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly);
+        var options = new JsonSerializerOptions().ForFhir();
 
         var identifier = JsonSerializer.Deserialize<Identifier>(ref reader, options)!;
         identifier.Should().BeOfType<Identifier>();
@@ -722,7 +722,7 @@ public class FhirJsonDeserializationTests
     [TestMethod]
     public void CanParseMixedClass()
     {
-        var options = new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly);
+        var options = new JsonSerializerOptions().ForFhir();
 
         var mc = new MixedClass
         {
@@ -862,7 +862,7 @@ public class FhirJsonDeserializationTests
     [DynamicData(nameof(getDuplicatePropertyTests), DynamicDataSourceType.Method)]
     public void TestDuplicateProperties(string testJson, string[] expectedErrs)
     {
-        var options = new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly);
+        var options = new JsonSerializerOptions().ForFhir();
 
         try
         {
@@ -888,7 +888,7 @@ public class FhirJsonDeserializationTests
 
         string expected = ERR.DUPLICATE_PROPERTY_CODE;
 
-        var jsonSerializerOptions = new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly);
+        var jsonSerializerOptions = new JsonSerializerOptions().ForFhir();
 
         try
         {
@@ -904,7 +904,7 @@ public class FhirJsonDeserializationTests
     [TestMethod]
     public void TestBackboneElementEmptyStack()
     {
-        var options = new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly);
+        var options = new JsonSerializerOptions().ForFhir();
 
         var bundleEntryComponent = new Parameters.ParameterComponent()
         {
@@ -926,31 +926,31 @@ public class FhirJsonDeserializationTests
     {
         yield return
         [
-            new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly)
+            new JsonSerializerOptions().ForFhir()
                 .UsingMode(DeserializationMode.Ostrich),
             new Predicate<IEnumerable<CodedException>>(errs => !errs.Any())
         ];
         yield return
         [
-            new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly)
+            new JsonSerializerOptions().ForFhir()
                 .UsingMode(DeserializationMode.Recoverable),
             new Predicate<IEnumerable<CodedException>>(errs => !errs.Any(e => CodedExceptionFilters.IsRecoverableIssue(e)))
         ];
         yield return
         [
-            new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly)
+            new JsonSerializerOptions().ForFhir()
                 .UsingMode(DeserializationMode.BackwardsCompatible),
             new Predicate<IEnumerable<CodedException>>(errs => !errs.Any(e => CodedExceptionFilters.IsBackwardsCompatibilityIssue(e)))
         ];
         yield return
         [
-            new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly)
+            new JsonSerializerOptions().ForFhir()
                 .Ignoring([COVE.INCORRECT_LITERAL_VALUE_TYPE_CODE]),
             new Predicate<IEnumerable<CodedException>>(errs => errs.All(e => e.ErrorCode != COVE.INCORRECT_LITERAL_VALUE_TYPE_CODE))
         ];
         yield return
         [
-            new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly).UsingMode(DeserializationMode.Ostrich)
+            new JsonSerializerOptions().ForFhir().UsingMode(DeserializationMode.Ostrich)
                 .Enforcing([ERR.ARRAYS_CANNOT_BE_EMPTY_CODE, COVE.LITERAL_INVALID_CODE]),
             new Predicate<IEnumerable<CodedException>>(errs =>
             {
@@ -989,7 +989,7 @@ public class FhirJsonDeserializationTests
         yield return
         [
             getPredicateFromOptions(new JsonSerializerOptions()
-                .ForFhir(typeof(Patient).Assembly)
+                .ForFhir()
                 .Ignoring([COVE.INCORRECT_LITERAL_VALUE_TYPE_CODE])
                 .Ignoring([ERR.ARRAYS_CANNOT_BE_EMPTY_CODE])
                 .Ignoring([COVE.INVALID_BASE64_VALUE_CODE])),
@@ -1000,7 +1000,7 @@ public class FhirJsonDeserializationTests
         yield return
         [
             getPredicateFromOptions(new JsonSerializerOptions()
-                .ForFhir(typeof(Patient).Assembly)
+                .ForFhir()
                 .Ignoring([COVE.INCORRECT_LITERAL_VALUE_TYPE_CODE])
                 .Enforcing([COVE.INCORRECT_LITERAL_VALUE_TYPE_CODE])),
             new Predicate<CodedException>(_ => false)
@@ -1008,7 +1008,7 @@ public class FhirJsonDeserializationTests
         yield return
         [
             getPredicateFromOptions(new JsonSerializerOptions()
-                .ForFhir(typeof(Patient).Assembly)
+                .ForFhir()
                 .Ignoring([COVE.INCORRECT_LITERAL_VALUE_TYPE_CODE])
                 .Enforcing([COVE.INCORRECT_LITERAL_VALUE_TYPE_CODE])
                 .Ignoring([COVE.INCORRECT_LITERAL_VALUE_TYPE_CODE])),
@@ -1018,7 +1018,7 @@ public class FhirJsonDeserializationTests
 
     private static IEnumerable<CodedException> getErrorsList()
     {
-        var testDeserializerOptions = new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly)
+        var testDeserializerOptions = new JsonSerializerOptions().ForFhir()
             .UsingMode(DeserializationMode.Strict);
         string testJson = File.ReadAllText(Path.Combine("TestData", "fp-test-patient-errors.json"));
 

--- a/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirJsonSerializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirJsonSerializationTests.cs
@@ -13,7 +13,7 @@ namespace Hl7.Fhir.Support.Poco.Tests
     [TestClass]
     public class FhirJsonSerializationTests
     {
-        public JsonSerializerOptions BaseOptions = new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly);
+        public JsonSerializerOptions BaseOptions = new JsonSerializerOptions().ForFhir();
 
         private (Patient, string) getEdgecases()
         {
@@ -29,7 +29,7 @@ namespace Hl7.Fhir.Support.Poco.Tests
         {
             var (poco, expected) = getEdgecases();
 
-            var options = new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly).Pretty();
+            var options = new JsonSerializerOptions().ForFhir().Pretty();
 
             string actual = JsonSerializer.Serialize(poco, options);
 
@@ -43,11 +43,11 @@ namespace Hl7.Fhir.Support.Poco.Tests
         {
             var (poco, _) = getEdgecases();
 
-            var optionsCompact = new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly);
+            var optionsCompact = new JsonSerializerOptions().ForFhir();
             string compact = JsonSerializer.Serialize(poco, optionsCompact);
             var compactWS = compact.Where(c => char.IsWhiteSpace(c)).Count();
 
-            var optionsPretty = new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly).Pretty();
+            var optionsPretty = new JsonSerializerOptions().ForFhir().Pretty();
             string pretty = JsonSerializer.Serialize(poco, optionsPretty);
             var prettyWS = pretty.Where(c => char.IsWhiteSpace(c)).Count();
 
@@ -58,7 +58,7 @@ namespace Hl7.Fhir.Support.Poco.Tests
         [TestMethod]
         public void SerializesInvalidData()
         {
-            var options = new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly);
+            var options = new JsonSerializerOptions().ForFhir();
 
             var b = new FhirBoolean() { JsonValue = "treu" };
             var pInvalid = new Patient { ActiveElement = b };

--- a/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirSerializationEngineTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirSerializationEngineTests.cs
@@ -13,7 +13,7 @@ namespace Hl7.Fhir.Support.Poco.Tests;
 [TestClass]
 public class FhirSerializationEngineTests
 {
-    private static readonly ModelInspector TESTINSPECTOR = ModelInspector.ForType(typeof(Patient));
+    private static readonly ModelInspector TESTINSPECTOR = ModelInfo.ModelInspector;
 
     // Shared test data for EM+Poco
     private const string CORRECTXML = """<Patient xmlns="http://hl7.org/fhir"><active value="true"  /></Patient>""";

--- a/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirXmlDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirXmlDeserializationTests.cs
@@ -585,8 +585,7 @@ namespace Hl7.Fhir.Support.Poco.Tests
             return reader;
         }
 
-        private static BaseFhirXmlDeserializer getTestDeserializer(DeserializerSettings settings) =>
-                new(ModelInspector.ForType<Patient>(), settings);
+        private static FhirXmlDeserializer getTestDeserializer(DeserializerSettings settings) => new(settings);
         
         [TestMethod]
         public void TestDateTimeStuff()

--- a/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirXmlSerializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/FhirXmlSerializationTests.cs
@@ -24,7 +24,7 @@ namespace Hl7.Fhir.Support.Poco.Tests
 
             // For now, deserialize with the existing deserializer, until we have completed
             // the dynamicserializer too.
-            return (FhirXmlNode.Parse(expected).ToPoco<Patient>(ModelInspector.ForType<Patient>()), expected);
+            return (FhirXmlNode.Parse(expected).ToPoco<Patient>(), expected);
         }
 
         [TestMethod]

--- a/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/SummaryFilterIntegrationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/SummaryFilterIntegrationTests.cs
@@ -59,12 +59,12 @@ namespace Hl7.Fhir.Support.Poco.Tests
                 ));
 
             var options = new JsonSerializerOptions()
-                .ForFhir(typeof(Patient).Assembly, new FhirJsonConverterOptions { SummaryFilter = filter })
+                .ForFhir(new FhirJsonConverterOptions { SummaryFilter = filter })
                 .Pretty();
             string actual = JsonSerializer.Serialize(b, options);
 
             // Root bundle should not have been filtered at all
-            var bp = FhirJsonNode.Parse(actual).ToPoco<Bundle>(ModelInspector.ForType<Patient>());
+            var bp = FhirJsonNode.Parse(actual).ToPoco<Bundle>();
             assertIdentifier(bp.Identifier);
             bp.Type.Value.Should().Be(Bundle.BundleType.Batch);
             bp.Count().Should().Be(4);
@@ -88,7 +88,7 @@ namespace Hl7.Fhir.Support.Poco.Tests
 
             // Non-bundle root resources should be filtered normally too 
             actual = JsonSerializer.Serialize(p, options);
-            pat = FhirJsonNode.Parse(actual).ToPoco<Patient>(ModelInspector.ForType<Patient>());
+            pat = FhirJsonNode.Parse(actual).ToPoco<Patient>();
             pat.Count().Should().Be(1);
             pat.Communication.Should().NotBeNull();
 
@@ -105,7 +105,7 @@ namespace Hl7.Fhir.Support.Poco.Tests
         public void AllSummaryIndeed()
         {
             var (_, summarized) = runSummarize<CodeSystem>("mask-text.xml", SerializationFilter.ForSummary());
-            var codeSystemCm = ModelInspector.ForAssembly(typeof(Patient).Assembly).FindClassMapping(typeof(CodeSystem))!;
+            var codeSystemCm = ModelInfo.ModelInspector.FindClassMapping(typeof(CodeSystem))!;
 
             summarized.EnumerateElements().All(element => codeSystemCm.FindMappedElementByName(element.Key)!.InSummary).Should().BeTrue();
             summarized.Count().Should().BeLessThan(codeSystemCm.PropertyMappings.Count(pm => pm.InSummary));
@@ -157,14 +157,14 @@ namespace Hl7.Fhir.Support.Poco.Tests
         private (T full, T summarized) runSummarize<T>(string filename, SerializationFilter filter) where T : Resource
         {
             var fullXml = File.ReadAllText(Path.Combine("TestData", filename));
-            var full = FhirXmlNode.Parse(fullXml).ToPoco<T>(ModelInspector.ForType<T>());
+            var full = FhirXmlNode.Parse(fullXml).ToPoco<T>();
 
             var options = new JsonSerializerOptions()
-                .ForFhir(typeof(Patient).Assembly, new FhirJsonConverterOptions { SummaryFilter = filter })
+                .ForFhir(new FhirJsonConverterOptions { SummaryFilter = filter })
                 .Pretty();
             string summarizedJson = JsonSerializer.Serialize(full, options);
 
-            var summarized = FhirJsonNode.Parse(summarizedJson).ToPoco<T>(ModelInspector.ForType<T>());
+            var summarized = FhirJsonNode.Parse(summarizedJson).ToPoco<T>();
 
             return (full, summarized);
         }

--- a/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/SummaryFilterTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/NewPocoSerializers/SummaryFilterTests.cs
@@ -16,7 +16,7 @@ namespace Hl7.Fhir.Support.Poco.Tests
             var epf = new ElementPrefixFilter("elem");
             var bf = new BundleFilter(epf);
 
-            var inspector = ModelInspector.ForAssembly(typeof(Organization).Assembly);
+            var inspector = ModelInfo.ModelInspector;
 
             bf.EnterObject(null, inspector.FindClassMapping("Bundle"));
             bf.TryEnterMember("bundleElement", null, null).Should().BeTrue();

--- a/src/Hl7.Fhir.Support.Poco.Tests/Rest/FhirClientMockTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Rest/FhirClientMockTests.cs
@@ -25,7 +25,7 @@ namespace Hl7.Fhir.Core.Tests.Rest
     [TestClass]
     public class FhirClientMockTest
     {
-        private static readonly ModelInspector TESTINSPECTOR = ModelInspector.ForType(typeof(Patient));
+        private static readonly ModelInspector TESTINSPECTOR = ModelInfo.ModelInspector;
         private static readonly string TESTVERSION = "3.0.1";
 
         private static async Task mockVersionResponse(string capabilityStatementResponseJson, string patientResponseJson, bool verifyFhirVersion = true)

--- a/src/Hl7.Fhir.Support.Poco.Tests/Rest/RequestMessageTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Rest/RequestMessageTests.cs
@@ -32,7 +32,7 @@ namespace Hl7.Fhir.Test
     public class RequestMessageTests
     {
         private static readonly Uri ENDPOINT = new("http://myserver.org/fhir/");
-        private static readonly ModelInspector TESTINSPECTOR = ModelInspector.ForType(typeof(Patient));
+        private static readonly ModelInspector TESTINSPECTOR = ModelInfo.ModelInspector;
         private static readonly IFhirSerializationEngine TESTENGINE = FhirSerializationEngineFactory.Strict(TESTINSPECTOR);
         private static readonly string TESTVERSION = "3.0.1";
 

--- a/src/Hl7.Fhir.Support.Poco.Tests/Rest/ResponseMessageTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Rest/ResponseMessageTests.cs
@@ -29,7 +29,7 @@ namespace Hl7.Fhir.Test
     public class ResponseMessageTests
     {
         private static readonly Uri ENDPOINT = new("http://myserver.org/fhir/");
-        private static readonly ModelInspector TESTINSPECTOR = ModelInspector.ForType(typeof(Patient));
+        private static readonly ModelInspector TESTINSPECTOR = ModelInfo.ModelInspector;
         private static readonly IFhirSerializationEngine ELEMENTENGINE = FhirSerializationEngineFactory.Legacy.Permissive(TESTINSPECTOR);
         private static readonly IFhirSerializationEngine POCOENGINE = FhirSerializationEngineFactory.Strict(TESTINSPECTOR);
 

--- a/src/Hl7.Fhir.Support.Poco.Tests/Rest/SubstituteBuilder.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Rest/SubstituteBuilder.cs
@@ -15,7 +15,7 @@ namespace Hl7.Fhir.Core.Tests.Rest
 {
     public class SubstituteBuilder
     {
-        private static readonly ModelInspector TESTINSPECTOR = ModelInspector.ForType(typeof(Patient));
+        private static readonly ModelInspector TESTINSPECTOR = ModelInfo.ModelInspector;
         private static readonly string TESTVERSION = "3.0.1";
 
         private TestHttpMessageHandler Instance { get; } = Substitute.For<TestHttpMessageHandler>();

--- a/src/Hl7.Fhir.Support.Tests/FhirPath/FhirPathTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/FhirPath/FhirPathTests.cs
@@ -75,10 +75,10 @@ namespace Hl7.Fhir.Support.Tests
             var xml = "<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"item\" /><valueString value=\"test\"/></parameter></Parameters>";
             var sourceNode = FhirXmlNode.Parse(xml);
 
-            yield return new object[] { sourceNode.ToTypedElement(ModelInspector.ForAssembly(typeof(Resource).Assembly)), "sourceNode to TypedElement" };
+            yield return [sourceNode.ToTypedElement(ModelInspector.Base), "sourceNode to TypedElement"];
 
             var poco = sourceNode.ToPoco<Parameters>(ModelInspector.Base);
-            yield return new object[] { poco.ToTypedElement(ModelInspector.Base), "poco to TypedElement" };
+            yield return [poco.ToTypedElement(ModelInspector.Base), "poco to TypedElement"];
         }
 
         public static IEnumerable<object[]> LowBoundaryTestCases() =>

--- a/src/Hl7.Fhir.Support.Tests/Introspection/ModelInspectorTest.cs
+++ b/src/Hl7.Fhir.Support.Tests/Introspection/ModelInspectorTest.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Introspection;
+using Hl7.Fhir.Specification;
 using Hl7.Fhir.Utility;
 
 namespace Hl7.Fhir.Tests.Introspection
@@ -73,6 +74,24 @@ namespace Hl7.Fhir.Tests.Introspection
             Assert.IsNull(codeOfT);
         }
 
+        [TestMethod]
+        public void CanManipulateClassMappingsList()
+        {
+            var inspector = new ModelInspector(FhirRelease.STU3);
+
+            // Inspect the HL7.Fhir.Model common assembly
+            inspector.Import(typeof(Resource).GetTypeInfo().Assembly);
+
+            // Try to remove a mapping
+            var metaMapping = inspector.FindClassMapping("Meta");
+            inspector.ClassMappings.Remove(metaMapping);
+            inspector.FindClassMapping("Meta").Should().BeNull();
+
+            // And add it back.
+            ClassMapping.TryGetMappingForType(typeof(Meta), FhirRelease.STU3, out var newMapping).Should().BeTrue();
+            inspector.ClassMappings.Add(newMapping);
+            inspector.FindClassMapping("Meta").Should().NotBeNull();
+        }
     }
 
     [FhirEnumeration("SomeEnum")]

--- a/src/Hl7.Fhir.Support.Tests/Utility/CodeGenTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/Utility/CodeGenTests.cs
@@ -26,35 +26,5 @@ namespace Hl7.Fhir.Utility.Tests
 
         internal PropertyInfo UrlPropInfo = typeof(Extension).GetProperty("Url");
         internal PropertyInfo ValuePropInfo = typeof(Extension).GetProperty("Value");
-
-        [TestMethod]
-        public void GetterSetterNetPrimitive()
-        {
-            var testee = new Extension();
-
-            var urlSetter = UrlPropInfo.GetValueSetter<Extension>();
-            urlSetter(testee, "test");
-
-            var urlGetter = UrlPropInfo.GetValueGetter<Extension>();
-            urlGetter(testee).Should().Be("test");
-
-            // These tests run against a target that support codegen.
-            PropertyInfoExtensions.NoCodeGenSupport.Should().BeFalse();
-        }
-
-        [TestMethod]
-        public void GetterSetterNetComplex()
-        {
-            var testee = new Extension();
-
-            var valueSetter = ValuePropInfo.GetValueSetter<Extension>();
-            valueSetter(testee, new FhirDecimal(3.14m));
-
-            var valueGetter = ValuePropInfo.GetValueGetter<Extension>();
-            valueGetter(testee).Should().BeOfType<FhirDecimal>().Which.Value.Should().Be(3.14m);
-
-            // These tests run against a target that support codegen.
-            PropertyInfoExtensions.NoCodeGenSupport.Should().BeFalse();
-        }
     }
 }


### PR DESCRIPTION
## Description
In the future, we want to expand on our overflow support by allowing users to add custom classmappings. This is also useful for pre-generated classmappings, as piloted by @almostchristian. To prepare, I have cherry-picked from work in #2820 and branch 6.0/refactor-classmappings, so we at least support pre-generated mappings. It will also prepare 6.0 for as much as possible to fully support manual classmappings.

## Related issues
Cherry picked from #2820, fixes #3087.
