### PR TITLE
Add fhirpath support for coalesce and sort

### DIFF
--- a/src/Hl7.Fhir.Base/FhirPath/Expressions/CallSignature.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Expressions/CallSignature.cs
@@ -38,13 +38,14 @@ namespace Hl7.FhirPath.Expressions
             return functionName == Name && arguments.Count() == ArgumentTypes.Length &&
                    arguments.Zip(ArgumentTypes, Typecasts.CanCastTo).All(r => r == true);
         }
+
         public bool DynamicExactMatches(string functionName, IEnumerable<object> arguments)
         {
             return functionName == Name && arguments.Count() == ArgumentTypes.Length &&
                    arguments.Zip(ArgumentTypes, Typecasts.IsOfExactType).All(r => r == true);
         }
 
-        public bool Matches(string functionName, int argCount)
+        virtual public bool Matches(string functionName, int argCount)
         {
             return functionName == Name && ArgumentTypes.Length == argCount;
         }

--- a/src/Hl7.Fhir.Base/FhirPath/Expressions/EchoVisitor.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Expressions/EchoVisitor.cs
@@ -1,7 +1,7 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2015, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
- * 
+ *
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
@@ -17,7 +17,7 @@ using P = Hl7.Fhir.ElementModel.Types;
 namespace Hl7.FhirPath.Expressions
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public class EchoVisitor : ExpressionVisitor<StringBuilder>
     {
@@ -124,7 +124,7 @@ namespace Hl7.FhirPath.Expressions
                     }
                     break;
                 case "String":
-                    _result.Append("'" + Functions.StringOperators.EscapeJson(t) + "'"); 
+                    _result.Append("'" + Functions.StringOperators.EscapeJson(t) + "'");
                     break;
                 case "Ratio":
                     _result.Append($"{t}");
@@ -161,6 +161,15 @@ namespace Hl7.FhirPath.Expressions
                 if (expression.Arguments.FirstOrDefault() is ConstantExpression ceVar)
                     _result.Append($"{ceVar.Value}");
                 _result.Append("`");
+                OutputTrailingTokens(expression);
+                return _result;
+            }
+            if (expression is SortDirectionExpression sd)
+            {
+                sd.Focus.Accept(this);
+                sd.Arguments.FirstOrDefault()?.Accept(this);
+                OutputPrecedingTokens(sd);
+                _result.Append($"{sd.Op}");
                 OutputTrailingTokens(expression);
                 return _result;
             }
