### PR TITLE
Added RemoveAllNonInheritableExtensions to ExpandElementAsync

### DIFF
--- a/src/Hl7.Fhir.Base/Model/IExtendable.cs
+++ b/src/Hl7.Fhir.Base/Model/IExtendable.cs
@@ -208,9 +208,29 @@ namespace Hl7.Fhir.Model
             }
         }
 
+        /// <summary>
+        /// Remove all extensions that are specified in the uris list, if any.
+        /// </summary>
+        /// <param name="extendable"></param>
+        /// <param name="uris"></param>
+        internal static void RemoveExtensions(this IExtendable extendable, IEnumerable<string> uris)
+        {
+            var remove = extendable.Extension.Where(ext => uris.Contains(ext.Url)).ToList();
+
+            foreach (var ext in remove)
+                extendable.Extension.Remove(ext);
+
+            if (extendable is IModifierExtendable me)
+            {
+                remove = me.ModifierExtension.Where(ext => uris.Contains(ext.Url)).ToList();
+
+                foreach (var ext in remove)
+                    me.ModifierExtension.Remove(ext);
+            }
+        }
 
         /// <summary>
-        /// Add an extension with the given uri and value, removing any pre-existsing extensions
+        /// Add an extension with the given uri and value, removing any pre-existing extensions
         /// with the same uri.
         /// </summary>
         /// <param name="extendable"></param>

--- a/src/Hl7.Fhir.Base/Specification/Snapshot/SnapshotGeneratorExtensions.cs
+++ b/src/Hl7.Fhir.Base/Specification/Snapshot/SnapshotGeneratorExtensions.cs
@@ -88,6 +88,27 @@ namespace Hl7.Fhir.Specification.Snapshot
             }
         }
 
+        internal static bool HasAnyNonInheritableExtensions(this Element element)
+        {
+            if (element == null) return false;
+            if (element.HasNonInheritableExtensions()) return true;
+            return element.Children.OfType<Element>().Any(child => child.HasAnyNonInheritableExtensions());
+        }
+
+        internal static bool HasNonInheritableExtensions(this IExtendable element)
+        {
+            if (element == null)
+                return false;
+
+            if (element.Extension.Any(ext => _nonInheritableExtensions.Contains(ext.Url)))
+                return true;
+
+            if (element is IModifierExtendable modifierElement)
+                return modifierElement.ModifierExtension.Any(ext => _nonInheritableExtensions.Contains(ext.Url));
+
+            return false;
+        }
+
         /// <summary>
         /// This extension removes all non-inheritable extensions from the specified element definition and all it's child objects.
         /// Non-inheritable extensions are extensions that should not be inherited by derived profiles.
@@ -106,13 +127,10 @@ namespace Hl7.Fhir.Specification.Snapshot
         internal static void RemoveNonInheritableExtensions(this IExtendable element)
         {
             if (element == null) { throw Error.ArgumentNull(nameof(element)); }
-            foreach (var ext in _nonInheritableExtensions)
-            {
-                element.RemoveExtension(ext);
-            }
+            element.RemoveExtensions(_nonInheritableExtensions);
         }
 
-        private static readonly List<string> _nonInheritableExtensions = [
+        private static readonly HashSet<string> _nonInheritableExtensions = [
          ResourceIdentity.CORE_BASE_URL + "elementdefinition-isCommonBinding",
          ResourceIdentity.CORE_BASE_URL + "structuredefinition-fmm",
          ResourceIdentity.CORE_BASE_URL + "structuredefinition-fmm-no-warnings",

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
@@ -233,6 +233,9 @@ namespace Hl7.Fhir.Specification.Snapshot
             try
             {
                 await expandElement(nav).ConfigureAwait(false);
+
+                foreach (var elem in nav.Elements)
+                    elem.RemoveAllNonInheritableExtensions();
             }
             finally
             {
@@ -260,7 +263,12 @@ namespace Hl7.Fhir.Specification.Snapshot
             _stack.OnStartRecursion();
             try
             {
-                return await expandElement(nav).ConfigureAwait(false);
+                var result = await expandElement(nav).ConfigureAwait(false);
+
+                foreach (var elem in nav.Elements)
+                    elem.RemoveAllNonInheritableExtensions();
+
+                return result;
             }
             finally
             {

--- a/src/Hl7.Fhir.STU3/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Snapshot/SnapshotGenerator.cs
@@ -228,6 +228,9 @@ namespace Hl7.Fhir.Specification.Snapshot
             try
             {
                 await expandElement(nav).ConfigureAwait(false);
+
+                foreach (var elem in nav.Elements)
+                    elem.RemoveAllNonInheritableExtensions();
             }
             finally
             {
@@ -255,7 +258,12 @@ namespace Hl7.Fhir.Specification.Snapshot
             _stack.OnStartRecursion();
             try
             {
-                return await expandElement(nav).ConfigureAwait(false);
+                var result = await expandElement(nav).ConfigureAwait(false);
+
+                foreach (var elem in nav.Elements)
+                    elem.RemoveAllNonInheritableExtensions();
+
+                return result;
             }
             finally
             {

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -1424,6 +1424,8 @@ namespace Hl7.Fhir.Specification.Tests
         {
             var expandElemPath = elem.Path;
 
+            Assert.IsFalse(elem.HasAnyNonInheritableExtensions());
+
             // Debug.WriteLine("\r\nOutput:");
             // Debug.WriteLine(string.Join(Environment.NewLine, result.Where(e => e.Path.StartsWith(expandElemPath)).Select(e => e.Path)));
 

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -1539,6 +1539,8 @@ namespace Hl7.Fhir.Specification.Tests
         {
             var expandElemPath = elem.Path;
 
+            Assert.IsFalse(elem.HasAnyNonInheritableExtensions());
+
             // Debug.WriteLine("\r\nOutput:");
             // Debug.WriteLine(string.Join(Environment.NewLine, result.Where(e => e.Path.StartsWith(expandElemPath)).Select(e => e.Path)));
 


### PR DESCRIPTION
Changed type for _nonInheritableExtensions from List to HashSet. Added RemoveExtensions extension method.

## Related issues
Resolves #3059.

## Testing
Updated existing unit test.

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes