### PR TITLE
Include PVAL109 in recoverable issues

### DIFF
--- a/src/Hl7.Fhir.Base/Serialization/FilterPredicateExtensions.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FilterPredicateExtensions.cs
@@ -2,6 +2,7 @@
 
 using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Utility;
+using Hl7.Fhir.Validation;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,7 +12,7 @@ namespace Hl7.Fhir.Serialization;
 internal static class FilterPredicateExtensions
 {
     internal static Predicate<CodedException> IsRecoverableIssue => 
-        FhirXmlException.RecoverableIssues.Concat(FhirJsonException.RecoverableIssues).ToPredicate();
+        FhirXmlException.RecoverableIssues.Concat(FhirJsonException.RecoverableIssues).Append(CodedValidationException.ID_LITERAL_INVALID_CODE).ToPredicate();
 
     internal static Predicate<CodedException> IsBackwardsCompatibilityIssue =>
         FhirXmlException.BackwardsCompatibilityAllowedIssues.Concat(FhirJsonException.BackwardsCompatibilityAllowedIssues).ToPredicate();


### PR DESCRIPTION
## Description
Adds PVAL109 - ID_LITERAL_INVALID_CODE as recoverable, as we do not lose data, it just is not a valid fhir.

## Related issues
Fixes #3255 