### PR TITLE
Small behavioral tweaks

### DIFF
--- a/src/Hl7.Fhir.Base/ElementModel/SourceNodeExtensions.Conversions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/SourceNodeExtensions.Conversions.cs
@@ -37,6 +37,17 @@ public static partial class SourceNodeExtensions
         => new TypedElementOnSourceNode(node, type, provider, settings: settings ?? new TypedElementSettings() { ErrorMode = TypedElementSettings.TypeErrorMode.Passthrough });
     
     /// <summary>
+    /// Turns the <c>ISourceNode</c> into a <see cref="ITypedElement"/> by adding type information from <see cref="ModelInspector.Base"/>.
+    /// </summary>
+    /// <param name="node">The node containing the source information.</param>
+    /// <returns>An <see cref="ITypedElement"/> that represents the data in the node, with type information
+    /// added to it.</returns>
+    /// <remarks>This extension method decorates the <c>ISourceNode</c> with a new instance of
+    /// an <see cref="TypedElementOnSourceNode"/>, passing on the parameters of this extension method.</remarks>
+    /// <seealso cref="ITypedElement"/>
+    public static ITypedElement ToTypedElement(this ISourceNode node) => node.ToTypedElement(ModelInspector.Base);
+    
+    /// <summary>
     /// Adapting an <c>ISourceNode</c> to a <see cref="ITypedElement"/> without adding type information to it.
     /// </summary>
     /// <param name="node"></param>
@@ -49,7 +60,7 @@ public static partial class SourceNodeExtensions
     [Obsolete("WARNING! For internal API use only. Turning an untyped SourceNode into an ITypedElement without providing" +
               "type information (see other overload) will cause side-effects with components in the API that are not prepared to deal with" +
               "missing type information. Please don't use this overload unless you know what you are doing.")]
-    public static ITypedElement ToTypedElement(this ISourceNode node) =>
+    public static ITypedElement ToTypedElementLegacy(this ISourceNode node) =>
         new SourceNodeToTypedElementAdapter(node);
 
 

--- a/src/Hl7.Fhir.Base/ElementModel/SourceNodeExtensions.Conversions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/SourceNodeExtensions.Conversions.cs
@@ -34,7 +34,7 @@ public static partial class SourceNodeExtensions
     /// an <see cref="TypedElementOnSourceNode"/>, passing on the parameters of this extension method.</remarks>
     /// <seealso cref="ITypedElement"/>
     public static ITypedElement ToTypedElement(this ISourceNode node, IStructureDefinitionSummaryProvider provider, string type = null, TypedElementSettings settings = null)
-        => new TypedElementOnSourceNode(node, type, provider, settings: settings);
+        => new TypedElementOnSourceNode(node, type, provider, settings: settings ?? new TypedElementSettings() { ErrorMode = TypedElementSettings.TypeErrorMode.Passthrough });
     
     /// <summary>
     /// Adapting an <c>ISourceNode</c> to a <see cref="ITypedElement"/> without adding type information to it.

--- a/src/Hl7.Fhir.Base/ElementModel/TypedElementExtensions.Conversions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/TypedElementExtensions.Conversions.cs
@@ -46,7 +46,7 @@ public static partial class TypedElementExtensions
             return pn;
         
         var model = inspector ?? node.Annotation<ModelInspector>() ?? ModelInspector.Base;
-        return node.ToPoco(model, new() { IgnoreUnknownMembers = true }).ToPocoNode(model, rootName: rootName);
+        return node.ToPoco(model, new() { IgnoreUnknownMembers = true, AllowUnrecognizedEnums = true }).ToPocoNode(model, rootName: rootName);
     }
 
     #region Json

--- a/src/Hl7.Fhir.Base/Model/PocoNode.TypedElement.cs
+++ b/src/Hl7.Fhir.Base/Model/PocoNode.TypedElement.cs
@@ -59,7 +59,7 @@ public partial record PocoNode
     
     private Lazy<string> SourceName => new (() => 
         Poco is DataType { TypeName: var tn } && 
-        ((ITypedElement)this).Definition!.IsChoiceElement 
+        ((ITypedElement)this).Definition?.IsChoiceElement is true 
             ? Name + tn.Capitalize() 
             : Name
     );

--- a/src/Hl7.Fhir.Base/Serialization/elementmodel/FhirJsonBuilder.cs
+++ b/src/Hl7.Fhir.Base/Serialization/elementmodel/FhirJsonBuilder.cs
@@ -35,7 +35,7 @@ namespace Hl7.Fhir.Serialization
             {
                 _roundtripMode = true;          // will allow unknown elements to be processed
 #pragma warning disable 612,618
-                return buildInternal(source.ToTypedElement());
+                return buildInternal(source.ToTypedElementLegacy());
 #pragma warning restore 612,618
             }
             else

--- a/src/Hl7.Fhir.Base/Serialization/elementmodel/FhirXmlBuilder.cs
+++ b/src/Hl7.Fhir.Base/Serialization/elementmodel/FhirXmlBuilder.cs
@@ -40,7 +40,7 @@ internal class FhirXmlBuilder : IExceptionSource
 
         _roundtripMode = true;
 #pragma warning disable CS0618 // Type or member is obsolete
-        return buildInternal(source.ToTypedElement());
+        return buildInternal(source.ToTypedElementLegacy());
 #pragma warning restore CS0618 // Type or member is obsolete
     }
 

