### PR TITLE
Add satellite ToPocoNode method

### DIFF
--- a/src/Hl7.Fhir.Shims.STU3AndUp/ElementModel/VersionedConversionExtensions.cs
+++ b/src/Hl7.Fhir.Shims.STU3AndUp/ElementModel/VersionedConversionExtensions.cs
@@ -57,4 +57,7 @@ public static class VersionedConversionExtensions
 
     public static T ToPoco<T>(this ITypedElement element, PocoBuilderSettings? settings = null) where T : Base =>
         (T)element.ToPoco(ModelInfo.ModelInspector, settings);
+    
+    public static PocoNode ToPocoNode(this ITypedElement node) =>
+        node.ToPocoNode(ModelInfo.ModelInspector);
 }


### PR DESCRIPTION
## Description
Added ToPocoNode method to sattelite methods to automatically infer the modelInspector when running version-specific code

(I hope this does not give trouble with ambiguity)