### PR TITLE
Improve resolution of ID-based local references

### DIFF
--- a/src/Hl7.Fhir.Base/Model/PocoNodeExtensions.cs
+++ b/src/Hl7.Fhir.Base/Model/PocoNodeExtensions.cs
@@ -62,9 +62,9 @@ public static class PocoNodeExtensions
                 return true;
             }
 
-            if (scan.Child<PrimitiveNode>("id")?.Value is string s && s == identity.Id)
+            if (scan.Child<PrimitiveNode>("id")?.Value is string s && s == identity.Id && scan.Poco.TypeName == identity.ResourceType)
             {
-                // if we encounter a resource with the correct id, return it
+                // if we encounter a resource with the correct id and type, return it
                 result = scan;
                 return true;
             }

--- a/src/Hl7.Fhir.Base/Model/PocoNodeExtensions.cs
+++ b/src/Hl7.Fhir.Base/Model/PocoNodeExtensions.cs
@@ -62,7 +62,7 @@ public static class PocoNodeExtensions
                 return true;
             }
 
-            if (scan.Child<PrimitiveNode>("id")?.Value is string s && s == identity.Id && scan.Poco.TypeName == identity.ResourceType)
+            if (scan.Child<PrimitiveNode>("id")?.Value is string s && s == identity.Id && (identity.ResourceType is null || scan.Poco.TypeName == identity.ResourceType))
             {
                 // if we encounter a resource with the correct id and type, return it
                 result = scan;


### PR DESCRIPTION
## Description
Our recent changes in the logic behind the resolution of local references seem to have had a small regression: when there are duplicate ID's, but WITHOUT duplicate resource types, the reference is ambiguous and will resolve to whichever is found first, even if the unique resource type is specified. This PR addresses that behaviour.