### PR TITLE
Changes after porting to cql sdk

### DIFF
--- a/src/Hl7.Fhir.Base/Model/Base.Extensions.cs
+++ b/src/Hl7.Fhir.Base/Model/Base.Extensions.cs
@@ -45,7 +45,7 @@ public static partial class BaseExtensions
 
     public static T DeepCopy<T>(this T source) where T : Base => (T)source.DeepCopyInternal();
 
-    public static void CopyTo<T>(this T source, T target) where T : Base => source.CopyToInternal(target);
+    public static void CopyTo(this Base source, Base target) => source.CopyToInternal(target);
 
     public static IEnumerable<T> DeepCopy<T>(this IEnumerable<T> source) where T : Base => source.DeepCopyInternal();
     
@@ -66,21 +66,6 @@ public static partial class BaseExtensions
             };
         }
     }
-
-    // internal static DynamicPrimitive ToDynamicPrimitive(this Base instance)
-    // {
-    //     var primitive = new DynamicPrimitive { DynamicTypeName = instance.TypeName};
-    //
-    //     foreach(var element in instance.EnumerateElements())
-    //     {
-    //         if(element.Key == "value")
-    //             primitive.ObjectValue = element.Value;
-    //         else
-    //             primitive.SetValue(element.Key, element.Value);
-    //     }
-    //
-    //     return primitive;
-    // }
 
     internal static DynamicDataType ToDynamicDataType(this Base instance)
     {

--- a/src/Hl7.Fhir.Base/Model/Code.cs
+++ b/src/Hl7.Fhir.Base/Model/Code.cs
@@ -76,4 +76,14 @@ public partial class Code : ICoded
 
     /// <inheritdoc cref="ICoded.ToCodings"/>
     public virtual IReadOnlyCollection<Coding> ToCodings() => [new(system: null, code: Value)];
+
+    /// <summary>
+    /// The literal of the code value, which is the same as the <see cref="Value"/>.
+    /// </summary>
+    public virtual string? Literal => Value;
+
+    /// <summary>
+    /// The system of the code value, which is always null for a Code.
+    /// </summary>
+    public virtual string? System => null;
 }

--- a/src/Hl7.Fhir.Base/Model/CodeOfT.cs
+++ b/src/Hl7.Fhir.Base/Model/CodeOfT.cs
@@ -132,6 +132,16 @@ public class Code<T> : Code, INullableValue<T> where T : struct, Enum
     /// <inheritdoc />
     public override IReadOnlyCollection<Coding> ToCodings() => [new(Value?.GetSystem(), Value?.GetLiteral())];
 
+    /// <summary>
+    /// The literal of the code value, taken from the enum that is in <see cref="Value"/>.
+    /// </summary>
+    public override string? Literal => Value?.GetSystem();
+
+    /// <summary>
+    /// The system of the code value, taken from the enum that is in <see cref="Value"/>.
+    /// </summary>
+    public override string? System => Value?.GetLiteral();
+
     protected internal override P.Any? TryConvertToSystemTypeInternal() =>
         Value is not null ? new P.Code(Value.GetSystem(), Value.GetLiteral()!, display: null, version: null) : null;
 

--- a/src/Hl7.Fhir.Base/Model/FhirDateTime.cs
+++ b/src/Hl7.Fhir.Base/Model/FhirDateTime.cs
@@ -66,6 +66,11 @@ public partial class FhirDateTime
     {
     }
 
