### PR TITLE
Fixed FhirUri.IsValidValue returning true when its value is empty (6.0)

### DIFF
--- a/src/Hl7.Fhir.Base/Model/FhirUri.cs
+++ b/src/Hl7.Fhir.Base/Model/FhirUri.cs
@@ -66,6 +66,9 @@ public partial class FhirUri : ICoded
     public static bool IsValidValue(string value)
     {
         Uri uri;
+        
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
 
         try
         {


### PR DESCRIPTION
## Related issues
fixes #3203