### PR TITLE
Clear out contentRef when copying children into an element.

### DIFF
--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
@@ -605,6 +605,27 @@ namespace Hl7.Fhir.Specification.Snapshot
                 // [WMR 20190926] #1123 Remove annotations and fix Base components!
                 copyChildren(nav, sourceNav);
 
+                // [EK 20250618] #3177 Ensure we don't have both children and a contentReference.
+                // We should restore the Type, since that's expected information if there is no
+                // content reference available.
+                defn.ContentReference = null;
+                defn.Type = sourceNav.Current.Type.DeepCopy().ToList();
+
+                // [EK 20250618] #3177 shouldn't we also copy other elements from
+                // sourceNav.Current, like defaultValue, fixed, pattern, example, minValue,
+                // maxValue, maxLength, or binding (everything that eld-5 forbids) now
+                // we don't have the contentReference anymore?
+                // defn.DefaultValue = (DataType)sourceNav.Current.DefaultValue.DeepCopy();
+                // defn.Fixed = (DataType)sourceNav.Current.Fixed.DeepCopy();
+                // defn.Pattern = (DataType)sourceNav.Current.Pattern.DeepCopy();
+                // defn.Example = sourceNav.Current.Example.DeepCopy().ToList();
+                // defn.MinValue = (DataType)sourceNav.Current.MinValue?.DeepCopy();
+                // defn.MaxValue = (DataType)sourceNav.Current.MaxValue?.DeepCopy();
+                // defn.MaxLength = sourceNav.Current.MaxLength;
+                // defn.Binding = (ElementDefinition.ElementDefinitionBindingComponent)sourceNav.Current.Binding?.DeepCopy();
+                // On second thought, a contentReference always points to a BackboneElement,
+                // and none of these properties make real sense for a BackboneElement.
+
                 // [WMR 20180410]
                 // - Regenerate element IDs
                 // - Notify subscribers by calling OnPrepareBaseElement, before merging diff constraints
@@ -1439,35 +1460,35 @@ namespace Hl7.Fhir.Specification.Snapshot
         }
 
         /// <summary>
-        /// Copy child elements from <paramref name="typeNav"/> to <paramref name="nav"/>.
+        /// Copy child elements from <paramref name="source"/> to <paramref name="dest"/>.
         /// Remove existing annotations, fix Base components
         /// </summary>
         // [WMR 20170501] OBSOLETE: notify listeners - moved to prepareTypeProfileChildren