@@ -242,7 +251,7 @@ namespace Hl7.FhirPath.Expressions
             if (expression is AxisExpression ae)
             {
                 // No need to output the `that` type
-                if (ae.AxisName == "that")
+                if (ae.AxisName == "that" || ae.AxisName == "this" && ae.Location == null)
                     return _result;
 
                 OutputPrecedingTokens(expression);

--- a/src/Hl7.Fhir.Base/FhirPath/Expressions/ExpressionNode.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Expressions/ExpressionNode.cs
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2015, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
- * 
+ *
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
@@ -91,7 +91,7 @@ namespace Hl7.FhirPath.Expressions
             {
                 if (other.Location == null)
                     return false;
-                var label = (ISourcePositionInfo posinfo) => 
+                var label = (ISourcePositionInfo posinfo) =>
                 {
                     var pi = (FhirPathExpressionLocationInfo)posinfo;
                     return $"Line: {pi.LineNumber}, LinePos: {pi.LinePosition}, RawPos: {pi.RawPosition}, Length: {pi.Length}";
@@ -169,7 +169,7 @@ namespace Hl7.FhirPath.Expressions
             LeftBrace = leftBrace;
             RightBrace = rightBrace;
         }
-        
+
         public Expression Operand { get; private set; }
 
         /// <summary>
@@ -474,6 +474,44 @@ namespace Hl7.FhirPath.Expressions
         BinaryExpression IPositionAware<BinaryExpression>.SetPos(Position startPos, int length) => SetPos<BinaryExpression>(startPos, length);
     }
 
+    public class SortDirectionExpression : FunctionCallExpression, Sprache.IPositionAware<SortDirectionExpression>
+    {
+        internal const string URY_PREFIX = "unary.";
+        internal static readonly int URY_PREFIX_LEN = URY_PREFIX.Length;
+
+        public SortDirectionExpression(char op, Expression operand) : this(new string(op, 1), operand)
+        {
+        }
+
+        public SortDirectionExpression(char op, Expression operand, ISourcePositionInfo location) : this(new string(op, 1), operand, location)
+        {
+        }
+
+        public SortDirectionExpression(string op, Expression operand) : base(AxisExpression.This, URY_PREFIX + op, TypeSpecifier.Any, operand)
+        {
+        }
+
+        public SortDirectionExpression(string op, Expression operand, ISourcePositionInfo location) : base(AxisExpression.This, URY_PREFIX + op, TypeSpecifier.Any, operand, location)
+        {
+        }
+
+        public string Op
+        {
+            get
+            {
+                return FunctionName.Substring(URY_PREFIX_LEN);
+            }
+        }
+
+        public Expression Operand
+        {
+            get
+            {
+                return Focus;
+            }
+        }
+        SortDirectionExpression IPositionAware<SortDirectionExpression>.SetPos(Position startPos, int length) => SetPos<SortDirectionExpression>(startPos, length);
+    }
 
     public class UnaryExpression : FunctionCallExpression, Sprache.IPositionAware<UnaryExpression>
     {

--- a/src/Hl7.Fhir.Base/FhirPath/Expressions/OrderedValue.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Expressions/OrderedValue.cs
@@ -1,0 +1,33 @@
+/* 
+ * Copyright (c) 2015, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Specification;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Hl7.FhirPath.Expressions
+{
+    internal class OrderedValue : ITypedElement
+    {
+        public bool Descending;
+        public ITypedElement value;
+
+        public string Location => value.Location;
+
+        public IElementDefinitionSummary Definition => value.Definition;
+
+        public string Name => value.Name;
+
+        public string InstanceType => value.InstanceType;
+
+        public object Value => value.Value;
+
+        public IEnumerable<ITypedElement> Children(string name = null) => value.Children(name);
+    }
+}

--- a/src/Hl7.Fhir.Base/FhirPath/Expressions/SymbolTableInit.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Expressions/SymbolTableInit.cs
@@ -220,6 +220,13 @@ public static class SymbolTableInit
         t.Add(new CallSignature("defineVariable", typeof(IEnumerable<ITypedElement>), typeof(object), typeof(string)), DefineVariable);
         t.Add(new CallSignature("defineVariable", typeof(IEnumerable<ITypedElement>), typeof(object), typeof(string), typeof(Invokee)), DefineVariable);
 
+        // Co-alesce and sort have variable number of arguments.
+        t.Add(new UnknownArgCountCallSignature("coalesce", typeof(IEnumerable<ITypedElement>)), runCoalesce);
+        t.Add(new UnknownArgCountCallSignature("sort", typeof(IEnumerable<ITypedElement>)), runSort);
+        // these unary operators just inject an ordering node that includes which direction the sort if processing
+        t.Add("unary.asc", (object f, ITypedElement a) => ElementNode.CreateList(new OrderedValue() { value = a }), doNullProp: true);
+        t.Add("unary.desc", (object f, ITypedElement a) => ElementNode.CreateList(new OrderedValue() { value = a, Descending = true }), doNullProp: true);
+
         t.Add(new CallSignature("aggregate", typeof(IEnumerable<ITypedElement>), typeof(Invokee), typeof(Invokee)), runAggregate);
         t.Add(new CallSignature("aggregate", typeof(IEnumerable<ITypedElement>), typeof(Invokee), typeof(Invokee), typeof(Invokee)), runAggregate);
 
@@ -266,6 +273,60 @@ public static class SymbolTableInit
         return "http://hl7.org/fhir/ValueSet/" + id;
     }
 
+    private static IEnumerable<ITypedElement> runSort(Closure ctx, IEnumerable<Invokee> arguments)
+    {
+        var focus = arguments.First()(ctx, InvokeeFactory.EmptyArgs);
+        var lambda = arguments.Skip(1);
+        if (!lambda.Any())
+        {
+            // Just sort using the native element comparer
+            // System.Linq.Enumerable.Order;
+            return CachedEnumerable.Create(focus.OrderBy(item => item, EqualityOperators.TypedElementComparer));
+        }
+
+        var keySelector = lambda.First();
+        IOrderedEnumerable<ITypedElement> orderedResult = focus.OrderBy(item => readElement(ctx, item, keySelector).FirstOrDefault(), EqualityOperators.TypedElementComparer);
+        lambda = lambda.Skip(1);
+        while (lambda.Any())
+        {
+            keySelector = lambda.First();
+            orderedResult = orderedResult.ThenBy(item => readElement(ctx, item, keySelector).FirstOrDefault(), EqualityOperators.TypedElementComparer);
+
+            // move onto the next item
+            lambda = lambda.Skip(1);
+        }
+
+        return orderedResult.ToList();
+    }
+
+    private static IEnumerable<ITypedElement> readElement(Closure ctx, ITypedElement element, Invokee selectProp)
+    {
+        var newFocus = ElementNode.CreateList(element);
+        var newContext = ctx.Nest(newFocus);
+        newContext.SetThis(newFocus);
+        var result = selectProp(newContext, InvokeeFactory.EmptyArgs);
+        foreach (var resultElement in result)       // implement SelectMany()
+            yield return resultElement;
+    }
+
+    private static IEnumerable<ITypedElement> runCoalesce(Closure ctx, IEnumerable<Invokee> arguments)
+    {
+        var focus = arguments.First()(ctx, InvokeeFactory.EmptyArgs);
+        var lambda = arguments.Skip(1);
+
+        while (lambda.Any())
+        {
+            var keySelector = lambda.First();
+            var results = keySelector(ctx, InvokeeFactory.EmptyArgs);
+            if (results.Any())
+                return results;
+
+            // move onto the next item
+            lambda = lambda.Skip(1);
+        }
+
+        return ElementNode.EmptyList;
+    }
     private static IEnumerable<ITypedElement> runAggregate(Closure ctx, IEnumerable<Invokee> arguments)
     {
         var focus = arguments.First()(ctx, InvokeeFactory.EmptyArgs);

--- a/src/Hl7.Fhir.Base/FhirPath/Functions/EqualityOperators.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Functions/EqualityOperators.cs
@@ -243,7 +243,29 @@ namespace Hl7.FhirPath.Functions
             }
         }
 
+        public static int? CompareTo(P.Any left, P.Any right)
+        {
+            // If one or both of the arguments is an empty collection, a comparison operator will return an empty collection.
+            // (though we might handle this more generally with the null-propagating functionality of the compiler
+            // framework already.
+            if (left == null || right == null) return null;
+
+            // Try to convert both operands to a common type if they differ.
+            // When that fails, the CompareTo function on each type will itself
+            // report an error if they cannot handle that.
+            // TODO: in the end the engine/compiler will handle this and report an overload resolution fail
+            tryCoerce(ref left, ref right);
+
+            if (left is P.ICqlOrderable orderable) return orderable.CompareTo(right);
+
+            // Now, only the non-comparables are left (coding, concept, boolean).
+            // TODO: We should be able to retrieve the cql name of the type, not the
+            // dotnet type somehow.
+            throw new InvalidOperationException($"Values of type {left.GetType().Name} is not an ordered type and cannot be compared.");
+        }
+
         public static readonly IEqualityComparer<ITypedElement> TypedElementEqualityComparer = new ValueProviderEqualityComparer();
+        public static readonly IComparer<ITypedElement?> TypedElementComparer = new ValueProviderComparer();
 
         private class ValueProviderEqualityComparer : IEqualityComparer<ITypedElement>
         {
@@ -271,6 +293,23 @@ namespace Hl7.FhirPath.Functions
                 }
 
                 return result;
+            }
+        }
+
+        private class ValueProviderComparer : IComparer<ITypedElement?>
+        {
+            public int Compare(ITypedElement? x, ITypedElement? y)
+            {
+                if (x is null && y is null) return 0;
+                if (x is null) return -1;
+                if (y is null) return 1;
+                if (P.Any.TryConvert(x.Value, out var orderableX) && P.Any.TryConvert(y.Value, out var orderableY))
+                {
+                    if (x is OrderedValue ov && ov.Descending)
+                        return -EqualityOperators.CompareTo(orderableX, orderableY) ?? 0;
+                    return EqualityOperators.CompareTo(orderableX, orderableY) ?? 0;
+                }
+                return 0;
             }
         }
     }

--- a/src/Hl7.Fhir.Base/FhirPath/Parser/Grammar.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Parser/Grammar.cs
@@ -116,8 +116,25 @@ namespace Hl7.FhirPath.Parser
                 .UsePositionFrom(n.Location);
         }
 
+        // Direction parser for sort function
+        public static readonly Parser<string> Direction =
+            Parse.String("asc").Text().Or(Parse.String("desc").Text()).Named("Direction");
+
         public static Parser<Expression> FunctionParameter(string name)
         {
+            // Special handling for sort function: allows optional direction argument
+            if (name == "sort")
+            {
+                return
+                    from wsLeading in WhitespaceOrComments()
+                    from expr in Grammar.Expression
+                    from wsDir in WhitespaceOrComments()
+                    from dir in Direction.Optional()
+                    from wsTrailing in WhitespaceOrComments()
+                    select dir.IsDefined
+                        ? new SortDirectionExpression(dir.Get(), expr.WithLeadingWS(wsLeading)).WithLeadingWS(wsDir).WithTrailingWS(wsTrailing)
+                        : expr.WithLeadingWS(wsLeading).WithTrailingWS(wsTrailing);
+            }
             // Make exception for is() and as() FUNCTIONS (operators are handled elsewhere), since they don't
             // take a normal parameter, but an identifier (which is not normally a FhirPath type)
             if (name != "is" && name != "as" && name != "ofType")

--- a/src/Hl7.Fhir.Base/FhirPath/Parser/Operators.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Parser/Operators.cs
@@ -17,8 +17,26 @@ namespace Hl7.FhirPath.Parser
     {
         internal static Parser<string> Operator(params string[] ops )
         {
-            var first = Parse.String(ops.First());
-            return ops.Skip(1).Aggregate(first, (expr, s) => expr.Or(Parse.String(s)), expr => expr.Text());
+            // Need to ensure that operators don't accidentally match a part
+            // of an input stream. E.g. 'as' should not match 'asc'.
+            var parsers = ops.Select(op => 
+            {
+                var baseParser = Parse.String(op);
+                
+                // For operators that are alphabetic (keywords), ensure they're followed by word boundaries
+                if (op.All(char.IsLetter))
+                {
+                    return from matched in baseParser
+                           from boundary in Parse.Not(Parse.LetterOrDigit).Return("")
+                           select matched;
+                }
+                else
+                {
+                    return baseParser;
+                }
+            });
+
+            return parsers.Aggregate((p1, p2) => p1.Or(p2)).Text();
         }
 
         internal static readonly Parser<string> PolarityOperator = Lexer.Operator("+", "-");

--- a/src/Hl7.Fhir.Base/FhirPath/UnknownArgCountCallSignature.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/UnknownArgCountCallSignature.cs
@@ -1,0 +1,27 @@
+﻿/* 
+ * Copyright (c) 2015, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Hl7.FhirPath.Expressions
+{
+    internal class UnknownArgCountCallSignature : CallSignature
+    {
+        public UnknownArgCountCallSignature(string name, Type returnType)
+            : base(name, returnType)
+        {
+        }
+
+        override public bool Matches(string functionName, int argCount)
+        {
+            return functionName == Name;
+        }
+    }
+}

--- a/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathSortTests.cs
+++ b/src/Hl7.FhirPath.R4.Tests/PocoTests/FhirPathSortTests.cs
@@ -1,0 +1,250 @@
+﻿/* 
+ * Copyright (c) 2015, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+// To introduce the DSTU2 FHIR specification
+// extern alias dstu2;
+
+using FluentAssertions;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.FhirPath;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Source;
+using Hl7.Fhir.Specification.Terminology;
+using Hl7.FhirPath.Expressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks.Dataflow;
+using P = Hl7.Fhir.ElementModel.Types;
+
+namespace Hl7.FhirPath.R4.Tests
+{
+    [TestClass]
+    public class FhirPathSortTests
+    {
+        // Initialize the test context
+        [TestInitialize]
+        public void Initialize()
+        {
+            ElementNavFhirExtensions.PrepareFhirSymbolTableFunctions();
+        }
+
+
+        /// <summary>
+        ///  Gets or sets the test context which provides
+        ///  information about and functionality for the current test run.
+        ///</summary>
+        public TestContext TestContext { get; set; }
+
+
+        [TestMethod]
+        public void TestFhirPathCoalesce1()
+        {
+            FhirPathCompiler compiler = new FhirPathCompiler();
+            var p = new Patient
+            {
+                Id = "pat1",
+                BirthDate = "1990-10-1",
+                Active = true,
+            };
+            var expr = compiler.Compile("coalesce(id)");
+            var result = expr(p.ToTypedElement(), new FhirEvaluationContext());
+
+            Assert.IsNotNull(result.FirstOrDefault());
+            Assert.AreEqual(1, result.Count());
+            Assert.AreEqual("pat1", result.ElementAt(0).Value);
+        }
+
+        [TestMethod]
+        public void TestFhirPathCoalesce2()
+        {
+            FhirPathCompiler compiler = new FhirPathCompiler();
+            var p = new Patient
+            {
+                Id = "pat1",
+                BirthDate = "1990-10-1",
+                Active = true,
+            };
+            var expr = compiler.Compile("coalesce(name, id)");
+            var result = expr(p.ToTypedElement(), new FhirEvaluationContext());
+
+            Assert.IsNotNull(result.FirstOrDefault());
+            Assert.AreEqual(1, result.Count());
+            Assert.AreEqual("pat1", result.ElementAt(0).Value);
+        }
+
+        [TestMethod]
+        public void TestFhirPathCoalesce3()
+        {
+            FhirPathCompiler compiler = new FhirPathCompiler();
+            var p = new Patient
+            {
+                Id = "pat1",
+                BirthDate = "1990-10-1",
+                Active = true,
+            };
+            var expr = compiler.Compile("coalesce(name, telecom, {}, address, extension, 'five', id, birthDate)");
+            var result = expr(p.ToTypedElement(), new FhirEvaluationContext());
+
+            Assert.IsNotNull(result.FirstOrDefault());
+            Assert.AreEqual(1, result.Count());
+            Assert.AreEqual("five", result.ElementAt(0).Value);
+        }
+
+        [TestMethod]
+        public void TestFhirPathSortNone()
+        {
+            FhirPathCompiler compiler = new FhirPathCompiler();
+            var expr = compiler.Compile("(1|2|3)");
+            var result = expr(null, new FhirEvaluationContext());
+
+            Assert.IsNotNull(result.FirstOrDefault());
+            Assert.AreEqual(3, result.Count());
+            Assert.AreEqual(1, result.ElementAt(0).Value);
+            Assert.AreEqual(2, result.ElementAt(1).Value);
+            Assert.AreEqual(3, result.ElementAt(2).Value);
+        }
+
+        [TestMethod]
+        public void TestFhirPathSort1()
+        {
+            FhirPathCompiler compiler = new FhirPathCompiler();
+            var expr = compiler.Compile("(1|2|3).sort()");
+            var result = expr(null, new FhirEvaluationContext());
+
+            Assert.IsNotNull(result.FirstOrDefault());
+            Assert.AreEqual(3, result.Count());
+            Assert.AreEqual(1, result.ElementAt(0).Value);
+            Assert.AreEqual(2, result.ElementAt(1).Value);
+            Assert.AreEqual(3, result.ElementAt(2).Value);
+        }
+
+        [TestMethod]
+        public void TestFhirPathSort2()
+        {
+            FhirPathCompiler compiler = new FhirPathCompiler();
+            var expr = compiler.Compile("(3|2|1).sort()");
+            var result = expr(null, new FhirEvaluationContext());
+
+            Assert.IsNotNull(result.FirstOrDefault());
+            Assert.AreEqual(3, result.Count());
+            Assert.AreEqual(1, result.ElementAt(0).Value);
+            Assert.AreEqual(2, result.ElementAt(1).Value);
+            Assert.AreEqual(3, result.ElementAt(2).Value);
+        }
+
+        [TestMethod]
+        public void TestFhirPathSort3()
+        {
+            FhirPathCompiler compiler = new FhirPathCompiler();
+            var expr = compiler.Compile("(3|2|1).sort($this)");
+            var result = expr(null, new FhirEvaluationContext());
+
+            Assert.IsNotNull(result.FirstOrDefault());
+            Assert.AreEqual(3, result.Count());
+            Assert.AreEqual(1, result.ElementAt(0).Value);
+            Assert.AreEqual(2, result.ElementAt(1).Value);
+            Assert.AreEqual(3, result.ElementAt(2).Value);
+        }
+
+        [TestMethod]
+        public void TestFhirPathSortDescending1_numeric()
+        {
+            FhirPathCompiler compiler = new FhirPathCompiler();
+            var expr = compiler.Compile("(1|2|3).sort($this desc)");
+            var result = expr(null, new FhirEvaluationContext());
+
+            Assert.IsNotNull(result.FirstOrDefault());
+            Assert.AreEqual(3, result.Count());
+            Assert.AreEqual(3, result.ElementAt(0).Value);
+            Assert.AreEqual(2, result.ElementAt(1).Value);
+            Assert.AreEqual(1, result.ElementAt(2).Value);
+        }
+
+        [TestMethod]
+        public void TestFhirPathSortDescending1_numericOddity()
+        {
+            // this isn't really using the official syntax,
+            // however for numerics the unary - operator works the same as the 'desc' keyword
+            FhirPathCompiler compiler = new FhirPathCompiler();
+            var expr = compiler.Compile("(1|2|3).sort(-$this)");
+            var result = expr(null, new FhirEvaluationContext());
+
+            Assert.IsNotNull(result.FirstOrDefault());
+            Assert.AreEqual(3, result.Count());
+            Assert.AreEqual(3, result.ElementAt(0).Value);
+            Assert.AreEqual(2, result.ElementAt(1).Value);
+            Assert.AreEqual(1, result.ElementAt(2).Value);
+        }
+
+        [TestMethod]
+        public void TestFhirPathSortDescending2_alpha()
+        {
+            FhirPathCompiler compiler = new FhirPathCompiler();
+            var exprString = "('a'|'b'|'c').sort($this desc)";
+            var exprAST = compiler.Parse(exprString);
+            var expr = compiler.Compile(exprString);
+            var result = expr(null, new FhirEvaluationContext());
+
+            Assert.IsNotNull(result.FirstOrDefault());
+            Assert.AreEqual(3, result.Count());
+            Assert.AreEqual("c", result.ElementAt(0).Value);
+            Assert.AreEqual("b", result.ElementAt(1).Value);
+            Assert.AreEqual("a", result.ElementAt(2).Value);
+        }
+
+        [TestMethod]
+        public void TestFhirPathSortAscending2_alpha()
+        {
+            FhirPathCompiler compiler = new FhirPathCompiler();
+            var expr = compiler.Compile("('b'|'a'|'c').sort($this asc)");
+            var result = expr(null, new FhirEvaluationContext());
+
+            Assert.IsNotNull(result.FirstOrDefault());
+            Assert.AreEqual(3, result.Count());
+            Assert.AreEqual("a", result.ElementAt(0).Value);
+            Assert.AreEqual("b", result.ElementAt(1).Value);
+            Assert.AreEqual("c", result.ElementAt(2).Value);
+        }
+
+        [TestMethod]
+        public void TestFhirPathSort4()
+        {
+            var patient = new Patient() { Id = "pat1"};
+            patient.Name.Add(new HumanName() { Family = "Smith", Given = new List<string>() { "Peter", "James" } });
+            FhirPathCompiler compiler = new FhirPathCompiler();
+            var expr = compiler.Compile("Patient.name.given.sort()");
+            var result = expr(patient.ToTypedElement(), new FhirEvaluationContext());
+
+            Assert.IsNotNull(result.FirstOrDefault());
+            Assert.AreEqual(2, result.Count());
+            Assert.AreEqual("James", result.ElementAt(0).Value);
+            Assert.AreEqual("Peter", result.ElementAt(1).Value);
+        }
+
+        [TestMethod]
+        public void TestFhirPathSort5()
+        {
+            var patient = new Patient() { Id = "pat1" };
+            patient.Name.Add(new HumanName() { ElementId = "1", Family = "Smith", Given = new List<string>() { "Peter", "James" } });
+            patient.Name.Add(new HumanName() { ElementId = "3", Family = "Pos", Given = new List<string>() { "Belinda" } });
+            patient.Name.Add(new HumanName() { ElementId = "2", Family = "Pos", Given = new List<string>() { "Brian", "R" } });
+            FhirPathCompiler compiler = new FhirPathCompiler();
+            var expr = compiler.Compile("Patient.name.sort(family, given.first()).id");
+            var result = expr(patient.ToTypedElement(), new FhirEvaluationContext());
+
+            Assert.IsNotNull(result.FirstOrDefault());
+            Assert.AreEqual(3, result.Count());
+            Assert.AreEqual("3", result.ElementAt(0).Value);
+            Assert.AreEqual("2", result.ElementAt(1).Value);
+            Assert.AreEqual("1", result.ElementAt(2).Value);
+        }
+    }
+}

--- a/src/Hl7.FhirPath.Tests/Tests/FhirPathGrammarEchoTest.cs
+++ b/src/Hl7.FhirPath.Tests/Tests/FhirPathGrammarEchoTest.cs
@@ -208,6 +208,20 @@ namespace Hl7.FhirPath.Tests
         }
 
         [TestMethod]
+        public void FhirPath_Echo_Sort()
+        {
+            var parser = Grammar.InvocationExpression.End();
+
+            AssertParser.SucceedsEcho(parser, " sort ( name  /* blah */ asc )");
+            AssertParser.SucceedsEcho(parser, "sort()");
+            AssertParser.SucceedsEcho(parser, " sort()");
+            AssertParser.SucceedsEcho(parser, " sort(name)");
+            AssertParser.SucceedsEcho(parser, "sort(name desc)");
+            AssertParser.SucceedsEcho(parser, " sort(name asc)");
+            AssertParser.SucceedsEcho(parser, " sort(name asc, tel desc)");
+        }
+
+        [TestMethod]
         public void FhirPath_Echo_Bracket()
         {
             var parser = Grammar.TypeExpression.End();

--- a/src/Hl7.FhirPath.Tests/Tests/FhirPathGrammarTest.cs
+++ b/src/Hl7.FhirPath.Tests/Tests/FhirPathGrammarTest.cs
@@ -1,7 +1,7 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2015, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
- * 
+ *
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
@@ -97,7 +97,7 @@ namespace Hl7.FhirPath.Tests
             AssertParser.SucceedsMatch(parser, "{}", NewNodeListInitExpression.Empty);
             AssertParser.SucceedsMatch(parser, "@2014-12-13T12:00:00+02:00", new ConstantExpression(P.DateTime.Parse("2014-12-13T12:00:00+02:00")));
             AssertParser.SucceedsMatch(parser, "78 'kg'", new ConstantExpression(new P.Quantity(78m, "kg")));
-            AssertParser.SucceedsMatch(parser, "10.1 'mg'", new ConstantExpression(new P.Quantity(10.1m, "mg"))); 
+            AssertParser.SucceedsMatch(parser, "10.1 'mg'", new ConstantExpression(new P.Quantity(10.1m, "mg")));
         }
 
         FhirPathExpressionLocationInfo SetLoc(int lineNo, int linePos, int rawPos, int length)
