### PR TITLE
Only sign NuGet packages on v* tag releases

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -158,7 +158,7 @@ stages:
         Write-Host "##[section]Metapackage packing completed successfully!"
       name: packMetapackages
       displayName: 'Pack NuGet Metapackages'    
-    - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    - ${{ if startswith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
       - template: codesign-nuget-package-using-trusted-signing.yml@templates
         parameters:
           azureServiceConnection: 'AzureTrustedSigningPrincipal'


### PR DESCRIPTION
Signing with Azure Trusted Signing is only needed when publishing to NuGet. This change ensures the signing step is skipped on regular branch builds and only runs when triggered by a `v*` release tag.