### PR TITLE
The ModelInfo.ModelInspector property was pretty expensive

### DIFF
--- a/src/Hl7.Fhir.Shims.STU3AndUp/Model/ModelInfo.cs
+++ b/src/Hl7.Fhir.Shims.STU3AndUp/Model/ModelInfo.cs
@@ -259,19 +259,18 @@ namespace Hl7.Fhir.Model
         /// Gets the <see cref="ModelInspector"/> providing metadata for the resources and
         /// datatypes in this release of FHIR.
         /// </summary>
-        public static ModelInspector ModelInspector
+        private static readonly Lazy<ModelInspector> _modelInspector = new(() =>
         {
-            get
+            var inspector = ModelInspector.ForAssembly(typeof(ModelInfo).GetTypeInfo().Assembly);
+            if (inspector.FhirRelease != Specification.FhirRelease.STU3)
             {
-                var inspector = ModelInspector.ForAssembly(typeof(ModelInfo).GetTypeInfo().Assembly);
-                if (inspector.FhirRelease != Specification.FhirRelease.STU3)
-                {
-                    // In case of release 4 or higher, also load the assembly with common conformance resources, like StructureDefinition
-                    inspector.Import(typeof(StructureDefinition).GetTypeInfo().Assembly);
-                }
-                return inspector;
+                // In case of release 4 or higher, also load the assembly with common conformance resources, like StructureDefinition
+                inspector.Import(typeof(StructureDefinition).GetTypeInfo().Assembly);
             }
-        }
+            return inspector;
+        });
+
+        public static ModelInspector ModelInspector => _modelInspector.Value;
     }
 
     public static class ModelInfoExtensions

--- a/src/Hl7.Fhir.Shims.STU3AndUp/Model/ModelInfo.cs
+++ b/src/Hl7.Fhir.Shims.STU3AndUp/Model/ModelInfo.cs
@@ -255,10 +255,6 @@ namespace Hl7.Fhir.Model
 
         public static Canonical? CanonicalUriForFhirCoreType(FHIRAllTypes type) => FhirTypeToFhirTypeName(type) is { } name ? CanonicalUriForFhirCoreType(name) : null;
 
-        /// <summary>
-        /// Gets the <see cref="ModelInspector"/> providing metadata for the resources and
-        /// datatypes in this release of FHIR.
-        /// </summary>
         private static readonly Lazy<ModelInspector> _modelInspector = new(() =>
         {
             var inspector = ModelInspector.ForAssembly(typeof(ModelInfo).GetTypeInfo().Assembly);
@@ -270,6 +266,10 @@ namespace Hl7.Fhir.Model
             return inspector;
         });
 
+        /// <summary>
+        /// Gets the <see cref="ModelInspector"/> providing metadata for the resources and
+        /// datatypes in this release of FHIR.
+        /// </summary>
         public static ModelInspector ModelInspector => _modelInspector.Value;
     }
 


### PR DESCRIPTION
## Description
ModelInfo.ModelInspector fetched a ModelInspector for the current assembly, and added base to it. A wasteful approach, since that can be cached. And ModelInfo.ModelInspector is a popular property....

## Related issues
Fixes #2883,
