### PR TITLE
Remove NoDuplicates from operations that allow for multiple params

### DIFF
--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/BaseTerminologyService.Closure.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/BaseTerminologyService.Closure.cs
@@ -21,7 +21,7 @@ public partial class BaseTerminologyService
     {
         try
         {
-            var validParams = new ClosureParameters(parameters.NoDuplicates());
+            var validParams = new ClosureParameters(parameters);
             TerminologyValidationHelpers.ValidateClosureParameters(validParams.Name, validParams.Concept, validParams.Version);
             return await Closure(validParams).ConfigureAwait(false);
         }

--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/BaseTerminologyService.Expand.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/BaseTerminologyService.Expand.cs
@@ -48,7 +48,7 @@ public partial class BaseTerminologyService
     {
         try
         {
-            var validParams = new ExpandParameters(parameters.NoDuplicates());
+            var validParams = new ExpandParameters(parameters);
             TerminologyValidationHelpers.ValidateExpandParameters(validParams.Url, validParams.ValueSet, validParams.Context, validParams.ContextDirection, validParams.Offset, validParams.Count);
             return await Expand(validParams).ConfigureAwait(false);
         }

--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/BaseTerminologyService.Lookup.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/BaseTerminologyService.Lookup.cs
@@ -49,7 +49,7 @@ public partial class BaseTerminologyService
     {
         try
         {
-            var validParams = new LookupParameters(parameters.NoDuplicates());
+            var validParams = new LookupParameters(parameters);
             TerminologyValidationHelpers.ValidateLookupParameters(validParams.Code, validParams.Coding, validParams.System);
             return await Lookup(validParams).ConfigureAwait(false);
         }


### PR DESCRIPTION
This pull request removes the use of the `NoDuplicates()` method when constructing parameter objects in terminology service methods. 
The change ensures that parameter objects are populated correctly when an operation allows multiples.