-        private static bool copyChildren(ElementDefinitionNavigator nav, ElementDefinitionNavigator typeNav) // , StructureDefinition typeStructure)
+        private static bool copyChildren(ElementDefinitionNavigator dest, ElementDefinitionNavigator source) // , StructureDefinition typeStructure)
         {
             // [WMR 20170426] IMPORTANT!
             // Do NOT modify typeNav/typeStructure
             // Call by mergeTypeProfiles: typeNav/typeStructure refers to modified clone of global type profile
             // Call by expandElement:     typeNav/typeStructure refers to global cached type profile (!)
 
-            Debug.Assert(!nav.AtRoot);
-            Debug.Assert(!typeNav.AtRoot);
+            Debug.Assert(!dest.AtRoot);
+            Debug.Assert(!source.AtRoot);
 
             // [WMR 20170220] CopyChildren returns false if nav already has children
-            if (nav.CopyChildren(typeNav))
+            if (dest.CopyChildren(source))
             {
                 // Fix the copied elements and notify observers
 
                 // [WMR 20190926] Also support contentReference
-                // typeNav positioned at target element of base profile (not the root element)
+                // source positioned at target element of base profile (not the root element)
                 // => process only the current subtree, not the full structure
 
-                var typeRootPath = typeNav.Path;
-                var typeRootPos = typeNav.OrdinalPosition.Value; // 0 for element type, >0 for content reference
-                var typeElems = typeNav.Elements;
-                var elems = nav.Elements;
+                var typeRootPath = source.Path;
+                var typeRootPos = source.OrdinalPosition.Value; // 0 for element type, >0 for content reference
+                var typeElems = source.Elements;
+                var elems = dest.Elements;
 
-                for (int pos = nav.OrdinalPosition.Value + 1, i = typeRootPos + 1;
+                for (int pos = dest.OrdinalPosition.Value + 1, i = typeRootPos + 1;
                     i < typeElems.Count && pos < elems.Count;
                     i++, pos++)
                 {
@@ -1476,7 +1497,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                     // [WMR 20190926] For contentReference, only process partial subtree
                     // Proceed while current target element is a (grand)child of the start element
 
-                    if (typeRootPos > 0 // If typeNav represents target of a contentReference...
+                    if (typeRootPos > 0 // If source represents target of a contentReference...
                                         // and if this element is NOT a child of the target contentReference...
                         && !ElementDefinitionNavigator.IsChildPath(typeRootPath, typeElem.Path))
                     {

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -9299,13 +9299,11 @@ namespace Hl7.Fhir.Specification.Tests
             //prepare 
             var generator = new SnapshotGenerator(_standardFhirSource, SnapshotGeneratorSettings.CreateDefault());
 
-
             //Test if core resource has relative content references.
             var coreQuestionnaire = await _testResolver.FindStructureDefinitionAsync("http://hl7.org/fhir/StructureDefinition/Questionnaire");
             var coreSnapshot = await generator.GenerateAsync(coreQuestionnaire);
             var item = coreSnapshot.Where(e => e.Path == "Questionnaire.item.item").FirstOrDefault();
             item.ContentReference.Should().Be("#Questionnaire.item");
-
 
             //Create profile for testing creation of absolute references.
             var profile = new StructureDefinition
@@ -9348,15 +9346,9 @@ namespace Hl7.Fhir.Specification.Tests
                         },
                         new ElementDefinition
                         {
-                            ElementId = "Questionnaire.item:booleanItem.type",
-                            Path = "Questionnaire.item.type",
-                            Fixed = new Code("boolean")
-                        },
-                        new ElementDefinition
-                        {
-                            ElementId = "Questionnaire.item:booleanItem.item.type",
-                            Path = "Questionnaire.item.item.type",
-                            Fixed = new Code("string")
+                            ElementId = "Questionnaire.item:booleanItem.item",
+                            Path = "Questionnaire.item.item",
+                            Min = 1
                         }
                     }
                 }
@@ -9365,11 +9357,10 @@ namespace Hl7.Fhir.Specification.Tests
             // test if profiles have absolute content references.
             var profileSnapshot = await generator.GenerateAsync(profile);
 
+            // Since we only changed the cardinality, the content reference should be the same as in the core resource,
+            // and thus be an absolute reference to the original definition in the core.
             var cref1 = profileSnapshot.Where(e => e.ElementId == "Questionnaire.item:booleanItem.item").FirstOrDefault();
             cref1.ContentReference.Should().Be("http://hl7.org/fhir/StructureDefinition/Questionnaire#Questionnaire.item");
-
-            var cref2 = profileSnapshot.Where(e => e.ElementId == "Questionnaire.item:booleanItem.item.item").FirstOrDefault();
-            cref2.ContentReference.Should().Be("http://hl7.org/fhir/StructureDefinition/Questionnaire#Questionnaire.item");
         }
 
         [DataTestMethod]
@@ -10185,6 +10176,123 @@ namespace Hl7.Fhir.Specification.Tests
             profile.Snapshot.Element[0].Binding.Extension.Should().BeEmpty();
         }
 
+
+        // Test whether we have fixed issue https://github.com/FirelyTeam/firely-net-sdk/issues/3177.
+        [TestMethod]
+        public async Tasks.Task TestSliceWithContentReference()
+        {
+            var sd = buildSliceOnContentReference();
+            _generator = new SnapshotGenerator(_testResolver, _settings);
+            var snapshot = await _generator.GenerateAsync(sd);
+
+            // If we have copied the contentReference's children to the slice, there should not be a contentReference
+            // on the slice itself anymore (but it should still exist on the intro).
+            snapshot.Single(e => e.ElementId == "Parameters.parameter.part")
+                .ContentReference.Should().NotBeNull();
+            snapshot.Should().ContainSingle(e => e.ElementId == "Parameters.parameter.part:medicationDispense.name");
+
+            // The slice itself should not have a contentReference, because it is copied the children below it.
+            var firstSlice = snapshot.Single(e => e.ElementId == "Parameters.parameter.part:medicationDispense");
+            firstSlice.ContentReference.Should().BeNull();
+
+            // But it should now have a TypeRef element!
+            firstSlice.Type.Should().ContainSingle(tr => tr.Code == "BackboneElement");
+        }
+
+        // Test whether fixing issue https://github.com/FirelyTeam/firely-net-sdk/issues/3177 does
+        // not break the snapshot generation when just the cardinality of the contentReference is changed.
+        [TestMethod]
+        public async Tasks.Task TestContentReferenceWithCardinalityChangeOnPart()
+        {
+            var sd = changeCardinalityOnContentReference();
+            _generator = new SnapshotGenerator(_testResolver, _settings);
+            var snapshot = await _generator.GenerateAsync(sd);
+
+            // Changing the cardinality will not copy the children, so the contentReference should still
+            // be there and NOT have a typeref.
+            var firstPart = snapshot.Single(e => e.ElementId == "Parameters.parameter.part");
+            firstPart.ContentReference.Should().NotBeNull();
+            firstPart.Type.Should().BeEmpty();
+        }
+
+        // Test whether fixing issue https://github.com/FirelyTeam/firely-net-sdk/issues/3177 does
+        // not break the snapshot generation when just the cardinality of a nested contentReference is changed.
+        [TestMethod]
+        public async Tasks.Task TestContentReferenceWithCardinalityChangeOnNestedPart()
+        {
+            var sd = changeCardinalityOnNestedContentReference();
+            _generator = new SnapshotGenerator(_testResolver, _settings);
+            var snapshot = await _generator.GenerateAsync(sd);
+
+            // Changing the cardinality in a child *will* copy the children, so the contentReference should
+            // now be gone, and it should have a TypeRef instead.
+            var firstPart = snapshot.Single(e => e.ElementId == "Parameters.parameter.part");
+            firstPart.ContentReference.Should().BeNull();
+            firstPart.Type.Should().ContainSingle(tr => tr.Code == "BackboneElement");
+
+            // But the nested part should still have a contentReference, and no typeref.
+            var nestedPart = snapshot.Single(e => e.ElementId == "Parameters.parameter.part.part");
+            nestedPart.ContentReference.Should().NotBeNull();
+            nestedPart.Type.Should().BeEmpty();
+        }
+
+        private static StructureDefinition buildSliceOnContentReference()
+        {
+            var result = TestProfileArtifactSource.CreateTestSd("http://validationtest.org/fhir/StructureDefinition/Parameters-issue-3177", "Parameters-issue-3177",
+                "Parameters with sliced parts - and so copied contentReferences", FHIRAllTypes.Parameters);
+
+            var cons = result.Differential.Element;
+
+            var slicingIntro = new ElementDefinition("Parameters.parameter.part")
+                .WithSlicingIntro(ElementDefinition.SlicingRules.Closed,
+                    (ElementDefinition.DiscriminatorType.Pattern, "name"))
+                .Required();
+
+            cons.Add(slicingIntro);
+
+            cons.Add(new ElementDefinition("Parameters.parameter.part")
+            {
+                ElementId = "Parameters.parameter.part:medicationDispense", SliceName = "medicationDispense",
+            }.Required());
+
+            cons.Add(new ElementDefinition("Parameters.parameter.part.name")
+            {
+                ElementId = "Parameters.parameter.part:medicationDispense.name",
+                Pattern = new FhirString("medicationDispense")
+            });
+
+            return result;
+        }
+
+        private static StructureDefinition changeCardinalityOnContentReference()
+        {
+            var result = TestProfileArtifactSource.CreateTestSd("http://validationtest.org/fhir/StructureDefinition/Parameters-issue-3177", "Parameters-issue-3177",
+                "Parameters with new cardinality on parts", FHIRAllTypes.Parameters);
+
+            var cons = result.Differential.Element;
+
+            var mainPart = new ElementDefinition("Parameters.parameter.part")
+                .Required();
+
+            cons.Add(mainPart);
+
+            return result;
+        }
+
+        private static StructureDefinition changeCardinalityOnNestedContentReference()
+        {
+            var result = TestProfileArtifactSource.CreateTestSd("http://validationtest.org/fhir/StructureDefinition/Parameters-issue-3177", "Parameters-issue-3177",
+                "Parameters with new cardinality on part.part", FHIRAllTypes.Parameters);
+
+            var cons = result.Differential.Element;
+
+            var nestedPart = new ElementDefinition("Parameters.parameter.part.part")
+                .Required();
+
+            cons.Add(nestedPart);
+
+            return result;
+        }
 
         [TestMethod]
         public async Tasks.Task TestNewR5Elements()

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/TestProfileArtifactSource.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/TestProfileArtifactSource.cs
@@ -56,12 +56,13 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
             buildBoolean(),
             buildMyExtension(),
             buildSliceOnChoice(),
-            buildConstrainBindableType()
+            buildConstrainBindableType(),
+            buildSliceOnContentReference()
         }.AddM(buildPatientWithProfiledReferences());
 
         private static StructureDefinition buildObservationWithTargetProfilesAndChildDefs()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/Observation-issue-1654", "Observation-issue-1654",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/Observation-issue-1654", "Observation-issue-1654",
                 "Observation with targetprofile on subject and children definition under subject as well", FHIRAllTypes.Observation);
 
             var cons = result.Differential.Element;
@@ -81,7 +82,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildTranslatableCodeableConcept()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/CodeableConceptTranslatable", "CodeableConceptTranslatable",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/CodeableConceptTranslatable", "CodeableConceptTranslatable",
                                   "Test CodeableConcept with an extension on CodeableConcept.text", FHIRAllTypes.CodeableConcept);
 
             var cons = result.Differential.Element;
@@ -97,7 +98,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildObservationWithTranslatableCode()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/ObservationWithTranslatableCode", "ObservationWithTranslatableCode",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/ObservationWithTranslatableCode", "ObservationWithTranslatableCode",
                        "Test Observation with a profiled CodeableConcept for Observation.code", FHIRAllTypes.Observation);
 
             var cons = result.Differential.Element;
@@ -111,7 +112,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition slicingWithCodeableConcept()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/ObservationSlicingCodeableConcept", "ObservationSlicingCodeableConcept",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/ObservationSlicingCodeableConcept", "ObservationSlicingCodeableConcept",
                        "Test Observation with slicing on value[x], first slice CodeableConcept", FHIRAllTypes.Observation);
 
             var cons = result.Differential.Element;
@@ -134,7 +135,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition slicingWithQuantity()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/ObservationValueSlicingQuantity", "ObservationSlicingQuantity",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/ObservationValueSlicingQuantity", "ObservationSlicingQuantity",
                        "Test Observation with slicing on value[x], first slice Quantity", FHIRAllTypes.Observation,
                        "http://validationtest.org/fhir/StructureDefinition/ObservationSlicingCodeableConcept");
 
@@ -159,7 +160,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildPatientWithIdentifierSlicing()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/PatientIdentifierSlicing", "PatientIdentifierSlicing",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/PatientIdentifierSlicing", "PatientIdentifierSlicing",
                        "Test Patient with slicing on Identifier, first slice BSN", FHIRAllTypes.Patient);
 
             var cons = result.Differential.Element;
@@ -185,7 +186,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildPatientWithExistsSlicing()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/PatientExistsSlicing", "PatientExistsSlicing",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/PatientExistsSlicing", "PatientExistsSlicing",
                        "Test Patient with exists slicing on Identifier", FHIRAllTypes.Patient);
 
             var cons = result.Differential.Element;
