### PR TITLE
3235 Redefine parser types

### DIFF
--- a/src/Hl7.Fhir.Base/Serialization/CodedExceptionFilters.cs
+++ b/src/Hl7.Fhir.Base/Serialization/CodedExceptionFilters.cs
@@ -2,6 +2,7 @@
 
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Utility;
+using Hl7.Fhir.Validation;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -15,25 +16,25 @@ namespace Hl7.Fhir.Serialization;
 public static class CodedExceptionFilters
 {
     /// <summary>
-    /// Creates a predicate that returns true if a <see cref="CodedException"/> is an issue with the json or xml syntax.
-    /// After parsing, these issues are not represented in the model. See <see cref="DeserializationMode.SyntaxOnly"/>.
-    /// </summary>
-    public static readonly Predicate<CodedException> IsSyntaxOnlyIssue =
-        ce => ce is ExtendedCodedException ece && ece.IssueType != OperationOutcome.IssueType.Structure;
-
-    /// <summary>
-    /// Creates a predicate that returns true if a <see cref="CodedException"/> is recoverable,
+    /// A predicate that returns true if a <see cref="CodedException"/> is recoverable,
     /// which means that all data is represented in the POCO, so there is no data loss.
     /// See <see cref="DeserializationMode.Recoverable"/>.
     /// </summary>
-    public static readonly Predicate<CodedException> IsRecoverableIssue =
+    public static readonly Predicate<CodedException> FilterRecoverableIssues =
         ce => ce is ExtendedCodedException ece && ece.IssueSeverity != OperationOutcome.IssueSeverity.Fatal;
 
     /// <summary>
-    /// Creates a predicate that returns true if a <see cref="CodedException"/> signifies a backwards compatibility issue.
+    /// A predicate that returns true if an error recoverable and also does not require
+    /// overflow to capture the data.
+    /// </summary>
+    public static readonly Predicate<CodedException> FilterNoOverflowIssues =
+        ce => FilterRecoverableIssues(ce) &&
+              !CodedValidationException.ISSUES_CAUSED_BY_OVERFLOW.Contains(ce.ErrorCode);
+    /// <summary>
+    /// A predicate that returns true if a <see cref="CodedException"/> signifies a backwards compatibility issue.
     /// See <see cref="DeserializationMode.BackwardsCompatible"/>.
     /// </summary>
-    public static readonly Predicate<CodedException> IsBackwardsCompatibilityIssue =
+    public static readonly Predicate<CodedException> FilterBackwardsCompatibilityIssues =
         ce => FhirJsonException.BACKWARDS_COMPATIBILITY_ALLOWED_ISSUES.Contains(ce.ErrorCode) ||
               FhirXmlException.BACKWARDS_COMPATIBILITY_ALLOWED_ISSUES.Contains(ce.ErrorCode);
 

--- a/src/Hl7.Fhir.Base/Serialization/DeserializerModes.cs
+++ b/src/Hl7.Fhir.Base/Serialization/DeserializerModes.cs
@@ -1,36 +1,50 @@
 #nullable enable
+using Hl7.Fhir.Model;
+
 namespace Hl7.Fhir.Serialization;
 
 /// <summary>
-/// Enumerates the modes with which a deserializer can be configured
+/// Enumerates the modes with which a deserializer can be configured. When a deserializer is configured with a specific mode,
+/// it will not throw (on Deserialize) or return false (on TryDeserialize) when certain classes of error are encountered.
 /// </summary>
+/// <remarks>In any other mode that <see cref="Strict"/>, the list of errors reported by the deserializer will be incomplete,
+/// as ignored errors are not reported or even stopped from being detected at all.</remarks>
 public enum DeserializationMode
 {
     /// <summary>
-    /// Do not ignore any errors (default behaviour for most implementations)
+    /// Do not ignore any errors (default behaviour for most implementations). Will report all errors.
     /// </summary>
     Strict,
 
     /// <summary>
-    /// An issue is allowable for backwards compatibility if it could be caused because an older parser encounters data coming from a newer
-    /// FHIR release. This means allowing unknown elements, attributes, codes and types in a choice element.
+    /// In this mode, the deserializer will ignore <see cref="Recoverable"/> errors, as long as the data can
+    /// be captured in the POCO model without using "overflow". This means that in this mode, after deserialization,
+    /// all properties and primitive `Value` properties are guaranteed not to throw because of incorrect data.
+    /// Also, no unknown elements will be not be allowed, so <see cref="Base.Overflow"/> can be ignored.
     /// </summary>
-    BackwardsCompatible,
+    NoOverflow,
 
     /// <summary>
-    /// An issue is a syntax issue when it is caused by a mistake in the FHIR rules for the use of xml and json.
-    /// These issues, once parsed, are not reflected in the POCOs.
-    /// </summary>
-    SyntaxOnly,
-
-    /// <summary>
-    /// An issue is recoverable if all data present in the parsed data could be retrieved and
-    /// captured in the POCO model, even if the syntax or the data was not fully FHIR compliant.
+    /// Less strict that <see cref="NoOverflow" />, this will ignore all errors as long as all data was captured
+    /// the POCO model and overflow, even if the syntax or the data type was not fully FHIR compliant.
     /// </summary>
     Recoverable,
 
     /// <summary>
-    /// Ignore all errors.
+    /// An issue is allowable for backwards compatibility if it could be caused because an older parser encounters data
+    /// coming from a newer FHIR release. This means allowing unknown elements, attributes, codes and types in a choice element.
+    /// Note that this means data could end up in the overflow, and property access may throw.
+    /// </summary>
+    BackwardsCompatible,
+
+    /// <summary>
+    /// An issue is a syntax issue when it is raised by the parsing phase, and is caused by a mistake in the syntax rules
+    /// for FHIR xml and json. These issues, once parsed, are not reflected in the POCOs and are not part of model validation.
+    /// </summary>
+    SyntaxOnly,
+
+    /// <summary>
+    /// Ignore all errors. Deserialization will never throw or return false. Overflow might be in use.
     /// </summary>
     Ostrich,
 }

--- a/src/Hl7.Fhir.Base/Serialization/DeserializerSettings.cs
+++ b/src/Hl7.Fhir.Base/Serialization/DeserializerSettings.cs
@@ -120,24 +120,30 @@ public record DeserializerSettings
             },
             DeserializationMode.BackwardsCompatible => this with
             {
-                ExceptionFilter = CodedExceptionFilters.IsBackwardsCompatibilityIssue,
+                ExceptionFilter = CodedExceptionFilters.FilterBackwardsCompatibilityIssues,
                 NarrativeValidation = nvk ?? NarrativeValidationKind.None
             },
             DeserializationMode.Recoverable => this with
             {
-                ExceptionFilter = CodedExceptionFilters.IsRecoverableIssue,
+                ExceptionFilter = CodedExceptionFilters.FilterRecoverableIssues,
                 NarrativeValidation = nvk ?? NarrativeValidationKind.None
             },
             DeserializationMode.SyntaxOnly => this with
             {
-                ExceptionFilter = CodedExceptionFilters.IsSyntaxOnlyIssue,
+                Validator = null,   // Disable all model validations, we don't care.
+                ExceptionFilter = null,  // All exceptions coming from the parser are reported, on filtering.
+                NarrativeValidation = NarrativeValidationKind.None // Irrelevant as the Validator = null.
+            },
+            DeserializationMode.NoOverflow => this with
+            {
+                ExceptionFilter = CodedExceptionFilters.FilterNoOverflowIssues,
                 NarrativeValidation = nvk ?? NarrativeValidationKind.None
             },
             DeserializationMode.Ostrich => this with
             {
-                Validator = null,   // Disable all validations, we don't care.
+                Validator = null,   // Disable all model validations, we don't care.
                 ExceptionFilter = _ => true,   // If there are still errors, ignore.
-                NarrativeValidation = nvk ?? NarrativeValidationKind.None   // We don't care about the narrative.
+                NarrativeValidation = NarrativeValidationKind.None  // Irrelevant as the Validator = null.
             },
             _ => throw Error.NotSupported("Unknown deserialization mode.")
         };
