### PR TITLE
Changed the parent property design on PocoNode

### DIFF
--- a/src/Hl7.Fhir.Base/FhirPath/Expressions/OrderedNode.cs
+++ b/src/Hl7.Fhir.Base/FhirPath/Expressions/OrderedNode.cs
@@ -12,7 +12,7 @@ using System.Linq;
 
 namespace Hl7.FhirPath.Expressions;
 
-internal record OrderedNode(PrimitiveType Primitive, PocoNodeOrList ParentNode, int? Index, string Name = null, bool Descending = false) : PrimitiveNode(Primitive, ParentNode, Index, Name)
+internal record OrderedNode(PrimitiveType Primitive, PocoNode Parent, int? Index, string Name = null, bool Descending = false) : PrimitiveNode(Primitive, Parent, Index, Name)
 {
     internal static OrderedNode FromPrimitiveNode(PocoNode primitiveNode, bool descending = false) =>
         new((PrimitiveType)primitiveNode.Poco, primitiveNode.Parent, primitiveNode.Index, primitiveNode.Name, descending);

--- a/src/Hl7.Fhir.Base/Model/PocoNode.Primitives.cs
+++ b/src/Hl7.Fhir.Base/Model/PocoNode.Primitives.cs
@@ -62,7 +62,7 @@ public partial record PocoNode
         values.Select(v => v as PocoNode ?? ForAnyPrimitive(v));
 }
 
