### PR TITLE
Include canonicals in failed resolve attempts

### DIFF
--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/BaseTerminologyService.Expand.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/BaseTerminologyService.Expand.cs
@@ -65,12 +65,13 @@ public partial class BaseTerminologyService
             throw FhirOperationException.NotSupported("The 'context' parameter is not supported.");
 
         var expander = new ValueSetExpander(CreateExpanderSettings(parameters));
-        
+
+        var canonical = $"{parameters.Url!}|{parameters.ValueSetVersion?.Value}";
         var vs = parameters.ValueSet as ValueSet 
-                 ?? await ResolveValueSet(new($"{parameters.Url!}|{parameters.ValueSetVersion?.Value}")).ConfigureAwait(false);
+                 ?? await ResolveValueSet(new(canonical)).ConfigureAwait(false);
 
         if (vs is null)
-            throw FhirOperationException.Unresolvable("Unable to resolve ValueSet.");
+            throw FhirOperationException.Unresolvable($"Unable to resolve ValueSet {canonical}.");
 
         // do not regenerate expansion if already present
         if (!vs.HasExpansion)

--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/BaseTerminologyService.ValueSetValidateCode.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/BaseTerminologyService.ValueSetValidateCode.cs
@@ -59,9 +59,10 @@ public partial class BaseTerminologyService
 
     protected async virtual T.Task<ValidateCodeResult> ValueSetValidateCode(ValidateCodeParameters parameters)
     {
+        var canonical = $"{parameters.Url!}|{parameters.ValueSetVersion?.Value}";
         var valueSet = parameters.ValueSet as ValueSet
-                       ?? await ResolveValueSet(new($"{parameters.Url!}|{parameters.ValueSetVersion?.Value}")).ConfigureAwait(false)
-                       ?? throw FhirOperationException.Unresolvable("Unable to resolve ValueSet.");
+                       ?? await ResolveValueSet(new(canonical)).ConfigureAwait(false)
+                       ?? throw FhirOperationException.Unresolvable($"Unable to resolve ValueSet {canonical}.");
         
         if (parameters.CodeableConcept is not null)
             return await validateConcept(valueSet, parameters.CodeableConcept, parameters.Abstract).ConfigureAwait(false);

--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/LocalTerminologyService.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/LocalTerminologyService.cs
@@ -51,7 +51,8 @@ public class LocalTerminologyService : BaseTerminologyService
 
     protected internal override async Task<ValueSet> ResolveValueSet(Canonical canonical)
     {
-        var valueset = await _resolver.FindValueSetAsync(canonical).ConfigureAwait(false);
+        var canonicalString = canonical.ToString();
+        var valueset = await _resolver.FindValueSetAsync(canonicalString).ConfigureAwait(false);
 
         if (valueset is not null)
             return valueset;
@@ -62,7 +63,7 @@ public class LocalTerminologyService : BaseTerminologyService
         if (_resolver is ICommonConformanceSource source)
 #endif
         {
-            var cs = source.FindCodeSystemByValueSet(canonical);
+            var cs = source.FindCodeSystemByValueSet(canonicalString);
             if (cs != null)
             {
                 valueset = new()
@@ -110,7 +111,7 @@ public class LocalTerminologyService : BaseTerminologyService
             }
         }
 
-        throw FhirOperationException.Unresolvable("Unable to resolve ValueSet.");
+        throw FhirOperationException.Unresolvable($"Unable to resolve ValueSet {canonicalString}.");
     }
 
     private async Task<ValueSet> getExpandedValueSet(ValueSet vs, string operation)


### PR DESCRIPTION
## Description
As part of validator release I noticed we changed how we report the errors of resolving ValueSet, where we lost the canonical of the unresolvable ValueSet.
This PR will again add the canonical in the error message.
