### PR TITLE
Apply UnsafeRelaxedJsonEscaping in regular serializer options as well

### DIFF
--- a/src/Hl7.Fhir.Base/Utility/SerializationUtil.cs
+++ b/src/Hl7.Fhir.Base/Utility/SerializationUtil.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -269,7 +270,7 @@ public static class SerializationUtil
     public static string WriteJsonToString(Action<Utf8JsonWriter> serializer, bool pretty = false)
     {
         using var stream = new MemoryStream();
-        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = pretty});
+        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = pretty, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
         serializer(writer);
         writer.Flush();
         return Encoding.UTF8.GetString(stream.ToArray());

--- a/src/Hl7.Fhir.R4.Tests/Serialization/SerializationTests.cs
+++ b/src/Hl7.Fhir.R4.Tests/Serialization/SerializationTests.cs
@@ -9,11 +9,27 @@
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace Hl7.Fhir.Tests.Serialization
 {
     public partial class SerializationTests
     {
+        [TestMethod]
+        public void TestReplacements()
+        {
+            var expectedJson = """{"resourceType":"Parameters","parameter":[{"name":"Measurement Period","valuePeriod":{"start":"2026-01-01T00:00:00+00:00","end":"2026-12-31T23:59:59.999+00:00"}}]}""";
+
+            var end = new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var p = new Parameters();
+            p.Add("Measurement Period", new Period(new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero), new(end.AddMilliseconds(-1))));
+            var json = p.ToJson();
+
+            var serializer = FhirJsonSerializer.SerializeToString(p);
+            Assert.AreEqual(json, serializer);
+            Assert.AreEqual(expectedJson, serializer);
+        }
+        
         /// <summary>
         /// This test verifies that the parser can handle a backbone element that has a property of resourceType
         /// (only found in the ExampleScenario resource in R4 and R4B - used to be in Claim)


### PR DESCRIPTION
Apply the same encoder as ForFhir calls do.