### PR TITLE
Remove $findmatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If you want to participate in this project, we're using [Git Flow][nvie] for our
 
 ## Binary Compatibility
 Our build pipeline automatically checks for binary compatibilty and fails when we break it. In some cases we can make an exception to break binary compatitibility. 
-To make sure the pipeline doesn't break, you should run ```dotnet pack /p:GenerateCompatibilitySuppressionFile=true``` locally to generate a suppression file. Please commit this file to make sure the build passes.
+To make sure the pipeline doesn't break, you should run ```dotnet pack /p:ApiCompatGenerateSuppressionFile``` locally to generate a suppression file. Please commit this file to make sure the build passes.
 
 
 

--- a/src/CrossVersionBenchmarks/Configuration/CrossVersionConfiguration.cs
+++ b/src/CrossVersionBenchmarks/Configuration/CrossVersionConfiguration.cs
@@ -69,7 +69,6 @@ public class CrossVersionConfigurationAttribute : Attribute, IConfigSource
                     yield return job;
             }
         }
-
     }
 
     static List<Argument> GetArgsFor(string constant)

--- a/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
+++ b/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
@@ -80,13 +80,6 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Hl7.Fhir.Specification.Terminology.MultiTerminologyService.Lookup(Hl7.Fhir.Model.Parameters,System.Boolean)</Target>
-    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
-    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Hl7.Fhir.Model.PocoListNode.#ctor(System.Collections.Generic.IReadOnlyList{Hl7.Fhir.Model.Base},Hl7.Fhir.Model.PocoNodeOrList,System.String)</Target>
     <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
     <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
@@ -158,13 +151,6 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Hl7.Fhir.Model.PrimitiveNode.#ctor(Hl7.Fhir.Model.PrimitiveType,Hl7.Fhir.Model.PocoNodeOrList,System.Nullable{System.Int32},System.String)</Target>
-    <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
-    <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Hl7.Fhir.Specification.Terminology.MultiTerminologyService.Lookup(Hl7.Fhir.Model.Parameters,System.Boolean)</Target>
     <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
     <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Hl7.Fhir.Base/Rest/FhirClientOperations.cs
+++ b/src/Hl7.Fhir.Base/Rest/FhirClientOperations.cs
@@ -81,11 +81,6 @@ namespace Hl7.Fhir.Rest
         /// "subsumes" operation
         /// </summary>
         public const string SUBSUMES = "subsumes";
-
-        /// <summary>
-        /// "find-matches" operation
-        /// </summary>
-        public const string FIND_MATCHES = "find-matches";
     }
 
 

--- a/src/Hl7.Fhir.Base/Specification/Terminology/CachingTerminologyService.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/CachingTerminologyService.cs
@@ -75,6 +75,17 @@ public class CachingTerminologyService : ITerminologyService
             : _terminologyService.CodeSystemValidateCode(parameters, id, useGet);
     }
 
+    public Task<Parameters> Lookup(Parameters parameters, bool useGet = false)
+    {
+        return parameters.GetParametersHashCode() is { } hash
+            ? _cache.GetOrCreate<Task<Parameters>>(hash, entry =>
+            {
+                entry.SetOptions(_entryOptions);
+                return _terminologyService.Lookup(parameters, useGet);
+            })!
+            : _terminologyService.Lookup(parameters, useGet);
+    }
+
     public Task<Resource> Expand(Parameters parameters, string? id = null, bool useGet = false)
     {
         return parameters.GetParametersHashCode() is { } hash
@@ -190,4 +201,3 @@ internal static class ParametersExtensions
         return hash.ToHashCode();
     }
 }
-

--- a/src/Hl7.Fhir.Base/Specification/Terminology/CustomValueSetTerminologyService.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/CustomValueSetTerminologyService.cs
@@ -51,7 +51,6 @@ public abstract class CustomValueSetTerminologyService : ITerminologyService
 
     public Task<Parameters> Lookup(Parameters parameters, string? id = null, bool useGet = false) => throw new NotImplementedException();
 
-    public Task<Parameters> FindMatches(Parameters parameters, string? id = null, bool useGet = false) => throw new NotImplementedException();
 
     ///<inheritdoc />
     public Task<Parameters> Subsumes(Parameters parameters, string? id = null, bool useGet = false) =>

