### PR TITLE
Add per-request HTTP header callback to FhirClient (#3298)

### DIFF
--- a/src/Hl7.Fhir.Base/Rest/BaseFhirClient.cs
+++ b/src/Hl7.Fhir.Base/Rest/BaseFhirClient.cs
@@ -1,6 +1,6 @@
 #nullable enable
 
-/* 
+/*
  * Copyright (c) 2023, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
  * 
@@ -152,6 +152,7 @@ public partial class BaseFhirClient : IDisposable
     /// <param name="ifNoneMatch">The (weak) ETag to use in a conditional read. Optional.</param>
     /// <param name="ifModifiedSince">Last modified since date in a conditional read. Optional. (refer to spec 2.1.0.5) If this is used, the client will throw an exception you need</param>
     /// <param name="ct" />
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <typeparam name="TResource">The type of resource to read. Resource or DomainResource is allowed if exact type is unknown</typeparam>
     /// <returns>
     /// The requested resource. This operation will throw an exception
@@ -161,7 +162,7 @@ public partial class BaseFhirClient : IDisposable
     /// </returns>
     /// <remarks>Since ResourceLocation is a subclass of Uri, you may pass in ResourceLocations too.</remarks>
     /// <exception cref="FhirOperationException">This will occur if conditional request returns a status 304 and optionally an OperationOutcome</exception>
-    public virtual Task<TResource?> ReadAsync<TResource>(Uri location, string? ifNoneMatch = null, DateTimeOffset? ifModifiedSince = null, CancellationToken? ct = null) where TResource : Resource
+    public virtual Task<TResource?> ReadAsync<TResource>(Uri location, string? ifNoneMatch = null, DateTimeOffset? ifModifiedSince = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource
     {
         if (location == null) throw Error.ArgumentNull(nameof(location));
 
@@ -178,7 +179,7 @@ public partial class BaseFhirClient : IDisposable
             tx = new TransactionBuilder(Endpoint).VRead(id.ResourceType, id.Id, id.VersionId).ToBundle();
         }
 
-        return executeAsync<TResource>(tx, HttpStatusCode.OK, ct);
+        return executeAsync<TResource>(tx, HttpStatusCode.OK, ct, requestHeaders);
     }
 
     /// <summary>
@@ -189,14 +190,15 @@ public partial class BaseFhirClient : IDisposable
     /// <param name="ifNoneMatch">The (weak) ETag to use in a conditional read. Optional.</param>
     /// <param name="ifModifiedSince">Last modified since date in a conditional read. Optional.</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <typeparam name="TResource">The type of resource to read. Resource or DomainResource is allowed if exact type is unknown</typeparam>
     /// <returns>The requested resource</returns>
     /// <remarks>This operation will throw an exception
     /// if the resource has been deleted or does not exist. The specified may be relative or absolute, if it is an absolute
     /// url, it must reference an address within the endpoint.</remarks>
-    public virtual Task<TResource?> ReadAsync<TResource>(string location, string? ifNoneMatch = null, DateTimeOffset? ifModifiedSince = null, CancellationToken? ct = null) where TResource : Resource
+    public virtual Task<TResource?> ReadAsync<TResource>(string location, string? ifNoneMatch = null, DateTimeOffset? ifModifiedSince = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource
     {
-        return ReadAsync<TResource>(new Uri(location, UriKind.RelativeOrAbsolute), ifNoneMatch, ifModifiedSince, ct);
+        return ReadAsync<TResource>(new Uri(location, UriKind.RelativeOrAbsolute), ifNoneMatch, ifModifiedSince, ct, requestHeaders);
     }
 
     #endregion
@@ -209,14 +211,15 @@ public partial class BaseFhirClient : IDisposable
     /// <typeparam name="TResource"></typeparam>
     /// <param name="current">The resource for which you want to get the most recent version.</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>A new instance of the resource, containing the most up-to-date data</returns>
     /// <remarks>This function will not overwrite the argument with new data, rather it will return a new instance
     /// which will have the newest data, leaving the argument intact.</remarks>
-    public virtual Task<TResource?> RefreshAsync<TResource>(TResource current, CancellationToken? ct = null) where TResource : Resource
+    public virtual Task<TResource?> RefreshAsync<TResource>(TResource current, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource
     {
         if (current == null) throw Error.ArgumentNull(nameof(current));
 
-        return ReadAsync<TResource>(ResourceIdentity.Build(current.TypeName, current.Id), ct: ct);
+        return ReadAsync<TResource>(ResourceIdentity.Build(current.TypeName, current.Id), ct: ct, requestHeaders: requestHeaders);
     }
 
     #endregion
@@ -229,12 +232,13 @@ public partial class BaseFhirClient : IDisposable
     /// <param name="resource">The resource to update</param>
     /// <param name="versionAware">If true, asks the server to verify we are updating the latest version</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <typeparam name="TResource">The type of resource that is being updated</typeparam>
     /// <returns>The body of the updated resource, unless ReturnFullResource is set to "false"</returns>
     /// <remarks>Throws an exception when the update failed, in particular when an update conflict is detected and the server returns a HTTP 409.
     /// If the resource does not yet exist - and the server allows client-assigned id's - a new resource with the given id will be
     /// created.</remarks>
-    public virtual Task<TResource?> UpdateAsync<TResource>(TResource resource, bool versionAware = false, CancellationToken? ct = null) where TResource : Resource
+    public virtual Task<TResource?> UpdateAsync<TResource>(TResource resource, bool versionAware = false, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource
     {
         if (resource == null) throw Error.ArgumentNull(nameof(resource));
         if (resource.Id == null) throw Error.Argument(nameof(resource), "Resource needs a non-null Id to send the update to");
@@ -246,7 +250,7 @@ public partial class BaseFhirClient : IDisposable
         else
             upd.Update(resource.Id, resource);
 
-        return internalUpdateAsync(resource, upd.ToBundle(), ct);
+        return internalUpdateAsync(resource, upd.ToBundle(), ct, requestHeaders);
     }
 
     /// <summary>
@@ -256,11 +260,12 @@ public partial class BaseFhirClient : IDisposable
     /// <param name="condition">Criteria used to locate the resource to update</param>
     /// <param name="versionAware">If true, asks the server to verify we are updating the latest version</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <typeparam name="TResource">The type of resource that is being updated</typeparam>
     /// <returns>The body of the updated resource, unless ReturnFullResource is set to "false"</returns>
     /// <remarks>Throws an exception when the update failed, in particular when an update conflict is detected and the server returns a HTTP 409.
     /// If the criteria passed in condition do not match a resource a new resource with a server assigned id will be created.</remarks>
-    public virtual Task<TResource?> ConditionalUpdateAsync<TResource>(TResource resource, SearchParams condition, bool versionAware = false, CancellationToken? ct = null) where TResource : Resource
+    public virtual Task<TResource?> ConditionalUpdateAsync<TResource>(TResource resource, SearchParams condition, bool versionAware = false, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource
     {
         if (resource == null) throw Error.ArgumentNull(nameof(resource));
         if (condition == null) throw Error.ArgumentNull(nameof(condition));
@@ -272,20 +277,20 @@ public partial class BaseFhirClient : IDisposable
         else
             upd.ConditionalUpdate(condition, resource);
 
-        return internalUpdateAsync(resource, upd.ToBundle(), ct);
+        return internalUpdateAsync(resource, upd.ToBundle(), ct, requestHeaders);
     }
 
-    private Task<TResource?> internalUpdateAsync<TResource>(TResource resource, Bundle tx, CancellationToken? ct) where TResource : Resource
+    private Task<TResource?> internalUpdateAsync<TResource>(TResource resource, Bundle tx, CancellationToken? ct, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource
     {
         resource.ResourceBase = Endpoint;
 
         // This might be an update of a resource that doesn't yet exist, so accept a status Created too
-        return executeAsync<TResource>(tx, new[] { HttpStatusCode.Created, HttpStatusCode.OK }, ct);
+        return executeAsync<TResource>(tx, new[] { HttpStatusCode.Created, HttpStatusCode.OK }, ct, requestHeaders);
     }
 
-    private TResource? internalUpdate<TResource>(TResource resource, Bundle tx, CancellationToken? ct) where TResource : Resource
+    private TResource? internalUpdate<TResource>(TResource resource, Bundle tx, CancellationToken? ct, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource
     {
-        return internalUpdateAsync(resource, tx, ct).WaitResult();
+        return internalUpdateAsync(resource, tx, ct, requestHeaders).WaitResult();
     }
 
     #endregion
@@ -297,17 +302,18 @@ public partial class BaseFhirClient : IDisposable
     /// </summary>
     /// <param name="location">endpoint of the resource to delete</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>Throws an exception when the delete failed, though this might
     /// just mean the server returned 404 (the resource didn't exist before) or 410 (the resource was
     /// already deleted).</returns>
-    public virtual async Task DeleteAsync(Uri location, CancellationToken? ct = null)
+    public virtual async Task DeleteAsync(Uri location, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (location == null) throw Error.ArgumentNull(nameof(location));
 
         var id = verifyResourceIdentity(location, needId: true, needVid: false);
         var tx = new TransactionBuilder(Endpoint).Delete(id.ResourceType, id.Id).ToBundle();
 
-        await executeAsync<Resource>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.NoContent }, ct).ConfigureAwait(false);
+        await executeAsync<Resource>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.NoContent }, ct, requestHeaders).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -315,12 +321,13 @@ public partial class BaseFhirClient : IDisposable
     /// </summary>
     /// <param name="location">endpoint of the resource to delete</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>Throws an exception when the delete failed, though this might
     /// just mean the server returned 404 (the resource didn't exist before) or 410 (the resource was
     /// already deleted).</returns>
-    public virtual Task DeleteAsync(string location, CancellationToken? ct = null)
+    public virtual Task DeleteAsync(string location, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
-        return DeleteAsync(new Uri(location, UriKind.Relative), ct);
+        return DeleteAsync(new Uri(location, UriKind.Relative), ct, requestHeaders);
     }
 
     /// <summary>
@@ -328,12 +335,13 @@ public partial class BaseFhirClient : IDisposable
     /// </summary>
     /// <param name="resource">The resource to delete</param>
     /// <param name="ct"></param>
-    public virtual async Task DeleteAsync(Resource resource, CancellationToken? ct = null)
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
+    public virtual async Task DeleteAsync(Resource resource, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (resource == null) throw Error.ArgumentNull(nameof(resource));
         if (resource.Id == null) throw Error.Argument(nameof(resource), "Entry must have an id");
 
-        await DeleteAsync(resource.ResourceIdentity(Endpoint).WithoutVersion(), ct).ConfigureAwait(false);
+        await DeleteAsync(resource.ResourceIdentity(Endpoint).WithoutVersion(), ct, requestHeaders).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -343,10 +351,11 @@ public partial class BaseFhirClient : IDisposable
     /// <param name="resourceType">The type of resource to delete (optional)</param>
     /// <param name="versionId">The versionId to be used for the if-match header</param>
     /// <param name="ct"></param>
-    public virtual async Task ConditionalDeleteSingleAsync(SearchParams condition, string? resourceType = null, string? versionId = null, CancellationToken? ct = null)
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
+    public virtual async Task ConditionalDeleteSingleAsync(SearchParams condition, string? resourceType = null, string? versionId = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         var tx = new TransactionBuilder(Endpoint).ConditionalDeleteSingle(condition, resourceType, versionId).ToBundle();
-        await executeAsync<Resource>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.NoContent }, ct).ConfigureAwait(false);
+        await executeAsync<Resource>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.NoContent }, ct, requestHeaders).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -355,10 +364,11 @@ public partial class BaseFhirClient : IDisposable
     /// <param name="condition">The search criteria to match the resources to be deleted.</param>
     /// <param name="resourceType">The type of resource to delete (optional)</param>
     /// <param name="ct"></param>
-    public virtual async Task ConditionalDeleteMultipleAsync(SearchParams condition, string? resourceType = null, CancellationToken? ct = null)
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
+    public virtual async Task ConditionalDeleteMultipleAsync(SearchParams condition, string? resourceType = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         var tx = new TransactionBuilder(Endpoint).ConditionalDeleteMultiple(condition, resourceType).ToBundle();
-        await executeAsync<Resource>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.NoContent }, ct).ConfigureAwait(false);
+        await executeAsync<Resource>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.NoContent }, ct, requestHeaders).ConfigureAwait(false);
     }
 
     #endregion
@@ -370,15 +380,16 @@ public partial class BaseFhirClient : IDisposable
     /// </summary>
     /// <param name="resource">The resource instance to create</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>The resource as created on the server, or an exception if the create failed.</returns>
     /// <typeparam name="TResource">The type of resource to create</typeparam>
-    public virtual Task<TResource?> CreateAsync<TResource>(TResource resource, CancellationToken? ct = null) where TResource : Resource
+    public virtual Task<TResource?> CreateAsync<TResource>(TResource resource, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource
     {
         if (resource == null) throw Error.ArgumentNull(nameof(resource));
 
         var tx = new TransactionBuilder(Endpoint).Create(resource).ToBundle();
 
-        return executeAsync<TResource>(tx, new[] { HttpStatusCode.Created, HttpStatusCode.OK }, ct);
+        return executeAsync<TResource>(tx, new[] { HttpStatusCode.Created, HttpStatusCode.OK }, ct, requestHeaders);
     }
 
     /// <summary>
@@ -387,16 +398,17 @@ public partial class BaseFhirClient : IDisposable
     /// <param name="resource">The resource instance to create</param>
     /// <param name="condition">The criteria</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>The resource as created on the server, or an exception if the create failed.</returns>
     /// <typeparam name="TResource">The type of resource to create</typeparam>
-    public virtual Task<TResource?> ConditionalCreateAsync<TResource>(TResource resource, SearchParams condition, CancellationToken? ct = null) where TResource : Resource
+    public virtual Task<TResource?> ConditionalCreateAsync<TResource>(TResource resource, SearchParams condition, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource
     {
         if (resource == null) throw Error.ArgumentNull(nameof(resource));
         if (condition == null) throw Error.ArgumentNull(nameof(condition));
 
         var tx = new TransactionBuilder(Endpoint).ConditionalCreate(resource, condition).ToBundle();
 
-        return executeAsync<TResource>(tx, new[] { HttpStatusCode.Created, HttpStatusCode.OK }, ct);
+        return executeAsync<TResource>(tx, new[] { HttpStatusCode.Created, HttpStatusCode.OK }, ct, requestHeaders);
     }
 
     #endregion
@@ -409,8 +421,9 @@ public partial class BaseFhirClient : IDisposable
     /// <param name="location">Location of the resource</param>
     /// <param name="patchParameters">A Parameters resource that includes the patch operation(s) to perform</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>The patched resource</returns>
-    public virtual Task<Resource?> PatchAsync(Uri location, Parameters patchParameters, CancellationToken? ct = null)
+    public virtual Task<Resource?> PatchAsync(Uri location, Parameters patchParameters, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (location == null) throw Error.ArgumentNull(nameof(location));
 
@@ -423,7 +436,7 @@ public partial class BaseFhirClient : IDisposable
         else
             tx.Patch(id.ResourceType, id.Id, patchParameters);
 
-        return executeAsync<Resource>(tx.ToBundle(), new[] { HttpStatusCode.Created, HttpStatusCode.OK }, ct);
+        return executeAsync<Resource>(tx.ToBundle(), new[] { HttpStatusCode.Created, HttpStatusCode.OK }, ct, requestHeaders);
     }
 
     /// <summary>
@@ -434,8 +447,9 @@ public partial class BaseFhirClient : IDisposable
     /// <param name="patchParameters">A Parameters resource that includes the patch operation(s) to perform</param>
     /// <param name="versionId">version id of the resource to patch</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>The patched resource</returns>
-    public virtual Task<TResource?> PatchAsync<TResource>(string id, Parameters patchParameters, string? versionId = null, CancellationToken? ct = null) where TResource : Resource
+    public virtual Task<TResource?> PatchAsync<TResource>(string id, Parameters patchParameters, string? versionId = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource
     {
         if (id == null) throw Error.ArgumentNull(nameof(id));
 
@@ -447,10 +461,10 @@ public partial class BaseFhirClient : IDisposable
         else
             tx.Patch(resourceType, id, patchParameters);
 
-        return executeAsync<TResource>(tx.ToBundle(), new[] { HttpStatusCode.Created, HttpStatusCode.OK }, ct);
+        return executeAsync<TResource>(tx.ToBundle(), new[] { HttpStatusCode.Created, HttpStatusCode.OK }, ct, requestHeaders);
     }
 
-    public virtual Task<TResource?> PatchAsync<TResource>(string id, string patchDocument, ResourceFormat format, CancellationToken? ct = null) where TResource : Resource
+    public virtual Task<TResource?> PatchAsync<TResource>(string id, string patchDocument, ResourceFormat format, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource
     {
         if (id == null) throw Error.ArgumentNull(nameof(id));
 
@@ -467,7 +481,7 @@ public partial class BaseFhirClient : IDisposable
             _ => throw Error.Argument(nameof(format), "Unsupported format")
         });
 
-        return executeAsync<TResource>(request, new[] { HttpStatusCode.Created, HttpStatusCode.OK }, ct);
+        return executeAsync<TResource>(request, new[] { HttpStatusCode.Created, HttpStatusCode.OK }, ct, requestHeaders);
     }
 
     /// <summary>
@@ -477,14 +491,15 @@ public partial class BaseFhirClient : IDisposable
     /// <param name="condition">Criteria used to locate the resource to update</param>
     /// <param name="patchParameters">A Parameters resource that includes the patch operation(s) to perform</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>The patched resource</returns>
-    public Task<TResource?> ConditionalPatchAsync<TResource>(SearchParams condition, Parameters patchParameters, CancellationToken? ct = null) where TResource : Resource
+    public Task<TResource?> ConditionalPatchAsync<TResource>(SearchParams condition, Parameters patchParameters, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource
     {
         var tx = new TransactionBuilder(Endpoint);
         var resourceType = typeNameOrDie<TResource>();
         tx.ConditionalPatch(resourceType, condition, patchParameters);
 
-        return executeAsync<TResource>(tx.ToBundle(), new[] { HttpStatusCode.Created, HttpStatusCode.OK }, ct);
+        return executeAsync<TResource>(tx.ToBundle(), new[] { HttpStatusCode.Created, HttpStatusCode.OK }, ct, requestHeaders);
     }
 
     #endregion
@@ -498,12 +513,13 @@ public partial class BaseFhirClient : IDisposable
     /// <param name="since">Optional. Returns only changes after the given date</param>
     /// <param name="pageSize">Optional. Asks server to limit the number of entries per page returned</param>
     /// <param name="summary">Optional. Asks the server to only provide the fields defined for the summary</param>
-    /// <param name="ct"></param>        
-    /// <returns>A bundle with the history for the indicated instance, may contain both 
+    /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
+    /// <returns>A bundle with the history for the indicated instance, may contain both
     /// ResourceEntries and DeletedEntries.</returns>
-    public Task<Bundle?> TypeHistoryAsync(string resourceType, DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null, CancellationToken? ct = null)
+    public Task<Bundle?> TypeHistoryAsync(string resourceType, DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
-        return internalHistoryAsync(resourceType, null, since, pageSize, summary, ct);
+        return internalHistoryAsync(resourceType, null, since, pageSize, summary, ct, requestHeaders);
     }
 
     /// <summary>
@@ -513,12 +529,13 @@ public partial class BaseFhirClient : IDisposable
     /// <param name="pageSize">Optional. Asks server to limit the number of entries per page returned</param>
     /// <param name="summary">Optional. Asks the server to only provide the fields defined for the summary</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <typeparam name="TResource">The type of Resource to get the history for</typeparam>
-    /// <returns>A bundle with the history for the indicated instance, may contain both 
+    /// <returns>A bundle with the history for the indicated instance, may contain both
     /// ResourceEntries and DeletedEntries.</returns>
-    public Task<Bundle?> TypeHistoryAsync<TResource>(DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null, CancellationToken? ct = null) where TResource : Resource, new()
+    public Task<Bundle?> TypeHistoryAsync<TResource>(DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource, new()
     {
-        return internalHistoryAsync(typeNameOrDie<TResource>(), null, since, pageSize, summary, ct);
+        return internalHistoryAsync(typeNameOrDie<TResource>(), null, since, pageSize, summary, ct, requestHeaders);
     }
 
     /// <summary>
@@ -529,14 +546,15 @@ public partial class BaseFhirClient : IDisposable
     /// <param name="pageSize">Optional. Asks server to limit the number of entries per page returned</param>
     /// <param name="summary">Optional. Asks the server to only provide the fields defined for the summary</param>
     /// <param name="ct"></param>
-    /// <returns>A bundle with the history for the indicated instance, may contain both 
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
+    /// <returns>A bundle with the history for the indicated instance, may contain both
     /// ResourceEntries and DeletedEntries.</returns>
-    public Task<Bundle?> HistoryAsync(Uri location, DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null, CancellationToken? ct = null)
+    public Task<Bundle?> HistoryAsync(Uri location, DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (location == null) throw Error.ArgumentNull(nameof(location));
 
         var id = BaseFhirClient.verifyResourceIdentity(location, needId: true, needVid: false);
-        return internalHistoryAsync(id.ResourceType, id.Id, since, pageSize, summary, ct);
+        return internalHistoryAsync(id.ResourceType, id.Id, since, pageSize, summary, ct, requestHeaders);
     }
 
     /// <summary>
@@ -547,11 +565,12 @@ public partial class BaseFhirClient : IDisposable
     /// <param name="pageSize">Optional. Asks server to limit the number of entries per page returned</param>
     /// <param name="summary">Optional. Asks the server to only provide the fields defined for the summary</param>
     /// <param name="ct"></param>
-    /// <returns>A bundle with the history for the indicated instance, may contain both 
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
+    /// <returns>A bundle with the history for the indicated instance, may contain both
     /// ResourceEntries and DeletedEntries.</returns>
-    public Task<Bundle?> HistoryAsync(string location, DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null, CancellationToken? ct = null)
+    public Task<Bundle?> HistoryAsync(string location, DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
-        return HistoryAsync(new Uri(location, UriKind.Relative), since, pageSize, summary, ct);
+        return HistoryAsync(new Uri(location, UriKind.Relative), since, pageSize, summary, ct, requestHeaders);
     }
 
     /// <summary>
@@ -561,14 +580,15 @@ public partial class BaseFhirClient : IDisposable
     /// <param name="pageSize">Optional. Asks server to limit the number of entries per page returned</param>
     /// <param name="summary">Optional. Indicates whether the returned resources should just contain the minimal set of elements</param>
     /// <param name="ct"></param>
-    /// <returns>A bundle with the history for the indicated instance, may contain both 
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
+    /// <returns>A bundle with the history for the indicated instance, may contain both
     /// ResourceEntries and DeletedEntries.</returns>
-    public Task<Bundle?> WholeSystemHistoryAsync(DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null, CancellationToken? ct = null)
+    public Task<Bundle?> WholeSystemHistoryAsync(DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
-        return internalHistoryAsync(null, null, since, pageSize, summary, ct);
+        return internalHistoryAsync(null, null, since, pageSize, summary, ct, requestHeaders);
     }
 
-    private Task<Bundle?> internalHistoryAsync(string? resourceType = null, string? id = null, DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null, CancellationToken? ct = null)
+    private Task<Bundle?> internalHistoryAsync(string? resourceType = null, string? id = null, DateTimeOffset? since = null, int? pageSize = null, SummaryType? summary = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         TransactionBuilder history;
 
@@ -579,7 +599,7 @@ public partial class BaseFhirClient : IDisposable
         else
             history = new TransactionBuilder(Endpoint).ResourceHistory(resourceType, id, summary, pageSize, since);
 
-        return executeAsync<Bundle>(history.ToBundle(), HttpStatusCode.OK, ct);
+        return executeAsync<Bundle>(history.ToBundle(), HttpStatusCode.OK, ct, requestHeaders);
     }
 
     #endregion
@@ -591,14 +611,15 @@ public partial class BaseFhirClient : IDisposable
     /// </summary>
     /// <param name="location">The location of the resource of which the history should be deleted</param>
     /// <param name="ct"></param>
-    public async Task DeleteHistoryAsync(Uri location, CancellationToken? ct = null)
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
+    public async Task DeleteHistoryAsync(Uri location, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (location == null) throw Error.ArgumentNull(nameof(location));
 
         var id = verifyResourceIdentity(location, needId: true, needVid: false);
         var tx = new TransactionBuilder(Endpoint).DeleteHistory(id.ResourceType, id.Id).ToBundle();
 
-        await executeAsync<Resource>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.NoContent }, ct).ConfigureAwait(false);
+        await executeAsync<Resource>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.NoContent }, ct, requestHeaders).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -606,9 +627,10 @@ public partial class BaseFhirClient : IDisposable
     /// </summary>
     /// <param name="location">The location of the resource of which the history should be deleted</param>
     /// <param name="ct"></param>
-    public async Task DeleteHistoryAsync(string location, CancellationToken? ct = null)
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
+    public async Task DeleteHistoryAsync(string location, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
-        await DeleteHistoryAsync(new Uri(location, UriKind.Relative), ct).ConfigureAwait(false);
+        await DeleteHistoryAsync(new Uri(location, UriKind.Relative), ct, requestHeaders).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -616,15 +638,16 @@ public partial class BaseFhirClient : IDisposable
     /// </summary>
     /// <param name="location">The location of the resource of which the history should be deleted. Should contain the version ID to be deleted</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <exception cref="ArgumentException"></exception>
-    public async Task DeleteHistoryVersionAsync(Uri location, CancellationToken? ct = null)
+    public async Task DeleteHistoryVersionAsync(Uri location, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (location == null) throw Error.ArgumentNull(nameof(location));
 
         var id = verifyResourceIdentity(location, needId: true, needVid: true);
         var tx = new TransactionBuilder(Endpoint).DeleteHistoryVersion(id.ResourceType, id.Id, id.VersionId).ToBundle();
 
-        await executeAsync<Resource>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.NoContent }, ct).ConfigureAwait(false);
+        await executeAsync<Resource>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.NoContent }, ct, requestHeaders).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -632,10 +655,11 @@ public partial class BaseFhirClient : IDisposable
     /// </summary>
     /// <param name="location">The location of the resource of which the history should be deleted. Should contain the version ID to be deleted</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <exception cref="ArgumentException"></exception>
-    public async Task DeleteHistoryVersionAsync(string location, CancellationToken? ct = null)
+    public async Task DeleteHistoryVersionAsync(string location, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
-        await DeleteHistoryVersionAsync(new Uri(location, UriKind.Relative), ct).ConfigureAwait(false);
+        await DeleteHistoryVersionAsync(new Uri(location, UriKind.Relative), ct, requestHeaders).ConfigureAwait(false);
     }
 
     #endregion
@@ -647,54 +671,55 @@ public partial class BaseFhirClient : IDisposable
     /// </summary>
     /// <param name="bundle">The bundled creates, updates and deleted</param>
     /// <param name="ct"></param>
-    /// <returns>A bundle as returned by the server after it has processed the transaction, or 
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
+    /// <returns>A bundle as returned by the server after it has processed the transaction, or
     /// a FhirOperationException will be thrown if an error occurred.</returns>
-    public Task<Bundle?> TransactionAsync(Bundle bundle, CancellationToken? ct = null)
+    public Task<Bundle?> TransactionAsync(Bundle bundle, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (bundle == null) throw new ArgumentNullException(nameof(bundle));
 
         var tx = new TransactionBuilder(Endpoint).Transaction(bundle).ToBundle();
-        return executeAsync<Bundle>(tx, HttpStatusCode.OK, ct);
+        return executeAsync<Bundle>(tx, HttpStatusCode.OK, ct, requestHeaders);
     }
 
     #endregion
 
     #region Operation
 
-    public virtual Task<Resource?> WholeSystemOperationAsync(string operationName, Parameters? parameters = null, bool useGet = false, CancellationToken? ct = null)
+    public virtual Task<Resource?> WholeSystemOperationAsync(string operationName, Parameters? parameters = null, bool useGet = false, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (operationName == null) throw Error.ArgumentNull(nameof(operationName));
-        return internalOperationAsync(operationName, parameters: parameters, useGet: useGet, ct: ct);
+        return internalOperationAsync(operationName, parameters: parameters, useGet: useGet, ct: ct, requestHeaders: requestHeaders);
     }
 
-    public virtual Task<Resource?> TypeOperationAsync<TResource>(string operationName, Parameters? parameters = null, bool useGet = false, CancellationToken? ct = null)
+    public virtual Task<Resource?> TypeOperationAsync<TResource>(string operationName, Parameters? parameters = null, bool useGet = false, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
         where TResource : Resource
     {
         if (operationName == null) throw Error.ArgumentNull(nameof(operationName));
         var typeName = typeNameOrDie<TResource>();
 
-        return TypeOperationAsync(operationName, typeName, parameters, useGet: useGet, ct);
+        return TypeOperationAsync(operationName, typeName, parameters, useGet: useGet, ct: ct, requestHeaders: requestHeaders);
     }
 
-    public virtual Task<Resource?> TypeOperationAsync(string operationName, string typeName, Parameters? parameters = null, bool useGet = false, CancellationToken? ct = null)
+    public virtual Task<Resource?> TypeOperationAsync(string operationName, string typeName, Parameters? parameters = null, bool useGet = false, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (operationName == null) throw Error.ArgumentNull(nameof(operationName));
         if (typeName == null) throw Error.ArgumentNull(nameof(typeName));
 
-        return internalOperationAsync(operationName, typeName, parameters: parameters, useGet: useGet, ct: ct);
+        return internalOperationAsync(operationName, typeName, parameters: parameters, useGet: useGet, ct: ct, requestHeaders: requestHeaders);
     }
 
-    public virtual Task<Resource?> InstanceOperationAsync(Uri location, string operationName, Parameters? parameters = null, bool useGet = false, CancellationToken? ct = null)
+    public virtual Task<Resource?> InstanceOperationAsync(Uri location, string operationName, Parameters? parameters = null, bool useGet = false, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (location == null) throw Error.ArgumentNull(nameof(location));
         if (operationName == null) throw Error.ArgumentNull(nameof(operationName));
 
         var id = BaseFhirClient.verifyResourceIdentity(location, needId: true, needVid: false);
 
-        return internalOperationAsync(operationName, id.ResourceType, id.Id, id.VersionId, parameters, useGet, ct);
+        return internalOperationAsync(operationName, id.ResourceType, id.Id, id.VersionId, parameters, useGet, ct, requestHeaders);
     }
 
-    public virtual Task<Resource?> OperationAsync(Uri location, string operationName, Parameters? parameters = null, bool useGet = false, CancellationToken? ct = null)
+    public virtual Task<Resource?> OperationAsync(Uri location, string operationName, Parameters? parameters = null, bool useGet = false, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (location == null) throw Error.ArgumentNull(nameof(location));
         if (operationName == null) throw Error.ArgumentNull(nameof(operationName));
@@ -702,36 +727,36 @@ public partial class BaseFhirClient : IDisposable
         var tx = new TransactionBuilder(Endpoint).EndpointOperation(new RestUrl(location), operationName, parameters, useGet).ToBundle();
 
         //operation responses are expected to return 2xx codes.
-        return executeAsync<Resource>(tx, _200Responses.Value, ct);
+        return executeAsync<Resource>(tx, _200Responses.Value, ct, requestHeaders);
     }
 
-    public virtual Task<Resource?> OperationAsync(Uri operation, Parameters? parameters = null, bool useGet = false, CancellationToken? ct = null)
+    public virtual Task<Resource?> OperationAsync(Uri operation, Parameters? parameters = null, bool useGet = false, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (operation == null) throw Error.ArgumentNull(nameof(operation));
 
         var tx = new TransactionBuilder(Endpoint).EndpointOperation(new RestUrl(operation), parameters, useGet).ToBundle();
 
         //operation responses are expected to return 2xx codes.
-        return executeAsync<Resource>(tx, _200Responses.Value, ct);
+        return executeAsync<Resource>(tx, _200Responses.Value, ct, requestHeaders);
     }
 
-    public virtual Task<Bundle?> ProcessMessageAsync(Bundle bundle, bool async = false, string? responseUrl = null, CancellationToken? ct = null)
+    public virtual Task<Bundle?> ProcessMessageAsync(Bundle bundle, bool async = false, string? responseUrl = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (bundle == null) throw new ArgumentNullException(nameof(bundle));
 
         var tx = new TransactionBuilder(Endpoint).ProcessMessage(bundle, async, responseUrl).ToBundle();
 
-        return executeAsync<Bundle>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.Accepted, HttpStatusCode.NoContent }, ct);
+        return executeAsync<Bundle>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.Accepted, HttpStatusCode.NoContent }, ct, requestHeaders);
     }
 
     private Task<Resource?> internalOperationAsync(string operationName, string? type = null, string? id = null, string? vid = null,
-        Parameters? parameters = null, bool useGet = false, CancellationToken? ct = null)
+        Parameters? parameters = null, bool useGet = false, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         // Brian: Not sure why we would create this parameters object as empty.
         //        I would imagine that a null parameters object is different to an empty one?
         // EK: What else could we do?  POST an empty body?  We cannot use GET unless the caller indicates this is an
         // idempotent call....
-        // MV: (related to issue #419): we only provide an empty parameter when we are not performing a GET operation. In r4 it will be allowed 
+        // MV: (related to issue #419): we only provide an empty parameter when we are not performing a GET operation. In r4 it will be allowed
         //     to provide an empty body in POST operations. In that case the line of code can be deleted.
         if (parameters == null && !useGet) parameters = new Parameters();
 
@@ -745,7 +770,7 @@ public partial class BaseFhirClient : IDisposable
             tx = new TransactionBuilder(Endpoint).ResourceOperation(type, id, vid, operationName, parameters, useGet).ToBundle();
 
         //operation responses are expected to return 2xx codes.
-        return executeAsync<Resource>(tx, _200Responses.Value, ct);
+        return executeAsync<Resource>(tx, _200Responses.Value, ct, requestHeaders);
     }
 
     #endregion
@@ -757,14 +782,15 @@ public partial class BaseFhirClient : IDisposable
     /// </summary>
     /// <param name="url">A relative or absolute url. If the url is absolute, it has to be located within the endpoint of the client.</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>A resource that is the outcome of the operation. The type depends on the definition of the operation at the given url</returns>
     /// <remarks>parameters to the method are simple, and are in the URL, and this is a GET operation</remarks>
-    public async Task<Resource?> GetAsync(Uri url, CancellationToken? ct = null)
+    public async Task<Resource?> GetAsync(Uri url, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (url == null) throw Error.ArgumentNull(nameof(url));
 
         var tx = new TransactionBuilder(Endpoint).Get(url).ToBundle();
-        return await executeAsync<Resource>(tx, HttpStatusCode.OK, ct).ConfigureAwait(false);
+        return await executeAsync<Resource>(tx, HttpStatusCode.OK, ct, requestHeaders).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -772,25 +798,26 @@ public partial class BaseFhirClient : IDisposable
     /// </summary>
     /// <param name="url">A relative or absolute url. If the url is absolute, it has to be located within the endpoint of the client.</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>A resource that is the outcome of the operation. The type depends on the definition of the operation at the given url</returns>
     /// <remarks>parameters to the method are simple, and are in the URL, and this is a GET operation</remarks>
-    public virtual Task<Resource?> GetAsync(string url, CancellationToken? ct = null)
+    public virtual Task<Resource?> GetAsync(string url, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (url == null) throw Error.ArgumentNull(nameof(url));
 
-        return GetAsync(new Uri(url, UriKind.RelativeOrAbsolute), ct);
+        return GetAsync(new Uri(url, UriKind.RelativeOrAbsolute), ct, requestHeaders);
     }
 
     #endregion
 
     #region ExecuteAsync
 
-    public Task<TResource?> executeAsync<TResource>(Model.Bundle tx, HttpStatusCode expect, CancellationToken? ct) where TResource : Model.Resource
+    public Task<TResource?> executeAsync<TResource>(Model.Bundle tx, HttpStatusCode expect, CancellationToken? ct, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Model.Resource
     {
-        return executeAsync<TResource>(tx, [expect], ct);
+        return executeAsync<TResource>(tx, [expect], ct, requestHeaders);
     }
 
-    private async Task<TResource?> executeAsync<TResource>(Bundle tx, IEnumerable<HttpStatusCode> expect, CancellationToken? ct) where TResource : Resource
+    private async Task<TResource?> executeAsync<TResource>(Bundle tx, IEnumerable<HttpStatusCode> expect, CancellationToken? ct, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource
     {
         var cancellation = ct ?? CancellationToken.None;
 
@@ -808,16 +835,20 @@ public partial class BaseFhirClient : IDisposable
             Settings,
             maybeBinaryInteraction);
 
+        requestHeaders?.Invoke(requestMessage.Headers);
+
         using var responseMessage = await Requester.ExecuteAsync(requestMessage, cancellation).ConfigureAwait(false);
 
         return await extractResourceFromHttpResponse<TResource>(expect, responseMessage, entryComponent: request, useBinaryProtocol: maybeBinaryInteraction);
     }
 
-    private async Task<TResource?> executeAsync<TResource>(HttpRequestMessage request, IEnumerable<HttpStatusCode> expect, CancellationToken? ct) where TResource : Resource
+    private async Task<TResource?> executeAsync<TResource>(HttpRequestMessage request, IEnumerable<HttpStatusCode> expect, CancellationToken? ct, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource
     {
         var cancellation = ct ?? CancellationToken.None;
 
         cancellation.ThrowIfCancellationRequested();
+
+        requestHeaders?.Invoke(request.Headers);
 
         using var responseMessage = await Requester.ExecuteAsync(request, cancellation).ConfigureAwait(false);
 

--- a/src/Hl7.Fhir.Base/Rest/FhirClientSearch.cs
+++ b/src/Hl7.Fhir.Base/Rest/FhirClientSearch.cs
@@ -13,6 +13,7 @@ using Hl7.Fhir.Utility;
 using System;
 using System.Linq;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 #pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
@@ -32,11 +33,12 @@ public partial class BaseFhirClient
     /// <param name="q">The Query resource containing the search parameters</param>
     /// <param name="resourceType">The type of resource to filter on (optional). If not specified, will search on all resource types.</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>A Bundle with all resources found by the search, or an empty Bundle if none were found.</returns>
-    public virtual Task<Bundle?> SearchAsync(SearchParams q, string? resourceType = null, CancellationToken? ct = null)
+    public virtual Task<Bundle?> SearchAsync(SearchParams q, string? resourceType = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         var tx = new TransactionBuilder(Endpoint).Search(q, resourceType).ToBundle();
-        return executeAsync<Bundle>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.Accepted }, ct);
+        return executeAsync<Bundle>(tx, new[] { HttpStatusCode.OK, HttpStatusCode.Accepted }, ct, requestHeaders);
     }
 
     /// <summary>
@@ -45,11 +47,12 @@ public partial class BaseFhirClient
     /// <param name="q">The Query resource containing the search parameters</param>
     /// <param name="resourceType">The type of resource to filter on (optional). If not specified, will search on all resource types.</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>A Bundle with all resources found by the search, or an empty Bundle if none were found.</returns>
-    public virtual Task<Bundle?> SearchUsingPostAsync(SearchParams q, string? resourceType = null, CancellationToken? ct = null)
+    public virtual Task<Bundle?> SearchUsingPostAsync(SearchParams q, string? resourceType = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         var tx = new TransactionBuilder(Endpoint).SearchUsingPost(q, resourceType).ToBundle();
-        return executeAsync<Bundle>(tx, new[] { HttpStatusCode.OK }, ct);
+        return executeAsync<Bundle>(tx, new[] { HttpStatusCode.OK }, ct, requestHeaders);
     }
 
     #endregion
@@ -61,18 +64,19 @@ public partial class BaseFhirClient
     /// </summary>
     /// <param name="q">The Query resource containing the search parameters</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <typeparam name="TResource">The type of resource to filter on</typeparam>
     /// <returns>A Bundle with all resources found by the search, or an empty Bundle if none were found.</returns>
-    public virtual Task<Bundle?> SearchAsync<TResource>(SearchParams q, CancellationToken? ct = null) where TResource : Resource
+    public virtual Task<Bundle?> SearchAsync<TResource>(SearchParams q, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource
     {
         // [WMR 20160421] GetResourceNameForType is obsolete
         // return Search(q, ModelInfo.GetResourceNameForType(typeof(TResource)));
-        return SearchAsync(q, Inspector.GetFhirTypeNameForType(typeof(TResource)), ct);
+        return SearchAsync(q, Inspector.GetFhirTypeNameForType(typeof(TResource)), ct, requestHeaders);
     }
 
-    public virtual Task<Bundle?> SearchUsingPostAsync<TResource>(SearchParams q, CancellationToken? ct = null) where TResource : Resource
+    public virtual Task<Bundle?> SearchUsingPostAsync<TResource>(SearchParams q, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource
     {
-        return SearchUsingPostAsync(q, Inspector.GetFhirTypeNameForType(typeof(TResource)), ct);
+        return SearchUsingPostAsync(q, Inspector.GetFhirTypeNameForType(typeof(TResource)), ct, requestHeaders);
     }
 
     #endregion
@@ -89,22 +93,23 @@ public partial class BaseFhirClient
     /// <param name="summary">Optional. Whether to include only return a summary of the resources in the Bundle</param>
     /// <param name="revIncludes">Optional. A list of reverse include paths</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <typeparam name="TResource">The type of resource to list</typeparam>
     /// <returns>A Bundle with all resources found by the search, or an empty Bundle if none were found.</returns>
-    /// <remarks>All parameters are optional, leaving all parameters empty will return an unfiltered list 
+    /// <remarks>All parameters are optional, leaving all parameters empty will return an unfiltered list
     /// of all resources of the given Resource type</remarks>
     public virtual Task<Bundle?> SearchAsync<TResource>(string[]? criteria, (string path, IncludeModifier modifier)[]? includes, int? pageSize,
-        SummaryType? summary, (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null)
+        SummaryType? summary, (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
         where TResource : Resource, new()
     {
-        return SearchAsync(typeNameOrDie<TResource>(), criteria, includes, pageSize, summary, revIncludes, ct);
+        return SearchAsync(typeNameOrDie<TResource>(), criteria, includes, pageSize, summary, revIncludes, ct, requestHeaders);
     }
 
     public virtual Task<Bundle?> SearchAsync<TResource>(string[]? criteria = null, string[]? includes = null, int? pageSize = null,
-        SummaryType? summary = null, string[]? revIncludes = null, CancellationToken? ct = null)
+        SummaryType? summary = null, string[]? revIncludes = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
         where TResource : Resource, new()
     {
-        return SearchAsync<TResource>(criteria, BaseFhirClient.stringToIncludeTuple(includes), pageSize, summary, BaseFhirClient.stringToIncludeTuple(revIncludes), ct);
+        return SearchAsync<TResource>(criteria, BaseFhirClient.stringToIncludeTuple(includes), pageSize, summary, BaseFhirClient.stringToIncludeTuple(revIncludes), ct, requestHeaders);
     }
 
     /// <summary>
@@ -117,23 +122,24 @@ public partial class BaseFhirClient
     /// <param name="summary">Optional. Whether to include only return a summary of the resources in the Bundle</param>
     /// <param name="revIncludes">Optional. A list of reverse include paths</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <typeparam name="TResource">The type of resource to list</typeparam>
     /// <returns>A Bundle with all resources found by the search, or an empty Bundle if none were found.</returns>
-    /// <remarks>All parameters are optional, leaving all parameters empty will return an unfiltered list 
+    /// <remarks>All parameters are optional, leaving all parameters empty will return an unfiltered list
     /// of all resources of the given Resource type</remarks>
     public virtual Task<Bundle?> SearchUsingPostAsync<TResource>(string[]? criteria, (string path, IncludeModifier modifier)[]? includes, int? pageSize,
-        SummaryType? summary, (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null)
+        SummaryType? summary, (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
         where TResource : Resource, new()
     {
-        return SearchUsingPostAsync(typeNameOrDie<TResource>(), criteria, includes, pageSize, summary, revIncludes, ct);
+        return SearchUsingPostAsync(typeNameOrDie<TResource>(), criteria, includes, pageSize, summary, revIncludes, ct, requestHeaders);
     }
 
     ///<inheritdoc cref="SearchUsingPostAsync{TResource}(string[], (string path, IncludeModifier modifier)[], int?, SummaryType?, (string path, IncludeModifier modifier)[])"/>
     public virtual Task<Bundle?> SearchUsingPostAsync<TResource>(string[]? criteria = null, string[]? includes = null, int? pageSize = null,
-        SummaryType? summary = null, string[]? revIncludes = null, CancellationToken? ct = null)
+        SummaryType? summary = null, string[]? revIncludes = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
         where TResource : Resource, new()
     {
-        return SearchUsingPostAsync<TResource>(criteria, stringToIncludeTuple(includes), pageSize, summary, stringToIncludeTuple(revIncludes), ct);
+        return SearchUsingPostAsync<TResource>(criteria, stringToIncludeTuple(includes), pageSize, summary, stringToIncludeTuple(revIncludes), ct, requestHeaders);
     }
 
     #endregion
@@ -151,22 +157,23 @@ public partial class BaseFhirClient
     /// <param name="summary">Optional. Whether to include only return a summary of the resources in the Bundle</param>
     /// <param name="revIncludes">Optional. A list of reverse include paths</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>A Bundle with all resources found by the search, or an empty Bundle if none were found.</returns>
-    /// <remarks>All parameters are optional, leaving all parameters empty will return an unfiltered list 
+    /// <remarks>All parameters are optional, leaving all parameters empty will return an unfiltered list
     /// of all resources of the given Resource type</remarks>
     public virtual Task<Bundle?> SearchAsync(string resource, string[]? criteria, (string path, IncludeModifier modifier)[]? includes, int? pageSize,
-        SummaryType? summary, (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null)
+        SummaryType? summary, (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (resource == null) throw Error.ArgumentNull(nameof(resource));
 
-        return SearchAsync(toQuery(criteria, includes, pageSize, summary, revIncludes), resource, ct);
+        return SearchAsync(toQuery(criteria, includes, pageSize, summary, revIncludes), resource, ct, requestHeaders);
     }
 
     ///<inheritdoc cref="SearchAsync(string, string[], (string path, IncludeModifier modifier)[], int?, SummaryType?, (string path, IncludeModifier modifier)[])"/>
     public virtual Task<Bundle?> SearchAsync(string resource, string[]? criteria = null, string[]? includes = null, int? pageSize = null,
-        SummaryType? summary = null, string[]? revIncludes = null, CancellationToken? ct = null)
+        SummaryType? summary = null, string[]? revIncludes = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
-        return SearchAsync(resource, criteria, stringToIncludeTuple(includes), pageSize, summary, stringToIncludeTuple(revIncludes), ct);
+        return SearchAsync(resource, criteria, stringToIncludeTuple(includes), pageSize, summary, stringToIncludeTuple(revIncludes), ct, requestHeaders);
     }
 
     /// <summary>
@@ -180,22 +187,23 @@ public partial class BaseFhirClient
     /// <param name="summary">Optional. Whether to include only return a summary of the resources in the Bundle</param>
     /// <param name="revIncludes">Optional. A list of reverse include paths</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>A Bundle with all resources found by the search, or an empty Bundle if none were found.</returns>
-    /// <remarks>All parameters are optional, leaving all parameters empty will return an unfiltered list 
+    /// <remarks>All parameters are optional, leaving all parameters empty will return an unfiltered list
     /// of all resources of the given Resource type</remarks>
     public virtual Task<Bundle?> SearchUsingPostAsync(string resource, string[]? criteria, (string path, IncludeModifier modifier)[]? includes, int? pageSize,
-        SummaryType? summary, (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null)
+        SummaryType? summary, (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (resource == null) throw Error.ArgumentNull(nameof(resource));
 
-        return SearchUsingPostAsync(toQuery(criteria, includes, pageSize, summary, revIncludes), resource, ct);
+        return SearchUsingPostAsync(toQuery(criteria, includes, pageSize, summary, revIncludes), resource, ct, requestHeaders);
     }
 
     ///<inheritdoc cref="SearchUsingPostAsync(string, string, (string path, IncludeModifier modifier)[], int?, (string path, IncludeModifier modifier)[])"/>
     public virtual Task<Bundle?> SearchUsingPostAsync(string resource, string[]? criteria = null, string[]? includes = null, int? pageSize = null,
-        SummaryType? summary = null, string[]? revIncludes = null, CancellationToken? ct = null)
+        SummaryType? summary = null, string[]? revIncludes = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
-        return SearchUsingPostAsync(resource, criteria, stringToIncludeTuple(includes), pageSize, summary, stringToIncludeTuple(revIncludes), ct);
+        return SearchUsingPostAsync(resource, criteria, stringToIncludeTuple(includes), pageSize, summary, stringToIncludeTuple(revIncludes), ct, requestHeaders);
     }
 
     #endregion
@@ -212,20 +220,21 @@ public partial class BaseFhirClient
     /// <param name="summary">Optional. Whether to include only return a summary of the resources in the Bundle</param>
     /// <param name="revIncludes">Optional. A list of reverse include paths</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>A Bundle with all resources found by the search, or an empty Bundle if none were found.</returns>
-    /// <remarks>All parameters are optional, leaving all parameters empty will return an unfiltered list 
+    /// <remarks>All parameters are optional, leaving all parameters empty will return an unfiltered list
     /// of all resources of the given Resource type</remarks>
     public virtual Task<Bundle?> WholeSystemSearchAsync(string[]? criteria, (string path, IncludeModifier modifier)[]? includes, int? pageSize,
-        SummaryType? summary, (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null)
+        SummaryType? summary, (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
-        return SearchAsync(toQuery(criteria, includes, pageSize, summary, revIncludes), ct: ct);
+        return SearchAsync(toQuery(criteria, includes, pageSize, summary, revIncludes), ct: ct, requestHeaders: requestHeaders);
     }
 
     ///<inheritdoc cref="WholeSystemSearchAsync(string[], (string path, IncludeModifier modifier)[], int?, SummaryType?, (string path, IncludeModifier modifier)[])"/>
     public virtual Task<Bundle?> WholeSystemSearchAsync(string[]? criteria = null, string[]? includes = null, int? pageSize = null,
-        SummaryType? summary = null, string[]? revIncludes = null, CancellationToken? ct = null)
+        SummaryType? summary = null, string[]? revIncludes = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
-        return WholeSystemSearchAsync(criteria, stringToIncludeTuple(includes), pageSize, summary, stringToIncludeTuple(revIncludes), ct);
+        return WholeSystemSearchAsync(criteria, stringToIncludeTuple(includes), pageSize, summary, stringToIncludeTuple(revIncludes), ct, requestHeaders);
     }
 
     /// <summary>
@@ -238,20 +247,21 @@ public partial class BaseFhirClient
     /// <param name="summary">Optional. Whether to include only return a summary of the resources in the Bundle</param>
     /// <param name="revIncludes">Optional. A list of reverse include paths</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>A Bundle with all resources found by the search, or an empty Bundle if none were found.</returns>
-    /// <remarks>All parameters are optional, leaving all parameters empty will return an unfiltered list 
+    /// <remarks>All parameters are optional, leaving all parameters empty will return an unfiltered list
     /// of all resources of the given Resource type</remarks>
     public virtual Task<Bundle?> WholeSystemSearchUsingPostAsync(string[]? criteria, (string path, IncludeModifier modifier)[]? includes, int? pageSize,
-        SummaryType? summary, (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null)
+        SummaryType? summary, (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
-        return SearchUsingPostAsync(toQuery(criteria, includes, pageSize, summary, revIncludes), ct: ct);
+        return SearchUsingPostAsync(toQuery(criteria, includes, pageSize, summary, revIncludes), ct: ct, requestHeaders: requestHeaders);
     }
 
     ///<inheritdoc cref="WholeSystemSearchUsingPostAsync(string[], (string path, IncludeModifier modifier)[], int?, SummaryType?, (string path, IncludeModifier modifier)[])"/>
     public virtual Task<Bundle?> WholeSystemSearchUsingPostAsync(string[]? criteria = null, string[]? includes = null, int? pageSize = null,
-        SummaryType? summary = null, string[]? revIncludes = null, CancellationToken? ct = null)
+        SummaryType? summary = null, string[]? revIncludes = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
-        return WholeSystemSearchUsingPostAsync(criteria, stringToIncludeTuple(includes), pageSize, summary, stringToIncludeTuple(revIncludes), ct);
+        return WholeSystemSearchUsingPostAsync(criteria, stringToIncludeTuple(includes), pageSize, summary, stringToIncludeTuple(revIncludes), ct, requestHeaders);
     }
 
     #endregion
@@ -266,6 +276,7 @@ public partial class BaseFhirClient
     /// <param name="pageSize">Optional. Asks server to limit the number of entries per page returned</param>
     /// <param name="revIncludes">Optional. A list of reverse include paths</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <typeparam name="TResource">The type of resource to search for</typeparam>
     /// <returns>A Bundle with the BundleEntry as identified by the id parameter or an empty
     /// Bundle if the resource wasn't found.</returns>
@@ -273,18 +284,18 @@ public partial class BaseFhirClient
     /// it is possible to specify include parameters to include resources in the bundle that the
     /// returned resource refers to.</remarks>
     public virtual Task<Bundle?> SearchByIdAsync<TResource>(string id, (string path, IncludeModifier modifier)[]? includes, int? pageSize,
-        (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null) where TResource : Resource, new()
+        (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource, new()
     {
         if (id == null) throw Error.ArgumentNull(nameof(id));
 
-        return SearchByIdAsync(typeNameOrDie<TResource>(), id, includes, pageSize, revIncludes, ct);
+        return SearchByIdAsync(typeNameOrDie<TResource>(), id, includes, pageSize, revIncludes, ct, requestHeaders);
     }
 
     ///<inheritdoc cref="SearchByIdAsync{TResource}(string, (string path, IncludeModifier modifier)[], int?, (string path, IncludeModifier modifier)[])"/>
     public virtual Task<Bundle?> SearchByIdAsync<TResource>(string id, string[]? includes = null, int? pageSize = null,
-        string[]? revIncludes = null, CancellationToken? ct = null) where TResource : Resource, new()
+        string[]? revIncludes = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource, new()
     {
-        return SearchByIdAsync<TResource>(id, stringToIncludeTuple(includes), pageSize, stringToIncludeTuple(revIncludes), ct);
+        return SearchByIdAsync<TResource>(id, stringToIncludeTuple(includes), pageSize, stringToIncludeTuple(revIncludes), ct, requestHeaders);
     }
 
     /// <summary>
@@ -295,6 +306,7 @@ public partial class BaseFhirClient
     /// <param name="pageSize">Optional. Asks server to limit the number of entries per page returned</param>
     /// <param name="revIncludes">Optional. A list of reverse include paths</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <typeparam name="TResource">The type of resource to search for</typeparam>
     /// <returns>A Bundle with the BundleEntry as identified by the id parameter or an empty
     /// Bundle if the resource wasn't found.</returns>
@@ -302,18 +314,17 @@ public partial class BaseFhirClient
     /// it is possible to specify include parameters to include resources in the bundle that the
     /// returned resource refers to.</remarks>
     public virtual Task<Bundle?> SearchByIdUsingPostAsync<TResource>(string id, (string path, IncludeModifier modifier)[]? includes, int? pageSize,
-        (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null) where TResource : Resource, new()
+        (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource, new()
     {
         if (id == null) throw Error.ArgumentNull(nameof(id));
 
-        return SearchByIdUsingPostAsync(typeNameOrDie<TResource>(), id, includes, pageSize, revIncludes, ct);
+        return SearchByIdUsingPostAsync(typeNameOrDie<TResource>(), id, includes, pageSize, revIncludes, ct, requestHeaders);
     }
 
-
     public virtual Task<Bundle?> SearchByIdUsingPostAsync<TResource>(string id, string[]? includes = null, int? pageSize = null,
-        string[]? revIncludes = null, CancellationToken? ct = null) where TResource : Resource, new()
+        string[]? revIncludes = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null) where TResource : Resource, new()
     {
-        return SearchByIdUsingPostAsync<TResource>(id, stringToIncludeTuple(includes), pageSize, stringToIncludeTuple(revIncludes), ct);
+        return SearchByIdUsingPostAsync<TResource>(id, stringToIncludeTuple(includes), pageSize, stringToIncludeTuple(revIncludes), ct, requestHeaders);
     }
 
     #endregion
@@ -329,25 +340,26 @@ public partial class BaseFhirClient
     /// <param name="pageSize">Optional. Asks server to limit the number of entries per page returned</param>
     /// <param name="revIncludes">Optional. A list of reverse include paths</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>A Bundle with the BundleEntry as identified by the id parameter or an empty
     /// Bundle if the resource wasn't found.</returns>
     /// <remarks>This operation is similar to Read, but additionally,
     /// it is possible to specify include parameters to include resources in the bundle that the
     /// returned resource refers to.</remarks>
     public virtual Task<Bundle?> SearchByIdAsync(string resource, string id, (string path, IncludeModifier modifier)[]? includes, int? pageSize,
-        (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null)
+        (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (resource == null) throw Error.ArgumentNull(nameof(resource));
         if (id == null) throw Error.ArgumentNull(nameof(id));
 
         string criterium = "_id=" + id;
-        return SearchAsync(toQuery(new string[] { criterium }, includes, pageSize, summary: null, revIncludes: revIncludes), resource, ct);
+        return SearchAsync(toQuery(new string[] { criterium }, includes, pageSize, summary: null, revIncludes: revIncludes), resource, ct, requestHeaders);
     }
 
     ///<inheritdoc cref="SearchByIdAsync(string resource, string id, (string path, IncludeModifier modifier)[]? includes, int? pageSize, (string path, IncludeModifier modifier)[]? revIncludes, CancellationToken? ct = null)"/>
-    public virtual Task<Bundle?> SearchByIdAsync(string resource, string id, string[]? includes = null, int? pageSize = null, string[]? revIncludes = null, CancellationToken? ct = null)
+    public virtual Task<Bundle?> SearchByIdAsync(string resource, string id, string[]? includes = null, int? pageSize = null, string[]? revIncludes = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
-        return SearchByIdAsync(resource, id, stringToIncludeTuple(includes), pageSize, stringToIncludeTuple(revIncludes), ct);
+        return SearchByIdAsync(resource, id, stringToIncludeTuple(includes), pageSize, stringToIncludeTuple(revIncludes), ct, requestHeaders);
     }
 
     /// <summary>
@@ -359,26 +371,26 @@ public partial class BaseFhirClient
     /// <param name="pageSize">Optional. Asks server to limit the number of entries per page returned</param>
     /// <param name="revIncludes">Optional. A list of reverse include paths</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>A Bundle with the BundleEntry as identified by the id parameter or an empty
     /// Bundle if the resource wasn't found.</returns>
     /// <remarks>This operation is similar to Read, but additionally,
     /// it is possible to specify include parameters to include resources in the bundle that the
     /// returned resource refers to.</remarks>
     public virtual Task<Bundle?> SearchByIdUsingPostAsync(string resource, string id, (string path, IncludeModifier modifier)[]? includes, int? pageSize,
-        (string path, IncludeModifier modifier)[]? revIncludes = null, CancellationToken? ct = null)
+        (string path, IncludeModifier modifier)[]? revIncludes = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (resource == null) throw Error.ArgumentNull(nameof(resource));
         if (id == null) throw Error.ArgumentNull(nameof(id));
 
         string criterium = "_id=" + id;
-        return SearchUsingPostAsync(toQuery(new string[] { criterium }, includes, pageSize, summary: null, revIncludes: revIncludes), resource, ct);
+        return SearchUsingPostAsync(toQuery(new string[] { criterium }, includes, pageSize, summary: null, revIncludes: revIncludes), resource, ct, requestHeaders);
     }
 
-
     ///<inheritdoc cref="SearchByIdUsingPostAsync(string, string, (string path, IncludeModifier modifier)[], int?, (string path, IncludeModifier modifier)[])"/>
-    public virtual Task<Bundle?> SearchByIdUsingPostAsync(string resource, string id, string[]? includes = null, int? pageSize = null, string[]? revIncludes = null, CancellationToken? ct = null)
+    public virtual Task<Bundle?> SearchByIdUsingPostAsync(string resource, string id, string[]? includes = null, int? pageSize = null, string[]? revIncludes = null, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
-        return SearchByIdUsingPostAsync(resource, id, stringToIncludeTuple(includes), pageSize, stringToIncludeTuple(revIncludes));
+        return SearchByIdUsingPostAsync(resource, id, stringToIncludeTuple(includes), pageSize, stringToIncludeTuple(revIncludes), ct, requestHeaders);
     }
 
     #endregion
@@ -391,9 +403,10 @@ public partial class BaseFhirClient
     /// <param name="current">The bundle as received from the last response</param>
     /// <param name="direction">Optional. Direction to browse to, default is the next page of results.</param>
     /// <param name="ct"></param>
+    /// <param name="requestHeaders">Optional. Callback to set additional per-request HTTP headers on the outgoing request.</param>
     /// <returns>A bundle containing a new page of results based on the browse direction, or null if
     /// the server did not have more results in that direction.</returns>
-    public virtual Task<Bundle?> ContinueAsync(Bundle current, PageDirection direction = PageDirection.Next, CancellationToken? ct = null)
+    public virtual Task<Bundle?> ContinueAsync(Bundle current, PageDirection direction = PageDirection.Next, CancellationToken? ct = null, Action<HttpRequestHeaders>? requestHeaders = null)
     {
         if (current == null) throw Error.ArgumentNull(nameof(current));
         if (current.Link == null) return Task.FromResult(default(Bundle));
@@ -415,7 +428,7 @@ public partial class BaseFhirClient
         if (continueAt != null)
         {
             var tx = new TransactionBuilder(Endpoint).Get(continueAt).ToBundle();
-            return executeAsync<Bundle>(tx, HttpStatusCode.OK, ct);
+            return executeAsync<Bundle>(tx, HttpStatusCode.OK, ct, requestHeaders);
         }
         else
         {


### PR DESCRIPTION
## Summary

Closes #3298.

`FhirClient.RequestHeaders` exposes `HttpClient.DefaultRequestHeaders`, which persists across all requests and is not thread-safe. This PR adds an optional `Action<HttpRequestHeaders>? requestHeaders = null` callback as the last parameter on every public method of `BaseFhirClient` and `FhirClientSearch`. The callback is applied to the per-request `HttpRequestMessage` just before it is sent, leaving `DefaultRequestHeaders` untouched and scoped to a single call.

**Example usage:**
\`\`\`csharp
var patient = await client.ReadAsync<Patient>("Patient/1",
    requestHeaders: h => h.Authorization = new AuthenticationHeaderValue("Bearer", token));
\`\`\`

## Changes

- `BaseFhirClient.cs`: Added `requestHeaders` parameter to both private `executeAsync` overloads (applied after `ToHttpRequestMessage`/before `ExecuteAsync`) and to all ~30 public methods plus private helpers `internalUpdateAsync`, `internalHistoryAsync`, `internalOperationAsync`.
- `FhirClientSearch.cs`: Same pattern for all search and paging methods.
- Parameter is placed after `ct` to avoid breaking existing callers using positional arguments.
- XML doc `<param name="requestHeaders">` tag added to every method that had existing XML documentation.

## Test plan

- [ ] `dotnet build src/Hl7.Fhir.Base` — clean, 0 warnings, 0 errors
- [ ] Existing unit tests pass (`dotnet test` excluding `IntegrationTest` and `LongRunner` categories)
- [ ] Verify existing callers with positional/named args still compile unchanged
- [ ] Spot-check: `client.ReadAsync<Patient>("1", requestHeaders: h => h.Authorization = new AuthenticationHeaderValue("Bearer", "tok"))` compiles and the header appears on the outgoing request

🤖 Generated with [Claude Code](https://claude.com/claude-code)