@@ -234,7 +235,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildMiPatient()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/mi-patient", "mi-Patient",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/mi-patient", "mi-Patient",
                       "Test a derived Patient introducing a new slice to the base introduction Slicing",
                       FHIRAllTypes.Patient, "http://validationtest.org/fhir/StructureDefinition/PatientIdentifierSlicing");
 
@@ -271,7 +272,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildOrganizationWithRegexConstraintOnName()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/MyOrganization", "My Organization",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/MyOrganization", "My Organization",
                     "Test an organization with Name containing regex", FHIRAllTypes.Organization);
             var cons = result.Differential.Element;
 
@@ -287,7 +288,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildOrganizationWithRegexConstraintOnType()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/MyOrganization2", "My Organization",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/MyOrganization2", "My Organization",
                     "Test an organization with Name containing regex", FHIRAllTypes.Organization);
             var cons = result.Differential.Element;
 
@@ -316,7 +317,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildDutchPatient()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/DutchPatient", "Dutch Patient",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/DutchPatient", "Dutch Patient",
                     "Test Patient which requires an Identifier with either BSN or drivers license", FHIRAllTypes.Patient);
             var cons = result.Differential.Element;
 
@@ -330,7 +331,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildIdentifierWithBSN()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/IdentifierWithBSN", "BSN Identifier",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/IdentifierWithBSN", "BSN Identifier",
                     "Test Identifier which requires a BSN oid", FHIRAllTypes.Identifier);
             var cons = result.Differential.Element;
 
@@ -344,7 +345,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildIdentifierWithDriversLicense()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/IdentifierWithDL", "Drivers license Identifier",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/IdentifierWithDL", "Drivers license Identifier",
                     "Test Identifier which requires a drivers license oid", FHIRAllTypes.Identifier);
             var cons = result.Differential.Element;
 
@@ -357,7 +358,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildQuestionnaireWithFixedType()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/QuestionnaireWithFixedType", "Fixed Questionnaire",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/QuestionnaireWithFixedType", "Fixed Questionnaire",
                     "Questionnaire with a fixed question type of 'decimal'", FHIRAllTypes.Questionnaire);
             var cons = result.Differential.Element;
 
@@ -369,7 +370,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildWeightQuantity()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/WeightQuantity", "Weight Quantity",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/WeightQuantity", "Weight Quantity",
                     "Quantity which allows just kilograms", FHIRAllTypes.Quantity);
 
             var cons = result.Differential.Element;
@@ -384,7 +385,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildHeightQuantity()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/HeightQuantity", "Height Quantity",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/HeightQuantity", "Height Quantity",
                     "Quantity which allows just centimeters", FHIRAllTypes.Quantity);
 
             var cons = result.Differential.Element;
@@ -399,7 +400,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildWeightHeightObservation()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/WeightHeightObservation", "Weight/Height Observation",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/WeightHeightObservation", "Weight/Height Observation",
                     "Observation with a choice of weight/height or another type of value", FHIRAllTypes.Observation);
 
             var cons = result.Differential.Element;
@@ -416,7 +417,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition bundleWithSpecificEntries(string prefix)
         {
-            var result = createTestSD($"http://validationtest.org/fhir/StructureDefinition/BundleWith{prefix}Entries", $"Bundle with specific {prefix} test entries",
+            var result = CreateTestSd($"http://validationtest.org/fhir/StructureDefinition/BundleWith{prefix}Entries", $"Bundle with specific {prefix} test entries",
                     $"Bundle with just Organization or {prefix} Patient entries", FHIRAllTypes.Bundle);
 
             var cons = result.Differential.Element;
@@ -431,7 +432,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition bundleWithConstrainedContained()
         {
-            var result = createTestSD($"http://validationtest.org/fhir/StructureDefinition/BundleWithConstrainedContained",
+            var result = CreateTestSd($"http://validationtest.org/fhir/StructureDefinition/BundleWithConstrainedContained",
                             $"Bundle with a constraint on the Bundle.entry.resource",
                     $"Bundle with a constraint on the Bundle.entry.resource", FHIRAllTypes.Bundle);
 
@@ -446,7 +447,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition patientWithSpecificOrganization(IEnumerable<ElementDefinition.AggregationMode> aggregation, string prefix)
         {
-            var result = createTestSD($"http://validationtest.org/fhir/StructureDefinition/PatientWith{prefix}Organization", $"Patient with {prefix} managing organization",
+            var result = CreateTestSd($"http://validationtest.org/fhir/StructureDefinition/PatientWith{prefix}Organization", $"Patient with {prefix} managing organization",
                     $"Patient for which the managingOrganization reference is limited to {prefix} references", FHIRAllTypes.Patient);
 
             var cons = result.Differential.Element;
@@ -461,7 +462,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildParametersWithBoundParams()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/ParametersWithBoundParams", "Parameters with term binding on Params",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/ParametersWithBoundParams", "Parameters with term binding on Params",
                     "Parameters resource where the parameter.value[x] is bound to a valueset", FHIRAllTypes.Parameters);
             var cons = result.Differential.Element;
 
@@ -477,7 +478,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildQuantityWithUnlimitedRootCardinality()
         {
-            var result = createTestSD(QUANTITY_WITH_UNLIMITED_ROOT_CARDINALITY_CANONICAL, "A Quantity with a root cardinality of 0..*",
+            var result = CreateTestSd(QUANTITY_WITH_UNLIMITED_ROOT_CARDINALITY_CANONICAL, "A Quantity with a root cardinality of 0..*",
                     "Parameters resource where the parameter.value[x] is bound to a valueset", FHIRAllTypes.Quantity);
             var cons = result.Differential.Element;
 
@@ -491,7 +492,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildRangeWithLowAsAQuantityWithUnlimitedRootCardinality()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/RangeWithLowAsAQuantityWithUnlimitedRootCardinality",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/RangeWithLowAsAQuantityWithUnlimitedRootCardinality",
                 "Range referring to a profiled quantity",
                 "Range that refers to a profiled quantity on its Range.low - this profiled Quantity has a 0..* root.",
                    FHIRAllTypes.Range);
@@ -507,7 +508,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildValueDescriminatorWithPattern()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/ValueDiscriminatorWithPattern", "A value discriminator including pattern[x]",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/ValueDiscriminatorWithPattern", "A value discriminator including pattern[x]",
                     "Expresses a discriminator of type value, which expects pattern[x] to be considered part of it too.", FHIRAllTypes.Practitioner);
             var cons = result.Differential.Element;
 
@@ -560,17 +561,18 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
             return result;
         }
 
-
-        private static StructureDefinition createTestSD(string url, string name, string description, FHIRAllTypes constrainedType, string baseUri = null)
+        internal static StructureDefinition CreateTestSd(string url, string name, string description, FHIRAllTypes constrainedType, string baseUri = null)
         {
-            var result = new StructureDefinition();
-
-            result.Url = url;
-            result.Name = name;
-            result.Status = PublicationStatus.Draft;
-            result.Description = new Markdown(description);
-            result.FhirVersion = EnumUtility.ParseLiteral<FHIRVersion>(ModelInfo.Version);
-            result.Derivation = StructureDefinition.TypeDerivationRule.Constraint;
+            var result = new StructureDefinition
+            {
+                Url = url, Name = name, Status = PublicationStatus.Draft, Description = new Markdown(description),
+                FhirVersion = EnumUtility.ParseLiteral<FHIRVersion>(ModelInfo.Version),
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Type = constrainedType.GetLiteral(),
+                Abstract = false,
+                BaseDefinition = baseUri ?? ResourceIdentity.Core(constrainedType.GetLiteral()).ToString(),
+                Differential = new StructureDefinition.DifferentialComponent()
+            };
 
             if (ModelInfo.IsKnownResource(constrainedType))
                 result.Kind = StructureDefinition.StructureDefinitionKind.Resource;
@@ -581,22 +583,12 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
             else
                 result.Kind = StructureDefinition.StructureDefinitionKind.Logical;
 
-            result.Type = constrainedType.GetLiteral();
-            result.Abstract = false;
-
-            if (baseUri == null)
-                baseUri = ResourceIdentity.Core(constrainedType.GetLiteral()).ToString();
-
-            result.BaseDefinition = baseUri;
-
-            result.Differential = new StructureDefinition.DifferentialComponent();
-
             return result;
         }
 
         private static StructureDefinition buildMyExtension()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/MyRangeExtension", "My Rage Extension",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/MyRangeExtension", "My Rage Extension",
                 "An extension with a value of type Range", FHIRAllTypes.Extension);
 
             var cons = result.Differential.Element;
@@ -610,7 +602,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildBoolean()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/RequiredBoolean", "Required Boolean",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/RequiredBoolean", "Required Boolean",
                 "A boolean type where the value is required", FHIRAllTypes.Boolean);
 
             var cons = result.Differential.Element;
@@ -623,7 +615,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildPatientWithDeceasedConstraints(string profile = null)
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/DeceasedPatient" + profile, "DeceasedPatient",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/DeceasedPatient" + profile, "DeceasedPatient",
                     "Test Patient with extra deceased constraints", FHIRAllTypes.Patient);
             var cons = result.Differential.Element;
 
@@ -651,10 +643,10 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static IEnumerable<StructureDefinition> buildPatientWithProfiledReferences()
         {
-            yield return createTestSD(PROFILED_ORG_URL, "A profiled organization",
+            yield return CreateTestSd(PROFILED_ORG_URL, "A profiled organization",
                     "A profiled Organization with no additional constraints", FHIRAllTypes.Organization);
 
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/PatientWithReferences", "Patient with References",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/PatientWithReferences", "Patient with References",
                     "Test Patient which has a profiled managing organization", FHIRAllTypes.Patient);
             var cons = result.Differential.Element;
 
@@ -665,7 +657,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildSliceOnChoice()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/MedicationRequest-issue-2132", "MedicationRequest-issue-2132",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/MedicationRequest-issue-2132", "MedicationRequest-issue-2132",
                 "MedicationRequest sliced on substitution.allowed[x]", FHIRAllTypes.MedicationRequest);
 
             var cons = result.Differential.Element;
@@ -692,7 +684,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildConstrainBindableType()
         {
-            var result = createTestSD("http://validationtest.org/fhir/StructureDefinition/MedicationRequest-issue-2132-2", "MedicationRequest-issue-2132",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/MedicationRequest-issue-2132-2", "MedicationRequest-issue-2132",
                 "MedicationRequest sliced on substitution.allowed[x]", FHIRAllTypes.MedicationRequest);
 
             var cons = result.Differential.Element;
@@ -704,5 +696,32 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
             return result;
         }
 
+        private static StructureDefinition buildSliceOnContentReference()
+        {
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/Parameters-issue-3177", "Parameters-issue-3177",
+                "Parameters with sliced parts - and so copied contentReferences", FHIRAllTypes.Parameters);
+
+            var cons = result.Differential.Element;
+
+            var slicingIntro = new ElementDefinition("Parameters.parameter.part")
+                .WithSlicingIntro(ElementDefinition.SlicingRules.Closed,
+                    (ElementDefinition.DiscriminatorType.Pattern, "name"))
+                .Required();
+
+            cons.Add(slicingIntro);
+
+            cons.Add(new ElementDefinition("Parameters.parameter.part")
+            {
+                ElementId = "Parameters.parameter.part:medicationDispense", SliceName = "medicationDispense",
+            }.Required());
+
+            cons.Add(new ElementDefinition("Parameters.parameter.part.name")
+            {
+                ElementId = "Parameters.parameter.part:medicationDispense.name",
+                Pattern = new FhirString("medicationDispense")
+            });
+
+            return result;
+        }
     }
 }

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/TestProfileArtifactSource.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/TestProfileArtifactSource.cs
@@ -1,6 +1,5 @@
 ﻿using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
