### PR TITLE
Sync test dependencies for test runner issues

### DIFF
--- a/src/Hl7.Fhir.Specification.Shared.Tests/Terminology/LanguageTerminologyServiceTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Terminology/LanguageTerminologyServiceTests.cs
@@ -101,7 +101,7 @@ namespace Hl7.Fhir.Specification.Tests
                 .WithCode(code: "male");
 
             Func<Task> validateCode = async () => await _service.CodeSystemValidateCode(csParameters);
-            await validateCode.Should().ThrowAsync<FhirOperationException>().WithMessage("Unknown code system 'http://hl7.org/fhir/administrative-gender'");
+            await validateCode.Should().ThrowAsync<FhirOperationException>().WithMessage($"This service only supports code system '{LanguageTerminologyService.LANGUAGE_SYSTEM}'.");
 
             // Test that system is required when using a Coding without system
             var codingWithoutSystem = new CodeSystemValidateCodeParameters()

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Terminology/MimeTypeTerminologyServiceTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Terminology/MimeTypeTerminologyServiceTests.cs
@@ -131,7 +131,7 @@ namespace Hl7.Fhir.Specification.Tests
                 .WithCode(code: "male");
 
             Func<Task> validateCode = async () => await _service.CodeSystemValidateCode(csParameters);
-            await validateCode.Should().ThrowAsync<FhirOperationException>().WithMessage("Unknown code system 'http://hl7.org/fhir/administrative-gender'");
+            await validateCode.Should().ThrowAsync<FhirOperationException>().WithMessage($"This service only supports code system '{MimeTypeTerminologyService.MIMETYPE_SYSTEM}'.");
 
             // Test that system is required when using a Coding without system
             var codingWithoutSystem = new CodeSystemValidateCodeParameters()

--- a/src/firely-net-sdk-tests.props
+++ b/src/firely-net-sdk-tests.props
@@ -23,7 +23,7 @@
 
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
 		<PackageReference Include="xunit" Version="2.9.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Description
Test runner crashes with differing versions of MSTest.TestFramework and MSTest.TestAdapter
