### PR TITLE
Fixed unit tests not running in pipeline OR locally

### DIFF
--- a/src/firely-net-sdk-tests.props
+++ b/src/firely-net-sdk-tests.props
@@ -23,7 +23,7 @@
 
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.0.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
 		<PackageReference Include="xunit" Version="2.9.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Description
Only 130 of our tests were running in the pipeline due to a version mismatch between MSTest and TestAdapter. This PR fixes that