-using Hl7.Fhir.Specification;
 using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Utility;
 using System.Collections.Generic;
@@ -31,7 +30,9 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
             bundleWithSpecificEntries("Contained"),
             patientWithSpecificOrganization(new[] { ElementDefinition.AggregationMode.Contained }, "Contained"),
             bundleWithSpecificEntries("ContainedBundled"),
-            patientWithSpecificOrganization(new[] { ElementDefinition.AggregationMode.Contained, ElementDefinition.AggregationMode.Bundled }, "ContainedBundled"),
+            patientWithSpecificOrganization(
+                new[] { ElementDefinition.AggregationMode.Contained, ElementDefinition.AggregationMode.Bundled },
+                "ContainedBundled"),
             bundleWithSpecificEntries("Bundled"),
             patientWithSpecificOrganization(new[] { ElementDefinition.AggregationMode.Bundled }, "Bundled"),
             bundleWithSpecificEntries("Referenced"),
@@ -57,24 +58,22 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
             buildMyExtension(),
             buildSliceOnChoice(),
             buildConstrainBindableType(),
-            buildSliceOnContentReference()
         }.AddM(buildPatientWithProfiledReferences());
 
         private static StructureDefinition buildObservationWithTargetProfilesAndChildDefs()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/Observation-issue-1654", "Observation-issue-1654",
-                "Observation with targetprofile on subject and children definition under subject as well", FHIRAllTypes.Observation);
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/Observation-issue-1654",
+                "Observation-issue-1654",
+                "Observation with targetprofile on subject and children definition under subject as well",
+                FHIRAllTypes.Observation);
 
             var cons = result.Differential.Element;
-            cons.Add(new ElementDefinition("Observation.subject")
-            {
-                ElementId = "Observation.subject",
-            }.OfReference(targetProfile: ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient)));
+            cons.Add(new ElementDefinition("Observation.subject") { ElementId = "Observation.subject", }.OfReference(
+                targetProfile: ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient)));
 
             cons.Add(new ElementDefinition("Observation.subject.display")
             {
-                ElementId = "Observation.subject.display",
-                MaxLength = 10
+                ElementId = "Observation.subject.display", MaxLength = 10
             });
 
             return result;
@@ -82,15 +81,14 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildTranslatableCodeableConcept()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/CodeableConceptTranslatable", "CodeableConceptTranslatable",
-                                  "Test CodeableConcept with an extension on CodeableConcept.text", FHIRAllTypes.CodeableConcept);
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/CodeableConceptTranslatable",
+                "CodeableConceptTranslatable",
+                "Test CodeableConcept with an extension on CodeableConcept.text", FHIRAllTypes.CodeableConcept);
 
             var cons = result.Differential.Element;
-            var ed = new ElementDefinition("CodeableConcept.text")
-            {
-                ElementId = "CodeableConcept.text",
-            };
-            ed.AddExtension("http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable", new FhirBoolean(true));
+            var ed = new ElementDefinition("CodeableConcept.text") { ElementId = "CodeableConcept.text", };
+            ed.AddExtension("http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                new FhirBoolean(true));
             cons.Add(ed);
 
             return result;
@@ -98,61 +96,64 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildObservationWithTranslatableCode()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/ObservationWithTranslatableCode", "ObservationWithTranslatableCode",
-                       "Test Observation with a profiled CodeableConcept for Observation.code", FHIRAllTypes.Observation);
+            var result = CreateTestSd(
+                "http://validationtest.org/fhir/StructureDefinition/ObservationWithTranslatableCode",
+                "ObservationWithTranslatableCode",
+                "Test Observation with a profiled CodeableConcept for Observation.code", FHIRAllTypes.Observation);
 
             var cons = result.Differential.Element;
-            cons.Add(new ElementDefinition("Observation.code")
-            {
-                ElementId = "Observation.code"
-            }.OfType(FHIRAllTypes.CodeableConcept, "http://validationtest.org/fhir/StructureDefinition/CodeableConceptTranslatable"));
+            cons.Add(new ElementDefinition("Observation.code") { ElementId = "Observation.code" }.OfType(
+                FHIRAllTypes.CodeableConcept,
+                "http://validationtest.org/fhir/StructureDefinition/CodeableConceptTranslatable"));
 
             return result;
         }
 
         private static StructureDefinition slicingWithCodeableConcept()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/ObservationSlicingCodeableConcept", "ObservationSlicingCodeableConcept",