-public record PrimitiveNode(PrimitiveType Primitive, PocoNodeOrList? ParentNode, int? Index, string? Name = null) : PocoNode(Primitive, ParentNode, Index, Name)
+public record PrimitiveNode(PrimitiveType Primitive, PocoNode? Parent, int? Index, string? Name = null) : PocoNode(Primitive, Parent, Index, Name)
 {
     protected override object? ValueInternal => Primitive.ToITypedElementValue();
     internal object? Value => ValueInternal;
@@ -86,10 +86,10 @@ public record PrimitiveNode(PrimitiveType Primitive, PocoNodeOrList? ParentNode,
     protected override string? TextInternal => Primitive.ToString();
 }
 
-internal record PrimitiveListNode(IReadOnlyList<PrimitiveType> Primitives, PocoNodeOrList? ParentNode, string? Name = null) : PocoListNode(Primitives, ParentNode, Name ?? "value")
+internal record PrimitiveListNode(IReadOnlyList<PrimitiveType> Primitives, PocoNode? Parent, string? Name = null) : PocoListNode(Primitives, Parent, Name ?? "value")
 {
     public override IEnumerator<PocoNode> GetEnumerator() =>
-        Primitives.Select((primitive, index) => new PrimitiveNode(primitive, ParentNode, index, Name)).GetEnumerator();
+        Primitives.Select((primitive, index) => new PrimitiveNode(primitive, Parent, index, Name)).GetEnumerator();
 
     internal IEnumerable<object?> Values => Primitives.Select(p => p.JsonValue);
 }

--- a/src/Hl7.Fhir.Base/Model/PocoNodeExtensions.cs
+++ b/src/Hl7.Fhir.Base/Model/PocoNodeExtensions.cs
@@ -298,7 +298,9 @@ public static class PocoNodeExtensions
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     public static PocoNode? FirstOrDefault<T>(this IEnumerable<PocoNode> node, Func<T, bool> predicate) where T : Base =>
-        node.FirstOrDefault(n => n.Poco is T t && predicate(t));
+        node is PocoListNode pln
+            ? pln.FirstOrDefault(predicate)
+            : node.FirstOrDefault(n => n.Poco is T t && predicate(t));
     
     /// <summary>
     /// Navigates to a child node or set of child nodes using a path. The path is a string that can contain dot-separated names and array indices, much like navigation in FhirPath.

--- a/src/Hl7.Fhir.Base/Model/PocoNodeOrList.cs
+++ b/src/Hl7.Fhir.Base/Model/PocoNodeOrList.cs
@@ -15,13 +15,9 @@ namespace Hl7.Fhir.Model;
 /// A singular node in a POCO node tree. This node represents either a repeating or singular POCO instance.
 /// </summary>
 /// <param name="Name"></param>
-public abstract record PocoNodeOrList(string Name) : IEnumerable<PocoNode>
+/// <param name="Parent"></param>
+public abstract record PocoNodeOrList(string Name, PocoNode? Parent) : IEnumerable<PocoNode>
 {
-    /// <summary>
-    /// The parent of this node. This is always a singular PocoNode. If the Parent field is set to a PocoListNode, this will construct and return the PocoNode at the specified index.
-    /// </summary>
-    public abstract PocoNode? Parent { get; }
-    
     public abstract IEnumerator<PocoNode> GetEnumerator();
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
@@ -36,20 +32,12 @@ public abstract record PocoNodeOrList(string Name) : IEnumerable<PocoNode>
 /// A singular node in a POCO node tree. This node represents a single POCO instance.
 /// </summary>
 /// <param name="Poco"></param>
-/// <param name="ParentNode"></param>
+/// <param name="Parent"></param>
 /// <param name="Index">This Poco's index in a list, if it is contained in one</param>
 /// <param name="Name"></param>
-public partial record PocoNode(Base Poco, PocoNodeOrList? ParentNode, int? Index, string? Name)
-    : PocoNodeOrList(Name ?? Poco.TypeName), ITypedElement, IShortPathGenerator, ISourceNode, IFhirValueProvider, IResourceTypeSupplier, IAnnotatable
+public partial record PocoNode(Base Poco, PocoNode? Parent, int? Index, string? Name)
+    : PocoNodeOrList(Name ?? Poco.TypeName, Parent), ITypedElement, IShortPathGenerator, ISourceNode, IFhirValueProvider, IResourceTypeSupplier, IAnnotatable
 {
-    /// <inheritdoc />
-    public override PocoNode? Parent => ParentNode switch
-    {
-        PocoListNode nodes => nodes[Index!.Value],
-        PocoNode node => node,
-        _ => null
-    };
-
     /// <summary>
     /// Enumerates all children of this node. These can each either be singular or repeating PocoNodes.
     /// </summary>
@@ -83,8 +71,8 @@ public partial record PocoNode(Base Poco, PocoNodeOrList? ParentNode, int? Index
         {
             PrimitiveType primitive => new PrimitiveNode(primitive, this, null, name),
             Base b => new PocoNode(b, this, null, name),
-            IEnumerable<PrimitiveType> primitiveList => new PrimitiveListNode(primitiveList.ToList(), this, name),
-            IEnumerable<Base> list => new PocoListNode(list.ToList(), this, name),
+            IReadOnlyList<PrimitiveType> primitiveList => new PrimitiveListNode(primitiveList.ToList(), this, name),
+            IReadOnlyList<Base> list => new PocoListNode(list.ToList(), this, name),
             _ => throw new InvalidOperationException("Unexpected element in child list")
         };
 
@@ -153,11 +141,10 @@ public partial record PocoNode(Base Poco, PocoNodeOrList? ParentNode, int? Index
 /// A single node for a repeating element. Note that since a repeating element has a single parent, this cannot be used for grouping "separate" pocos that are not repeating in the specification.
 /// </summary>
 /// <param name="Pocos"></param>
-/// <param name="ParentNode"></param>
+/// <param name="Parent"></param>
 /// <param name="Name"></param>
-public record PocoListNode(IReadOnlyList<Base> Pocos, PocoNodeOrList? ParentNode, string Name) : PocoNodeOrList(Name)
+public record PocoListNode(IReadOnlyList<Base> Pocos, PocoNode? Parent, string Name) : PocoNodeOrList(Name, Parent)
 {
     public PocoNode this[int index] => new(Pocos[index], Parent, index, Name);
-    public override PocoNode? Parent => ParentNode as PocoNode; // safe because FHIR knows no nested lists
     public override IEnumerator<PocoNode> GetEnumerator() => Pocos.Select((poco, index) => new PocoNode(poco, Parent, index, Name)).GetEnumerator();
 }


### PR DESCRIPTION
## Description
When reviewing the documentation, we came across a confusing ambiguity between ParentNode and Parent on PocoNode. We found that, effectively, ParentNode can never be a PocoListNode, and so we decided to remove the ParentNode field. 

Technically, this field was public, so this is a breaking change. This being said, ParentNode was always the worse version of Parent, and it was originally meant for slight optimisations which now seem superfluous. I hope the difficulty in using ParentNode has prevented anyone from using it so far :)