### PR TITLE
Remove deprecated IssueComponent.Location assignment from Issue creation

### DIFF
--- a/src/Hl7.Fhir.Base/Specification/Issue.cs
+++ b/src/Hl7.Fhir.Base/Specification/Issue.cs
@@ -46,7 +46,6 @@ namespace Hl7.Fhir.Support
                 ic.Expression = new List<string> { path };
                 // we no longer set IssueComponent.Location for backwards compatibility, it's been long enough since it got deprecated
                 // https://github.com/FirelyTeam/firely-validator-api/issues/523
-                // ic.Location = new List<string> { path };
             }
 
             return ic;

--- a/src/Hl7.Fhir.Base/Specification/Issue.cs
+++ b/src/Hl7.Fhir.Base/Specification/Issue.cs
@@ -44,8 +44,9 @@ namespace Hl7.Fhir.Support
             if (path is not null)
             {
                 ic.Expression = new List<string> { path };
-                // IssueComponent.Location is deprecated but we still set this because of backwards compatibility.
-                ic.Location = new List<string> { path };
+                // we no longer set IssueComponent.Location for backwards compatibility, it's been long enough since it got deprecated
+                // https://github.com/FirelyTeam/firely-validator-api/issues/523
+                // ic.Location = new List<string> { path };
             }
 
             return ic;

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -1146,7 +1146,7 @@ namespace Hl7.Fhir.Specification.Tests
             }
             if (location != null && location.Length > 0)
             {
-                Assert.IsTrue(location.SequenceEqual(issue.Location));
+                Assert.IsTrue(location.SequenceEqual(issue.Expression));
             }
         }
 


### PR DESCRIPTION
Closes [firely-validator-api/523](https://github.com/FirelyTeam/firely-validator-api/issues/523)