-                       "Test Observation with slicing on value[x], first slice CodeableConcept", FHIRAllTypes.Observation);
+            var result = CreateTestSd(
+                "http://validationtest.org/fhir/StructureDefinition/ObservationSlicingCodeableConcept",
+                "ObservationSlicingCodeableConcept",
+                "Test Observation with slicing on value[x], first slice CodeableConcept", FHIRAllTypes.Observation);
 
             var cons = result.Differential.Element;
 
             var slicingIntro = new ElementDefinition("Observation.value[x]")
-               .WithSlicingIntro(ElementDefinition.SlicingRules.Closed)
-               .OfType(FHIRAllTypes.CodeableConcept);
+                .WithSlicingIntro(ElementDefinition.SlicingRules.Closed)
+                .OfType(FHIRAllTypes.CodeableConcept);
 
             cons.Add(slicingIntro);
 
             cons.Add(new ElementDefinition("Observation.value[x]")
-            {
-                ElementId = "Observation.value[x]:valueCodeableConcept",
-                SliceName = "valueCodeableConcept",
-            }.OfType(FHIRAllTypes.CodeableConcept)
-             .WithBinding("http://somewhere/something", BindingStrength.Required));
+                {
+                    ElementId = "Observation.value[x]:valueCodeableConcept", SliceName = "valueCodeableConcept",
+                }.OfType(FHIRAllTypes.CodeableConcept)
+                .WithBinding("http://somewhere/something", BindingStrength.Required));
 
             return result;
         }
 
         private static StructureDefinition slicingWithQuantity()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/ObservationValueSlicingQuantity", "ObservationSlicingQuantity",
-                       "Test Observation with slicing on value[x], first slice Quantity", FHIRAllTypes.Observation,
-                       "http://validationtest.org/fhir/StructureDefinition/ObservationSlicingCodeableConcept");
+            var result = CreateTestSd(
+                "http://validationtest.org/fhir/StructureDefinition/ObservationValueSlicingQuantity",
+                "ObservationSlicingQuantity",
+                "Test Observation with slicing on value[x], first slice Quantity", FHIRAllTypes.Observation,
+                "http://validationtest.org/fhir/StructureDefinition/ObservationSlicingCodeableConcept");
 
             var cons = result.Differential.Element;
 
             var slicingIntro = new ElementDefinition("Observation.value[x]")
-               .WithSlicingIntro(ElementDefinition.SlicingRules.Closed)
-               .OfType(FHIRAllTypes.Quantity);
+                .WithSlicingIntro(ElementDefinition.SlicingRules.Closed)
+                .OfType(FHIRAllTypes.Quantity);
 
             cons.Add(slicingIntro);
 
             cons.Add(new ElementDefinition("Observation.value[x]")
-            {
-                ElementId = "Observation.value[x]:valueQuantity",
-                SliceName = "valueQuantity",
-            }.OfType(FHIRAllTypes.Quantity)
-             .WithBinding("http://somewhere/something-else", BindingStrength.Required));
+                {
+                    ElementId = "Observation.value[x]:valueQuantity", SliceName = "valueQuantity",
+                }.OfType(FHIRAllTypes.Quantity)
+                .WithBinding("http://somewhere/something-else", BindingStrength.Required));
 
             return result;
         }
@@ -160,47 +161,45 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildPatientWithIdentifierSlicing()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/PatientIdentifierSlicing", "PatientIdentifierSlicing",
-                       "Test Patient with slicing on Identifier, first slice BSN", FHIRAllTypes.Patient);
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/PatientIdentifierSlicing",
+                "PatientIdentifierSlicing",
+                "Test Patient with slicing on Identifier, first slice BSN", FHIRAllTypes.Patient);
 
             var cons = result.Differential.Element;
             var slicingIntro = new ElementDefinition("Patient.identifier")
-               .WithSlicingIntro(ElementDefinition.SlicingRules.Closed,
-               (ElementDefinition.DiscriminatorType.Value, "system"));
+                .WithSlicingIntro(ElementDefinition.SlicingRules.Closed,
+                    (ElementDefinition.DiscriminatorType.Value, "system"));
 
             cons.Add(slicingIntro);
 
             cons.Add(new ElementDefinition("Patient.identifier")
             {
-                ElementId = "Patient.identifier:BSN",
-                SliceName = "BSN"
+                ElementId = "Patient.identifier:BSN", SliceName = "BSN"
             });
 
-            cons.Add(new ElementDefinition("Patient.identifier.system")
-            {
-                ElementId = "Patient.identifier:BSN.system",
-            }.Value(fix: new FhirUri("http://example.com/someuri")));
+            cons.Add(new ElementDefinition("Patient.identifier.system") { ElementId = "Patient.identifier:BSN.system", }
+                .Value(fix: new FhirUri("http://example.com/someuri")));
 
             return result;
         }
 
         private static StructureDefinition buildPatientWithExistsSlicing()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/PatientExistsSlicing", "PatientExistsSlicing",
-                       "Test Patient with exists slicing on Identifier", FHIRAllTypes.Patient);
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/PatientExistsSlicing",
+                "PatientExistsSlicing",
+                "Test Patient with exists slicing on Identifier", FHIRAllTypes.Patient);
 
             var cons = result.Differential.Element;
             var slicingIntro = new ElementDefinition("Patient.identifier")
-               .WithSlicingIntro(ElementDefinition.SlicingRules.Closed,
-               (ElementDefinition.DiscriminatorType.Exists, "use"));
+                .WithSlicingIntro(ElementDefinition.SlicingRules.Closed,
+                    (ElementDefinition.DiscriminatorType.Exists, "use"));
 
             cons.Add(slicingIntro);
 
             // Slice 1: if there is no use, then there should not be a system
             cons.Add(new ElementDefinition("Patient.identifier")
             {
-                ElementId = "Patient.identifier:WithoutUse",
-                SliceName = "WithoutUse"
+                ElementId = "Patient.identifier:WithoutUse", SliceName = "WithoutUse"
             });
 
             cons.Add(new ElementDefinition("Patient.identifier.use")
@@ -216,8 +215,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
             // Slice 2: if there is a use, then there should be a system
             cons.Add(new ElementDefinition("Patient.identifier")
             {
-                ElementId = "Patient.identifier:WithUse",
-                SliceName = "WithUse"
+                ElementId = "Patient.identifier:WithUse", SliceName = "WithUse"
             });
 
             cons.Add(new ElementDefinition("Patient.identifier.use")
@@ -236,15 +234,14 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
         private static StructureDefinition buildMiPatient()
         {
             var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/mi-patient", "mi-Patient",
-                      "Test a derived Patient introducing a new slice to the base introduction Slicing",
-                      FHIRAllTypes.Patient, "http://validationtest.org/fhir/StructureDefinition/PatientIdentifierSlicing");
+                "Test a derived Patient introducing a new slice to the base introduction Slicing",
+                FHIRAllTypes.Patient, "http://validationtest.org/fhir/StructureDefinition/PatientIdentifierSlicing");
 
             var cons = result.Differential.Element;
 
             cons.Add(new ElementDefinition("Patient.identifier")
             {
-                ElementId = "Patient.identifier:BSN",
-                SliceName = "BSN"
+                ElementId = "Patient.identifier:BSN", SliceName = "BSN"
             });
 
             // adding extra constraint on existing slice in base
@@ -258,13 +255,11 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
             // adding a new slice
             cons.Add(new ElementDefinition("Patient.identifier")
             {
-                ElementId = "Patient.identifier:newSlice",
-                SliceName = "newSlice"
+                ElementId = "Patient.identifier:newSlice", SliceName = "newSlice"
             });
             cons.Add(new ElementDefinition("Patient.identifier.system")
             {
-                ElementId = "Patient.identifier:newSlice.system",
-                Definition = new Markdown("Test_1295")
+                ElementId = "Patient.identifier:newSlice.system", Definition = new Markdown("Test_1295")
             });
 
             return result;
@@ -272,8 +267,9 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildOrganizationWithRegexConstraintOnName()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/MyOrganization", "My Organization",
-                    "Test an organization with Name containing regex", FHIRAllTypes.Organization);
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/MyOrganization",
+                "My Organization",
+                "Test an organization with Name containing regex", FHIRAllTypes.Organization);
             var cons = result.Differential.Element;
 
             cons.Add(new ElementDefinition("Organization").OfType(FHIRAllTypes.Organization));