+    public FhirDateTime(int year, int month, int day, int hr, int min, int sec, int millis, TimeSpan offset)
+        : this(new DateTimeOffset(year, month, day, hr, min, sec, millis, offset))
+    {
+    }
+
     public FhirDateTime(int year, int month, int day, int hr, int min, int sec, TimeSpan offset)
         : this(new DateTimeOffset(year, month, day, hr, min, sec, offset))
     {

--- a/src/Hl7.Fhir.Base/Model/Initializers.cs
+++ b/src/Hl7.Fhir.Base/Model/Initializers.cs
@@ -118,7 +118,7 @@ public partial class Identifier
     {
     }
 
-    public Identifier(string system, string value)
+    public Identifier(string? system, string? value)
     {
         this.System = system;
         this.Value = value;
@@ -132,7 +132,7 @@ public partial class Period
     {
     }
 
-    public Period(FhirDateTime start, FhirDateTime end)
+    public Period(FhirDateTime? start, FhirDateTime? end)
     {
         StartElement = start;
         EndElement = end;
@@ -175,7 +175,7 @@ public partial class Quantity
     {
     }
 
-    public Quantity(decimal value, string unit, string system = "http://unitsofmeasure.org")
+    public Quantity(decimal value, string? unit, string? system = "http://unitsofmeasure.org")
     {
         Value = value;
         Unit = unit;

--- a/src/Hl7.Fhir.Base/Model/PrimitiveType.cs
+++ b/src/Hl7.Fhir.Base/Model/PrimitiveType.cs
@@ -45,7 +45,7 @@ public partial class PrimitiveType : P.IToSystemPrimitive
     /// Returns true if the primitive has any child elements (currently in FHIR this can
     /// be only the element id and zero or more extensions).
     /// </summary>
-    public bool HasElements => ElementIdElement?.JsonValue is not null || Extension?.Any() == true;
+    public bool HasElements => ElementIdElement?.JsonValue is not null || Extension.Any();
 
     protected internal abstract P.Any? TryConvertToSystemTypeInternal();
 

--- a/src/Hl7.Fhir.Base/Model/Time.cs
+++ b/src/Hl7.Fhir.Base/Model/Time.cs
@@ -43,17 +43,31 @@ namespace Hl7.Fhir.Model;
 public partial class Time
 {
     public const string FMT_HOURMINSEC = "{0:D2}:{1:D2}:{2:D2}";
+    public const string FMT_HOURMINSECMS = "{0:D2}:{1:D2}:{2:D2}.{3:D2}";
 
     public Time(int hour, int minute, int second) : this(string.Format(CultureInfo.InvariantCulture, FMT_HOURMINSEC, hour, minute, second))
     {
         // Nothing
     }
     
+    public Time(int hour, int minute, int second, int millis) :
+        this(string.Format(CultureInfo.InvariantCulture, FMT_HOURMINSECMS, hour, minute, second, millis))
+    {
+        // Nothing
+    }
+
     /// <summary>
     /// Takes the hour, minute and second of a given <see cref="DateTimeOffset"/> in the indicated timezone, and uses this
     /// to construct a new Time.
     /// </summary>
-    public static Time FromDateTimeOffset(DateTimeOffset dto) => new(dto.Hour, dto.Minute, dto.Second);
+    /// <remarks>Note that by default, milliseconds are not included in the Time value. This is due to
+    /// the nature of the FHIR Time datatype, which is normally used to communicate a time of day, e.g. for
+    /// a medication administration. It is unusual to include milliseconds in such a time.
+    /// </remarks>
+    public static Time FromDateTimeOffset(DateTimeOffset dto, bool includeMillis = false) =>
+        includeMillis
+            ? new Time(dto.Hour, dto.Minute, dto.Second, dto.Millisecond)
+            : new Time(dto.Hour, dto.Minute, dto.Second);
 
     public static Time Now() => FromDateTimeOffset(DateTimeOffset.Now);
 

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonConverterOptions.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonConverterOptions.cs
@@ -9,6 +9,8 @@
 
 #nullable enable
 
+using System;
+
 namespace Hl7.Fhir.Serialization;
 
 /// <summary>
@@ -21,3 +23,6 @@ public record FhirJsonConverterOptions : DeserializerSettings
     /// </summary>
     public SerializationFilter? SummaryFilter { get; init; } = null;
 }
+
+[Obsolete("Use FhirJsonConverterOptions instead. This will be removed in a future version.")]
+public record FhirJsonPocoDeserializerSettings : FhirJsonConverterOptions;

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/TimeTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/TimeTests.cs
@@ -28,6 +28,18 @@ namespace Hl7.Fhir.Tests.Model
         }
 
         [TestMethod]
+        public void FromDateTimeOffsetWithMilliseconds()
+        {
+            var stamp = new DateTimeOffset(1972, 11, 30, 15, 10, 0, 123, TimeSpan.Zero);
+
+            var dt = Time.FromDateTimeOffset(stamp);
+            dt.Value.Should().Be("15:10:00");
+
+            dt = Time.FromDateTimeOffset(stamp, includeMillis: true);
+            dt.Value.Should().Be("15:10:00.123");
+        }
+
+        [TestMethod]
         public void TryToTimeSpan()
         {
             var fdt = new Time(13, 4, 18);
@@ -107,7 +119,17 @@ namespace Hl7.Fhir.Tests.Model
             dt.Millis.Should().Be(123);
             dt.Precision.Should().Be(ElementModel.Types.DateTimePrecision.Fraction);
 
+            dft = new Time(11,12,34,123);
+            dft.TryToSystemTime(out dt).Should().BeTrue();
+            dt.Millis.Should().Be(123);
+            dt.Precision.Should().Be(ElementModel.Types.DateTimePrecision.Fraction);
+
             dft = new Time(null);
+            dft.TryToSystemTime(out dt).Should().BeFalse();
+            dt.Should().BeNull();
+
+            // Time cannot have an offset, so this should fail
+            dft = new Time("01:01:01.001Z");
             dft.TryToSystemTime(out dt).Should().BeFalse();
             dt.Should().BeNull();
         }


### PR DESCRIPTION
While porting CQL SDK to use SDK6, I found some improvements we could make to SDK6 to make migration easier. See the comments about that on https://github.com/FirelyTeam/firely-cql-sdk/pull/932.

In this PR I have executed some of these. I have also improved our SDK6.0 breaking changes to reflect these changes.