### PR TITLE
Enable PocoNode roundtrippability in Dynamic mode

### DIFF
--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
@@ -15,10 +15,7 @@ using Hl7.Fhir.Specification;
 using Hl7.Fhir.Utility;
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 using ET = Hl7.Fhir.ElementModel.Types;
 
 namespace Hl7.Fhir.ElementModel;
@@ -276,7 +273,17 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
     private void setOrAddProperty(ITypedElement node, Base target,
         Base convertedValue, PropertyMapping? propertyMapping)
     {
-        var existing = target.TryGetValue(node.Name, out var existingValue) ? existingValue : null;
+        // Original ITypedElement had more detailed information about the type of data it represents than the Poco we're building now.
+        // If we had no information of what to build, we will default to using Dynamic types to represent it.
+        // In this case we will add back the choice suffixes, so the data will represent values as they would be serialized
+        // and keep an option to type the data properly later, and consistent if the original ITypedElement didn't have the information as well.
+        // It will also allow us to later build properly typed Poco using PocoNode implementing ITypedElement/ISourceNode to call ToPoco<T>()
+        // Covered by tests PocoNodeSerializationRoundtrip.CanConvertCircularPocoNode and https://github.com/FirelyTeam/firely-net-sdk/issues/3278
+        var propertyName = propertyMapping is null && node.Definition?.IsChoiceElement == true ?
+            node.Name + node.InstanceType.Capitalize() :
+            node.Name;
+        
+        var existing = target.TryGetValue(propertyName, out var existingValue) ? existingValue : null;
 
         // If there are, just add this new value.
         if (existing is IList list)
@@ -334,9 +341,9 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
         try
         {
             if (propertyMapping?.IsPrimitive == true && convertedValue is PrimitiveType { JsonValue: { } value })
-                target[node.Name] = value;
+                target[propertyName] = value;
             else
-                target[node.Name] = convertedValue;
+                target[propertyName] = convertedValue;
         }
         catch (InvalidCastException)
         {

--- a/src/Hl7.Fhir.Serialization.Shared.Tests/Hl7.Fhir.Serialization.Shared.Tests.projitems
+++ b/src/Hl7.Fhir.Serialization.Shared.Tests/Hl7.Fhir.Serialization.Shared.Tests.projitems
@@ -17,6 +17,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ParseDemoPatientXmlTyped.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ParseDemoPatientXmlUntyped.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ParseXMLElements.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PocoNodeSerializationRoundtrip.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RoundTripAttachments.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RoundtripAllSerializers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SerializeDemoPatientJson.cs" />

--- a/src/Hl7.Fhir.Serialization.Shared.Tests/PocoNodeSerializationRoundtrip.cs
+++ b/src/Hl7.Fhir.Serialization.Shared.Tests/PocoNodeSerializationRoundtrip.cs
@@ -1,0 +1,32 @@
+using FluentAssertions;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Introspection;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Validation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Hl7.Fhir.Serialization.STU3.Tests;
+
+[TestClass]
+public class PocoNodeSerializationRoundtrip
+{
+    [TestMethod]
+    public void CanConvertCircularPocoNode()
+    {
+        var originalJson = @"{""resourceType"":""Patient"",""deceasedBoolean"":true}";
+        var sn = FhirJsonNode.Parse(originalJson);
+        // build TypedElement with correct type info
+        var typed = sn.ToTypedElement(ModelInfo.ModelInspector);
+        // then use base when building PocoNode - no information about Patient
+        var pnOnTypedElementBase = typed.ToPocoNode(ModelInspector.Base);
+        var pnOnTypedElement = typed.ToPocoNode();
+        // check SourceNode version too, but if SourceNode has no information
+        // it would serialize everything as strings, so we just check relevant version.
+        var pnOnSourceNode = sn.ToPoco().ToPocoNode();
+            
+        var jsonTypedBase = pnOnTypedElementBase.ToJson(false);
+        var jsonTyped = pnOnTypedElement.ToJson(false);
+        var jsonSourceBase = pnOnSourceNode.ToJson(false);
+        jsonTypedBase.Should().Be(jsonSourceBase).And.Be(jsonTyped).And.Be(originalJson);
+    }
+}


### PR DESCRIPTION
## Description
Will allow to serialize PocoNode to json in a valid format when the ModelInspector used to build the poco was unaware of actual types.

## Related issues
Closes #3278 