### PR TITLE
Cherry pick changes to SDK5 branch

### DIFF
--- a/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
@@ -187,7 +187,12 @@ namespace Hl7.Fhir.Introspection
         /// <returns>The created ClassMapping.</returns>
         public ClassMapping? ImportType(Type type)
         {
-            if (!ClassMapping.TryGetMappingForType(type, FhirRelease, out var mapping))
+            if (FindClassMapping(type) is { } existingMapping) return existingMapping;
+            
+            // Check for cross-version type import before proceeding
+            ValidateSatelliteAssemblyCompatibility(type);
+            
+            if (!ClassMapping.TryCreate(type, out var mapping, FhirRelease))
                 return null;
 
             _classMappings.Add(mapping!);
@@ -202,6 +207,51 @@ namespace Hl7.Fhir.Introspection
             return mapping;
         }
 
+        /// <summary>
+        /// Validates that a type being imported is compatible with this ModelInspector's FHIR release.
+        /// </summary>
+        /// <param name="type">The type being imported</param>
+        /// <exception cref="InvalidOperationException">Thrown when attempting to import a type from
+        /// a different FHIR version assembly</exception>
+        private void ValidateSatelliteAssemblyCompatibility(Type type)
+        {
+            var typeAssembly = type.Assembly;
+            
+            // Get the FhirModelAssemblyAttribute from the type's assembly
+            var typeAssemblyAttr = typeAssembly.GetCustomAttribute<FhirModelAssemblyAttribute>();
+            
+            // If the type is not from a FHIR model assembly, it's safe to import
+            // (e.g., system types, CQL types)
+            if (typeAssemblyAttr is null) return;
+            
+            // Check if the type is from the Base assembly. The Base assembly is marked with
+            // FhirRelease.STU3 but is compatible with all FHIR releases, so we should not
+            // reject types from it.
+            var baseAssembly = typeof(ModelInspector).Assembly;
+            if (typeAssembly == baseAssembly) return;
+            
+            // Check if the type is from the Conformance assembly. The Conformance assembly is marked
+            // with FhirRelease.R4 but contains conformance resources (like StructureDefinition) that are
+            // compatible with R4, R4B, R5, and R6, so we should not reject types from it when the
+            // inspector is for R4 or later.
+            var assemblyName = typeAssembly.GetName().Name;
+            if (assemblyName == "Hl7.Fhir.Conformance" && FhirRelease >= FhirRelease.R4)
+                return;
+            
+            // For any other assembly with FhirModelAssemblyAttribute, validate version compatibility
+            // This applies to all assemblies containing POCO definitions, not just satellite assemblies
+            if (typeAssemblyAttr.Since != FhirRelease)
+            {
+                var message = $"Type '{type.FullName}' from assembly '{assemblyName}' " +
+                             $"(FHIR {typeAssemblyAttr.Since}) is being imported into a ModelInspector " +
+                             $"configured for FHIR {FhirRelease}. This can lead to unexpected behavior " +
+                             $"when types from different FHIR versions are mixed. " +
+                             $"Ensure you are using the correct ModelInspector for your FHIR version.";
+                
+                throw new InvalidOperationException(message);
+            }
+        }
+    
         private void extractEnums(IEnumerable<Type> enumTypes)
         {
             foreach (var enumType in enumTypes)

--- a/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
@@ -30,11 +30,18 @@ namespace Hl7.Fhir.Introspection
     public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
     {
         private static readonly ConcurrentDictionary<string, ModelInspector> _inspectedAssemblies = new();
+        
+        // Cache for assembly-level FhirModelAssemblyAttribute to avoid repeated reflection calls
+        private static readonly ConcurrentDictionary<Assembly, FhirModelAssemblyAttribute?> _assemblyAttributeCache = new();
 
         /// <summary>
         /// Removes all known mappings from the inspector.
         /// </summary>
-        public static void Clear() => _inspectedAssemblies.Clear();
+        public static void Clear()
+        {
+            _inspectedAssemblies.Clear();
+            _assemblyAttributeCache.Clear();
+        }
 
         /// <summary>
         /// Finds or creates the <see cref="ClassMapping"/> for a given type.
@@ -217,8 +224,10 @@ namespace Hl7.Fhir.Introspection
         {
             var typeAssembly = type.Assembly;
             
-            // Get the FhirModelAssemblyAttribute from the type's assembly
-            var typeAssemblyAttr = typeAssembly.GetCustomAttribute<FhirModelAssemblyAttribute>();
+            // Get the FhirModelAssemblyAttribute from the type's assembly (cached to avoid repeated reflection)
+            var typeAssemblyAttr = _assemblyAttributeCache.GetOrAdd(
+                typeAssembly,
+                assembly => assembly.GetCustomAttribute<FhirModelAssemblyAttribute>());
             
             // If the type is not from a FHIR model assembly, it's safe to import
             // (e.g., system types, CQL types)

--- a/src/Hl7.Fhir.R4.Tests/Properties/AssemblyInfo.cs
+++ b/src/Hl7.Fhir.R4.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
 using Hl7.Fhir.Introspection;
 
-[assembly: FhirModelAssembly]
+[assembly: FhirModelAssembly(Hl7.Fhir.Specification.FhirRelease.R4)]
 //[assembly: CqlModelAssembly("FHIR", "4.0.1", "http://hl7.org/fhir")]

--- a/src/Hl7.Fhir.R4B.Tests/Properties/AssemblyInfo.cs
+++ b/src/Hl7.Fhir.R4B.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
 using Hl7.Fhir.Introspection;
 
 
-[assembly: FhirModelAssembly]
+[assembly: FhirModelAssembly(Hl7.Fhir.Specification.FhirRelease.R4B)]

--- a/src/Hl7.Fhir.R5.Tests/Properties/AssemblyInfo.cs
+++ b/src/Hl7.Fhir.R5.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
 using Hl7.Fhir.Introspection;
 
 
-[assembly: FhirModelAssembly]
+[assembly: FhirModelAssembly(Hl7.Fhir.Specification.FhirRelease.R5)]

--- a/src/Hl7.Fhir.STU3.Tests/Properties/AssemblyInfo.cs
+++ b/src/Hl7.Fhir.STU3.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using Hl7.Fhir.Introspection;
+
+
+[assembly: FhirModelAssembly(Hl7.Fhir.Specification.FhirRelease.STU3)]


### PR DESCRIPTION
## Description

Cherry-picks critical performance and validation fixes from develop to the `support/sdk5` branch:

**Assembly attribute caching (#3425)**
- Caches `FhirModelAssemblyAttribute` lookups to eliminate repeated reflection overhead
- Resolves serialization test timeouts caused by per-type attribute lookups when importing hundreds of types

**Cross-version type conflict detection (#3417)**
- Validates FHIR version compatibility when importing types into ModelInspector
- Prevents runtime errors from mixing STU3/R4/R4B/R5 types in same context
- Updates test assembly attributes to properly declare FHIR versions

**Azure Trusted Signing migration**
- Replaces certificate-based signing with Azure Trusted Signing in CI pipeline

## Testing

Changes validated on develop branch in PRs #3425 and #3417. Serialization test timeouts resolved, cross-version type imports now throw `InvalidOperationException` with clear diagnostic messages.