@@ -288,8 +284,9 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildOrganizationWithRegexConstraintOnType()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/MyOrganization2", "My Organization",
-                    "Test an organization with Name containing regex", FHIRAllTypes.Organization);
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/MyOrganization2",
+                "My Organization",
+                "Test an organization with Name containing regex", FHIRAllTypes.Organization);
             var cons = result.Differential.Element;
 
             cons.Add(new ElementDefinition("Organization").OfType(FHIRAllTypes.Organization));
@@ -304,6 +301,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
             return result;
         }
+
         public Resource ResolveByCanonicalUri(string uri)
         {
             return TestProfiles.SingleOrDefault(p => p.Url == uri);
@@ -317,26 +315,30 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildDutchPatient()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/DutchPatient", "Dutch Patient",
-                    "Test Patient which requires an Identifier with either BSN or drivers license", FHIRAllTypes.Patient);
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/DutchPatient",
+                "Dutch Patient",
+                "Test Patient which requires an Identifier with either BSN or drivers license", FHIRAllTypes.Patient);
             var cons = result.Differential.Element;
 
             cons.Add(new ElementDefinition("Patient").OfType(FHIRAllTypes.Patient));
             cons.Add(new ElementDefinition("Patient.identifier").Required(max: "*")
-                        .OfType(FHIRAllTypes.Identifier, "http://validationtest.org/fhir/StructureDefinition/IdentifierWithBSN")
-                        .OrType(FHIRAllTypes.Identifier, "http://validationtest.org/fhir/StructureDefinition/IdentifierWithDL"));
+                .OfType(FHIRAllTypes.Identifier, "http://validationtest.org/fhir/StructureDefinition/IdentifierWithBSN")
+                .OrType(FHIRAllTypes.Identifier,
+                    "http://validationtest.org/fhir/StructureDefinition/IdentifierWithDL"));
 
             return result;
         }
 
         private static StructureDefinition buildIdentifierWithBSN()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/IdentifierWithBSN", "BSN Identifier",
-                    "Test Identifier which requires a BSN oid", FHIRAllTypes.Identifier);
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/IdentifierWithBSN",
+                "BSN Identifier",
+                "Test Identifier which requires a BSN oid", FHIRAllTypes.Identifier);
             var cons = result.Differential.Element;
 
             cons.Add(new ElementDefinition("Identifier").OfType(FHIRAllTypes.Identifier));
-            cons.Add(new ElementDefinition("Identifier.system").Required().Value(fix: new FhirUri("urn:oid:2.16.840.1.113883.2.4.6.3")));
+            cons.Add(new ElementDefinition("Identifier.system").Required()
+                .Value(fix: new FhirUri("urn:oid:2.16.840.1.113883.2.4.6.3")));
             cons.Add(new ElementDefinition("Identifier.period").Prohibited());
             cons.Add(new ElementDefinition("Identifier.assigner").Prohibited());
 
@@ -345,12 +347,14 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildIdentifierWithDriversLicense()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/IdentifierWithDL", "Drivers license Identifier",
-                    "Test Identifier which requires a drivers license oid", FHIRAllTypes.Identifier);
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/IdentifierWithDL",
+                "Drivers license Identifier",
+                "Test Identifier which requires a drivers license oid", FHIRAllTypes.Identifier);
             var cons = result.Differential.Element;
 
             cons.Add(new ElementDefinition("Identifier").OfType(FHIRAllTypes.Identifier));
-            cons.Add(new ElementDefinition("Identifier.system").Required().Value(fix: new FhirUri("urn:oid:2.16.840.1.113883.2.4.6.12")));
+            cons.Add(new ElementDefinition("Identifier.system").Required()
+                .Value(fix: new FhirUri("urn:oid:2.16.840.1.113883.2.4.6.12")));
 
             return result;
         }
@@ -358,8 +362,9 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildQuestionnaireWithFixedType()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/QuestionnaireWithFixedType", "Fixed Questionnaire",
-                    "Questionnaire with a fixed question type of 'decimal'", FHIRAllTypes.Questionnaire);
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/QuestionnaireWithFixedType",
+                "Fixed Questionnaire",
+                "Questionnaire with a fixed question type of 'decimal'", FHIRAllTypes.Questionnaire);
             var cons = result.Differential.Element;
 
             cons.Add(new ElementDefinition("Questionnaire").OfType(FHIRAllTypes.Questionnaire));
@@ -370,14 +375,16 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildWeightQuantity()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/WeightQuantity", "Weight Quantity",
-                    "Quantity which allows just kilograms", FHIRAllTypes.Quantity);
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/WeightQuantity",
+                "Weight Quantity",
+                "Quantity which allows just kilograms", FHIRAllTypes.Quantity);
 
             var cons = result.Differential.Element;
 
             cons.Add(new ElementDefinition("Quantity").OfType(FHIRAllTypes.Quantity));
             cons.Add(new ElementDefinition("Quantity.unit").Required().Value(fix: new FhirString("kg")));
-            cons.Add(new ElementDefinition("Quantity.system").Required().Value(fix: new FhirUri("http://unitsofmeasure.org")));
+            cons.Add(new ElementDefinition("Quantity.system").Required()
+                .Value(fix: new FhirUri("http://unitsofmeasure.org")));
             cons.Add(new ElementDefinition("Quantity.code").Required().Value(fix: new Code("kg")));
 
             return result;
@@ -385,14 +392,16 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildHeightQuantity()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/HeightQuantity", "Height Quantity",
-                    "Quantity which allows just centimeters", FHIRAllTypes.Quantity);
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/HeightQuantity",
+                "Height Quantity",
+                "Quantity which allows just centimeters", FHIRAllTypes.Quantity);
 
             var cons = result.Differential.Element;
 
             cons.Add(new ElementDefinition("Quantity").OfType(FHIRAllTypes.Quantity));
             cons.Add(new ElementDefinition("Quantity.unit").Required().Value(fix: new FhirString("cm")));
-            cons.Add(new ElementDefinition("Quantity.system").Required().Value(fix: new FhirUri("http://unitsofmeasure.org")));
+            cons.Add(new ElementDefinition("Quantity.system").Required()
+                .Value(fix: new FhirUri("http://unitsofmeasure.org")));
             cons.Add(new ElementDefinition("Quantity.code").Required().Value(fix: new Code("cm")));
 
             return result;
@@ -400,8 +409,9 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildWeightHeightObservation()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/WeightHeightObservation", "Weight/Height Observation",
-                    "Observation with a choice of weight/height or another type of value", FHIRAllTypes.Observation);
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/WeightHeightObservation",
+                "Weight/Height Observation",
+                "Observation with a choice of weight/height or another type of value", FHIRAllTypes.Observation);
 
             var cons = result.Differential.Element;
 
