### PR TITLE
Poco conversion fixes

### DIFF
--- a/src/Hl7.Fhir.Base/ElementModel/LegacyPocoBuilder.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/LegacyPocoBuilder.cs
@@ -77,7 +77,7 @@ namespace Hl7.Fhir.Serialization
             TypedElementSettings typedSettings = new TypedElementSettings
             {
                 ErrorMode = _settings.IgnoreUnknownMembers ?
-                    TypedElementSettings.TypeErrorMode.Ignore
+                    TypedElementSettings.TypeErrorMode.Passthrough
                     : TypedElementSettings.TypeErrorMode.Report,
 
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -96,15 +96,16 @@ namespace Hl7.Fhir.Serialization
 
             var typedSource = source.ToTypedElement(_inspector, dataType, typedSettings);
 
-            return BuildFrom(typedSource);
+            return BuildFrom(typedSource, mapping?.NativeType);
         }
 
         /// <summary>
         /// Build a POCO from an ITypedElement.
         /// </summary>
         /// <param name="source"></param>
+        /// <param name="typeHint"></param>
         /// <returns></returns>
-        public Base BuildFrom(ITypedElement source)
+        public Base BuildFrom(ITypedElement source, Type typeHint = null)
         {
             if (source == null) throw Error.ArgumentNull(nameof(source));
 
@@ -121,7 +122,7 @@ namespace Hl7.Fhir.Serialization
             Base build()
             {
                 var newBuilder = new NewPocoBuilder(_inspector, _settings);
-                return newBuilder.BuildFrom(source);
+                return newBuilder.BuildFrom(source, typeHint);
             }
         }
     }

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
@@ -65,8 +65,8 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
             if (newInstance is DynamicPrimitive)
                 objectValue = value;
             // we're trying to add the type data to untyped values
-            else if (node is PocoNode { Poco: IDynamicType } && classMapping.PrimitiveValueProperty is not null)
-                objectValue = PrimitiveTypeConverter.ConvertTo(value, classMapping.PrimitiveValueProperty.ImplementingType);
+            else if (node is PocoNode { Poco: IDynamicType } && value is string s && classMapping.PrimitiveValueProperty is not null)
+                objectValue = PrimitiveTypeConverter.ConvertTo(s, classMapping.PrimitiveValueProperty.ImplementingType);
             else
                 objectValue = convertTypedElementValue(value);
 

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
@@ -95,10 +95,9 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
         {
             var propertyMapping = classMapping.FindMappedElementByName(child.Name);
 
+            // we didn't find direct match, we are in a dynamic context, so try to detect a choice-type
             if (propertyMapping is null && child is PocoNode { Poco: IDynamicType })
-            {
                 propertyMapping = classMapping.PropertyMappings.FirstOrDefault(x => child.Name.StartsWith(x.Name));
-            }
             
             if (propertyMapping is null && settings?.IgnoreUnknownMembers == false)
                 raiseFormatError($"Encountered unknown member '{child.Name}' while de-serializing", child.Location);

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
@@ -122,7 +122,7 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
 
     private static Base buildNewInstance(ClassMapping mapping, bool hasValue)
     {
-        if(hasValue && !mapping.IsFhirPrimitive)
+        if (hasValue && !mapping.IsFhirPrimitive)
             return new DynamicPrimitive();
         
         if (mapping.NativeType.IsAbstract) 
@@ -194,7 +194,7 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
             return propertyClassMapping;
 
         // We don't know the type, but we know the type being requested
-        if(typeHint is not null)
+        if (typeHint is not null)
             return getClassMapping(typeHint);
         
         // No useable concrete type in the property, nor in the instance type, so we need to create

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
@@ -39,10 +39,6 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
         if (source == null) throw Error.ArgumentNull(nameof(source));
 
         var classMapping = classMappingForElement(source, null, typeHint);
-        
-        if(typeHint is not null && typeof(IDynamicType).IsAssignableFrom(classMapping.NativeType))
-            classMapping = getClassMapping(typeHint);
-        
         return readFromElement(source, classMapping);
     }
 

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
@@ -69,8 +69,8 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
             if (newInstance is DynamicPrimitive)
                 objectValue = value;
             // we're trying to add the type data to untyped values
-            else if (node is PocoNode { Poco: IDynamicType dyn } && value is string s)
-                objectValue = PrimitiveTypeConverter.ConvertTo(value, classMapping.PrimitiveValueProperty?.ImplementingType);
+            else if (node is PocoNode { Poco: IDynamicType } && classMapping.PrimitiveValueProperty is not null)
+                objectValue = PrimitiveTypeConverter.ConvertTo(value, classMapping.PrimitiveValueProperty.ImplementingType);
             else
                 objectValue = convertTypedElementValue(value);
 

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
@@ -253,7 +253,9 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
                 bool => getClassMapping<FhirBoolean>(),
                 int => getClassMapping<Integer>(),
                 long => getClassMapping<Integer64>(),
-                // string when node is not PocoNode { Poco: IDynamicType } => getClassMapping<FhirString>(),
+                // when TypedElement was built on a SourceNode without type information, string backed types would
+                // be unrecognizable from actual string data, so let's default to DynamicPrimitive
+                // string => getClassMapping<FhirString>(),
                 _ => ClassMapping.DynamicPrimitive
             };
         }

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
@@ -34,17 +34,21 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
     /// <summary>
     /// Build a POCO from an <see cref="ITypedElement"/>.
     /// </summary>
