### PR TITLE
Remove version from bundle entry resourceidentity with meta.versionId set

### DIFF
--- a/src/Hl7.Fhir.Base/Model/ResourceIdentityExtensions.cs
+++ b/src/Hl7.Fhir.Base/Model/ResourceIdentityExtensions.cs
@@ -18,7 +18,8 @@ namespace Hl7.Fhir.Model
 
             if (fullUrl is not null)
             {
-                result = r.VersionId == null ? new ResourceIdentity(fullUrl) : new ResourceIdentity(fullUrl).WithVersion(r.VersionId);
+                var identity = new ResourceIdentity(fullUrl);
+                result = (r.VersionId == null || identity.IsUrn) ? identity : identity.WithVersion(r.VersionId);
             }
             else if (r.Id is not null)
             {


### PR DESCRIPTION
## Description
Should no longer crash on URNs that have meta.versionId set. this is needed for the validator

## Related issues
needed for #3023 