### PR TITLE
Fix IsAbsolute property to handle null values and improve error handling

### DIFF
--- a/src/Hl7.Fhir.Base/Model/Canonical.cs
+++ b/src/Hl7.Fhir.Base/Model/Canonical.cs
@@ -152,7 +152,7 @@ public partial class Canonical
     /// <summary>
     /// Whether the canonical is a relative or an absolute uri.
     /// </summary>
-    public bool IsAbsolute => ToUri().IsAbsoluteUri;
+    public bool IsAbsolute => new Uri(Uri ?? throw new InvalidOperationException("Cannot determine an absolute value from a canonical without a value"), UriKind.RelativeOrAbsolute).IsAbsoluteUri;
 
     /// <summary>
     /// Whether the canonical has a version part.

--- a/src/Hl7.Fhir.Base/Model/Canonical.cs
+++ b/src/Hl7.Fhir.Base/Model/Canonical.cs
@@ -152,8 +152,7 @@ public partial class Canonical
     /// <summary>
     /// Whether the canonical is a relative or an absolute uri.
     /// </summary>
-    public bool IsAbsolute => new Uri(Uri ?? throw new InvalidOperationException("Cannot determine an absolute value from a canonical without a value"), UriKind.RelativeOrAbsolute).IsAbsoluteUri;
-
+    public bool IsAbsolute => Uri is not null && new Uri(this.Uri, UriKind.RelativeOrAbsolute).IsAbsoluteUri;
     /// <summary>
     /// Whether the canonical has a version part.
     /// </summary>

--- a/src/Hl7.Fhir.Support.Tests/ElementModel/CanonicalTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/ElementModel/CanonicalTests.cs
@@ -41,6 +41,16 @@ namespace Hl7.Fhir.ElementModel.Tests
             testee.HasAnchor.Should().BeTrue();
             testee.Fragment.Should().Be("anchor");
             testee.IsAbsolute.Should().BeTrue();
+            
+            // no path
+            testee = new Canonical("http://example.org|3.4.5#anchor");
+            testee.Value.Should().Be("http://example.org|3.4.5#anchor");
+            testee.Uri.Should().Be("http://example.org");
+            testee.HasVersion.Should().BeTrue();
+            testee.Version.Should().Be("3.4.5");
+            testee.HasAnchor.Should().BeTrue();
+            testee.Fragment.Should().Be("anchor");
+            testee.IsAbsolute.Should().BeTrue();
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
Fixes possible uri format exception when canonical is versioned, but has no path. 

## Related issues
Closes https://github.com/FirelyTeam/firely-validator-api/issues/621
