### PR TITLE
Handle serializing primitives

### DIFF
--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonSerializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonSerializer.cs
@@ -20,10 +20,10 @@ using System.Text.Json;
 namespace Hl7.Fhir.Serialization;
 
 /// <summary>
-/// Serializes the contents of an IReadOnlyDictionary[string,object] according to the rules of FHIR Json serialization.
+/// Serializes the contents of an instance of Base, according to the rules of FHIR Json serialization.
 /// </summary>
 /// <remarks>The serializer uses the format documented in https://www.hl7.org/fhir/json.html. Since all POCOs included
-/// in the SDK implement IReadOnlyDictionary, these methods can be used to serialize POCOs to Json.
+/// in the SDK implement Base, these methods can be used to serialize POCOs to Json.
 /// </remarks>
 public class BaseFhirJsonSerializer(ModelInspector inspector)
 {
@@ -45,7 +45,19 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
         if (filter is not null)
             instance = SerializationUtil.MakeSubsettedClone(instance);
 
-        serializeInternal(instance, writer, filter);
+        // This handles an edge-case where we are asked to serialize just a primitive value.
+        // For compatibility with SDK5 logic, we emit object with pseudo-property 'value' and value of the fhir primitive.
+        // Issue for context: https://github.com/FirelyTeam/firely-net-sdk/issues/3286
+        if (instance is not PrimitiveType val)
+        {
+            serializeInternal(instance, writer, filter);
+        }
+        else
+        {
+            writer.WriteStartObject();
+            serializeFhirPrimitive("value", val, writer, filter);
+            writer.WriteEndObject();
+        }
     }
 
     /// <summary>

--- a/src/Hl7.Fhir.Shared.Tests/Serialization/SerializationTests.cs
+++ b/src/Hl7.Fhir.Shared.Tests/Serialization/SerializationTests.cs
@@ -535,6 +535,31 @@ namespace Hl7.Fhir.Tests.Serialization
 
             Assert.AreEqual(1, newPoco.Name.Count);
         }
+        
+        [TestMethod]
+        public void SerializesHandlesPrimitiveWithExtension()
+        {
+            var expected = "{\"value\":\"Test\",\"_value\":{\"extension\":[{\"url\":\"http://test\",\"valueString\":\"data\"}]}}";
+            var test = new FhirString("Test")
+            {
+                Extension = [new("http://test", new FhirString("data"))]
+            };
+
+            var actual = new FhirJsonSerializer().SerializeToString(test);
+
+            Assert.AreEqual(expected, actual);
+        }
+        
+        [TestMethod]
+        public void SerializesHandlesPrimitive()
+        {
+            var expected = "{\"value\":\"Test\"}";
+            var test = new FhirString("Test");
+
+            var actual = new FhirJsonSerializer().SerializeToString(test);
+
+            Assert.AreEqual(expected, actual);
+        }
 
         [TestMethod]
         public void IncludeMandatoryInElementsSummaryTest()


### PR DESCRIPTION
## Description
When getting just a primitive to serialize, we will now serialize it as an object with a property named `value`.

## Related issues
Closes #3286 