### PR TITLE
PocoNode.SourceName use Choice annotation only when definition is missing

### DIFF
--- a/src/Hl7.Fhir.Base/FhirPath/Functions/TypeOperators.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Functions/TypeOperators.cs
@@ -29,7 +29,7 @@ namespace Hl7.FhirPath.Functions
 #pragma warning disable CS0618 // Type or member is obsolete
                 .Select(t => ModelInspector.ForAssembly(t.Assembly).GetFhirTypeNameForType(t))
 #pragma warning restore CS0618 // Type or member is obsolete
-                .Append(((ITypedElement)focus).InstanceType);
+                .Prepend(((ITypedElement)focus).InstanceType);
             return selfAndBaseClasses.Any(typeString => Is(typeString, type));
             
             static IEnumerable<Type> getBaseClasses(Type t)
@@ -41,8 +41,8 @@ namespace Hl7.FhirPath.Functions
         public static bool Is(string? instanceType, string declaredType)
         {
             // Bit of a hack, this hardwires the FhirPath implementation to FHIR
-            if (instanceType?.Contains(".") is false) instanceType = "FHIR." + instanceType;
-            if (declaredType.Contains("."))
+            if (instanceType?.Contains('.') is false) instanceType = "FHIR." + instanceType;
+            if (declaredType.Contains('.'))
                 return instanceType == declaredType;
             else
             {

--- a/src/Hl7.Fhir.Base/Model/PocoNode.TypedElement.cs
+++ b/src/Hl7.Fhir.Base/Model/PocoNode.TypedElement.cs
@@ -65,11 +65,13 @@ public partial record PocoNode
     {
         if (Poco is not DataType dt)
             return Name;
-
-        if(dt.HasAnnotation<ChoiceElementAnnotation>() || ((ITypedElement)this).Definition?.IsChoiceElement is true)
-            return Name + dt.TypeName.Capitalize();
-
-        return Name;
+        
+        return ((ITypedElement)this).Definition switch
+        {
+            { IsChoiceElement: true } => Name + dt.TypeName.Capitalize(),
+            null when dt.HasAnnotation<ChoiceElementAnnotation>() => Name + dt.TypeName.Capitalize(),
+            _ => Name
+        };
     });
     
     string ISourceNode.Name => SourceName.Value;


### PR DESCRIPTION
## Description
An edge case, choice annotation should only be considered if the definition is missing, otherwise definition is deciding.