@@ -166,7 +172,7 @@ public record ParserSettings : DeserializerSettings
     {
 #pragma warning disable CS0618 // Type or member is obsolete
     //    if (PermissiveParsing) augmentedFilter = augmentedFilter.Or(CodedExceptionFilters.IsRecoverableIssue);
-    get => PermissiveParsing ? base.ExceptionFilter.Or(CodedExceptionFilters.IsRecoverableIssue) : base.ExceptionFilter;
+    get => PermissiveParsing ? base.ExceptionFilter.Or(CodedExceptionFilters.FilterRecoverableIssues) : base.ExceptionFilter;
 #pragma warning restore CS0618 // Type or member is obsolete
 
 
@@ -176,7 +182,7 @@ public record ParserSettings : DeserializerSettings
     /// <summary>
     /// Do not raise exceptions for recoverable errors.
     /// </summary>
-    /// <remarks>This is the same as adding <see cref="CodedExceptionFilters.IsRecoverableIssue"/> to the exception filter.</remarks>
+    /// <remarks>This is the same as adding <see cref="CodedExceptionFilters.FilterRecoverableIssues"/> to the exception filter.</remarks>
     [Obsolete("Use WithMode(DeserializationMode.Recoverable) instead.")]
     public bool PermissiveParsing { get; init; }
 }

--- a/src/Hl7.Fhir.Base/Validation/CodedValidationException.cs
+++ b/src/Hl7.Fhir.Base/Validation/CodedValidationException.cs
@@ -51,27 +51,20 @@ public class CodedValidationException : ExtendedCodedException
     public const string UNKNOWN_ELEMENT_CODE = "PVAL128";
     public const string ELEMENT_CANNOT_BE_EMPTY_CODE = "PVAL129";
 