--- a/src/Hl7.Fhir.Serialization.Shared.Tests/ParseDemoPatientJsonUntyped.cs
+++ b/src/Hl7.Fhir.Serialization.Shared.Tests/ParseDemoPatientJsonUntyped.cs
@@ -25,7 +25,7 @@ namespace Hl7.Fhir.Serialization.Tests
             var tp = await File.ReadAllTextAsync(Path.Combine("TestData", "fp-test-patient.json"));
             var nav = await getJsonNodeU(tp);
 #pragma warning disable 612, 618
-            ParseDemoPatient.CanReadThroughTypedElement(nav.ToTypedElement(), typed: false);
+            ParseDemoPatient.CanReadThroughTypedElement(nav.ToTypedElementLegacy(), typed: false);
 #pragma warning restore 612, 618
         }
 
@@ -83,7 +83,7 @@ namespace Hl7.Fhir.Serialization.Tests
             var bundle = await File.ReadAllTextAsync(Path.Combine("TestData", "BundleWithOneEntry.json"));
             var nav = await getJsonNodeU(bundle);
 #pragma warning disable 612,618
-            ParseDemoPatient.CheckBundleEntryNavigation(nav.ToTypedElement());
+            ParseDemoPatient.CheckBundleEntryNavigation(nav.ToTypedElementLegacy());
 #pragma warning restore 612, 618
         }
 

--- a/src/Hl7.Fhir.Serialization.Shared.Tests/ParseDemoPatientXmlTyped.cs
+++ b/src/Hl7.Fhir.Serialization.Shared.Tests/ParseDemoPatientXmlTyped.cs
@@ -140,7 +140,7 @@ namespace Hl7.Fhir.Serialization.Tests
             var tpXml = File.ReadAllText(Path.Combine("TestData", "typeErrors.xml"));
             var patient = getXmlNode(tpXml);
             var result = patient.VisitAndCatch();
-            Assert.AreEqual(10, result.Count);
+            Assert.AreEqual(9, result.Count);
         }
 
         [TestMethod]
@@ -190,7 +190,7 @@ namespace Hl7.Fhir.Serialization.Tests
              "<status value='generated' />" +
              "<div><p>Donald</p></div></text></Patient>");
             errors = nav.VisitAndCatch();
-            Assert.AreEqual(2, errors.Count);
+            Assert.AreEqual(3, errors.Count);
             Assert.IsTrue(errors.Any(e => e.Message.Contains("should be an XHTML element")));
 
             // Active content

--- a/src/Hl7.Fhir.Serialization.Shared.Tests/ParseDemoPatientXmlUntyped.cs
+++ b/src/Hl7.Fhir.Serialization.Shared.Tests/ParseDemoPatientXmlUntyped.cs
@@ -31,7 +31,7 @@ namespace Hl7.Fhir.Serialization.Tests
             var tpXml = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
             var nav = getXmlUntyped(tpXml);
 #pragma warning disable 612,618
-            ParseDemoPatient.CanReadThroughTypedElement(nav.ToTypedElement(), typed: false);
+            ParseDemoPatient.CanReadThroughTypedElement(nav.ToTypedElementLegacy(), typed: false);
 #pragma warning restore 612, 618
         }
 
@@ -218,7 +218,7 @@ namespace Hl7.Fhir.Serialization.Tests
             var bundle = File.ReadAllText(Path.Combine("TestData", "BundleWithOneEntry.xml"));
             var node = getXmlUntyped(bundle);
 #pragma warning disable 612, 618
-            ParseDemoPatient.CheckBundleEntryNavigation(node.ToTypedElement());
+            ParseDemoPatient.CheckBundleEntryNavigation(node.ToTypedElementLegacy());
 #pragma warning restore 612, 618
         }
 

--- a/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
+++ b/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathTest.cs
@@ -444,7 +444,7 @@ namespace Hl7.Fhir.FhirPath.R4.Tests
             );
             
  #pragma warning disable CS0618 // Type or member is obsolete
-            var expr = res.ToTypedElement().Children("link").First();
+            var expr = res.ToTypedElementLegacy().Children("link").First();
  #pragma warning restore CS0618 // Type or member is obsolete
             var loc = expr.Select("url").Select(x => x.Location).Single();
             loc.Should().Be("Bundle.link[0].url[0]");

--- a/src/Hl7.FhirPath.Tests/Tests/BasicFunctionTests.cs
+++ b/src/Hl7.FhirPath.Tests/Tests/BasicFunctionTests.cs
@@ -40,7 +40,7 @@ namespace Hl7.FhirPath.Tests
 #pragma warning disable CS0618 // Type or member is internal
             var input = SourceNode.Node("root",
                     SourceNode.Valued("child", "Hello world!"),
-                    SourceNode.Valued("child", "4")).ToTypedElement();
+                    SourceNode.Valued("child", "4")).ToTypedElementLegacy();
 #pragma warning restore CS0618 // Type or member is internal
             Assert.AreEqual("ello", input.Scalar(@"$this.child[0].substring(1,%context.child[1].toInteger())"));
         }


### PR DESCRIPTION
For discussion:

Tweaks from FS integration
- ToTypedElement default error mode was less tolerant of unknown members than in the past
- We should also allow unknown enum values alongside unknown members, the access to the coded value will still result in an exception, but it won't block PocoNode building
- Properly check nullable definition when building elements SourceName