### PR TITLE
Add propert ISourceNode.Name on PocoNode

### DIFF
--- a/src/Hl7.Fhir.Base/Model/PocoNode.TypedElement.cs
+++ b/src/Hl7.Fhir.Base/Model/PocoNode.TypedElement.cs
@@ -67,6 +67,8 @@ public partial record PocoNode
             ? Name + tn.Capitalize() 
             : Name
     );
+    
+    string ISourceNode.Name => SourceName.Value;
 
     string ISourceNode.Location =>
         (Index, Parent) switch


### PR DESCRIPTION
Fixes a case where an ISourceNode wrapper around PocoNode would use model name, rather than choice name, and throw an exception when then building ITypedElement on it.