### PR TITLE
Fix snapshot generator errors and CodeOfT values

### DIFF
--- a/src/Hl7.Fhir.Base/Model/CodeOfT.cs
+++ b/src/Hl7.Fhir.Base/Model/CodeOfT.cs
@@ -135,12 +135,12 @@ public class Code<T> : Code, INullableValue<T> where T : struct, Enum
     /// <summary>
     /// The literal of the code value, taken from the enum that is in <see cref="Value"/>.
     /// </summary>
-    public override string? Literal => Value?.GetSystem();
+    public override string? Literal => Value?.GetLiteral();
 
     /// <summary>
     /// The system of the code value, taken from the enum that is in <see cref="Value"/>.
     /// </summary>
-    public override string? System => Value?.GetLiteral();
+    public override string? System => Value?.GetSystem();
 
     protected internal override P.Any? TryConvertToSystemTypeInternal() =>
         Value is not null ? new P.Code(Value.GetSystem(), Value.GetLiteral()!, display: null, version: null) : null;

--- a/src/Hl7.Fhir.Shims.Base/Specification/Source/SnapshotSource.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Source/SnapshotSource.cs
@@ -134,7 +134,7 @@ namespace Hl7.Fhir.Specification.Source
                     
                     if(Generator.Outcome?.Success is false)
                     {
-                        return ResolverException.SnapshotOutcome(Generator.Outcome);
+                        return new(sd, ResolverException.SnapshotOutcome(Generator.Outcome));
                     }
                 }
             }

--- a/src/Hl7.Fhir.Specification.STU3.Tests/DiscriminatorInterpreterTests.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/DiscriminatorInterpreterTests.cs
@@ -131,7 +131,6 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [TestMethod]
-        [Ignore("Test resource has broken snapshot chain due to missing base profile")]
         public async Tasks.Task WalkToInlineComplexExtensionConstraints()
         {
             var sd = await _source.FindStructureDefinitionAsync("http://unittest.com/StructureDefinition/patient-sliced-complex-extension");

--- a/src/Hl7.Fhir.Specification.STU3.Tests/StructureDefinitionWalkerTests.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/StructureDefinitionWalkerTests.cs
@@ -116,7 +116,6 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
         [TestMethod]
-        [Ignore("Test resource has broken snapshot chain due to missing base profile")]
         public async Tasks.Task WalkAcrossInlineExtension()
         {
             var sd = await _source.FindStructureDefinitionAsync("http://unittest.com/StructureDefinition/patient-sliced-complex-extension");


### PR DESCRIPTION
## Description
Turns out SnapshotGenerator uses 'Error' level outcome for stuff like empty differential, which does not break the StructureDefinition itself.