### PR TITLE
Clean up pipeline

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -20,10 +20,6 @@ variables:
 - group: APIKeys
 - template: build-variables.yml
 - template: pipeline-variables.yml
-- name: DOTNET_CLI_FORCE_ANSI_COLOR
-  value: true
-- name: TERM
-  value: xterm
   
 pool:
   vmImage: windows-latest
@@ -90,7 +86,7 @@ stages:
           nuGetSources: --source https://nuget.pkg.github.com/FirelyTeam/index.json
           
     - ${{ if eq(variables.useGitHubPackageFeed, 'no') }}:
-      - script: dotnet restore --source https://api.nuget.org/v3/index.json /clp:ForceConsoleColor
+      - script: dotnet restore --source https://api.nuget.org/v3/index.json 
         displayName: 'Run dotnet restore'
         
     - task: DotNetCoreCLI@2
@@ -98,7 +94,7 @@ stages:
       inputs:
         command: build
         projects: ./Hl7.Fhir.sln
-        arguments: --configuration $(buildConfiguration) --no-restore /p:ContinuousIntegrationBuild=true /clp:ForceConsoleColor
+        arguments: --configuration $(buildConfiguration) --no-restore /p:ContinuousIntegrationBuild=true 
 
     - task: DotNetCoreCLI@2
       displayName: Create Test artifacts
@@ -109,7 +105,7 @@ stages:
          **/Hl7.FhirPath.R4.Tests/*.csproj
         publishWebProjects: false
         zipAfterPublish: false
-        arguments: --configuration $(buildConfiguration) --no-build -f $(TEST_TARGETFRAMEWORK) /clp:ForceConsoleColor
+        arguments: --configuration $(buildConfiguration) --no-build -f $(TEST_TARGETFRAMEWORK) 
 
     - task: CopyFiles@2
       displayName: 'Copy Test artifacts to $(System.DefaultWorkingDirectory)/bin'
@@ -135,7 +131,6 @@ stages:
         configurationToPack: $(buildConfiguration)
         nobuild: true
         verbosityPack: Normal
-        arguments: '/clp:ForceConsoleColor'
     - powershell: |
         if ([string]::IsNullOrEmpty($Env:CurrentSuffix))
         {

--- a/build/templates/test-job-template.yml
+++ b/build/templates/test-job-template.yml
@@ -31,9 +31,6 @@ steps:
     projects: ${{ parameters.projects }}
     arguments: '-f $(TEST_TARGETFRAMEWORK) --filter TestCategory!=IntegrationTest&TestCategory!=FhirClient --collect "Code coverage"'
     testRunTitle: ${{ parameters.testRunTitle }}
-  env:
-    DOTNET_CLI_FORCE_ANSI_COLOR: true
-    TERM: xterm
 
 - powershell: |
     Write-Host "##[section]✓ Test execution completed: ${{ parameters.testRunTitle }}"


### PR DESCRIPTION
This pull request updates the Azure Pipelines configuration to remove forced ANSI color output and related environment variables from the build and test steps. The changes simplify the pipeline scripts and may improve compatibility with environments that do not support ANSI color codes.

Pipeline variable and argument cleanup:

* Removed `DOTNET_CLI_FORCE_ANSI_COLOR` and `TERM` environment variables from both the global pipeline variables and the test job template (`build/azure-pipelines.yml`, `build/templates/test-job-template.yml`). [[1]](diffhunk://#diff-5324d0d190cad8c6fa3025075de2f8f6bb002aca13c2850cb0b36af01af2ff8aL23-L26) [[2]](diffhunk://#diff-8d0b2ebbeadd18207af8c2afcdf21e0c7b3b8d9509166f5fc136cc97f04e7a16L34-L36)
* Eliminated `/clp:ForceConsoleColor` and related color-forcing arguments from all `dotnet` CLI commands in the pipeline (`build/azure-pipelines.yml`). [[1]](diffhunk://#diff-5324d0d190cad8c6fa3025075de2f8f6bb002aca13c2850cb0b36af01af2ff8aL93-R97) [[2]](diffhunk://#diff-5324d0d190cad8c6fa3025075de2f8f6bb002aca13c2850cb0b36af01af2ff8aL112-R108) [[3]](diffhunk://#diff-5324d0d190cad8c6fa3025075de2f8f6bb002aca13c2850cb0b36af01af2ff8aL138)