-    public Base BuildFrom(ITypedElement source)
+    public Base BuildFrom(ITypedElement source, Type? typeHint = null)
     {
         if (source == null) throw Error.ArgumentNull(nameof(source));
 
-        var classMapping = classMappingForElement(source, null);
+        var classMapping = classMappingForElement(source, null, typeHint);
+        
+        if(typeHint is not null && typeof(IDynamicType).IsAssignableFrom(classMapping.NativeType))
+            classMapping = getClassMapping(typeHint);
+        
         return readFromElement(source, classMapping);
     }
 
     private Base readFromElement(ITypedElement node, ClassMapping classMapping)
     {
-        var newInstance = buildNewInstance(classMapping);
+        var newInstance = buildNewInstance(classMapping, node.Value is { });
 
         // add a link back to TypedElement to persist it's annotations on pocos
         // this is specifically for backwards compatibility with many implementations of ITypedElement wrappers that implement their own annotations
@@ -54,14 +58,21 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
 
         // Capture the instance type if this is a dynamic type.
         if (newInstance is IDynamicType dt)
-            dt.DynamicTypeName = node.InstanceType ?? node.Annotation<IResourceTypeSupplier>()?.ResourceType;
+            dt.DynamicTypeName = node.InstanceType ?? node.Annotation<IResourceTypeSupplier>()?.ResourceType ?? classMapping.GetTypeName();
 
         // Value is a kind of pseudo-property, so we need to handle it separately.
         // If this is a standard Fhir primitive, we need to convert the ITypedElement.Value
         // to the used ObjectValue, if not, just set the value immediately on the DynamicPrimitive.
         if (node.Value is { } value)
         {
-            var objectValue = newInstance is DynamicPrimitive ? value : convertTypedElementValue(value);
+            object objectValue;
+            if (newInstance is DynamicPrimitive)
+                objectValue = value;
+            // we're trying to add the type data to untyped values
+            else if (node is PocoNode { Poco: IDynamicType dyn } && value is string s)
+                objectValue = PrimitiveTypeConverter.ConvertTo(value, classMapping.PrimitiveValueProperty?.ImplementingType);
+            else
+                objectValue = convertTypedElementValue(value);
 
             if (newInstance is PrimitiveType pt)
                 pt.JsonValue = objectValue;
@@ -88,6 +99,11 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
         {
             var propertyMapping = classMapping.FindMappedElementByName(child.Name);
 
+            if (propertyMapping is null && child is PocoNode { Poco: IDynamicType })
+            {
+                propertyMapping = classMapping.PropertyMappings.FirstOrDefault(x => child.Name.StartsWith(x.Name));
+            }
+            
             if (propertyMapping is null && settings?.IgnoreUnknownMembers == false)
                 raiseFormatError($"Encountered unknown member '{child.Name}' while de-serializing", child.Location);
 
@@ -109,10 +125,13 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
         throw Error.Format("While building a POCO: " + message, location);
     }
 
-    private static Base buildNewInstance(ClassMapping mapping)
+    private static Base buildNewInstance(ClassMapping mapping, bool hasValue)
     {
+        if(hasValue && !mapping.IsFhirPrimitive)
+            return new DynamicPrimitive();
+        
         if (mapping.NativeType.IsAbstract) 
-            return mapping.IsResource ? new DynamicResource() { DynamicTypeName = mapping.GetTypeName() } : new DynamicDataType() { DynamicTypeName = mapping.GetTypeName() };
+            return mapping.IsResource ? new DynamicResource() : new DynamicDataType();
         
         if (mapping.CreateInstance() is Base b) return b;
 
@@ -137,12 +156,24 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
         return propertyClassMapping.CreateList();
     }
 
-    private ClassMapping classMappingForElement(ITypedElement node, PropertyMapping? propertyMapping)
+    private ClassMapping classMappingForElement(ITypedElement node, PropertyMapping? propertyMapping, Type? typeHint = null)
     {
         var propertyClassMapping = propertyMapping is not null
             ? getClassMapping(propertyMapping.ImplementingType)
             : null;
 
+        // we're coming from a context where original PocoNode was built without necessary
+        // type information - that would result in instanceType being wrong
+        // we have type info now, we can use it to determine the type of the property
+        if (node is PocoNode { Poco: IDynamicType } && propertyClassMapping is not null)
+        {
+            if (propertyClassMapping is { NativeType.IsAbstract: false })
+                return propertyClassMapping;
+            
+            if (node.Name.Substring(propertyMapping!.Name.Length) is { Length: > 0} choice && inspector.FindClassMapping(choice) is {} cm)
+                return cm;
+        }
+        
         // If we have a concrete instanceType, and it's not the same as the property type, we need to
         // check if we have a mapping for it. If we do, we can use that.
         // Note that this is not the same as the "best" mapping, which is determined below.
@@ -150,8 +181,10 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
         if (node.InstanceType is { } instanceType)
         {
             if (instanceType == propertyClassMapping?.GetTypeName() || (instanceType == "code" && propertyClassMapping?.IsCodeOfT is true))
-                return propertyClassMapping; // only case in which we return the propertyClassMapping.
-            if (inspector.FindClassMapping(instanceType) is { } mapping && typeof(Base).IsAssignableFrom(mapping.NativeType))
+                return propertyClassMapping; // propertyClassMapping matches the instanceType, we can safely use that
+            
+            // try to get mapping for instanceType, but only if we're not in a dynamic context
+            if (!instanceType.StartsWith("Dynamic") && inspector.FindClassMapping(instanceType) is { } mapping && typeof(Base).IsAssignableFrom(mapping.NativeType))
                 return mapping;
         }
 
@@ -165,11 +198,15 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
         else if (propertyClassMapping is { NativeType.IsAbstract: false, IsPrimitive: false })
             return propertyClassMapping;
 
+        // We don't know the type, but we know the type being requested
+        if(typeHint is not null)
+            return getClassMapping(typeHint);
+        
         // No useable concrete type in the property, nor in the instance type, so we need to create
         // one of our dynamic flavours. If we do have an abstract type of the property, we can use that
         // as a hint.
         if (propertyClassMapping is not null)
-            return determineBestDynamicMappingForType(propertyClassMapping.NativeType);
+            return determineBestDynamicMappingForType(node, propertyClassMapping.NativeType);
 
         // Failing all that, guess what the best dynamic type is based on the instance data.
         return determineBestDynamicMappingForElement(node);
@@ -180,11 +217,11 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
     /// </summary>
     /// <exception cref="NotSupportedException">The POCO's property is not a Resource or DataType
     /// subclass.</exception>
-    private ClassMapping determineBestDynamicMappingForType(Type elementType)
+    private ClassMapping determineBestDynamicMappingForType(ITypedElement node, Type elementType)
     {
         if (typeof(Resource).IsAssignableFrom(elementType))
             return ClassMapping.DynamicResource;
-        if (typeof(PrimitiveType).IsAssignableFrom(elementType))
+        if (typeof(PrimitiveType).IsAssignableFrom(elementType) || node.Value is { })
             return ClassMapping.DynamicPrimitive;
         if (typeof(DataType).IsAssignableFrom(elementType))
             return ClassMapping.DynamicDataType;
@@ -212,13 +249,16 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
             return node.Value switch
             {
                 ET.DateTime => getClassMapping<FhirDateTime>(),
+                string when node.InstanceType is "System.DateTime" => getClassMapping<FhirDateTime>(),
                 ET.Date => getClassMapping<Date>(),
+                string when node.InstanceType is "System.Date" => getClassMapping<Date>(),
                 ET.Time => getClassMapping<Time>(),
+                string when node.InstanceType is "System.Time" => getClassMapping<Time>(),
                 decimal => getClassMapping<FhirDecimal>(),
                 bool => getClassMapping<FhirBoolean>(),
                 int => getClassMapping<Integer>(),
                 long => getClassMapping<Integer64>(),
-                string => getClassMapping<FhirString>(),
+                // string when node is not PocoNode { Poco: IDynamicType } => getClassMapping<FhirString>(),
                 _ => ClassMapping.DynamicPrimitive
             };
         }
@@ -229,8 +269,10 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
         throw Error.InvalidOperation($"Cannot find ClassMapping for type '{dynTypeName}'.");
 
     private ClassMapping getClassMapping(Type t) =>
-        inspector.FindOrImportClassMapping(t) ??
-        throw Error.InvalidOperation($"Cannot find ClassMapping for type '{t.Name}'.");
+        inspector.FindClassMapping(t) ?? 
+        (ClassMapping.TryCreate(inspector, t, out var newMapping) 
+            ? newMapping 
+            : throw Error.InvalidOperation($"Cannot find ClassMapping for type '{t.Name}'."));
 
     private ClassMapping getClassMapping<T>() => getClassMapping(typeof(T));
 

--- a/src/Hl7.Fhir.Base/ElementModel/SourceNodeExtensions.Conversions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/SourceNodeExtensions.Conversions.cs
@@ -16,11 +16,16 @@ namespace Hl7.Fhir.ElementModel;
 public static partial class SourceNodeExtensions
 {
     public static Base ToPoco(this ISourceNode source, ModelInspector inspector, Type pocoType = null, PocoBuilderSettings settings = null) =>
-        new LegacyPocoBuilder(inspector, settings).BuildFrom(source, pocoType);
+        new LegacyPocoBuilder(inspector, settings ?? new() { AllowUnrecognizedEnums = true, IgnoreUnknownMembers = true}).BuildFrom(source, pocoType);
 
-    public static T ToPoco<T>(this ISourceNode source, ModelInspector inspector, PocoBuilderSettings settings = null) where T : Base =>
-        (T)source.ToPoco(inspector, typeof(T), settings);
-    
+    public static T ToPoco<T>(this ISourceNode source, ModelInspector inspector, PocoBuilderSettings settings = null) where T : Base
+    {
+        if (source is PocoNode { Poco: T poco })
+            return poco;
+
+        return (T)source.ToPoco(inspector, typeof(T), settings);
+    }
+
     /// <summary>
     /// Turns the <c>ISourceNode</c> into a <see cref="ITypedElement"/> by adding type information to it.
     /// </summary>
@@ -34,7 +39,7 @@ public static partial class SourceNodeExtensions
     /// an <see cref="TypedElementOnSourceNode"/>, passing on the parameters of this extension method.</remarks>
     /// <seealso cref="ITypedElement"/>
     public static ITypedElement ToTypedElement(this ISourceNode node, IStructureDefinitionSummaryProvider provider, string type = null, TypedElementSettings settings = null)
-        => new TypedElementOnSourceNode(node, type, provider, settings: settings ?? new TypedElementSettings() { ErrorMode = TypedElementSettings.TypeErrorMode.Passthrough });
+        => node as ITypedElement ?? new TypedElementOnSourceNode(node, type, provider, settings: settings ?? new TypedElementSettings() { ErrorMode = TypedElementSettings.TypeErrorMode.Passthrough });
     
     /// <summary>
     /// Turns the <c>ISourceNode</c> into a <see cref="ITypedElement"/> by adding type information from <see cref="ModelInspector.Base"/>.

--- a/src/Hl7.Fhir.Base/ElementModel/TypedElementExtensions.Conversions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/TypedElementExtensions.Conversions.cs
@@ -28,13 +28,18 @@ public static partial class TypedElementExtensions
     public static ScopedNode ToScopedNode(this ITypedElement node) =>
         node as ScopedNode ?? new ScopedNode(node);
     
-    public static ISourceNode ToSourceNode(this ITypedElement node) => new TypedElementToSourceNodeAdapter(node);
-    
-    public static T ToPoco<T>(this ITypedElement element, ModelInspector inspector, PocoBuilderSettings? settings = null) where T : Base =>
-        (T)new NewPocoBuilder(inspector, settings ?? new PocoBuilderSettings()).BuildFrom(element);
+    public static ISourceNode ToSourceNode(this ITypedElement node) => node as ISourceNode ?? new TypedElementToSourceNodeAdapter(node);
 
-    public static Base ToPoco(this ITypedElement element, ModelInspector inspector, PocoBuilderSettings? settings = null) =>
-        new NewPocoBuilder(inspector, settings ?? new PocoBuilderSettings()).BuildFrom(element);
+    public static T ToPoco<T>(this ITypedElement element, ModelInspector inspector, PocoBuilderSettings? settings = null) where T : Base
+    {
+        if (element is PocoNode { Poco: T poco })
+            return poco;
+        
+        return (T)new NewPocoBuilder(inspector, settings ?? new PocoBuilderSettings() { AllowUnrecognizedEnums = true, IgnoreUnknownMembers = true }).BuildFrom(element, typeof(T));
+    }
+
+    public static Base ToPoco(this ITypedElement element, ModelInspector inspector, Type? pocoType = null, PocoBuilderSettings? settings = null) =>
+        new NewPocoBuilder(inspector, settings ?? new PocoBuilderSettings() { AllowUnrecognizedEnums = true, IgnoreUnknownMembers = true }).BuildFrom(element, pocoType);
 
     /// <summary>
     /// Converts a typed element to a PocoNode.
@@ -46,7 +51,7 @@ public static partial class TypedElementExtensions
             return pn;
         
         var model = inspector ?? node.Annotation<ModelInspector>() ?? ModelInspector.Base;
-        return node.ToPoco(model, new() { IgnoreUnknownMembers = true, AllowUnrecognizedEnums = true }).ToPocoNode(model, rootName: rootName);
+        return node.ToPoco(model, null, new() { IgnoreUnknownMembers = true, AllowUnrecognizedEnums = true }).ToPocoNode(model, rootName: rootName);
     }
 
     #region Json

--- a/src/Hl7.Fhir.Base/ElementModel/TypedElementOnSourceNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/TypedElementOnSourceNode.cs
@@ -6,6 +6,7 @@
  * available at https://github.com/FirelyTeam/firely-net-sdk/blob/master/LICENSE
  */
 
+using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification;
 using Hl7.Fhir.Utility;
 using System;
@@ -282,6 +283,8 @@ namespace Hl7.Fhir.ElementModel
             if (info.IsChoiceElement)
             {
                 var suffix = current.Name.Substring(info.ElementName.Length);
+                if(string.IsNullOrEmpty(suffix) && current is PocoNode { Poco: DataType { TypeName: {} tn}})
+                    suffix = tn.Capitalize();
 
                 if (string.IsNullOrEmpty(suffix))
                 {
@@ -402,13 +405,10 @@ namespace Hl7.Fhir.ElementModel
             // no name filter: work on all the parent's children
             if (name == null)
                 childSet = parent.Children();
+            else if (dis.TryGetValue(name, out var info) && info.IsChoiceElement)
+                childSet = parent.Children(name + "*");
             else
-            {
-                var hit = dis.TryGetValue(name, out var info);
-                childSet = hit
-                    ? (info!.IsChoiceElement ? parent.Children(name + "*") : parent.Children(name))
-                    : Enumerable.Empty<ISourceNode>();
-            }
+                childSet = parent.Children(name);
 
             string? lastName = null;
             int _nameIndex = 0;

--- a/src/Hl7.Fhir.Base/ElementModel/TypedElementOnSourceNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/TypedElementOnSourceNode.cs
@@ -283,7 +283,7 @@ namespace Hl7.Fhir.ElementModel
             if (info.IsChoiceElement)
             {
                 var suffix = current.Name.Substring(info.ElementName.Length);
-                if(string.IsNullOrEmpty(suffix) && current is PocoNode { Poco: DataType { TypeName: {} tn}})
+                if (string.IsNullOrEmpty(suffix) && current is PocoNode { Poco: DataType { TypeName: {} tn}})
                     suffix = tn.Capitalize();
 
                 if (string.IsNullOrEmpty(suffix))

--- a/src/Hl7.Fhir.Base/Model/PocoNode.TypedElement.cs
+++ b/src/Hl7.Fhir.Base/Model/PocoNode.TypedElement.cs
@@ -42,11 +42,15 @@ public partial record PocoNode
             if (this.FindInspector() is not { } inspector)
                 return null;
 
-            if (this.Parent is not {} node) 
-                return ElementDefinitionSummary.ForRoot(inspector.FindOrImportClassMapping(Poco.GetType()), Name);
-            
-            var classMapping = inspector.FindOrImportClassMapping(node.Poco.GetType());
-            return classMapping?.FindMappedElementByName(Name);
+            // we could get definitions with FindOrImportClassMapping, but then we're modifying inspector mappings
+            // which either should already have the type, or is expected to be immutable!
+            if (this.Parent is {} node && inspector.FindClassMapping(node.Poco.GetType()) is {} classMapping)
+                return classMapping.FindMappedElementByName(Name);
+
+            if (inspector.FindClassMapping(Poco.GetType()) is {} cm)
+                return ElementDefinitionSummary.ForRoot(cm, Name);
+
+            return null;
         }
     }
     

--- a/src/Hl7.Fhir.Base/Model/PocoNodeOrList.cs
+++ b/src/Hl7.Fhir.Base/Model/PocoNodeOrList.cs
@@ -72,9 +72,9 @@ public partial record PocoNode(Base Poco, PocoNodeOrList? ParentNode, int? Index
     private PocoNodeOrList nodeFor(string name, object value) =>
         value switch
         {
-            PrimitiveType primitive => new PrimitiveNode(primitive, null, null, name) { ParentNode = this },
+            PrimitiveType primitive => new PrimitiveNode(primitive, this, null, name),
             Base b => new PocoNode(b, this, null, name),
-            IEnumerable<PrimitiveType> primitiveList => new PrimitiveListNode(primitiveList.ToList(), null, name) { ParentNode = this },
+            IEnumerable<PrimitiveType> primitiveList => new PrimitiveListNode(primitiveList.ToList(), this, name),
             IEnumerable<Base> list => new PocoListNode(list.ToList(), this, name),
             _ => throw new InvalidOperationException("Unexpected element in child list")
         };

--- a/src/Hl7.Fhir.Base/Model/PocoNodeOrList.cs
+++ b/src/Hl7.Fhir.Base/Model/PocoNodeOrList.cs
@@ -111,7 +111,9 @@ public partial record PocoNode(Base Poco, PocoNodeOrList? ParentNode, int? Index
     /// <inheritdoc />
     IEnumerable<object> IAnnotated.Annotations(Type type)
     {
-        if (type == typeof(ITypedElement) || type == typeof(IShortPathGenerator))
+        if (type == typeof(PocoNode))
+            return [this];
+        if (type == typeof(ITypedElement) || type == typeof(IShortPathGenerator) || type == typeof(ISourceNode))
             return [this];
         if (type == typeof(IFhirValueProvider))
             return [this];

--- a/src/Hl7.Fhir.ElementModel.Shared.Tests/TypedElementToSourceNodeAdapterTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Shared.Tests/TypedElementToSourceNodeAdapterTests.cs
@@ -1,9 +1,9 @@
 ﻿using FluentAssertions;
 using Hl7.Fhir.ElementModel.Adapters;
-using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Specification;
+using Hl7.FhirPath;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 using Tasks = System.Threading.Tasks;
@@ -20,7 +20,7 @@ namespace Hl7.Fhir.ElementModel.Tests
         public void AnnotationsTest()
         {
             var patient = new Patient() { Active = true };
-            var typedElement = patient.ToTypedElement();
+            var typedElement = patient.ToTypedElementLegacy();
             var sourceNode = typedElement.ToSourceNode();
 
             var result = sourceNode.Annotation<ISourceNode>();
@@ -114,6 +114,46 @@ namespace Hl7.Fhir.ElementModel.Tests
             result.Children("extension").First().Children("valueDateTime").First().Location.Should()
                 .Be(extensionValueSourceLocation,
                     "On a SourceNode from a TypedElement, a choice type should again have the same Location as if it was constructed as SourceNode");
+        }
+        
+        [TestMethod]
+        public void UnknownResource_ContainsPatient_CanRetrievePoco()
+        {
+            var sourceNode = 
+                SourceNode.Resource("Test", "Unknown", 
+                SourceNode.Resource("resource", "Patient",
+                SourceNode.Valued("active", "true"),
+                SourceNode.Node("extension",
+                SourceNode.Valued("url", "http://hl7.org/fhir/StructureDefinition/patient-birthTime"),
+                SourceNode.Valued("valueDateTime", "2021-01-01T00:00:00Z"))));
+
+            var sourcePoco = sourceNode.Children("resource").First().ToPoco<Resource>();
+            var typedElement = sourceNode.ToTypedElement(ModelInfo.ModelInspector);
+            ISourceNode fhirPath = typedElement.Select("resource").First().ToPocoNode();
+            var patient = fhirPath.ToPoco<Patient>();
+            patient.Should().NotBeNull();
+            patient.Active.Should().BeTrue();
+        }
+        
+        [TestMethod]
+        public void DynamicDataType_CanConvertToPoco()
+        {
+            var sourceNode = SourceNode.Resource("Test", "CustomCodeableConcept", 
+                SourceNode.Node("coding",
+                    SourceNode.Valued("system", "http://loinc.org"),
+                    SourceNode.Valued("code", "8302-2"),
+                    SourceNode.Valued("display", "Testing")
+                    ));
+            var pn = sourceNode.ToTypedElement().Select("coding").First().ToPocoNode();
+            pn.Poco.Should().BeOfType<DynamicDataType>();
+            ISourceNode sn = pn;
+            ITypedElement te = pn;
+            var teCC = te.ToPoco<Coding>();
+            var cc = sn.ToPoco<Coding>();
+            cc.HasOverflow.Should().Be(teCC.HasOverflow);
+            cc.Display.Should().Be("Testing").And.Be(teCC.Display);
+            cc.System.Should().Be("http://loinc.org").And.Be(teCC.System);
+            cc.Code.Should().Be("8302-2").And.Be(teCC.Code);
         }
     }
 }

--- a/src/Hl7.Fhir.Shims.STU3AndUp/ElementModel/VersionedConversionExtensions.cs
+++ b/src/Hl7.Fhir.Shims.STU3AndUp/ElementModel/VersionedConversionExtensions.cs
@@ -49,15 +49,26 @@ public static class VersionedConversionExtensions
     public static Base ToPoco(this ISourceNode source, Type? pocoType = null, PocoBuilderSettings? settings = null) =>
         source.ToPoco(ModelInfo.ModelInspector, pocoType, settings);
 
-    public static T ToPoco<T>(this ISourceNode source, PocoBuilderSettings? settings = null) where T : Base =>
-        (T)source.ToPoco(ModelInfo.ModelInspector, typeof(T), settings);
+    public static T ToPoco<T>(this ISourceNode source, PocoBuilderSettings? settings = null) where T : Base
+    {
+        if (source is PocoNode { Poco: T {} poco })
+            return poco;
 
-    public static Base ToPoco(this ITypedElement element, PocoBuilderSettings? settings = null) =>
-        element.ToPoco(ModelInfo.ModelInspector, settings);
+        return (T)source.ToPoco(ModelInfo.ModelInspector, typeof(T), settings);
+    }
 
-    public static T ToPoco<T>(this ITypedElement element, PocoBuilderSettings? settings = null) where T : Base =>
-        (T)element.ToPoco(ModelInfo.ModelInspector, settings);
-    
+    public static Base ToPoco(this ITypedElement element, Type? pocoType = null, PocoBuilderSettings? settings = null) =>
+        element.ToPoco(ModelInfo.ModelInspector, pocoType, settings);
+
+    public static T ToPoco<T>(this ITypedElement element, PocoBuilderSettings? settings = null) where T : Base
+    {
+        // no need to build a poco, we already have the requested type
+        if (element is PocoNode { Poco: T {} poco })
+            return poco;
+
+        return (T)element.ToPoco(ModelInfo.ModelInspector, typeof(T), settings);
+    }
+
     public static PocoNode ToPocoNode(this ITypedElement node) =>
-        node.ToPocoNode(ModelInfo.ModelInspector);
+        node.ToPocoNode(ModelInfo.ModelInspector, node.Name);
 }

--- a/src/Hl7.Fhir.Shims.STU3AndUp/ElementModel/VersionedConversionExtensions.cs
+++ b/src/Hl7.Fhir.Shims.STU3AndUp/ElementModel/VersionedConversionExtensions.cs
@@ -62,7 +62,6 @@ public static class VersionedConversionExtensions
 
     public static T ToPoco<T>(this ITypedElement element, PocoBuilderSettings? settings = null) where T : Base
     {
-        // no need to build a poco, we already have the requested type
         if (element is PocoNode { Poco: T {} poco })
             return poco;
 

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/TypedElementToPocoTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/TypedElementToPocoTests.cs
@@ -48,7 +48,6 @@ public class TypedElementToPocoTests
 
             return
             [
-                [typeof(FhirString), "hi!", null],
                 [typeof(Integer), 42, null],
                 [typeof(Integer64), 42L, "42"],
                 [typeof(FhirBoolean), true, null],
@@ -57,6 +56,9 @@ public class TypedElementToPocoTests
                 [typeof(FhirDateTime), dtNow, dtNow.ToString()],
                 [typeof(Time), timeNow, timeNow.ToString()],
                 [typeof(Date), dateToday, dateToday.ToString()],
+                // strings will be parsed as DynamicPrimitive to allow for detection of string backed primitive types
+                // that were built with no type information, but we get the correct type at a later point
+                [typeof(DynamicPrimitive), "hi!", null]
             ];
         }
     }


### PR DESCRIPTION
Improve Poco conversions: 

- avoiding building a new poco if we already have one of requested type (via PocoNode)
- handling the case where PocoNode got constructed with no information of the type of data (Dynamic...), but later gets converted to a specific Poco, where we now are aware of a correct type of the data