### PR TITLE
Enable public signing

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -159,10 +159,12 @@ stages:
       name: packMetapackages
       displayName: 'Pack NuGet Metapackages'    
     - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-      - template: codesign-nuget-packages.yml@templates
+      - template: codesign-nuget-package-using-trusted-signing.yml@templates
         parameters:
-          certificateValue: $(FirelyCodeSignerCertificate)
-          certificatePasswordValue: $(CodeSigningPassword)
+          azureServiceConnection: 'AzureTrustedSigningPrincipal'
+          trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'
+          trustedSigningAccountName: 'FirelyCodeSigning'
+          certificateProfileName: 'FirelyCodeSigning'
           packagePaths: $(Build.ArtifactStagingDirectory)\*.nupkg
 
     - task: PublishBuildArtifacts@1


### PR DESCRIPTION
This pull request updates the NuGet package signing process in the Azure Pipelines configuration to use Azure Trusted Signing instead of the previous code signing method. This change enhances the security and reliability of the package signing workflow.

**Build pipeline improvements:**

* Replaced the `codesign-nuget-packages.yml` template with `codesign-nuget-package-using-trusted-signing.yml` to utilize Azure Trusted Signing for NuGet packages.
* Updated signing parameters to use Azure service connection and trusted signing account details, removing direct certificate and password variables.