### PR TITLE
Feature/enable trusted signing

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -129,12 +129,11 @@ stages:
     - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
       - template: codesign-nuget-packages-using-trusted-signing.yml@templates
         parameters:
-          azureServiceConnection: 'AzureTrustedSigningPrincipal',
-          trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/',
-          trustedSigningAccountName: 'FirelyCodeSigning',
-          certificateProfileName: 'FirelyCodeSigning',
+          azureServiceConnection: 'AzureTrustedSigningPrincipal'
+          trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'
+          trustedSigningAccountName: 'FirelyCodeSigning'
+          certificateProfileName: 'FirelyCodeSigning'
           packagePaths: $(Build.ArtifactStagingDirectory)\*.nupkg
-
     - task: PublishBuildArtifacts@1
       displayName: Publish Artifact
       inputs:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -127,10 +127,12 @@ stages:
       name: packMetapackages
       displayName: 'Pack NuGet Metapackages'    
     - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-      - template: codesign-nuget-packages.yml@templates
+      - template: codesign-nuget-packages-using-trusted-signing.yml@templates
         parameters:
-          certificateValue: $(FirelyCodeSignerCertificate)
-          certificatePasswordValue: $(CodeSigningPassword)
+          azureServiceConnection: 'AzureTrustedSigningPrincipal',
+          trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/',
+          trustedSigningAccountName: 'FirelyCodeSigning',
+          certificateProfileName: 'FirelyCodeSigning',
           packagePaths: $(Build.ArtifactStagingDirectory)\*.nupkg
 
     - task: PublishBuildArtifacts@1

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -127,7 +127,7 @@ stages:
       name: packMetapackages
       displayName: 'Pack NuGet Metapackages'    
     - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-      - template: codesign-nuget-packages-using-trusted-signing.yml@templates
+      - template: codesign-nuget-package-using-trusted-signing.yml@templates
         parameters:
           azureServiceConnection: 'AzureTrustedSigningPrincipal'
           trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'


### PR DESCRIPTION
This pull request updates the NuGet package signing process in the Azure Pipelines configuration to use Azure Trusted Signing instead of the previous manual certificate-based approach. The main change is the switch to a new signing template and associated parameters, aligning with more secure and automated signing practices.

**Build pipeline improvements:**

* Replaced the `codesign-nuget-packages.yml@templates` template with `codesign-nuget-package-using-trusted-signing.yml@templates` for NuGet package signing, and updated parameters to use Azure Trusted Signing (e.g., `azureServiceConnection`, `trustedSigningAccountEndpoint`, `trustedSigningAccountName`, and `certificateProfileName`) instead of direct certificate values.