--- a/src/Hl7.Fhir.Base/Specification/Terminology/ITerminologyService.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/ITerminologyService.cs
@@ -67,7 +67,7 @@ public interface ICodeSystemTerminologyService
     /// <returns>Output parameters containing the result of the operation</returns>
     /// <exception cref="FhirOperationException">Thrown when the terminology service encounters an error</exception>
     /// <remarks>This function corresponds to the <seealso href="http://hl7.org/fhir/codesystem-operation-lookup.html">$lookup</seealso> operation.</remarks>
-    Task<Parameters> Lookup(Parameters parameters, bool useGet);
+    Task<Parameters> Lookup(Parameters parameters, bool useGet = false);
 }
 
 

--- a/src/Hl7.Fhir.Base/Specification/Terminology/ITerminologyService.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/ITerminologyService.cs
@@ -67,31 +67,7 @@ public interface ICodeSystemTerminologyService
     /// <returns>Output parameters containing the result of the operation</returns>
     /// <exception cref="FhirOperationException">Thrown when the terminology service encounters an error</exception>
     /// <remarks>This function corresponds to the <seealso href="http://hl7.org/fhir/codesystem-operation-lookup.html">$lookup</seealso> operation.</remarks>
-    [Obsolete("Implementers should use the overload with 'id' parameter to specify the CodeSystem to lookup against.")]
-    Task<Parameters> Lookup(Parameters parameters, bool useGet) =>
-        Lookup(parameters, null, useGet);
-
-    /// <summary>
-    /// Given a code/system, or a Coding, get additional details about the concept, including definition, status, designations, and properties.
-    /// </summary>
-    /// <param name="parameters">Input parameters for the operation</param>
-    /// <param name="id">Id of a specific CodeSystem which is used for the lookup</param>
-    /// <param name="useGet">Use the GET instead of POST Http method</param>
-    /// <returns>Output parameters containing the result of the operation</returns>
-    /// <exception cref="FhirOperationException">Thrown when the terminology service encounters an error</exception>
-    /// <remarks>This function corresponds to the <seealso href="http://hl7.org/fhir/codesystem-operation-lookup.html">$lookup</seealso> operation.</remarks>
-    Task<Parameters> Lookup(Parameters parameters, string? id = null, bool useGet = false) => throw new NotImplementedException();
-
-    /// <summary>
-    /// Given a set of properties (and text), return one or more possible matching codes.
-    /// </summary>
-    /// <param name="parameters">Input parameters for the operation</param>
-    /// <param name="id">Id of a specific CodeSystem which is used to find matches in</param>
-    /// <param name="useGet">Use the GET instead of POST Http method</param>
-    /// <returns>Output parameters containing the result of the operation</returns>
-    /// <exception cref="FhirOperationException">Thrown when the terminology service encounters an error</exception>
-    /// <remarks>This function corresponds to the <seealso href="http://hl7.org/fhir/codesystem-operation-find-matches.html">$find-matches</seealso> operation.</remarks>
-    Task<Parameters> FindMatches(Parameters parameters, string? id = null, bool useGet = false) => throw new NotImplementedException();
+    Task<Parameters> Lookup(Parameters parameters, bool useGet);
 }
 
 

--- a/src/Hl7.Fhir.Base/Specification/Terminology/MultiTerminologyService.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/MultiTerminologyService.cs
@@ -128,11 +128,8 @@ public class MultiTerminologyService : ITerminologyService
         tryMulti((s, p) => s.Expand(p, id, useGet), parameters);
 
     /// <inheritdoc/>
-    public Task<Parameters> Lookup(Parameters parameters, string? id = null, bool useGet = false) =>
-        tryMulti((s, p) => s.Lookup(p, id, useGet), parameters);
-
-    public Task<Parameters> FindMatches(Parameters parameters, string? id = null, bool useGet = false) =>
-        tryMulti((s, p) => s.FindMatches(p, id, useGet), parameters);
+    public Task<Parameters> Lookup(Parameters parameters, bool useGet = false) =>
+        tryMulti((s, p) => s.Lookup(p, useGet), parameters);
 
     /// <inheritdoc/>
     public Task<Parameters> Translate(Parameters parameters, string? id = null, bool useGet = false) =>

