### PR TITLE
Add TrimWhiteSpacesInJson to trim string values

### DIFF
--- a/src/Hl7.Fhir.Base/Serialization/CommonFhirJsonSerializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/CommonFhirJsonSerializer.cs
@@ -24,7 +24,7 @@ namespace Hl7.Fhir.Serialization
         }
 
         private FhirJsonSerializationSettings buildFhirJsonWriterSettings() =>
-            new() { Pretty = Settings.Pretty, AppendNewLine = Settings.AppendNewLine };
+            new() { Pretty = Settings.Pretty, AppendNewLine = Settings.AppendNewLine, TrimWhiteSpacesInJson = Settings.TrimWhiteSpacesInJson };
 
         /// <inheritdoc cref="SerializeToStringAsync(Base, SummaryType, string[])" />
         public string SerializeToString(Base instance, SummaryType summary = SummaryType.False, string[]? elements = null) =>

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonBuilder.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonBuilder.cs
@@ -203,7 +203,7 @@ namespace Hl7.Fhir.Serialization
         private JValue buildValue(object value, string requiredType = null) => value switch
         {
             bool or decimal or Int32 or Int16 or ulong or double or BigInteger or float => new JValue(value),
-            string s => new JValue(s.Trim()),
+            string s => _settings.TrimWhiteSpacesInJson ? new JValue(s.Trim()) : new JValue(s),
             long l when requiredType is "integer" or "unsignedInt" or "positiveInt" => new JValue(l),
             _ => new JValue(PrimitiveTypeConverter.ConvertTo<string>(value)),
         };

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonSerializationSettings.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonSerializationSettings.cs
@@ -31,6 +31,8 @@ namespace Hl7.Fhir.Serialization
         /// </summary>
         public bool AppendNewLine { get; set; } // = false;
 
+        public bool TrimWhiteSpacesInJson { get; set; } = true;
+
         /// <summary>Default constructor. Creates a new <see cref="FhirJsonSerializationSettings"/> instance with default property values.</summary>
         public FhirJsonSerializationSettings() { }
 
@@ -52,6 +54,7 @@ namespace Hl7.Fhir.Serialization
             other.IgnoreUnknownElements = IgnoreUnknownElements;
             other.Pretty = Pretty;
             other.AppendNewLine = AppendNewLine;
+            other.TrimWhiteSpacesInJson = TrimWhiteSpacesInJson;
         }
 
         /// <summary>Creates a new <see cref="FhirJsonSerializationSettings"/> object that is a copy of the current instance.</summary>

--- a/src/Hl7.Fhir.Base/Serialization/SerializerSettings.cs
+++ b/src/Hl7.Fhir.Base/Serialization/SerializerSettings.cs
@@ -30,6 +30,11 @@ namespace Hl7.Fhir.Serialization
         public bool TrimWhiteSpacesInXml { get; set; } = true;
 
         /// <summary>
+        /// Trim whitespaces at the beginning and end of json string values
+        /// </summary>
+        public bool TrimWhiteSpacesInJson { get; set; } = true;
+
+        /// <summary>
         /// Include mandatory elements when serializing a subset of chosen elements (_elements). 
         /// </summary>
         public bool IncludeMandatoryInElementsSummary { get; set; } = false;
@@ -55,6 +60,7 @@ namespace Hl7.Fhir.Serialization
             other.Pretty = Pretty;
             other.AppendNewLine = AppendNewLine;
             other.TrimWhiteSpacesInXml = TrimWhiteSpacesInXml;
+            other.TrimWhiteSpacesInJson = TrimWhiteSpacesInJson;
             other.IncludeMandatoryInElementsSummary = IncludeMandatoryInElementsSummary;
         }
 

--- a/src/Hl7.Fhir.Serialization.Shared.Tests/FhirJsonParserTests.cs
+++ b/src/Hl7.Fhir.Serialization.Shared.Tests/FhirJsonParserTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
 
 namespace Hl7.Fhir.Support.Tests.Serialization;
 
@@ -37,5 +38,42 @@ public class FhirJsonParserTests
         var res = new FhirJsonParser().Parse<Patient>(json);
         
         res.Id.Should().Be("whitespace");
+    }
+    
+      [TestMethod]
+  public void FhirJsonParserSerializer_KeepsWhitespace()
+    {
+      string json = """
+  {
+    "resourceType": "Practitioner",
+    "id": " resourceID",
+    "identifier": [
+        {
+          "use": "usual",
+          "type": {
+              "text": "INTERNAL"
+          },
+          "system": "urn:oid:1.2.840.114350.1.13.211.3.7.2.697780",
+          "value": " identifier"
+        }
+    ],
+    "active": true,
+    "gender": "female"
+  }
+  """;
+  
+      var res = new FhirJsonParser(new()
+      {
+        PreserveWhitespaceInValues = true
+      }).Parse<Practitioner>(json);
+
+      res.Id.Should().Be(" resourceID");
+
+      var internalId = res.Identifier?.FirstOrDefault(i => i.Type?.Text == "INTERNAL")?.Value;
+      internalId.Should().Be(" identifier");
+      var str = new FhirJsonSerializer().SerializeToString(res);
+      str.Should().Contain("\"value\":\"identifier\"");
+      str = new FhirJsonSerializer(new SerializerSettings { TrimWhiteSpacesInJson = false }).SerializeToString(res);
+      str.Should().Contain("\"value\":\" identifier\"");
     }
 }


### PR DESCRIPTION
Add TrimWhiteSpacesInJson setting to optionally trim string values in json during serialization

## Description
Add serializer setting to optionally trim whitespace from string values in json. Related to discussion https://github.com/FirelyTeam/firely-net-sdk/discussions/3266

## Related issues
Closes https://github.com/FirelyTeam/firely-net-sdk/discussions/3266

## Testing
Unit test added to FhirJsonParserTests.cs

## FirelyTeam Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] Mark the PR with the label **breaking change** when this PR introduces breaking changes