### PR TITLE
Replaced skipped occurence of LastBodyAsResource with bodyAsResource

### DIFF
--- a/src/Hl7.Fhir.Base/Rest/BaseFhirClient.cs
+++ b/src/Hl7.Fhir.Base/Rest/BaseFhirClient.cs
@@ -894,7 +894,7 @@ public partial class BaseFhirClient : IDisposable
         // NOTE: Since these lines may call GetAsync(), the executeAsync() method we're in might get called "recursively",
         // and all state (e.g. Last Result etc) will be overwritten from this point on.
         var execResult = shouldFetchFullRepresentation && result?.Location is not null ?
-            await GetAsync(result.Location).ConfigureAwait(false) : LastBodyAsResource;
+            await GetAsync(result.Location).ConfigureAwait(false) : bodyAsResource;
 
         // We have a success code (2xx), we have a body, but the body may not be of the type we expect.
         return execResult switch


### PR DESCRIPTION
## Description
Updated `extractResourceFromHttpResponse` logic in `BaseFhirClient` to replace remaining `LastBodyAsResource` with `bodyAsResource`. Sorry for missing this in  #3430 

## Related issues
- None

## Testing
- Not tested

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] Mark the PR with the label **breaking change** when this PR introduces breaking changes