--- a/src/Hl7.Fhir.Conformance/CompatibilitySuppressions.xml
+++ b/src/Hl7.Fhir.Conformance/CompatibilitySuppressions.xml
@@ -1,46 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Hl7.Fhir.Specification.Terminology.ExternalTerminologyService.Lookup(Hl7.Fhir.Model.Parameters,System.Boolean)</Target>
-    <Left>lib/net8.0/Hl7.Fhir.Conformance.dll</Left>
-    <Right>lib/net8.0/Hl7.Fhir.Conformance.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Hl7.Fhir.Specification.Terminology.FallbackTerminologyService.Lookup(Hl7.Fhir.Model.Parameters,System.Boolean)</Target>
-    <Left>lib/net8.0/Hl7.Fhir.Conformance.dll</Left>
-    <Right>lib/net8.0/Hl7.Fhir.Conformance.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Hl7.Fhir.Specification.Terminology.LocalTerminologyService.Lookup(Hl7.Fhir.Model.Parameters,System.Boolean)</Target>
-    <Left>lib/net8.0/Hl7.Fhir.Conformance.dll</Left>
-    <Right>lib/net8.0/Hl7.Fhir.Conformance.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Hl7.Fhir.Specification.Terminology.ExternalTerminologyService.Lookup(Hl7.Fhir.Model.Parameters,System.Boolean)</Target>
-    <Left>lib/netstandard2.1/Hl7.Fhir.Conformance.dll</Left>
-    <Right>lib/netstandard2.1/Hl7.Fhir.Conformance.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Hl7.Fhir.Specification.Terminology.FallbackTerminologyService.Lookup(Hl7.Fhir.Model.Parameters,System.Boolean)</Target>
-    <Left>lib/netstandard2.1/Hl7.Fhir.Conformance.dll</Left>
-    <Right>lib/netstandard2.1/Hl7.Fhir.Conformance.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Hl7.Fhir.Specification.Terminology.LocalTerminologyService.Lookup(Hl7.Fhir.Model.Parameters,System.Boolean)</Target>
-    <Left>lib/netstandard2.1/Hl7.Fhir.Conformance.dll</Left>
-    <Right>lib/netstandard2.1/Hl7.Fhir.Conformance.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
 </Suppressions>

--- a/src/Hl7.Fhir.STU3/CompatibilitySuppressions.xml
+++ b/src/Hl7.Fhir.STU3/CompatibilitySuppressions.xml
@@ -1,46 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Hl7.Fhir.Specification.Terminology.ExternalTerminologyService.Lookup(Hl7.Fhir.Model.Parameters,System.Boolean)</Target>
-    <Left>lib/net8.0/Hl7.Fhir.STU3.dll</Left>
-    <Right>lib/net8.0/Hl7.Fhir.STU3.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Hl7.Fhir.Specification.Terminology.FallbackTerminologyService.Lookup(Hl7.Fhir.Model.Parameters,System.Boolean)</Target>
-    <Left>lib/net8.0/Hl7.Fhir.STU3.dll</Left>
-    <Right>lib/net8.0/Hl7.Fhir.STU3.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Hl7.Fhir.Specification.Terminology.LocalTerminologyService.Lookup(Hl7.Fhir.Model.Parameters,System.Boolean)</Target>
-    <Left>lib/net8.0/Hl7.Fhir.STU3.dll</Left>
-    <Right>lib/net8.0/Hl7.Fhir.STU3.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Hl7.Fhir.Specification.Terminology.ExternalTerminologyService.Lookup(Hl7.Fhir.Model.Parameters,System.Boolean)</Target>
-    <Left>lib/netstandard2.1/Hl7.Fhir.STU3.dll</Left>
-    <Right>lib/netstandard2.1/Hl7.Fhir.STU3.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Hl7.Fhir.Specification.Terminology.FallbackTerminologyService.Lookup(Hl7.Fhir.Model.Parameters,System.Boolean)</Target>
-    <Left>lib/netstandard2.1/Hl7.Fhir.STU3.dll</Left>
-    <Right>lib/netstandard2.1/Hl7.Fhir.STU3.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Hl7.Fhir.Specification.Terminology.LocalTerminologyService.Lookup(Hl7.Fhir.Model.Parameters,System.Boolean)</Target>
-    <Left>lib/netstandard2.1/Hl7.Fhir.STU3.dll</Left>
-    <Right>lib/netstandard2.1/Hl7.Fhir.STU3.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
 </Suppressions>

--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/ExternalTerminologyService.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/ExternalTerminologyService.cs
@@ -73,20 +73,8 @@ public class ExternalTerminologyService : ITerminologyService
     }
 
     ///<inheritdoc />
