### PR TITLE
Solve NullReferenceException in serialization with SummaryFilter being used

### DIFF
--- a/src/Hl7.Fhir.Base/Model/Base.Extensions.cs
+++ b/src/Hl7.Fhir.Base/Model/Base.Extensions.cs
@@ -43,7 +43,18 @@ public static partial class BaseExtensions
         }
     }
 
-    public static T DeepCopy<T>(this T source) where T : Base => (T)source.DeepCopyInternal();
+    /// <summary>
+    /// Creates a deep copy of the specified object. The resulting object is a new instance with all
+    /// of the source's data recursively duplicated.
+    /// </summary>
+    /// <param name="source">The object to copy.</param>
+    /// <typeparam name="T">The concrete type cast the copy of <paramref name="source"/> to.</typeparam>
+    /// <return> A deep copy of the source object, or <c>null</c> if the source is <c>null</c>. </return>
+    /// <remarks>
+    /// We do null conditional access operator to not throw on nulls, then ignore if it is null to keep default nullability.
+    /// Should not happen unless someone explicitly assigned null on poco then ignored warnings.
+    /// </remarks>
+    public static T DeepCopy<T>(this T source) where T : Base => (T)source?.DeepCopyInternal()!;
 
     public static void CopyTo(this Base source, Base target) => source.CopyToInternal(target);
 

--- a/src/Hl7.Fhir.Base/Utility/SerializationUtil.cs
+++ b/src/Hl7.Fhir.Base/Utility/SerializationUtil.cs
@@ -703,8 +703,9 @@ public static class SerializationUtil
         addSubsetted(instance, true);
         return;
 
-        static void addSubsetted(Base instance, bool atRoot)
+        static void addSubsetted(Base? instance, bool atRoot)
         {
+            if (instance is null) return;
             var isBundleAtRoot = instance is Bundle && atRoot;
 
             if (instance is Resource resource && !isBundleAtRoot)

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/SummaryFilterIntegrationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/SummaryFilterIntegrationTests.cs
@@ -32,6 +32,20 @@ namespace Hl7.Fhir.Support.Poco.Tests
         }
         
         [TestMethod]
+        public void SerializationWontCrashWithFilterAndNullListElements()
+        {
+            var patient = new Patient
+            {
+                BirthDateElement = new Date("1990")
+                {
+                    Extension = [ null, new Extension("birthTime", new Instant(DateTimeOffset.Now)) ]
+                }
+            };
+            var (_, summarized) = runSummarize<Patient>(patient, SerializationFilter.ForSummary);
+            summarized.Extension.Should().BeEmpty();
+        }
+        
+        [TestMethod]
         public void Basics()
         {
             // This bundle should get through unfiltered


### PR DESCRIPTION
## Description
When serializing with a filter, we copy the serialized Poco. With explicitly ignored null in a list, we would crash, now we will roundtrip nulls correctly.

## Related issues
Closes #3329