@@ -143,14 +143,14 @@ namespace Hl7.FhirPath.Tests
         {
             var parser = Grammar.Term.End();
             // The length of the function includes all the way to the end of the closing brackets (not just the function name)
-            AssertParser.SucceedsMatch(parser, "today()", 
+            AssertParser.SucceedsMatch(parser, "today()",
                 new FunctionCallExpression(
                     AxisExpression.This,
-                    "today", 
+                    "today",
                     new SubToken('(', SetLoc(1, 14, 13, 1)),
                     new SubToken(')', SetLoc(1, 15, 14, 1)),
-                    TypeSpecifier.Any, 
-                    new Expression[] { }, 
+                    TypeSpecifier.Any,
+                    new Expression[] { },
                     SetLoc(1, 1, 0, 5)));
         }
 
@@ -204,9 +204,9 @@ namespace Hl7.FhirPath.Tests
         public void FhirPath_LocationInfo_FunctionWithParams()
         {
             var parser = Grammar.Term.End();
-            AssertParser.SucceedsMatch(parser, "doSomething('hi', 3.14)", 
+            AssertParser.SucceedsMatch(parser, "doSomething('hi', 3.14)",
                     new FunctionCallExpression(
-                        AxisExpression.This, 
+                        AxisExpression.This,
                         "doSomething",
                         new SubToken('(', SetLoc(1, 1, 0, 23)),
                         new SubToken(')', SetLoc(1, 1, 0, 23)),
@@ -266,7 +266,7 @@ namespace Hl7.FhirPath.Tests
         public void FhirPath_LocationInfo_Brackets()
         {
             var parser = Grammar.Expression.End();
-            AssertParser.SucceedsMatch(parser, "  ( 3 ) ", 
+            AssertParser.SucceedsMatch(parser, "  ( 3 ) ",
                 new BracketExpression(
                     new ConstantExpression(3, SetLoc(1, 2, 2, 1)),
                     SetLoc(1, 3, 2, 5)));
@@ -343,13 +343,13 @@ namespace Hl7.FhirPath.Tests
         public void FhirPath_LocationInfo_Identifier()
         {
             var parser = Grammar.Term.End();
-            AssertParser.SucceedsMatch(parser, "ofType(Patient)", 
+            AssertParser.SucceedsMatch(parser, "ofType(Patient)",
                 new FunctionCallExpression(
                     AxisExpression.This,
-                    "ofType", 
+                    "ofType",
                     new SubToken('(', SetLoc(1, 7, 6, 1)),
                     new SubToken(')', SetLoc(1, 15, 14, 1)),
-                    TypeSpecifier.Any, 
+                    TypeSpecifier.Any,
                     new[] { new IdentifierExpression("Patient", SetLoc(1, 8, 7, 7)) },
                     SetLoc(1, 1, 0, 6)
                 ));
@@ -441,6 +441,22 @@ namespace Hl7.FhirPath.Tests
             AssertParser.FailsMatch(parser, "78 kg");
             AssertParser.FailsMatch(parser, "four 'kg'");
             AssertParser.FailsMatch(parser, "4 decennia");
+        }
+
+        [TestMethod]
+        public void FhirPath_Gramm_Sort()
+        {
+            var parser = Grammar.Expression.End();
+            AssertParser.SucceedsMatch(parser, "sort()", new FunctionCallExpression(AxisExpression.This, "sort", TypeSpecifier.Any));
+            AssertParser.SucceedsMatch(parser, "sort(given)", new FunctionCallExpression(AxisExpression.This, "sort", TypeSpecifier.Any, [new ChildExpression(AxisExpression.This, "given")]));
+            AssertParser.SucceedsMatch(parser, "sort(given desc)", new FunctionCallExpression(AxisExpression.This, "sort", TypeSpecifier.Any, [new SortDirectionExpression("desc", new ChildExpression(AxisExpression.This, "given"))]));
+        }
+
+        [TestMethod]
+        public void FhirPath_Gramm_SortAsc()
+        {
+            var parser = Grammar.Expression.End();
+            AssertParser.SucceedsMatch(parser, "sort(given asc)", new FunctionCallExpression(AxisExpression.This, "sort", TypeSpecifier.Any, [new SortDirectionExpression("asc", new ChildExpression(AxisExpression.This, "given"))]));
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
These 2 functions have been approved by HL7 for inclusion in the next version of the fhirpath specification.
So implement support for them as per specification.
https://build.fhir.org/ig/HL7/FHIRPath/branches/BP-2025-ballot-recon2/#coalesce
https://build.fhir.org/ig/HL7/FHIRPath/branches/BP-2025-ballot-recon2/#sortkeyselector-expression-asc--desc--keyselector-expression-asc--desc---collection

## Testing
Unit tests have been added to verify the functionality

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes