### PR TITLE
Check assignability in property validation

### DIFF
--- a/src/Hl7.Fhir.Base/Validation/FhirAttributeValidator.cs
+++ b/src/Hl7.Fhir.Base/Validation/FhirAttributeValidator.cs
@@ -52,11 +52,8 @@ public class FhirAttributeValidator : IPocoValidator
         // if(propertyValue is IReadOnlyCollection<IDynamicType> dtCollection && dtCollection.FirstOrDefault() is { DynamicTypeName: not null } dte)
         //     return [CodedValidationException.CHOICE_TYPE_NOT_ALLOWED(context, dte.DynamicTypeName)];
 
-        // if we have no allowed types attribute, we should still check against the implementing type, in case someone messed with the model (overflow)
-        if (
-            !propertyMapping.ValidationAttributes.Any(attr => attr is AllowedTypesAttribute) && 
-            !propertyMapping.PropertyType.IsInstanceOfType(propertyValue)
-        )
+        // check whether the value is assignable to the property, we'll complain in runAttributeValidation about other issues
+        if (!propertyMapping.PropertyType.IsInstanceOfType(propertyValue))
         {
             return [
                 CodedValidationException.FromTypes(propertyMapping.PropertyType, propertyValue, context),

--- a/src/Hl7.Fhir.Shared.Tests/Validation/ValidationTests_LowLevelApi.cs
+++ b/src/Hl7.Fhir.Shared.Tests/Validation/ValidationTests_LowLevelApi.cs
@@ -90,6 +90,16 @@ public class ValidationTests_LowLevelApi
         assertPropertyValidationErrors(p.Meta, "tag"); // throws no errors because this code validation is not run here
     }
 
+    [TestMethod]
+    public void ValidatesInvalidListType()
+    {
+        const string prop = "profile";
+        var meta = new Meta();
+        meta.SetValue(prop, new List<FhirUri>());
+
+        assertPropertyValidationErrors(meta, prop, "PVAL127");
+    }
+
     [DataTestMethod]
     [DataRow("urn:oid:1.2.3", null)]
     [DataRow("urn:oid:datmagdusniet", CodedValidationException.LITERAL_INVALID_CODE)]


### PR DESCRIPTION
## Description
Default to just assignability check, the AllowedTypes will be checked anyway in both cases.

## Related issues
Closes #3141 