-    public async Task<Parameters> Lookup(Parameters parameters, string? id=null, bool useGet = false)
-    {
-        return string.IsNullOrEmpty(id)
-            ? assertIs<Parameters>(await Endpoint.TypeOperationAsync<CodeSystem>(RestOperation.CONCEPT_LOOKUP, parameters, useGet).ConfigureAwait(false))
-            : assertIs<Parameters>(await Endpoint.InstanceOperationAsync(constructUri(FhirTypeNames.CODESYSTEM_NAME, id), RestOperation.CONCEPT_LOOKUP, parameters, useGet).ConfigureAwait(false));
-    }
-
-    ///<inheritdoc />
-    public async Task<Parameters> FindMatches(Parameters parameters, string? id = null, bool useGet = false)
-    {
-        return string.IsNullOrEmpty(id)
-            ? assertIs<Parameters>(await Endpoint.TypeOperationAsync<CodeSystem>(RestOperation.FIND_MATCHES, parameters, useGet).ConfigureAwait(false))
-            : assertIs<Parameters>(await Endpoint.InstanceOperationAsync(constructUri(FhirTypeNames.CODESYSTEM_NAME, id), RestOperation.FIND_MATCHES, parameters, useGet).ConfigureAwait(false));
-    }
+    public async Task<Parameters> Lookup(Parameters parameters, bool useGet = false) =>
+        assertIs<Parameters>(await Endpoint.TypeOperationAsync<CodeSystem>(RestOperation.CONCEPT_LOOKUP, parameters, useGet).ConfigureAwait(false));
 
     ///<inheritdoc />
     public async Task<Parameters> Translate(Parameters parameters, string? id = null, bool useGet = false)

--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/FallbackTerminologyService.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/FallbackTerminologyService.cs
@@ -85,11 +85,8 @@ public class FallbackTerminologyService : ITerminologyService
         tryFallback((s, p) => s.Expand(p, id, useGet), parameters);
 
     /// <inheritdoc/>
-    public Task<Parameters> Lookup(Parameters parameters, string? id = null, bool useGet = false) =>
-        tryFallback((s, p) => s.Lookup(p, id, useGet), parameters);
-
-    public Task<Parameters> FindMatches(Parameters parameters, string? id = null, bool useGet = false) =>
-        tryFallback((s, p) => s.FindMatches(p, id, useGet), parameters);
+    public Task<Parameters> Lookup(Parameters parameters, bool useGet = false) =>
+        tryFallback((s, p) => s.Lookup(p, useGet), parameters);
 
     /// <inheritdoc/>
     public Task<Parameters> Translate(Parameters parameters, string? id = null, bool useGet = false) =>

--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/LocalTerminologyService.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/LocalTerminologyService.cs
@@ -234,10 +234,11 @@ public class LocalTerminologyService : ITerminologyService
     }
 
     ///<inheritdoc />
-    public Task<Parameters> Lookup(Parameters parameters, string? id = null, bool useGet = false) => throw new NotImplementedException();
-
-    ///<inheritdoc />
-    public Task<Parameters> FindMatches(Parameters parameters, string? id = null, bool useGet = false) => throw new NotImplementedException();
+    public Task<Parameters> Lookup(Parameters parameters, bool useGet = false)
+    {
+        // make this method async, when implementing
+        throw new NotImplementedException();
+    }
 
     ///<inheritdoc />
     public Task<Parameters> Translate(Parameters parameters, string? id = null, bool useGet = false)

--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/TerminologyServiceExtensions.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/TerminologyServiceExtensions.cs
@@ -30,14 +30,9 @@ namespace Hl7.Fhir.Specification.Terminology
             return srv.Expand(parameters.Build(), id, useGet);
         }
 
-        public static Task<Parameters> Lookup(this ITerminologyService srv, LookupParameters parameters, bool useGet)
+        public static Task<Parameters> Lookup(this ITerminologyService srv, LookupParameters parameters, bool useGet = false)
         {
-            return srv.Lookup(parameters.Build(), null, useGet);
-        }
-
-        public static Task<Parameters> Lookup(this ITerminologyService srv, LookupParameters parameters, string? id = null, bool useGet = false)
-        {
-            return srv.Lookup(parameters.Build(), id, useGet);
+            return srv.Lookup(parameters.Build(), useGet);
         }
 
         public static Task<Parameters> Translate(this ITerminologyService srv, TranslateParameters parameters, string? id = null, bool useGet = false)


### PR DESCRIPTION
We introduced $findmatches, but it has been removed from FHIR R6 and … we don't need it after all.

Also, I undid the tuning of Lookup (introducing an `id` parameter), since I'd like to review the use of "id" (truly meaningless in ITerminologyService as it requires the context of a database of resources to match and id to a canonical), much like that I'd like to review (basically remove) `useGet` (as this has nothing to do with ITS).

