### PR TITLE
3237 Use generated getter setter instead of GetValue/SetValue

### DIFF
--- a/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
@@ -202,20 +202,6 @@ public class PropertyMapping : IElementDefinitionSummary
     public string? BindingName { get; init; }
 
     /// <summary>
-    /// The function to use to get the value of this property on an instance of the class.
-    /// </summary>
-    /// <remarks>If left null, the framework will determine the fastest way to get the value on the
-    /// first call to <see cref="GetValue"/>.</remarks>
-    public Func<Base, object?>? Getter { get => _getter; init => _getter = value; }
-
-    /// <summary>
-    /// The function to use to set the value of this property on an instance of the class.
-    /// </summary>
-    /// <remarks>If left null, the framework will determine the fastest way to set the value on the
-    /// first call to <see cref="SetValue"/>.</remarks>
-    public Action<Base, object?>? Setter { get => _setter; init => _setter = value; }
-
-    /// <summary>
     /// The <see cref="ModelInspector"/> for which this mapping was created.
     /// </summary>
     public ModelInspector Inspector => DeclaringClass.Inspector;
@@ -352,14 +338,26 @@ public class PropertyMapping : IElementDefinitionSummary
     private static bool isAllowedNativeTypeForDataTypeValue(Type type) =>
         type.IsEnum || ClassMapping.SupportedDotNetPrimitiveTypes.Contains(type);
 
+// I have disabled this code since the deserializer and serializer no longer use these properties
+// instead they are calling TryGetValue and TrySetValue of the new dynamic/overflow subsystem.
+// Since these properties would enable some novel usecases in the future (like creating custom properties
+// that set cross-version extensions), I have left the code in place.
+ #if USE_GETTER_SETTER_AND_CODEGEN
+
     /// <summary>
-    /// Given an instance of the parent class, gets the value for this property.
+    /// The function to use to get the value of this property on an instance of the class.
     /// </summary>
-    public object? GetValue(Base instance) =>
-        LazyInitializer.EnsureInitialized(ref _getter, getValueGetter)!.Invoke(instance);
+    /// <remarks>If not explicitly set, the framework will determine the fastest way to get the value
+    /// the first time get is called.</remarks>
+    public Func<Base, object?> Getter
+    {
+        get => LazyInitializer.EnsureInitialized(ref _getter, buildValueGetter)!;
+        init => _getter = value;
+    }
+
     private Func<Base, object?>? _getter;
 
-    private Func<Base, object?> getValueGetter()
+    private Func<Base, object?> buildValueGetter()
     {
         // If this is a custom property, or this platform does not support code generation,
         // use dictionary access, otherwise use the generated getter.
@@ -368,19 +366,36 @@ public class PropertyMapping : IElementDefinitionSummary
     }
 
     /// <summary>
-    /// Given an instance of the parent class, sets the value for this property.
+    /// The function to use to set the value of this property on an instance of the class.
     /// </summary>
-    public void SetValue(Base instance, object? value) =>
-        LazyInitializer.EnsureInitialized(ref _setter, getValueSetter)!(instance, value);
+    /// <remarks>If not explicitly set, the framework will determine the fastest way to get the value
+    /// the first time set is called.</remarks>
+    public Action<Base, object?> Setter
+    {
+        get => LazyInitializer.EnsureInitialized(ref _setter, buildValueSetter)!;
+        init => _setter = value;
+    }
+
     private Action<Base, object?>? _setter;
 
-    private Action<Base, object?> getValueSetter()
+    private Action<Base, object?> buildValueSetter()
     {
-        // If this is a custom property, or this platform does not support code generation,
-        // use dictionary access, otherwise use the generated setter.
-        if (NativeProperty?.GetValueSetter<Base>() is { } setter) return setter;
+        // If this is a not custom property and the platform support codes generation,
+        // use the generated setter, unless we need overflow (type inequality).
+        if (NativeProperty?.GetValueSetter<Base>() is {} setter)
+        {
+            return (b, v) =>
+            {
+                if (v is null || NativeProperty.PropertyType.IsInstanceOfType(v))
+                    setter(b, v);
+                else
+                    b.SetValue(Name, v);
+            };
+        }
+
         return (b,v) => b.SetValue(Name, v);
     }
+#endif
 
     public PropertyMapping PromoteToList()
     {

--- a/src/Hl7.Fhir.Base/Utility/PropertyInfoExtensions.cs
+++ b/src/Hl7.Fhir.Base/Utility/PropertyInfoExtensions.cs
@@ -69,9 +69,6 @@ public static class PropertyInfoExtensions
         {
             MethodInfo getMethod = propertyInfo.GetMethod ?? throw new InvalidOperationException($"Property {propertyInfo.Name} does not have a getter.");
 
-         //   if (typeof(T) != propertyInfo.DeclaringType && typeof(T) != typeof(object))
-         //       throw new ArgumentException("Generic param T should be the type of property's declaring class.", nameof(propertyInfo));
-
             try
             {
                 if (NoCodeGenSupport) return null;

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
@@ -1049,6 +1049,9 @@ public partial class FhirJsonDeserializationTests
         JsonAssert.AreSame("parsed", json, serialized);
     }
 
+// This test is only relevant when we have getter/setter codegen enabled. - See PropertyMapping's
+// Getter and Setter, which are also excluded by this preprocessor directive.
+#if USE_GETTER_SETTER_AND_CODEGEN
 
     [TestMethod]
     public void CanAccessPropertiesViaPropertyMapping()
@@ -1075,13 +1078,14 @@ public partial class FhirJsonDeserializationTests
         var parsed = parser.DeserializeResource(json).Should().BeOfType<Patient>().Subject;
 
         var activePm = patientMapping.FindMappedElementByName("active")!;
-        activePm.GetValue(parsed).Should().BeOfType<FhirBoolean>().Which.Value.Should().BeTrue();
-        activePm.SetValue(parsed, new FhirBoolean(false));
+        activePm.Getter(parsed).Should().BeOfType<FhirBoolean>().Which.Value.Should().BeTrue();
+        activePm.Setter(parsed, new FhirBoolean(false));
         parsed.Active.Should().BeFalse();
 
-        patientLocPm.GetValue(parsed).Should().BeOfType<FhirUri>().Which.Value.Should().Be("http://nu.nl");
-        patientLocPm.SetValue(parsed, new FhirUri("there"));
+        patientLocPm.Getter(parsed).Should().BeOfType<FhirUri>().Which.Value.Should().Be("http://nu.nl");
+        patientLocPm.Setter(parsed, new FhirUri("there"));
         parsed["patientLocation"].Should().BeOfType<FhirUri>().Which.Value.Should().Be("there");
     }
 
+#endif
 }


### PR DESCRIPTION
The new overflow access functions TryGetValue and TrySetValue are quite efficient, and replacing them with the existing generated getters/setters required more overhead than using these new functions.  So, I have commented out the Getter/Setter code for now (but am keeping it for newer scenarios).  On Mac's access should be way faster anyway, since we're not falling back to super-slow reflection-based getting/setting anymore since we've bene using TryGetValue/TrySetValue.

Fixes #3237.
