### PR TITLE
Give major runtime deps individual PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,18 +48,6 @@ updates:
           - "minor"
           - "patch"
 
-      # Runtime deps — majors separate for careful review
-      runtime-dependencies-major:
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "xunit*"
-          - "Moq"
-          - "FluentAssertions"
-          - "Microsoft.NET.Test.Sdk"
-          - "MSTest.*"
-        update-types:
-          - "major"
 
     ignore:
       - dependency-name: "Moq"


### PR DESCRIPTION
## Summary
- Removes the `runtime-dependencies-major` dependabot group so that each major runtime dependency update gets its own individual PR, making them easier to review and merge independently.

## Test plan
- [ ] Verify dependabot creates separate PRs for major runtime dependency bumps on the next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)