-    // A list of all issues mentioned above, so we can filter on them.
-    internal static readonly HashSet<string> POCO_VALIDATION_ISSUES =
+    // A list of all issues that would throw an exception if the user used the
+    // properties on the POCOs (and specifically the Value prop on datatypes).
+    // Otherwise said, if none of these are raised, the user should be able to
+    // use the POCOs without us throwing validation exceptions and should not be
+    // required to check the <see cref="Base.Overflow"/> for unknown elements.
+    internal static readonly HashSet<string> ISSUES_CAUSED_BY_OVERFLOW =
     [
-        CHOICE_TYPE_NOT_ALLOWED_CODE,
-        INCORRECT_CARDINALITY_MIN_CODE,
-        INCORRECT_CARDINALITY_MAX_CODE,
-        REPEATING_ELEMENT_CANNOT_CONTAIN_NULL_CODE,
-        MANDATORY_ELEMENT_MUST_BE_PRESENT_CODE,
-        NARRATIVE_XML_IS_MALFORMED_CODE,
-        NARRATIVE_XML_IS_INVALID_CODE,
         INVALID_CODED_VALUE_CODE,
-        CONTAINED_RESOURCES_CANNOT_BE_NESTED_CODE,
         INVALID_STRING_LENGTH_CODE,
         INVALID_BASE64_VALUE_CODE,
         INCORRECT_LITERAL_VALUE_TYPE_CODE,
         LITERAL_INVALID_CODE,
-        POSITIVE_INT_MUST_BE_POSITIVE_CODE,
-        UNSIGNED_INT_MUST_NOT_BE_NEGATIVE_CODE,
         PROPERTY_TYPE_MISMATCH_CODE,
         UNKNOWN_ELEMENT_CODE,
-        ELEMENT_CANNOT_BE_EMPTY_CODE
     ];
 
     internal static COVE CHOICE_TYPE_NOT_ALLOWED(PocoValidationContext context, string typeName) => Initialize(context, CHOICE_TYPE_NOT_ALLOWED_CODE, $"Value is of type '{typeName}', which is not an allowed choice.", OO_Sev.Error, OO_Typ.Value);

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/CodedExceptionFilterTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/CodedExceptionFilterTests.cs
@@ -1,0 +1,32 @@
+using FluentAssertions;
+using Hl7.Fhir.Serialization;
+using Hl7.Fhir.Validation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using ERR = Hl7.Fhir.Serialization.FhirJsonException;
+
+namespace Hl7.Fhir.Support.Poco.Tests;
+
+[TestClass]
+public class CodedExceptionFilterTests
+{
+    [TestMethod]
+    [DataRow(CodedValidationException.INCORRECT_CARDINALITY_MAX_CODE, true)]
+    [DataRow(CodedValidationException.MANDATORY_ELEMENT_MUST_BE_PRESENT_CODE, true)]
+    [DataRow(CodedValidationException.INVALID_BASE64_VALUE_CODE, false)]
+    [DataRow(CodedValidationException.UNKNOWN_ELEMENT_CODE, false)]
+    public void NoOverflowFilterDetectsOverflowIssue(string code, bool shouldBeFiltered)
+    {
+        CodedValidationException test = new(code, "test message");
+        CodedExceptionFilters.FilterNoOverflowIssues(test).Should().Be(shouldBeFiltered);
+    }
+
+    [TestMethod]
+    public void NoOverflowFilterDetectsFatalIssue()
+    {
+        Utf8JsonReader reader = new();
+        var fatal = ERR.DUPLICATE_PROPERTY(ref reader, "test", "test");
+
+        CodedExceptionFilters.FilterNoOverflowIssues(fatal).Should().Be(false);
+    }
+}

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
@@ -886,13 +886,13 @@ public partial class FhirJsonDeserializationTests
         [
             new JsonSerializerOptions().ForFhir()
                 .UsingMode(DeserializationMode.Recoverable),
-            new Predicate<IEnumerable<CodedException>>(errs => !errs.Any(e => CodedExceptionFilters.IsRecoverableIssue(e)))
+            new Predicate<IEnumerable<CodedException>>(errs => !errs.Any(e => CodedExceptionFilters.FilterRecoverableIssues(e)))
         ];
         yield return
         [
             new JsonSerializerOptions().ForFhir()
                 .UsingMode(DeserializationMode.BackwardsCompatible),
-            new Predicate<IEnumerable<CodedException>>(errs => !errs.Any(e => CodedExceptionFilters.IsBackwardsCompatibilityIssue(e)))
+            new Predicate<IEnumerable<CodedException>>(errs => !errs.Any(e => CodedExceptionFilters.FilterBackwardsCompatibilityIssues(e)))
         ];
         yield return
         [


### PR DESCRIPTION
Fixes #3235

* Added a new NoOverflow mode to the deserializer
* Improved the description of all deserializer modes to reflect their exact purpose.
* Refined Syntax mode to simply be all errors not coming from model validation.