@@ -417,24 +427,27 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition bundleWithSpecificEntries(string prefix)
         {
-            var result = CreateTestSd($"http://validationtest.org/fhir/StructureDefinition/BundleWith{prefix}Entries", $"Bundle with specific {prefix} test entries",
-                    $"Bundle with just Organization or {prefix} Patient entries", FHIRAllTypes.Bundle);
+            var result = CreateTestSd($"http://validationtest.org/fhir/StructureDefinition/BundleWith{prefix}Entries",
+                $"Bundle with specific {prefix} test entries",
+                $"Bundle with just Organization or {prefix} Patient entries", FHIRAllTypes.Bundle);
 
             var cons = result.Differential.Element;
 
             cons.Add(new ElementDefinition("Bundle").OfType(FHIRAllTypes.Bundle));
             cons.Add(new ElementDefinition("Bundle.entry.resource")
                 .OfType(FHIRAllTypes.Organization)
-                .OrType(FHIRAllTypes.Patient, $"http://validationtest.org/fhir/StructureDefinition/PatientWith{prefix}Organization"));
+                .OrType(FHIRAllTypes.Patient,
+                    $"http://validationtest.org/fhir/StructureDefinition/PatientWith{prefix}Organization"));
 
             return result;
         }
 
         private static StructureDefinition bundleWithConstrainedContained()
         {
-            var result = CreateTestSd($"http://validationtest.org/fhir/StructureDefinition/BundleWithConstrainedContained",
-                            $"Bundle with a constraint on the Bundle.entry.resource",
-                    $"Bundle with a constraint on the Bundle.entry.resource", FHIRAllTypes.Bundle);
+            var result = CreateTestSd(
+                $"http://validationtest.org/fhir/StructureDefinition/BundleWithConstrainedContained",
+                $"Bundle with a constraint on the Bundle.entry.resource",
+                $"Bundle with a constraint on the Bundle.entry.resource", FHIRAllTypes.Bundle);
 
             var cons = result.Differential.Element;
 
@@ -445,10 +458,14 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
         }
 
 
-        private static StructureDefinition patientWithSpecificOrganization(IEnumerable<ElementDefinition.AggregationMode> aggregation, string prefix)
+        private static StructureDefinition patientWithSpecificOrganization(
+            IEnumerable<ElementDefinition.AggregationMode> aggregation, string prefix)
         {
-            var result = CreateTestSd($"http://validationtest.org/fhir/StructureDefinition/PatientWith{prefix}Organization", $"Patient with {prefix} managing organization",
-                    $"Patient for which the managingOrganization reference is limited to {prefix} references", FHIRAllTypes.Patient);
+            var result = CreateTestSd(
+                $"http://validationtest.org/fhir/StructureDefinition/PatientWith{prefix}Organization",
+                $"Patient with {prefix} managing organization",
+                $"Patient for which the managingOrganization reference is limited to {prefix} references",
+                FHIRAllTypes.Patient);
 
             var cons = result.Differential.Element;
 
@@ -462,29 +479,34 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildParametersWithBoundParams()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/ParametersWithBoundParams", "Parameters with term binding on Params",
-                    "Parameters resource where the parameter.value[x] is bound to a valueset", FHIRAllTypes.Parameters);
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/ParametersWithBoundParams",
+                "Parameters with term binding on Params",
+                "Parameters resource where the parameter.value[x] is bound to a valueset", FHIRAllTypes.Parameters);
             var cons = result.Differential.Element;
 
             cons.Add(new ElementDefinition("Parameters").OfType(FHIRAllTypes.Parameters));
             cons.Add(new ElementDefinition("Parameters.parameter.value[x]")
-                    .WithBinding("http://hl7.org/fhir/ValueSet/data-absent-reason", BindingStrength.Required));
+                .WithBinding("http://hl7.org/fhir/ValueSet/data-absent-reason", BindingStrength.Required));
 
             return result;
         }
 
-        private const string QUANTITY_WITH_UNLIMITED_ROOT_CARDINALITY_CANONICAL = "http://validationtest.org/fhir/StructureDefinition/QuantityWithUnlimitedRootCardinality";
-        public const string PROFILED_ORG_URL = "http://validationtest.org/fhir/StructureDefinition/ProfiledOrganization";
+        private const string QUANTITY_WITH_UNLIMITED_ROOT_CARDINALITY_CANONICAL =
+            "http://validationtest.org/fhir/StructureDefinition/QuantityWithUnlimitedRootCardinality";
+
+        public const string PROFILED_ORG_URL =
+            "http://validationtest.org/fhir/StructureDefinition/ProfiledOrganization";
 
         private static StructureDefinition buildQuantityWithUnlimitedRootCardinality()
         {
-            var result = CreateTestSd(QUANTITY_WITH_UNLIMITED_ROOT_CARDINALITY_CANONICAL, "A Quantity with a root cardinality of 0..*",
-                    "Parameters resource where the parameter.value[x] is bound to a valueset", FHIRAllTypes.Quantity);
+            var result = CreateTestSd(QUANTITY_WITH_UNLIMITED_ROOT_CARDINALITY_CANONICAL,
+                "A Quantity with a root cardinality of 0..*",
+                "Parameters resource where the parameter.value[x] is bound to a valueset", FHIRAllTypes.Quantity);
             var cons = result.Differential.Element;
 
             var quantityRoot = new ElementDefinition("Quantity").OfType(FHIRAllTypes.Quantity);
             quantityRoot.Min = 0;
-            quantityRoot.Max = "*";  // this is actually the case in all core classes as well.
+            quantityRoot.Max = "*"; // this is actually the case in all core classes as well.
             cons.Add(quantityRoot);
 
             return result;
@@ -492,40 +514,42 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildRangeWithLowAsAQuantityWithUnlimitedRootCardinality()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/RangeWithLowAsAQuantityWithUnlimitedRootCardinality",
+            var result = CreateTestSd(
+                "http://validationtest.org/fhir/StructureDefinition/RangeWithLowAsAQuantityWithUnlimitedRootCardinality",
                 "Range referring to a profiled quantity",
                 "Range that refers to a profiled quantity on its Range.low - this profiled Quantity has a 0..* root.",
-                   FHIRAllTypes.Range);
+                FHIRAllTypes.Range);
             var cons = result.Differential.Element;
 
             cons.Add(new ElementDefinition("Range").OfType(FHIRAllTypes.Range));
             cons.Add(new ElementDefinition("Range.low")
                 .OfType(FHIRAllTypes.Quantity, profile: QUANTITY_WITH_UNLIMITED_ROOT_CARDINALITY_CANONICAL)
-                .Required(min: 1, max: null));   // just set min to 1 and leave max out.
+                .Required(min: 1, max: null)); // just set min to 1 and leave max out.
 
             return result;
         }
 
         private static StructureDefinition buildValueDescriminatorWithPattern()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/ValueDiscriminatorWithPattern", "A value discriminator including pattern[x]",
