### PR TITLE
Ensure correct overload gets called for parents location

### DIFF
--- a/src/Hl7.Fhir.Base/Model/PocoNode.TypedElement.cs
+++ b/src/Hl7.Fhir.Base/Model/PocoNode.TypedElement.cs
@@ -72,9 +72,9 @@ public partial record PocoNode
         (Index, Parent) switch
         {
             // if we have an index, write it
-            ({ } idx, { } parent) => $"{((ITypedElement)parent).Location}.{SourceName.Value}[{idx}]",
+            ({ } idx, { } parent) => $"{((ISourceNode)parent).Location}.{SourceName.Value}[{idx}]",
             // if we do not, write 0 as idx
-            (_, { } parent) => $"{((ITypedElement)parent).Location}.{SourceName.Value}[0]",
+            (_, { } parent) => $"{((ISourceNode)parent).Location}.{SourceName.Value}[0]",
             // if we have neither, we are the root.
             _ => SourceName.Value
         };

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/PocoNodeTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/PocoNodeTests.cs
@@ -1,0 +1,32 @@
+﻿/* 
+ * Copyright (c) 2014, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+using FluentAssertions;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace Hl7.Fhir.Tests.Model;
+
+[TestClass]
+public class PocoNodeTests
+{
+    [TestMethod]
+    public void PocoNode_ImplementationBasedLocations_ReturnCorrectLocations()
+    {
+        var ext = new Extension() { Url = "http://example.org/fhir/test", Value = new ResourceReference("Patient/john-doe") };
+        var pn = ext.ToPocoNode(ModelInfo.ModelInspector);
+        var navigate = pn.NavigateTo("value.reference").First();
+        string typedElementLocation = ((ITypedElement)navigate).Location;
+        string sourceNodeLocation = ((ISourceNode)navigate).Location;
+        
+        typedElementLocation.Should().Be("Extension.value[0].reference[0]");
+        sourceNodeLocation.Should().Be("Extension.valueReference[0].reference[0]");
+    }
+}


### PR DESCRIPTION
Wrong overload getting called would result in different behavior at node vs at child node
`Extension.valueReference` -> `Extension.value.reference`