### PR TITLE
Override deepcopy on the terminology parameters

### DIFF
--- a/src/Hl7.Fhir.Base/Specification/Terminology/ClosureParameters.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/ClosureParameters.cs
@@ -81,6 +81,8 @@ public class ClosureParameters : Parameters
         return this;
     }
     #endregion
+    
+    protected internal override Base DeepCopyInternal() => new ClosureParameters(this);
 
     [Obsolete("This is just a DeepCopy of the current instance, use the instance or DeepCopy() instead", false)]
     public Parameters Build() => this.DeepCopy();

--- a/src/Hl7.Fhir.Base/Specification/Terminology/CodeSystemValidateCodeParameters.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/CodeSystemValidateCodeParameters.cs
@@ -186,6 +186,8 @@ public class CodeSystemValidateCodeParameters : Parameters
     }
     #endregion
 
+    protected internal override Base DeepCopyInternal() => new CodeSystemValidateCodeParameters(this);
+    
     [Obsolete("This is just a DeepCopy of the current instance, use the instance or DeepCopy() instead", false)]
     public Parameters Build() => this.DeepCopy();
 }

--- a/src/Hl7.Fhir.Base/Specification/Terminology/ExpandParameters.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/ExpandParameters.cs
@@ -282,6 +282,9 @@ public class ExpandParameters : Parameters
     }
 
     #endregion
+    
+    
+    protected internal override Base DeepCopyInternal() => new ExpandParameters(this);
 
     [Obsolete("This is just a DeepCopy of the current instance, use the instance or DeepCopy() instead", false)]
     public Parameters Build() => this.DeepCopy();

--- a/src/Hl7.Fhir.Base/Specification/Terminology/LookupParameters.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/LookupParameters.cs
@@ -122,6 +122,8 @@ public class LookupParameters : Parameters
     }
     #endregion
 
+    protected internal override Base DeepCopyInternal() => new LookupParameters(this);
+    
     [Obsolete("This is just a DeepCopy of the current instance, use the instance or DeepCopy() instead", false)]
     public Parameters Build() => (Parameters)this.DeepCopyInternal();
 }

--- a/src/Hl7.Fhir.Base/Specification/Terminology/SubsumesParameters.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/SubsumesParameters.cs
@@ -109,6 +109,8 @@ public class SubsumesParameters : Parameters
     }
     #endregion
 
+    protected internal override Base DeepCopyInternal() => new SubsumesParameters(this);
+    
     [Obsolete("This is just a DeepCopy of the current instance, use the instance or DeepCopy() instead", false)]
     public Parameters Build() => this.DeepCopy();
 }

--- a/src/Hl7.Fhir.Base/Specification/Terminology/TranslateParameters.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/TranslateParameters.cs
@@ -200,6 +200,8 @@ public class TranslateParameters : Parameters
 
     #endregion
 
+    protected internal override Base DeepCopyInternal() => new TranslateParameters(this);
+
     [Obsolete("This is just a DeepCopy of the current instance, use the instance or DeepCopy() instead", false)]
     public Parameters Build() => this.DeepCopy();
 }

--- a/src/Hl7.Fhir.Base/Specification/Terminology/ValidateCodeParameters.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/ValidateCodeParameters.cs
@@ -229,6 +229,8 @@ public class ValidateCodeParameters : Parameters
     }
     #endregion
 
+    protected internal override Base DeepCopyInternal() => new ValidateCodeParameters(this);
+    
     [Obsolete("This is just a DeepCopy of the current instance, use the instance or DeepCopy() instead", false)]
     public Parameters Build() => this.DeepCopy();
 }


### PR DESCRIPTION
## Description
With recent terminology changes, DeepCopy would try to create Parameters resource then cast it to the \<Operation\>Parameters, and throw a cast exception.