-                    "Expresses a discriminator of type value, which expects pattern[x] to be considered part of it too.", FHIRAllTypes.Practitioner);
+            var result = CreateTestSd(
+                "http://validationtest.org/fhir/StructureDefinition/ValueDiscriminatorWithPattern",
+                "A value discriminator including pattern[x]",
+                "Expresses a discriminator of type value, which expects pattern[x] to be considered part of it too.",
+                FHIRAllTypes.Practitioner);
             var cons = result.Differential.Element;
 
             cons.Add(new ElementDefinition("Practitioner").OfType(FHIRAllTypes.Practitioner));
 
             var slicingIntro = new ElementDefinition("Practitioner.identifier")
                 .WithSlicingIntro(ElementDefinition.SlicingRules.Closed,
-                (ElementDefinition.DiscriminatorType.Pattern, "type"));
+                    (ElementDefinition.DiscriminatorType.Pattern, "type"));
 
             cons.Add(slicingIntro);
 
             // Slice 1 - binds to FHIR's identifier-type (req) PLUS requires a local code translation
             cons.Add(new ElementDefinition("Practitioner.identifier")
             {
-                ElementId = "Practitioner.identifier:slice1",
-                SliceName = "slice1",
-                Max = "1"
+                ElementId = "Practitioner.identifier:slice1", SliceName = "slice1", Max = "1"
             });
             cons.Add(new ElementDefinition("Practitioner.identifier.type")
             {
@@ -536,9 +560,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
             // Slice 2 - binds to FHIR's identifier-type (req) PLUS requires another local code translation
             cons.Add(new ElementDefinition("Practitioner.identifier")
             {
-                ElementId = "Practitioner.identifier:slice2",
-                SliceName = "slice2",
-                Max = "*"
+                ElementId = "Practitioner.identifier:slice2", SliceName = "slice2", Max = "*"
             });
             cons.Add(new ElementDefinition("Practitioner.identifier.type")
             {
@@ -549,9 +571,7 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
             // Slice 3 - binds to FHIR's identifier-type (req), no other requirements
             cons.Add(new ElementDefinition("Practitioner.identifier")
             {
-                ElementId = "Practitioner.identifier:slice3",
-                SliceName = "slice3",
-                Max = "*"
+                ElementId = "Practitioner.identifier:slice3", SliceName = "slice3", Max = "*"
             });
             cons.Add(new ElementDefinition("Practitioner.identifier.type")
             {
@@ -561,11 +581,15 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
             return result;
         }
 
-        internal static StructureDefinition CreateTestSd(string url, string name, string description, FHIRAllTypes constrainedType, string baseUri = null)
+        internal static StructureDefinition CreateTestSd(string url, string name, string description,
+            FHIRAllTypes constrainedType, string baseUri = null)
         {
             var result = new StructureDefinition
             {
-                Url = url, Name = name, Status = PublicationStatus.Draft, Description = new Markdown(description),
+                Url = url,
+                Name = name,
+                Status = PublicationStatus.Draft,
+                Description = new Markdown(description),
                 FhirVersion = EnumUtility.ParseLiteral<FHIRVersion>(ModelInfo.Version),
                 Derivation = StructureDefinition.TypeDerivationRule.Constraint,
                 Type = constrainedType.GetLiteral(),
@@ -588,13 +612,15 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildMyExtension()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/MyRangeExtension", "My Rage Extension",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/MyRangeExtension",
+                "My Rage Extension",
                 "An extension with a value of type Range", FHIRAllTypes.Extension);
 
             var cons = result.Differential.Element;
 
             cons.Add(new ElementDefinition("Extension").OfType(FHIRAllTypes.Extension));
-            cons.Add(new ElementDefinition("Extension.url").Value(new FhirUri("http://validationtest.org/fhir/StructureDefinition/MyRangeExtension")));
+            cons.Add(new ElementDefinition("Extension.url").Value(
+                new FhirUri("http://validationtest.org/fhir/StructureDefinition/MyRangeExtension")));
             cons.Add(new ElementDefinition("Extension.value[x]").OfType(FHIRAllTypes.Range));
 
             return result;
@@ -602,7 +628,8 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildBoolean()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/RequiredBoolean", "Required Boolean",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/RequiredBoolean",
+                "Required Boolean",
                 "A boolean type where the value is required", FHIRAllTypes.Boolean);
 
             var cons = result.Differential.Element;
@@ -615,8 +642,9 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildPatientWithDeceasedConstraints(string profile = null)
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/DeceasedPatient" + profile, "DeceasedPatient",
-                    "Test Patient with extra deceased constraints", FHIRAllTypes.Patient);
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/DeceasedPatient" + profile,
+                "DeceasedPatient",
+                "Test Patient with extra deceased constraints", FHIRAllTypes.Patient);
             var cons = result.Differential.Element;
 
             cons.Add(new ElementDefinition("Patient").OfType(FHIRAllTypes.Patient));
@@ -629,25 +657,27 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
             }
 
             var slicingIntro = new ElementDefinition("Patient.deceased[x].extension")
-                .WithSlicingIntro(ElementDefinition.SlicingRules.Open, (ElementDefinition.DiscriminatorType.Value, "url"));
+                .WithSlicingIntro(ElementDefinition.SlicingRules.Open,
+                    (ElementDefinition.DiscriminatorType.Value, "url"));
 
             cons.Add(slicingIntro);
 
             cons.Add(new ElementDefinition("Patient.deceased[x].extension")
             {
-                ElementId = "Patient.deceased[x].extension:range",
-                SliceName = "range",
-            }.OfType(FHIRAllTypes.Extension, "http://validationtest.org/fhir/StructureDefinition/MyRangeExtension"));
+                ElementId = "Patient.deceased[x].extension:range", SliceName = "range",
+            }.OfType(FHIRAllTypes.Extension,
+                "http://validationtest.org/fhir/StructureDefinition/MyRangeExtension"));
             return result;
         }
 
         private static IEnumerable<StructureDefinition> buildPatientWithProfiledReferences()
         {
             yield return CreateTestSd(PROFILED_ORG_URL, "A profiled organization",
-                    "A profiled Organization with no additional constraints", FHIRAllTypes.Organization);
+                "A profiled Organization with no additional constraints", FHIRAllTypes.Organization);
 
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/PatientWithReferences", "Patient with References",
-                    "Test Patient which has a profiled managing organization", FHIRAllTypes.Patient);
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/PatientWithReferences",
+                "Patient with References",
+                "Test Patient which has a profiled managing organization", FHIRAllTypes.Patient);
             var cons = result.Differential.Element;
 
             cons.Add(new ElementDefinition("Patient").OfType(FHIRAllTypes.Patient));
@@ -657,13 +687,15 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildSliceOnChoice()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/MedicationRequest-issue-2132", "MedicationRequest-issue-2132",
+            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/MedicationRequest-issue-2132",
+                "MedicationRequest-issue-2132",
                 "MedicationRequest sliced on substitution.allowed[x]", FHIRAllTypes.MedicationRequest);
 
             var cons = result.Differential.Element;
 
             var slicingIntro = new ElementDefinition("MedicationRequest.substitution.allowed[x]")
-               .WithSlicingIntro(ElementDefinition.SlicingRules.Closed, (ElementDefinition.DiscriminatorType.Type, "$this"));
+                .WithSlicingIntro(ElementDefinition.SlicingRules.Closed,
+                    (ElementDefinition.DiscriminatorType.Type, "$this"));
 
             cons.Add(slicingIntro);
 
@@ -684,42 +716,17 @@ namespace Hl7.Fhir.Specification.Tests.Snapshot
 
         private static StructureDefinition buildConstrainBindableType()
         {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/MedicationRequest-issue-2132-2", "MedicationRequest-issue-2132",
+            var result = CreateTestSd(
+                "http://validationtest.org/fhir/StructureDefinition/MedicationRequest-issue-2132-2",
+                "MedicationRequest-issue-2132",
                 "MedicationRequest sliced on substitution.allowed[x]", FHIRAllTypes.MedicationRequest);
 
             var cons = result.Differential.Element;
 
-            var typeConstraint = new ElementDefinition("MedicationRequest.substitution.allowed[x]").OfType(FHIRAllTypes.Boolean);
+            var typeConstraint =
+                new ElementDefinition("MedicationRequest.substitution.allowed[x]").OfType(FHIRAllTypes.Boolean);
 
             cons.Add(typeConstraint);
-
-            return result;
-        }
-
-        private static StructureDefinition buildSliceOnContentReference()
-        {
-            var result = CreateTestSd("http://validationtest.org/fhir/StructureDefinition/Parameters-issue-3177", "Parameters-issue-3177",
-                "Parameters with sliced parts - and so copied contentReferences", FHIRAllTypes.Parameters);
-
-            var cons = result.Differential.Element;
-
-            var slicingIntro = new ElementDefinition("Parameters.parameter.part")
-                .WithSlicingIntro(ElementDefinition.SlicingRules.Closed,
-                    (ElementDefinition.DiscriminatorType.Pattern, "name"))
-                .Required();
-
-            cons.Add(slicingIntro);
-
-            cons.Add(new ElementDefinition("Parameters.parameter.part")
-            {
-                ElementId = "Parameters.parameter.part:medicationDispense", SliceName = "medicationDispense",
-            }.Required());
-
-            cons.Add(new ElementDefinition("Parameters.parameter.part.name")
-            {
-                ElementId = "Parameters.parameter.part:medicationDispense.name",
-                Pattern = new FhirString("medicationDispense")
-            });
 
             return result;
         }


### PR DESCRIPTION
Fixes #3177.

The java tooling gets confused when a snapshot contains both a contentRef to an element, and the (copied) children of that element, so we are now suppressing the contentReference link when we have copied the children.

ℹ️ Rider has reformatted the sourcecode in TestProfileArtifactSource, but there are (or should be) no real changes beyond making one of its private methods internal.
