### PR TITLE
Expose MemberName by passing it through the ValidationContext

### DIFF
--- a/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
+++ b/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
@@ -3048,6 +3048,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Validation.CodedValidationException.#ctor(System.String,System.String,System.String,System.Nullable{System.Int64},System.Nullable{System.Int64},Hl7.Fhir.Model.OperationOutcome.IssueSeverity,Hl7.Fhir.Model.OperationOutcome.IssueType)</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Hl7.FhirPath.CompiledExpression.BeginInvoke(Hl7.Fhir.Model.IScopedNode,Hl7.FhirPath.EvaluationContext,System.AsyncCallback,System.Object)</Target>
     <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
     <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
@@ -5366,6 +5373,13 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Hl7.Fhir.Utility.SerializationUtil.WriteXmlToStringAsync(System.Func{System.Xml.XmlWriter,System.Threading.Tasks.Task},System.Boolean,System.Boolean)</Target>
+    <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Hl7.Fhir.Validation.CodedValidationException.#ctor(System.String,System.String,System.String,System.Nullable{System.Int64},System.Nullable{System.Int64},Hl7.Fhir.Model.OperationOutcome.IssueSeverity,Hl7.Fhir.Model.OperationOutcome.IssueType)</Target>
     <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
     <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonDeserializer.cs
@@ -291,20 +291,19 @@ public class BaseFhirJsonDeserializer
         
         if (Settings.Validator is not null)
         {
+            var elementName = propertyMapping?.Name ?? name;
             var deserializationContext = new PocoValidationContext(
                 target,
                 _inspector,
                 state.Path.GetInstancePath,
                 line, pos,
                 Settings.NarrativeValidation
-            );
+            ) { MemberName = elementName };
 
             // If this is a FhirPrimitive, make sure we delay validation until we had the
             // chance to encounter both the `name` and `_name` property.
             if (propertyValueMapping?.Original.IsFhirPrimitive is true || forceDelayedValidation)
             {
-                var elementName = propertyMapping?.Name ?? name;
-
                 delayedValidations.ScheduleDelayedValidation(
                     elementName + PROPERTY_VALIDATION_KEY_SUFFIX,
                     () =>

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
@@ -304,7 +304,8 @@ public class BaseFhirXmlDeserializer
                 _inspector,
                 state.Path.GetInstancePath, // should this path GetPath or this?
                 lineNumber, position,
-                Settings.NarrativeValidation);
+                Settings.NarrativeValidation)
+                { MemberName = propName };
 
             state.Errors.Add(Settings.Validator.ValidateProperty(elementName, newPropValue, propMapping, context));
         }

--- a/src/Hl7.Fhir.Base/Validation/CodedValidationException.cs
+++ b/src/Hl7.Fhir.Base/Validation/CodedValidationException.cs
@@ -139,7 +139,7 @@ public class CodedValidationException : ExtendedCodedException
             code, message, path,
             context?.LineNumber, context?.LinePosition, 
             issueSeverity, issueType,
-            context?.MemberName ?? memberName);
+            memberName ?? context?.MemberName);
 
         return codedException;
     }

--- a/src/Hl7.Fhir.Base/Validation/CodedValidationException.cs
+++ b/src/Hl7.Fhir.Base/Validation/CodedValidationException.cs
@@ -18,6 +18,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using COVE = Hl7.Fhir.Validation.CodedValidationException;
 using OO_Sev = Hl7.Fhir.Model.OperationOutcome.IssueSeverity;
 using OO_Typ = Hl7.Fhir.Model.OperationOutcome.IssueType;
@@ -130,7 +131,7 @@ public class CodedValidationException : ExtendedCodedException
         MemberName = memberName;
     }
 
-    internal static COVE Initialize(PocoValidationContext? context, string code, string message, OperationOutcome.IssueSeverity issueSeverity, OperationOutcome.IssueType issueType)
+    internal static COVE Initialize(PocoValidationContext? context, string code, string message, OperationOutcome.IssueSeverity issueSeverity, OperationOutcome.IssueType issueType, string? memberName = null)
     {
         var path = context?.PathProducer.Invoke();
 
@@ -138,7 +139,7 @@ public class CodedValidationException : ExtendedCodedException
             code, message, path,
             context?.LineNumber, context?.LinePosition, 
             issueSeverity, issueType,
-            context?.MemberName);
+            context?.MemberName ?? memberName);
 
         return codedException;
     }
@@ -148,7 +149,7 @@ public class CodedValidationException : ExtendedCodedException
     /// </summary>
     public string? MemberName { get; init; }
 
-    internal static COVE FromTypes(Type expected, object? actual, PocoValidationContext? context = null)
+    internal static COVE FromTypes(Type expected, object? actual, PocoValidationContext? context = null, [CallerMemberName] string memberName = "")
     {
         bool expectedList = typeof(IList).IsAssignableFrom(expected);
         bool actualList = actual is IList;

--- a/src/Hl7.Fhir.Base/Validation/CodedValidationException.cs
+++ b/src/Hl7.Fhir.Base/Validation/CodedValidationException.cs
@@ -123,10 +123,11 @@ public class CodedValidationException : ExtendedCodedException
         long? lineNumber,
         long? position,
         OperationOutcome.IssueSeverity issueSeverity,
-        OperationOutcome.IssueType issueType) :
+        OperationOutcome.IssueType issueType,
+        string? memberName) :
         base(errorCode, baseMessage, instancePath, lineNumber, position, issueSeverity, issueType)
     {
-        // Nothing
+        MemberName = memberName;
     }
 
     internal static COVE Initialize(PocoValidationContext? context, string code, string message, OperationOutcome.IssueSeverity issueSeverity, OperationOutcome.IssueType issueType)
@@ -134,14 +135,18 @@ public class CodedValidationException : ExtendedCodedException
         var path = context?.PathProducer.Invoke();
 
         var codedException = new COVE(
-            code,
-            message,
-            path,
-            context?.LineNumber,
-            context?.LinePosition, issueSeverity, issueType);
+            code, message, path,
+            context?.LineNumber, context?.LinePosition, 
+            issueSeverity, issueType,
+            context?.MemberName);
 
         return codedException;
     }
+    
+    /// <summary>
+    /// Name of member property on which the error was encountered.
+    /// </summary>
+    public string? MemberName { get; init; }
 
     internal static COVE FromTypes(Type expected, object? actual, PocoValidationContext? context = null)
     {

--- a/src/Hl7.Fhir.Base/Validation/PocoValidationContext.cs
+++ b/src/Hl7.Fhir.Base/Validation/PocoValidationContext.cs
@@ -38,6 +38,11 @@ public record PocoValidationContext
     public ModelInspector ModelInspector { get; set; }
 
     /// <summary>
+    /// Name of the property being validated.
+    /// </summary>
+    public string? MemberName { get; set; }
+
+    /// <summary>
     /// In the context of property validation this is the POCO this property is an element of. In the context
     /// of validating an object, this should be the same as the object passed to the validation function.
     /// </summary>


### PR DESCRIPTION
## Description
Adds name of the property that's being validated on the PocoValidationContext to report in case of issues.

## Related issues
Closes #3167