### PR TITLE
Add direct ISourceNode.ToPoco() implementation

### DIFF
--- a/src/Benchmarks/DeserializationBenchmark.cs
+++ b/src/Benchmarks/DeserializationBenchmark.cs
@@ -1,6 +1,5 @@
 ﻿using BenchmarkDotNet.Attributes;
 using Hl7.Fhir.ElementModel;
-using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using System.IO;
@@ -14,10 +13,12 @@ namespace Firely.Sdk.Benchmarks
     {
         internal string JsonData;
         internal string XmlData;
+        internal SourceNode JsonSourceNode;
+        internal SourceNode XmlSourceNode;
         internal BaseFhirXmlDeserializer XmlDeserializer;
         internal BaseFhirJsonDeserializer JsonDeserializer;
-        internal XmlReader xmlreader;
-        internal JsonSerializerOptions options;
+        internal XmlReader XmlReader;
+        internal JsonSerializerOptions Options;
 
         [GlobalSetup]
         public void BenchmarkSetup()
@@ -31,7 +32,10 @@ namespace Firely.Sdk.Benchmarks
             XmlDeserializer = new FhirXmlDeserializer();
             JsonDeserializer = new FhirJsonDeserializer();
 
-            options = new JsonSerializerOptions().ForFhir();
+            JsonSourceNode = SourceNode.FromNode(FhirJsonNode.Parse(JsonData));
+            XmlSourceNode = SourceNode.FromNode(FhirXmlNode.Parse(XmlData));
+
+            Options = new JsonSerializerOptions().ForFhir();
         }
 
         [Benchmark]
@@ -39,7 +43,7 @@ namespace Firely.Sdk.Benchmarks
         {
             try
             {
-                return JsonSerializer.Deserialize<Patient>(JsonData, options);
+                return JsonSerializer.Deserialize<Patient>(JsonData, Options);
             }
             catch (DeserializationFailedException e)
             {
@@ -51,10 +55,10 @@ namespace Firely.Sdk.Benchmarks
         [Benchmark]
         public Resource XmlDictionaryDeserializer()
         {
-            xmlreader = XmlReader.Create(new StringReader(XmlData));
+            XmlReader = XmlReader.Create(new StringReader(XmlData));
             try
             {
-                return XmlDeserializer.DeserializeResource(xmlreader);
+                return XmlDeserializer.DeserializeResource(XmlReader);
             }
             catch (DeserializationFailedException e)
             {
@@ -63,16 +67,32 @@ namespace Firely.Sdk.Benchmarks
         }
 
 
-        [Benchmark]
-        public Patient TypedElementDeserializerJson()
+        [Benchmark(Baseline = true)]
+        public Patient TypedElementBridgeDeserializerJson()
         {
-            return FhirJsonNode.Parse(JsonData).ToPoco<Patient>();
+            return JsonSourceNode
+                .ToTypedElement(ModelInfo.ModelInspector)
+                .ToPoco<Patient>();
         }
 
         [Benchmark]
-        public Resource TypedElementDeserializerXml()
+        public Patient DirectSourceNodeDeserializerJson()
         {
-            return FhirXmlNode.Parse(XmlData).ToPoco<Patient>();
+            return JsonSourceNode.ToPoco<Patient>();
+        }
+
+        [Benchmark]
+        public Patient TypedElementBridgeDeserializerXml()
+        {
+            return XmlSourceNode
+                .ToTypedElement(ModelInfo.ModelInspector)
+                .ToPoco<Patient>();
+        }
+
+        [Benchmark]
+        public Patient DirectSourceNodeDeserializerXml()
+        {
+            return XmlSourceNode.ToPoco<Patient>();
         }
     }
 }

--- a/src/Benchmarks/DeserializationBenchmark.cs
+++ b/src/Benchmarks/DeserializationBenchmark.cs
@@ -55,10 +55,10 @@ namespace Firely.Sdk.Benchmarks
         [Benchmark]
         public Resource XmlDictionaryDeserializer()
         {
-            using var _xmlReader = XmlReader.Create(new StringReader(XmlData));
+            using var xmlReader = XmlReader.Create(new StringReader(XmlData));
             try
             {
-                return XmlDeserializer.DeserializeResource(_xmlReader);
+                return XmlDeserializer.DeserializeResource(xmlReader);
             }
             catch (DeserializationFailedException e)
             {
@@ -68,7 +68,7 @@ namespace Firely.Sdk.Benchmarks
 
 
         [Benchmark(Baseline = true)]
-        public Patient TypedElementBridgeDeserializerJson()
+        public Patient PocoBuilderViaBridgeJson()
         {
             return JsonSourceNode
                 .ToTypedElement(ModelInfo.ModelInspector)
@@ -76,13 +76,13 @@ namespace Firely.Sdk.Benchmarks
         }
 
         [Benchmark]
-        public Patient DirectSourceNodeDeserializerJson()
+        public Patient PocoBuilderDirectJson()
         {
             return JsonSourceNode.ToPoco<Patient>();
         }
 
         [Benchmark]
-        public Patient TypedElementBridgeDeserializerXml()
+        public Patient PocoBuilderViaBridgeXml()
         {
             return XmlSourceNode
                 .ToTypedElement(ModelInfo.ModelInspector)
@@ -90,7 +90,7 @@ namespace Firely.Sdk.Benchmarks
         }
 
         [Benchmark]
-        public Patient DirectSourceNodeDeserializerXml()
+        public Patient PocoBuilderDirectXml()
         {
             return XmlSourceNode.ToPoco<Patient>();
         }

--- a/src/Benchmarks/DeserializationBenchmark.cs
+++ b/src/Benchmarks/DeserializationBenchmark.cs
@@ -17,7 +17,7 @@ namespace Firely.Sdk.Benchmarks
         internal SourceNode XmlSourceNode;
         internal BaseFhirXmlDeserializer XmlDeserializer;
         internal BaseFhirJsonDeserializer JsonDeserializer;
-        internal XmlReader XmlReader;
+
         internal JsonSerializerOptions Options;
 
         [GlobalSetup]
@@ -55,10 +55,10 @@ namespace Firely.Sdk.Benchmarks
         [Benchmark]
         public Resource XmlDictionaryDeserializer()
         {
-            XmlReader = XmlReader.Create(new StringReader(XmlData));
+            using var _xmlReader = XmlReader.Create(new StringReader(XmlData));
             try
             {
-                return XmlDeserializer.DeserializeResource(XmlReader);
+                return XmlDeserializer.DeserializeResource(_xmlReader);
             }
             catch (DeserializationFailedException e)
             {

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.Shared.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.Shared.cs
@@ -48,7 +48,7 @@ internal partial class NewPocoBuilder
 
     private void validateEnumLiteral(object originalValue, object storedValue, ClassMapping classMapping, string location)
     {
-        if (_settings?.AllowUnrecognizedEnums == false &&
+        if (settings?.AllowUnrecognizedEnums == false &&
             classMapping.EnumType is not null &&
             storedValue is string enumLiteral &&
             EnumUtility.ParseLiteral(enumLiteral, classMapping.EnumType) == null)
@@ -76,8 +76,8 @@ internal partial class NewPocoBuilder
     }
 
     private ClassMapping getClassMapping(Type t) =>
-        _inspector.FindClassMapping(t) ??
-        (ClassMapping.TryCreate(_inspector, t, out var newMapping)
+        inspector.FindClassMapping(t) ??
+        (ClassMapping.TryCreate(inspector, t, out var newMapping)
             ? newMapping
             : throw Error.InvalidOperation($"Cannot find ClassMapping for type '{t.Name}'."));
 
@@ -153,6 +153,19 @@ internal partial class NewPocoBuilder
             var typeString = convertedValue is IDynamicType dynamicType ? dynamicType.DynamicTypeName : convertedValue.GetType().Name;
             throw Error.InvalidOperation($"Cannot assign data of type {typeString} to property '{propertyName}'.");
         }
+    }
+
+    /// <exception cref="NotSupportedException">The property type is not a Resource or DataType subclass.</exception>
+    private static ClassMapping determineBestDynamicMappingForType(Type elementType, bool hasValue)
+    {
+        if (typeof(Resource).IsAssignableFrom(elementType))
+            return ClassMapping.DynamicResource;
+        if (typeof(PrimitiveType).IsAssignableFrom(elementType) || hasValue)
+            return ClassMapping.DynamicPrimitive;
+        if (typeof(DataType).IsAssignableFrom(elementType))
+            return ClassMapping.DynamicDataType;
+
+        throw new NotSupportedException($"Cannot determine dynamic type for abstract type '{elementType.Name}'.");
     }
 
     private static object normalizePrimitiveValueForPocoStorage(object value) => value switch

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.Shared.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.Shared.cs
@@ -1,0 +1,173 @@
+#nullable enable
+
+using Hl7.Fhir.Introspection;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification;
+using Hl7.Fhir.Utility;
+using System;
+using System.Collections;
+using ET = Hl7.Fhir.ElementModel.Types;
+
+namespace Hl7.Fhir.ElementModel;
+
+internal partial class NewPocoBuilder
+{
+    private static string getMappingTypeName(ClassMapping classMapping) =>
+        ((IStructureDefinitionSummary)classMapping).TypeName;
+
+    private static void raiseFormatError(string message, string location) =>
+        throw Error.Format("While building a POCO: " + message, location);
+
+    private static Base buildNewInstance(ClassMapping mapping, bool hasValue)
+    {
+        if (hasValue && !mapping.IsFhirPrimitive)
+            return new DynamicPrimitive();
+
+        if (mapping.NativeType.IsAbstract)
+            return mapping.IsResource ? new DynamicResource() : new DynamicDataType();
+
+        if (mapping.CreateInstance() is { } b) return b;
+
+        throw Error.InvalidOperation($"Class Factory for '{mapping.Name}' did not return a " +
+                                     $"Base, which is required for " +
+                                     $"building up POCO's dynamically.");
+    }
+
+    private static void attachAnnotationsFrom(object node, Base newInstance)
+    {
+        // add a link back to the original node to persist its annotations on pocos
+        if (node is IAnnotated annotated)
+            newInstance.AddAnnotation(new TypedElementAnnotatedProvider(annotated));
+    }
+
+    private static void setDynamicTypeName(Base newInstance, string? explicitTypeName, ClassMapping classMapping)
+    {
+        if (newInstance is IDynamicType dynamicType)
+            dynamicType.DynamicTypeName = explicitTypeName ?? getMappingTypeName(classMapping);
+    }
+
+    private void validateEnumLiteral(object originalValue, object storedValue, ClassMapping classMapping, string location)
+    {
+        if (_settings?.AllowUnrecognizedEnums == false &&
+            classMapping.EnumType is not null &&
+            storedValue is string enumLiteral &&
+            EnumUtility.ParseLiteral(enumLiteral, classMapping.EnumType) == null)
+        {
+            raiseFormatError(
+                $"Literal '{originalValue}' is not a valid value for enumeration '{classMapping.EnumType.Name}'",
+                location);
+        }
+    }
+
+    private IList buildNewList(PropertyMapping? propertyMapping, Type elementType)
+    {
+        // For lists, we need to create a list of exactly the type that the property expects,
+        // if we don't know the property type, we'll just create a list of Base, so any type
+        // that we find will fit (it's going in the overflow anyway, so we can chose the
+        // type of list to use).
+        if (propertyMapping is null)
+        {
+            var elementMapping = getClassMapping(elementType);
+            return elementMapping.CreateList();
+        }
+
+        var propertyClassMapping = getClassMapping(propertyMapping.ImplementingType);
+        return propertyClassMapping.CreateList();
+    }
+
+    private ClassMapping getClassMapping(Type t) =>
+        _inspector.FindClassMapping(t) ??
+        (ClassMapping.TryCreate(_inspector, t, out var newMapping)
+            ? newMapping
+            : throw Error.InvalidOperation($"Cannot find ClassMapping for type '{t.Name}'."));
+
+    private ClassMapping getClassMapping<T>() => getClassMapping(typeof(T));
+
+    private void assignOrAddProperty(
+        string propertyName,
+        Base target,
+        Base convertedValue,
+        PropertyMapping? propertyMapping,
+        bool isCollection,
+        bool annotateAsChoice)
+    {
+        // Original inputs can contain more detailed type information than the Poco we're building now.
+        // If we had no concrete information about what to build, we may default to Dynamic types and
+        // need to retain that this value came from a choice element for correct roundtripping.
+        if (annotateAsChoice)
+            convertedValue.AddAnnotation(new ChoiceElementAnnotation());
+
+        var existing = target.TryGetValue(propertyName, out var existingValue) ? existingValue : null;
+
+        if (existing is IList list)
+        {
+            try
+            {
+                list.Add(convertedValue);
+                return;
+            }
+            catch (ArgumentException)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot add element of type '{convertedValue.GetType()}' to property '{propertyName}' of type '{list.GetType()}'.");
+            }
+        }
+
+        if (existing is not null)
+        {
+            var dynamicTypeHint = existing.GetType() != convertedValue.GetType() ? typeof(Base) : existing.GetType();
+            var newList = buildNewList(propertyMapping, dynamicTypeHint);
+            newList.Add(existing);
+            newList.Add(convertedValue);
+
+            try
+            {
+                target[propertyName] = newList;
+            }
+            catch (InvalidCastException)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot assign list of type '{newList.GetType()}' to property '{propertyName}' of type '{target.GetType()}'.");
+            }
+
+            return;
+        }
+
+        if (isCollection)
+        {
+            var newList = buildNewList(propertyMapping, convertedValue.GetType());
+            newList.Add(convertedValue);
+            target[propertyName] = newList;
+            return;
+        }
+
+        try
+        {
+            if (propertyMapping?.IsPrimitive == true && convertedValue is PrimitiveType { JsonValue: { } value })
+                target[propertyName] = value;
+            else
+                target[propertyName] = convertedValue;
+        }
+        catch (InvalidCastException)
+        {
+            var typeString = convertedValue is IDynamicType dynamicType ? dynamicType.DynamicTypeName : convertedValue.GetType().Name;
+            throw Error.InvalidOperation($"Cannot assign data of type {typeString} to property '{propertyName}'.");
+        }
+    }
+
+    private static object normalizePrimitiveValueForPocoStorage(object value) => value switch
+    {
+        // Some POCO primitive JsonValue properties store the canonical string form.
+        ET.DateTime => value.ToString()!,
+        ET.Time => value.ToString()!,
+        ET.Date => value.ToString()!,
+
+        // Integer64 uses string in the POCOs.
+        long l => new ET.Long(l).ToString(),
+
+        _ => value
+    };
+}
+
+
+

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.SourceNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.SourceNode.cs
@@ -41,7 +41,7 @@ internal partial class NewPocoBuilder
         {
             var propertyMapping = classMapping.FindMappedElementByChoiceName(child.Name);
 
-            if (propertyMapping is null && _settings?.IgnoreUnknownMembers == false)
+            if (propertyMapping is null && settings?.IgnoreUnknownMembers == false)
                 raiseFormatError($"Encountered unknown member '{child.Name}' while de-serializing", child.Location);
 
             var childClassMapping = classMappingForElement(child, propertyMapping);
@@ -69,9 +69,9 @@ internal partial class NewPocoBuilder
             return getClassMapping(typeHint);
 
         if (node.Annotation<IResourceTypeSupplier>()?.ResourceType is { } resourceType)
-            return _inspector.FindClassMapping(resourceType) is { IsResource: true } resourceMapping
+            return inspector.FindClassMapping(resourceType) is { IsResource: true } resourceMapping
                 ? resourceMapping
-                : new ClassMapping(_inspector, resourceType, typeof(DynamicResource));
+                : new ClassMapping(inspector, resourceType, typeof(DynamicResource));
 
         var propertyClassMapping = propertyMapping is not null
             ? getClassMapping(propertyMapping.GetInstantiableType())
@@ -82,10 +82,10 @@ internal partial class NewPocoBuilder
             var choiceSuffix = getChoiceTypeSuffix(node, propertyMapping);
             if (!string.IsNullOrEmpty(choiceSuffix))
             {
-                if (_inspector.FindClassMapping(choiceSuffix) is { } choiceMapping && typeof(Base).IsAssignableFrom(choiceMapping.NativeType))
+                if (inspector.FindClassMapping(choiceSuffix) is { } choiceMapping && typeof(Base).IsAssignableFrom(choiceMapping.NativeType))
                     return choiceMapping;
 
-                return new ClassMapping(_inspector, choiceSuffix, determineBestDynamicMappingForElement(node).NativeType);
+                return new ClassMapping(inspector, choiceSuffix, determineBestDynamicMappingForElement(node).NativeType);
             }
         }
 
@@ -96,9 +96,9 @@ internal partial class NewPocoBuilder
             return ClassMapping.DynamicPrimitive;
 
         if (propertyClassMapping is not null)
-            return determineBestDynamicMappingForType(node, propertyClassMapping.NativeType);
+            return determineBestDynamicMappingForType(propertyClassMapping.NativeType, node.Text is not null);
 
-        if (_inspector.FindClassMapping(node.Name) is { } exactMapping && typeof(Base).IsAssignableFrom(exactMapping.NativeType))
+        if (inspector.FindClassMapping(node.Name) is { } exactMapping && typeof(Base).IsAssignableFrom(exactMapping.NativeType))
             return exactMapping;
 
         return determineBestDynamicMappingForElement(node);
@@ -118,29 +118,17 @@ internal partial class NewPocoBuilder
         return normalizePrimitiveValueForPocoStorage(convertedValue);
     }
 
-    private static ClassMapping determineBestDynamicMappingForType(ISourceNode node, Type elementType)
-    {
-        if (typeof(Resource).IsAssignableFrom(elementType))
-            return ClassMapping.DynamicResource;
-        if (typeof(PrimitiveType).IsAssignableFrom(elementType) || node.Text is not null)
-            return ClassMapping.DynamicPrimitive;
-        if (typeof(DataType).IsAssignableFrom(elementType))
-            return ClassMapping.DynamicDataType;
-
-        throw new NotSupportedException($"Cannot determine dynamic type for abstract type '{elementType.Name}'.");
-    }
-
     private ClassMapping determineBestDynamicMappingForElement(ISourceNode node)
     {
         if (node.Annotation<IResourceTypeSupplier>()?.ResourceType is not null)
             return ClassMapping.DynamicResource;
 
-        if (_inspector.FindClassMapping(node.Name) is { } exactMapping && typeof(Base).IsAssignableFrom(exactMapping.NativeType))
+        if (inspector.FindClassMapping(node.Name) is { } exactMapping && typeof(Base).IsAssignableFrom(exactMapping.NativeType))
             return exactMapping;
 
         return node.Text is { }
-            ? new ClassMapping(_inspector, node.Name, typeof(DynamicPrimitive))
-            : new ClassMapping(_inspector, node.Name, typeof(DynamicDataType));
+            ? new ClassMapping(inspector, node.Name, typeof(DynamicPrimitive))
+            : new ClassMapping(inspector, node.Name, typeof(DynamicDataType));
     }
 }
 

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.SourceNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.SourceNode.cs
@@ -1,0 +1,147 @@
+#nullable enable
+
+using Hl7.Fhir.Introspection;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using System;
+
+namespace Hl7.Fhir.ElementModel;
+
+internal partial class NewPocoBuilder
+{
+    private Base readFromElement(ISourceNode node, ClassMapping classMapping)
+    {
+        if (node is PocoNode { Poco: { } poco } &&
+            classMapping.NativeType.IsInstanceOfType(poco) &&
+            poco is not IDynamicType)
+        {
+            return poco;
+        }
+
+        var newInstance = buildNewInstance(classMapping, node.Text is not null);
+        attachAnnotationsFrom(node, newInstance);
+        setDynamicTypeName(newInstance, node.Annotation<IResourceTypeSupplier>()?.ResourceType, classMapping);
+
+        if (node.Text is { } text)
+        {
+            var objectValue = newInstance is DynamicPrimitive
+                ? text
+                : convertSourceNodeValue(text, classMapping);
+
+            if (newInstance is PrimitiveType pt)
+                pt.JsonValue = objectValue;
+            else
+                raiseFormatError($"{node.Name} is a primitive with value '{text}', but the target POCO is a {newInstance.GetType()}, " +
+                                 $"which is not FHIR primitive.", node.Location);
+
+            validateEnumLiteral(text, objectValue, classMapping, node.Location);
+        }
+
+        foreach (var child in node.Children())
+        {
+            var propertyMapping = classMapping.FindMappedElementByChoiceName(child.Name);
+
+            if (propertyMapping is null && _settings?.IgnoreUnknownMembers == false)
+                raiseFormatError($"Encountered unknown member '{child.Name}' while de-serializing", child.Location);
+
+            var childClassMapping = classMappingForElement(child, propertyMapping);
+            var convertedValue = readFromElement(child, childClassMapping);
+            var propertyName = propertyMapping?.Name ?? child.Name;
+            var annotateAsChoice = propertyMapping?.Choice == ChoiceType.DatatypeChoice &&
+                                   propertyName != child.Name &&
+                                   convertedValue is IDynamicType;
+
+            assignOrAddProperty(
+                propertyName,
+                newInstance,
+                convertedValue,
+                propertyMapping,
+                propertyMapping?.IsCollection == true,
+                annotateAsChoice);
+        }
+
+        return newInstance;
+    }
+
+    private ClassMapping classMappingForElement(ISourceNode node, PropertyMapping? propertyMapping, Type? typeHint = null)
+    {
+        if (typeHint is not null)
+            return getClassMapping(typeHint);
+
+        if (node.Annotation<IResourceTypeSupplier>()?.ResourceType is { } resourceType)
+            return _inspector.FindClassMapping(resourceType) is { IsResource: true } resourceMapping
+                ? resourceMapping
+                : new ClassMapping(_inspector, resourceType, typeof(DynamicResource));
+
+        var propertyClassMapping = propertyMapping is not null
+            ? getClassMapping(propertyMapping.ImplementingType)
+            : null;
+
+        if (propertyMapping?.Choice == ChoiceType.DatatypeChoice)
+        {
+            var choiceSuffix = getChoiceTypeSuffix(node, propertyMapping);
+            if (!string.IsNullOrEmpty(choiceSuffix))
+            {
+                if (_inspector.FindClassMapping(choiceSuffix) is { } choiceMapping && typeof(Base).IsAssignableFrom(choiceMapping.NativeType))
+                    return choiceMapping;
+
+                return new ClassMapping(_inspector, choiceSuffix, determineBestDynamicMappingForElement(node).NativeType);
+            }
+        }
+
+        if (propertyClassMapping is { NativeType.IsAbstract: false, IsPrimitive: false })
+            return propertyClassMapping;
+
+        if (propertyMapping?.IsPrimitive == true)
+            return ClassMapping.DynamicPrimitive;
+
+        if (propertyClassMapping is not null)
+            return determineBestDynamicMappingForType(node, propertyClassMapping.NativeType);
+
+        if (_inspector.FindClassMapping(node.Name) is { } exactMapping && typeof(Base).IsAssignableFrom(exactMapping.NativeType))
+            return exactMapping;
+
+        return determineBestDynamicMappingForElement(node);
+    }
+
+    private static string getChoiceTypeSuffix(ISourceNode node, PropertyMapping propertyMapping) =>
+        node.Name.Length > propertyMapping.Name.Length
+            ? node.Name[propertyMapping.Name.Length..]
+            : string.Empty;
+
+    private static object convertSourceNodeValue(string text, ClassMapping classMapping)
+    {
+        if (classMapping.EnumType is not null || classMapping.PrimitiveValueProperty is not { } primitiveValueProperty)
+            return text;
+
+        var convertedValue = PrimitiveTypeConverter.ConvertTo(text, primitiveValueProperty.ImplementingType);
+        return normalizePrimitiveValueForPocoStorage(convertedValue);
+    }
+
+    private static ClassMapping determineBestDynamicMappingForType(ISourceNode node, Type elementType)
+    {
+        if (typeof(Resource).IsAssignableFrom(elementType))
+            return ClassMapping.DynamicResource;
+        if (typeof(PrimitiveType).IsAssignableFrom(elementType) || node.Text is not null)
+            return ClassMapping.DynamicPrimitive;
+        if (typeof(DataType).IsAssignableFrom(elementType))
+            return ClassMapping.DynamicDataType;
+
+        throw new NotSupportedException($"Cannot determine dynamic type for abstract type '{elementType.Name}'.");
+    }
+
+    private ClassMapping determineBestDynamicMappingForElement(ISourceNode node)
+    {
+        if (node.Annotation<IResourceTypeSupplier>()?.ResourceType is not null)
+            return ClassMapping.DynamicResource;
+
+        if (_inspector.FindClassMapping(node.Name) is { } exactMapping && typeof(Base).IsAssignableFrom(exactMapping.NativeType))
+            return exactMapping;
+
+        return node.Text is { }
+            ? new ClassMapping(_inspector, node.Name, typeof(DynamicPrimitive))
+            : new ClassMapping(_inspector, node.Name, typeof(DynamicDataType));
+    }
+}
+
+

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.SourceNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.SourceNode.cs
@@ -74,7 +74,7 @@ internal partial class NewPocoBuilder
                 : new ClassMapping(_inspector, resourceType, typeof(DynamicResource));
 
         var propertyClassMapping = propertyMapping is not null
-            ? getClassMapping(propertyMapping.ImplementingType)
+            ? getClassMapping(propertyMapping.GetInstantiableType())
             : null;
 
         if (propertyMapping?.Choice == ChoiceType.DatatypeChoice)

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.TypedElement.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.TypedElement.cs
@@ -13,14 +13,30 @@ internal partial class NewPocoBuilder
     private Base readFromElement(ITypedElement node, ClassMapping classMapping)
     {
         var newInstance = buildNewInstance(classMapping, node.Value is { });
+
+        // add a link back to TypedElement to persist its annotations on pocos.
+        // This is specifically for backwards compatibility with many implementations of ITypedElement
+        // wrappers that implement their own annotations. Base will then check for this annotation and
+        // call the original TypedElement.Annotations().
         attachAnnotationsFrom(node, newInstance);
+
+        // Capture the instance type if this is a dynamic type.
         setDynamicTypeName(newInstance, node.InstanceType ?? node.Annotation<IResourceTypeSupplier>()?.ResourceType, classMapping);
 
+        // Value is a kind of pseudo-property, so we need to handle it separately.
+        // If this is a standard Fhir primitive, we need to convert the ITypedElement.Value
+        // to the used ObjectValue, if not, just set the value immediately on the DynamicPrimitive.
         if (node.Value is { } value)
         {
             object objectValue;
             if (newInstance is DynamicPrimitive)
                 objectValue = value;
+            
+            // The ITypedElement is a PocoNode built with no information about the Poco — whether built
+            // with ModelInspector.Base or representing a custom resource — so it uses DynamicPrimitive
+            // to store values typed as in the serialization source. With numeric values the JsonValue
+            // will already be correct, but with strings it can represent FhirDateTime, FhirUri, etc.
+            // Now that we have the ClassMapping, convert the string to the expected primitive type.
             else if (node is PocoNode { Poco: IDynamicType } && value is string s && classMapping.PrimitiveValueProperty is not null)
                 objectValue = PrimitiveTypeConverter.ConvertTo(s, classMapping.PrimitiveValueProperty.ImplementingType);
             else
@@ -35,15 +51,21 @@ internal partial class NewPocoBuilder
             validateEnumLiteral(value, objectValue, classMapping, node.Location);
         }
 
+        // Now, read the children
         foreach (var child in node.Children())
         {
             var propertyMapping = classMapping.FindMappedElementByChoiceName(child.Name);
 
-            if (propertyMapping is null && _settings?.IgnoreUnknownMembers == false)
+            if (propertyMapping is null && settings?.IgnoreUnknownMembers == false)
                 raiseFormatError($"Encountered unknown member '{child.Name}' while de-serializing", child.Location);
 
             var childClassMapping = classMappingForElement(child, propertyMapping);
             var convertedValue = readFromElement(child, childClassMapping);
+
+            // In case the convertedValue does not agree with the actual POCO type of the property, this
+            // method will throw an InvalidCastException. Later, we could salvage the data we have so far
+            // and put it in an annotation. This will be fixed in
+            // https://github.com/FirelyTeam/firely-net-sdk/issues/2908.
             assignOrAddProperty(
                 child.Name,
                 newInstance,
@@ -59,7 +81,7 @@ internal partial class NewPocoBuilder
     private ClassMapping classMappingForElement(ITypedElement node, PropertyMapping? propertyMapping, Type? typeHint = null)
     {
         var propertyClassMapping = propertyMapping is not null
-            ? getClassMapping(propertyMapping.ImplementingType)
+            ? getClassMapping(propertyMapping.GetInstantiableType())
             : null;
 
         // we're coming from a context where original PocoNode was built without necessary
@@ -70,45 +92,46 @@ internal partial class NewPocoBuilder
             if (propertyClassMapping is { NativeType.IsAbstract: false })
                 return propertyClassMapping;
 
-            if (node.Name.Substring(propertyMapping!.Name.Length) is { Length: > 0 } choice && _inspector.FindClassMapping(choice) is { } cm)
+            if (node.Name.Substring(propertyMapping!.Name.Length) is { Length: > 0 } choice && inspector.FindClassMapping(choice) is { } cm)
                 return cm;
         }
 
+        // If we have a concrete instanceType, and it's not the same as the property type, we need to
+        // check if we have a mapping for it. If we do, we can use that.
+        // Note that this is not the same as the "best" mapping, which is determined below.
+        // We "purposefully" create the suboptimal mapping anyway so our instance type is preserved.
         if (node.InstanceType is { } instanceType)
         {
             if (instanceType == (propertyClassMapping is not null ? getMappingTypeName(propertyClassMapping) : null) ||
                 (instanceType == "code" && propertyClassMapping?.IsCodeOfT is true))
-                return propertyClassMapping!;
+                return propertyClassMapping!; // propertyClassMapping matches the instanceType, we can safely use that
 
-            if (!instanceType.StartsWith("Dynamic") && _inspector.FindClassMapping(instanceType) is { } mapping && typeof(Base).IsAssignableFrom(mapping.NativeType))
+            // try to get mapping for instanceType, but only if we're not in a dynamic context
+            if (!instanceType.StartsWith("Dynamic") && inspector.FindClassMapping(instanceType) is { } mapping && typeof(Base).IsAssignableFrom(mapping.NativeType))
                 return mapping;
         }
+
+        // Normal case: we have a property mapping and it's not abstract, so we can use the actual
+        // type used by the POCO. The "IsPrimitive" check avoids picking up .NET string mappings for
+        // Extension.url and Element.id. This can go when
+        // https://github.com/FirelyTeam/firely-net-sdk/issues/2963 is solved.
+        //
+        // Note the else here: we never return the propertyClassMapping when we have an instanceType
+        // that does not correspond to that mapping.
         else if (propertyClassMapping is { NativeType.IsAbstract: false, IsPrimitive: false })
             return propertyClassMapping;
 
+        // We don't know the type, but we know the type being requested.
         if (typeHint is not null)
             return getClassMapping(typeHint);
 
+        // No usable concrete type in the property, nor in the instance type, so create one of our
+        // dynamic flavours. If we do have an abstract type on the property, use that as a hint.
         if (propertyClassMapping is not null)
-            return determineBestDynamicMappingForType(node, propertyClassMapping.NativeType);
+            return determineBestDynamicMappingForType(propertyClassMapping.NativeType, node.Value is { });
 
+        // Failing all that, guess the best dynamic type based on the instance data.
         return determineBestDynamicMappingForElement(node);
-    }
-
-    /// <summary>
-    /// Determine the "best" dynamic type, based on the abstract type of a POCO property.
-    /// </summary>
-    /// <exception cref="NotSupportedException">The POCO's property is not a Resource or DataType subclass.</exception>
-    private ClassMapping determineBestDynamicMappingForType(ITypedElement node, Type elementType)
-    {
-        if (typeof(Resource).IsAssignableFrom(elementType))
-            return ClassMapping.DynamicResource;
-        if (typeof(PrimitiveType).IsAssignableFrom(elementType) || node.Value is { })
-            return ClassMapping.DynamicPrimitive;
-        if (typeof(DataType).IsAssignableFrom(elementType))
-            return ClassMapping.DynamicDataType;
-
-        throw new NotSupportedException($"Cannot determine dynamic type for abstract type '{elementType.Name}'.");
     }
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.TypedElement.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.TypedElement.cs
@@ -1,0 +1,148 @@
+#nullable enable
+
+using Hl7.Fhir.Introspection;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using System;
+using ET = Hl7.Fhir.ElementModel.Types;
+
+namespace Hl7.Fhir.ElementModel;
+
+internal partial class NewPocoBuilder
+{
+    private Base readFromElement(ITypedElement node, ClassMapping classMapping)
+    {
+        var newInstance = buildNewInstance(classMapping, node.Value is { });
+        attachAnnotationsFrom(node, newInstance);
+        setDynamicTypeName(newInstance, node.InstanceType ?? node.Annotation<IResourceTypeSupplier>()?.ResourceType, classMapping);
+
+        if (node.Value is { } value)
+        {
+            object objectValue;
+            if (newInstance is DynamicPrimitive)
+                objectValue = value;
+            else if (node is PocoNode { Poco: IDynamicType } && value is string s && classMapping.PrimitiveValueProperty is not null)
+                objectValue = PrimitiveTypeConverter.ConvertTo(s, classMapping.PrimitiveValueProperty.ImplementingType);
+            else
+                objectValue = normalizePrimitiveValueForPocoStorage(value);
+
+            if (newInstance is PrimitiveType pt)
+                pt.JsonValue = objectValue;
+            else
+                raiseFormatError($"{node.Name} is a primitive of type {value.GetType()}, but the target POCO is a {newInstance.GetType()}, " +
+                                 $"which is not FHIR primitive.", node.Location);
+
+            validateEnumLiteral(value, objectValue, classMapping, node.Location);
+        }
+
+        foreach (var child in node.Children())
+        {
+            var propertyMapping = classMapping.FindMappedElementByChoiceName(child.Name);
+
+            if (propertyMapping is null && _settings?.IgnoreUnknownMembers == false)
+                raiseFormatError($"Encountered unknown member '{child.Name}' while de-serializing", child.Location);
+
+            var childClassMapping = classMappingForElement(child, propertyMapping);
+            var convertedValue = readFromElement(child, childClassMapping);
+            assignOrAddProperty(
+                child.Name,
+                newInstance,
+                convertedValue,
+                propertyMapping,
+                child.Definition?.IsCollection == true || propertyMapping?.IsCollection == true,
+                propertyMapping is null && child.Definition?.IsChoiceElement is true);
+        }
+
+        return newInstance;
+    }
+
+    private ClassMapping classMappingForElement(ITypedElement node, PropertyMapping? propertyMapping, Type? typeHint = null)
+    {
+        var propertyClassMapping = propertyMapping is not null
+            ? getClassMapping(propertyMapping.ImplementingType)
+            : null;
+
+        // we're coming from a context where original PocoNode was built without necessary
+        // type information - that would result in instanceType being wrong
+        // we have type info now, we can use it to determine the type of the property
+        if (node is PocoNode { Poco: IDynamicType } && propertyClassMapping is not null)
+        {
+            if (propertyClassMapping is { NativeType.IsAbstract: false })
+                return propertyClassMapping;
+
+            if (node.Name.Substring(propertyMapping!.Name.Length) is { Length: > 0 } choice && _inspector.FindClassMapping(choice) is { } cm)
+                return cm;
+        }
+
+        if (node.InstanceType is { } instanceType)
+        {
+            if (instanceType == (propertyClassMapping is not null ? getMappingTypeName(propertyClassMapping) : null) ||
+                (instanceType == "code" && propertyClassMapping?.IsCodeOfT is true))
+                return propertyClassMapping!;
+
+            if (!instanceType.StartsWith("Dynamic") && _inspector.FindClassMapping(instanceType) is { } mapping && typeof(Base).IsAssignableFrom(mapping.NativeType))
+                return mapping;
+        }
+        else if (propertyClassMapping is { NativeType.IsAbstract: false, IsPrimitive: false })
+            return propertyClassMapping;
+
+        if (typeHint is not null)
+            return getClassMapping(typeHint);
+
+        if (propertyClassMapping is not null)
+            return determineBestDynamicMappingForType(node, propertyClassMapping.NativeType);
+
+        return determineBestDynamicMappingForElement(node);
+    }
+
+    /// <summary>
+    /// Determine the "best" dynamic type, based on the abstract type of a POCO property.
+    /// </summary>
+    /// <exception cref="NotSupportedException">The POCO's property is not a Resource or DataType subclass.</exception>
+    private ClassMapping determineBestDynamicMappingForType(ITypedElement node, Type elementType)
+    {
+        if (typeof(Resource).IsAssignableFrom(elementType))
+            return ClassMapping.DynamicResource;
+        if (typeof(PrimitiveType).IsAssignableFrom(elementType) || node.Value is { })
+            return ClassMapping.DynamicPrimitive;
+        if (typeof(DataType).IsAssignableFrom(elementType))
+            return ClassMapping.DynamicDataType;
+
+        throw new NotSupportedException($"Cannot determine dynamic type for abstract type '{elementType.Name}'.");
+    }
+
+    /// <summary>
+    /// Determine the "best" dynamic type based on the actual contents of the ITypedElement.
+    /// </summary>
+    private ClassMapping determineBestDynamicMappingForElement(ITypedElement node)
+    {
+        if (node.Value is not null || (node.InstanceType is { } it && char.IsLower(it[0])))
+            return DetermineBestPrimitiveMapping();
+
+        if (node.Annotation<IResourceTypeSupplier>()?.ResourceType is not null || node.Definition?.IsResource is true)
+            return ClassMapping.DynamicResource;
+
+        return ClassMapping.DynamicDataType;
+
+        ClassMapping DetermineBestPrimitiveMapping()
+        {
+            return node.Value switch
+            {
+                ET.DateTime => getClassMapping<FhirDateTime>(),
+                string when node.InstanceType is "System.DateTime" => getClassMapping<FhirDateTime>(),
+                ET.Date => getClassMapping<Date>(),
+                string when node.InstanceType is "System.Date" => getClassMapping<Date>(),
+                ET.Time => getClassMapping<Time>(),
+                string when node.InstanceType is "System.Time" => getClassMapping<Time>(),
+                decimal => getClassMapping<FhirDecimal>(),
+                bool => getClassMapping<FhirBoolean>(),
+                int => getClassMapping<Integer>(),
+                long => getClassMapping<Integer64>(),
+                _ => ClassMapping.DynamicPrimitive
+            };
+        }
+    }
+}
+
+
+

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
@@ -11,26 +11,30 @@
 using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
-using Hl7.Fhir.Specification;
 using Hl7.Fhir.Utility;
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Reflection;
-using ET = Hl7.Fhir.ElementModel.Types;
 
 namespace Hl7.Fhir.ElementModel;
 
 /// <summary>
 /// Traverses an <see cref="ITypedElement"/> tree and constructs a POCO from it.
 /// </summary>
-/// <param name="inspector">The inspector providing the necessary metadata about the FHIR POCO classes
-/// <param name="settings">Configuration for building the POCO.</param>
-/// used in the construction.</param>
-internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? settings = null)
+internal partial class NewPocoBuilder
 {
+    private readonly ModelInspector _inspector;
+    private readonly PocoBuilderSettings? _settings;
+
+    /// <summary>
+    /// Initializes a builder that can traverse typed or source nodes and construct POCO instances.
+    /// </summary>
+    /// <param name="inspector">The inspector providing the necessary metadata about the FHIR POCO classes used in the construction.</param>
+    /// <param name="settings">Configuration for building the POCO.</param>
+    public NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? settings = null)
+    {
+        this._inspector = inspector ?? throw Error.ArgumentNull(nameof(inspector));
+        this._settings = settings;
+    }
+
     /// <summary>
     /// Build a POCO from an <see cref="ITypedElement"/>.
     /// </summary>
@@ -42,336 +46,32 @@ internal class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? set
         return readFromElement(source, classMapping);
     }
 
-    private Base readFromElement(ITypedElement node, ClassMapping classMapping)
-    {
-        var newInstance = buildNewInstance(classMapping, node.Value is { });
-
-        // add a link back to TypedElement to persist it's annotations on pocos
-        // this is specifically for backwards compatibility with many implementations of ITypedElement wrappers that implement their own annotations
-        // Base will then check for this annotation and call the original TypedElement.Annotations()
-        if(node is IAnnotated an)
-            newInstance.AddAnnotation(new TypedElementAnnotatedProvider(an));
-
-        // Capture the instance type if this is a dynamic type.
-        if (newInstance is IDynamicType dt)
-            dt.DynamicTypeName = node.InstanceType ?? node.Annotation<IResourceTypeSupplier>()?.ResourceType ?? classMapping.GetTypeName();
-
-        // Value is a kind of pseudo-property, so we need to handle it separately.
-        // If this is a standard Fhir primitive, we need to convert the ITypedElement.Value
-        // to the used ObjectValue, if not, just set the value immediately on the DynamicPrimitive.
-        if (node.Value is { } value)
-        {
-            object objectValue;
-            if (newInstance is DynamicPrimitive)
-                objectValue = value;
-            
-            // the ITypedElement is a PocoNode built with no information about the Poco, whether built with ModelInspector.Base,
-            // or representing a custom resource - it will be using DynamicPrimitive to store the values typed as in serialization source.
-            // With numeric values the JsonValue will be already good enough, but with strings it can represent FhirDateTime, FhirUri etc.
-            // now that we have ClassMapping, we can check what is the expected primitive type and convert the string value accordingly
-            else if (node is PocoNode { Poco: IDynamicType } && value is string s && classMapping.PrimitiveValueProperty is not null)
-                objectValue = PrimitiveTypeConverter.ConvertTo(s, classMapping.PrimitiveValueProperty.ImplementingType);
-            else
-                objectValue = convertTypedElementValue(value);
-
-            if (newInstance is PrimitiveType pt)
-                pt.JsonValue = objectValue;
-            else
-                raiseFormatError($"{node.Name} is a primitive of type {value.GetType()}, but the target POCO is a {newInstance.GetType()}, " +
-                                 $"which is not FHIR primitive.", node.Location);
-
-            if (settings?.AllowUnrecognizedEnums == false &&
-                classMapping.EnumType is not null &&
-                objectValue is string enumLiteral)
-            {
-                // Backwards-compatible check for enums. Although our POCOs accept strings rather
-                // than enum values, this check is still useful for catching typos in the data and may
-                // be used by older code.
-                if (EnumUtility.ParseLiteral(enumLiteral, classMapping.EnumType) == null)
-                    raiseFormatError(
-                        $"Literal '{value}' is not a valid value for enumeration '{classMapping.EnumType.Name}'",
-                        node.Location);
-            }
-        }
-
-        // Now, read the children
-        foreach (var child in node.Children())
-        {
-            var propertyMapping = classMapping.FindMappedElementByChoiceName(child.Name);
-            
-            if (propertyMapping is null && settings?.IgnoreUnknownMembers == false)
-                raiseFormatError($"Encountered unknown member '{child.Name}' while de-serializing", child.Location);
-
-            var childClassMapping = classMappingForElement(child, propertyMapping);
-            var convertedValue = readFromElement(child, childClassMapping);
-
-            // In case the convertedValue does not agree with the actual POCO type of the property, this
-            // method will throw an InvalidCastException. Later, we could salvage
-            // the data we have so far, and put it in an annotation.
-            // This will be fixed in https://github.com/FirelyTeam/firely-net-sdk/issues/2908.
-            setOrAddProperty(child, newInstance, convertedValue, propertyMapping);
-        }
-
-        return newInstance;
-    }
-
-    private static void raiseFormatError(string message, string location)
-    {
-        throw Error.Format("While building a POCO: " + message, location);
-    }
-
-    private static Base buildNewInstance(ClassMapping mapping, bool hasValue)
-    {
-        if (hasValue && !mapping.IsFhirPrimitive)
-            return new DynamicPrimitive();
-        
-        if (mapping.NativeType.IsAbstract) 
-            return mapping.IsResource ? new DynamicResource() : new DynamicDataType();
-        
-        if (mapping.CreateInstance() is Base b) return b;
-
-        throw Error.InvalidOperation($"Class Factory for '{mapping.Name}' did not return a " +
-                                     $"Base, which is required for " +
-                                     $"building up POCO's dynamically.");
-    }
-
-    private IList buildNewList(PropertyMapping? propertyMapping, Type elementType)
-    {
-        // For lists, we need to create a list of exactly the type that the property expects,
-        // if we don't know the property type, we'll just create a list of Base, so any type
-        // that we find will fit (it's going in the overflow anyway, so we can chose the
-        // type of list to use).
-        if (propertyMapping is null)
-        {
-            var elementMapping = getClassMapping(elementType);
-            return elementMapping.CreateList();
-        }
-
-        var propertyClassMapping = getClassMapping(propertyMapping.ImplementingType);
-        return propertyClassMapping.CreateList();
-    }
-
-    private ClassMapping classMappingForElement(ITypedElement node, PropertyMapping? propertyMapping, Type? typeHint = null)
-    {
-        var propertyClassMapping = propertyMapping is not null
-            ? getClassMapping(propertyMapping.ImplementingType)
-            : null;
-
-        // we're coming from a context where original PocoNode was built without necessary
-        // type information - that would result in instanceType being wrong
-        // we have type info now, we can use it to determine the type of the property
-        if (node is PocoNode { Poco: IDynamicType } && propertyClassMapping is not null)
-        {
-            if (propertyClassMapping is { NativeType.IsAbstract: false })
-                return propertyClassMapping;
-            
-            if (node.Name.Substring(propertyMapping!.Name.Length) is { Length: > 0} choice && inspector.FindClassMapping(choice) is {} cm)
-                return cm;
-        }
-        
-        // If we have a concrete instanceType, and it's not the same as the property type, we need to
-        // check if we have a mapping for it. If we do, we can use that.
-        // Note that this is not the same as the "best" mapping, which is determined below.
-        // We "purposefully" create the suboptimal mapping anyway so our instance type is preserved.
-        if (node.InstanceType is { } instanceType)
-        {
-            if (instanceType == propertyClassMapping?.GetTypeName() || (instanceType == "code" && propertyClassMapping?.IsCodeOfT is true))
-                return propertyClassMapping; // propertyClassMapping matches the instanceType, we can safely use that
-            
-            // try to get mapping for instanceType, but only if we're not in a dynamic context
-            if (!instanceType.StartsWith("Dynamic") && inspector.FindClassMapping(instanceType) is { } mapping && typeof(Base).IsAssignableFrom(mapping.NativeType))
-                return mapping;
-        }
-
-        // Normal case, we have a property mapping, and it's not abstract, so we can use the actual
-        // type used by the POCO. The "IsPrimitive" check is a bit of a hack, and is there to avoid
-        // us coming up with .NET string mappings for Extension.url and Element.id. This can go when
-        // we have solved https://github.com/FirelyTeam/firely-net-sdk/issues/2963.
-
-        // Note the else here, since we never want to return the propertyClassMapping if we have an
-        // instanceType which does not correspond to that mapping
-        else if (propertyClassMapping is { NativeType.IsAbstract: false, IsPrimitive: false })
-            return propertyClassMapping;
-
-        // We don't know the type, but we know the type being requested
-        if (typeHint is not null)
-            return getClassMapping(typeHint);
-        
-        // No useable concrete type in the property, nor in the instance type, so we need to create
-        // one of our dynamic flavours. If we do have an abstract type of the property, we can use that
-        // as a hint.
-        if (propertyClassMapping is not null)
-            return determineBestDynamicMappingForType(node, propertyClassMapping.NativeType);
-
-        // Failing all that, guess what the best dynamic type is based on the instance data.
-        return determineBestDynamicMappingForElement(node);
-    }
-
     /// <summary>
-    /// Determine the "best" dynamic type, based on the abstract type of a POCO property.
+    /// Build a POCO from an <see cref="ISourceNode"/>.
     /// </summary>
-    /// <exception cref="NotSupportedException">The POCO's property is not a Resource or DataType
-    /// subclass.</exception>
-    private ClassMapping determineBestDynamicMappingForType(ITypedElement node, Type elementType)
+    public Base BuildFrom(ISourceNode source, Type? typeHint = null)
     {
-        if (typeof(Resource).IsAssignableFrom(elementType))
-            return ClassMapping.DynamicResource;
-        if (typeof(PrimitiveType).IsAssignableFrom(elementType) || node.Value is { })
-            return ClassMapping.DynamicPrimitive;
-        if (typeof(DataType).IsAssignableFrom(elementType))
-            return ClassMapping.DynamicDataType;
+        switch (source)
+        {
+            case null:
+                throw Error.ArgumentNull(nameof(source));
+            case PocoNode { Poco: { } poco } when
+                (typeHint is null || typeHint.IsInstanceOfType(poco)):
+                return poco;
+        }
 
-        throw new NotSupportedException($"Cannot determine dynamic type for abstract type '{elementType.Name}'.");
+        if (typeHint is null &&
+            source.Annotation<IResourceTypeSupplier>()?.ResourceType is null &&
+            _inspector.FindClassMapping(source.Name) is { } rootMapping &&
+            typeof(Base).IsAssignableFrom(rootMapping.NativeType))
+        {
+            return readFromElement(source, rootMapping);
+        }
+
+        var classMapping = classMappingForElement(source, null, isAbstractResourceType(typeHint) ? null : typeHint);
+        return readFromElement(source, classMapping);
     }
 
-    /// <summary>
-    /// Determine the "best" dynamic type based on the actual contents of the ITypedElement.
-    /// </summary>
-    private ClassMapping determineBestDynamicMappingForElement(ITypedElement node)
-    {
-        if (node.Value is not null || (node.InstanceType is { } it && char.IsLower(it[0])))
-            return determineBestPrimitiveMapping();
-
-        if (node.Annotation<IResourceTypeSupplier>()?.ResourceType is not null || node.Definition?.IsResource is true)
-            return ClassMapping.DynamicResource;
-
-        return ClassMapping.DynamicDataType;
-
-        // Instead of just picking a DynamicPrimitive, we can try to pick the best primitive type
-        // based on the ITypedElement's value.
-        ClassMapping determineBestPrimitiveMapping()
-        {
-            return node.Value switch
-            {
-                ET.DateTime => getClassMapping<FhirDateTime>(),
-                string when node.InstanceType is "System.DateTime" => getClassMapping<FhirDateTime>(),
-                ET.Date => getClassMapping<Date>(),
-                string when node.InstanceType is "System.Date" => getClassMapping<Date>(),
-                ET.Time => getClassMapping<Time>(),
-                string when node.InstanceType is "System.Time" => getClassMapping<Time>(),
-                decimal => getClassMapping<FhirDecimal>(),
-                bool => getClassMapping<FhirBoolean>(),
-                int => getClassMapping<Integer>(),
-                long => getClassMapping<Integer64>(),
-                // when TypedElement was built on a SourceNode without type information, string backed types would
-                // be unrecognizable from actual string data, so let's default to DynamicPrimitive
-                // string => getClassMapping<FhirString>(),
-                _ => ClassMapping.DynamicPrimitive
-            };
-        }
-    }
-
-    private ClassMapping getClassMapping(string dynTypeName) =>
-        inspector.FindClassMapping(dynTypeName) ??
-        throw Error.InvalidOperation($"Cannot find ClassMapping for type '{dynTypeName}'.");
-
-    private ClassMapping getClassMapping(Type t) =>
-        inspector.FindClassMapping(t) ?? 
-        (ClassMapping.TryCreate(inspector, t, out var newMapping) 
-            ? newMapping 
-            : throw Error.InvalidOperation($"Cannot find ClassMapping for type '{t.Name}'."));
-
-    private ClassMapping getClassMapping<T>() => getClassMapping(typeof(T));
-
-    private void setOrAddProperty(ITypedElement node, Base target,
-        Base convertedValue, PropertyMapping? propertyMapping)
-    {
-        // Original ITypedElement had more detailed information about the type of data it represents than the Poco we're building now.
-        // If we had no information of what to build, we will default to using Dynamic types to represent it.
-        // In this case we will annotate the Poco element with information that it is a Choice type.
-        // Then serializers will check for it to determine whether it should append the choice type to the property name when serializing it.
-        // It will allow us to serialize the Poco back to xml/json correctly, as well as build properly typed Poco
-        // when using PocoNode implementing ITypedElement/ISourceNode to call ToPoco<T>()
-        // Covered by tests PocoNodeSerializationRoundtrip.CanConvertCircularPocoNode and https://github.com/FirelyTeam/firely-net-sdk/issues/3278
-        if(propertyMapping is null && node.Definition?.IsChoiceElement is true)
-            convertedValue.AddAnnotation(new ChoiceElementAnnotation());
-        
-        var existing = target.TryGetValue(node.Name, out var existingValue) ? existingValue : null;
-
-        // If there are, just add this new value.
-        if (existing is IList list)
-        {
-            try
-            {
-                list.Add(convertedValue);
-                return;
-            }
-            catch (ArgumentException)
-            {
-                throw new InvalidOperationException(
-                    $"Cannot add element of type '{convertedValue.GetType()}' to property '{node.Name}' of type '{list.GetType()}'.");
-            }
-        }
-
-        // If we already have a value, but it's not a list, we know we are now dealing with a list.
-        // So, create a list, and add both the existing and the new value. Note that assigning a list to
-        // that same property only works if this element is in the overflow and we did not know it was a list
-        // before. In all other cases, the indexed assignment will fail.
-        if (existing is not null)
-        {
-            var dynamicTypeHint = existing.GetType() != convertedValue.GetType() ? typeof(Base) : existing.GetType();
-            var newList = buildNewList(propertyMapping, dynamicTypeHint);
-            newList.Add(existing);
-            newList.Add(convertedValue);
-
-            try
-            {
-                target[node.Name] = newList;
-            }
-            catch (InvalidCastException)
-            {
-                throw new InvalidOperationException(
-                    $"Cannot assign list of type '{newList.GetType()}' to property '{node.Name}' of type '{target.GetType()}'.");
-            }
-
-            return;
-        }
-
-        // No existing value, but we know it's a collection, so create a list and add the element.
-        if (node.Definition?.IsCollection == true || propertyMapping?.IsCollection == true)
-        {
-            var newList = buildNewList(propertyMapping, convertedValue.GetType());
-            newList.Add(convertedValue);
-
-            // This should always work, so I am not catching InvalidCastException here.
-            target[node.Name] = newList;
-            return;
-        }
-
-        // No existing value, and not a list, just set the element.
-        // Note that some exceptional primitive properties (like Extension.url and Element.id) are
-        // represented in the POCO as .NET primitives, not as FHIR datatypes, so we need to get the value out.
-        try
-        {
-            if (propertyMapping?.IsPrimitive == true && convertedValue is PrimitiveType { JsonValue: { } value })
-                target[node.Name] = value;
-            else
-                target[node.Name] = convertedValue;
-        }
-        catch (InvalidCastException)
-        {
-            var typeString = convertedValue is IDynamicType it ? it.DynamicTypeName : convertedValue.GetType().Name;
-            throw Error.InvalidOperation($"Cannot assign data of type {typeString} to property '{node.Name}'.");
-        }
-    }
-
-    /// <summary>
-    /// Convert the value of a typed element to a value that can be set on a POCO property.
-    /// </summary>
-    private static object convertTypedElementValue(object value)
-    {
-        return value switch
-        {
-            // Some ITypedElement date/time values are strings in the POCO's ObjectValue.
-            ET.DateTime => value.ToString()!,
-            ET.Time => value.ToString()!,
-            ET.Date => value.ToString()!,
-
-            // Integer64 uses string in the POCOs
-            long l => new ET.Long(l).ToString(),
-
-            // All other primitives are one-on-one convertible to their .NET counterparts.
-            _ => value
-        };
-    }
+    private static bool isAbstractResourceType(Type? typeHint) =>
+        typeHint is not null && typeof(Resource).IsAssignableFrom(typeHint) && typeHint.IsAbstract;
 }

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.cs
@@ -17,24 +17,12 @@ using System;
 namespace Hl7.Fhir.ElementModel;
 
 /// <summary>
-/// Traverses an <see cref="ITypedElement"/> tree and constructs a POCO from it.
+/// Traverses an <see cref="ITypedElement"/> or <see cref="ISourceNode"/> tree and constructs a POCO from it.
 /// </summary>
-internal partial class NewPocoBuilder
+/// <param name="inspector">The inspector providing the necessary metadata about the FHIR POCO classes used in the construction.</param>
+/// <param name="settings">Configuration for building the POCO.</param>
+internal partial class NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? settings = null)
 {
-    private readonly ModelInspector _inspector;
-    private readonly PocoBuilderSettings? _settings;
-
-    /// <summary>
-    /// Initializes a builder that can traverse typed or source nodes and construct POCO instances.
-    /// </summary>
-    /// <param name="inspector">The inspector providing the necessary metadata about the FHIR POCO classes used in the construction.</param>
-    /// <param name="settings">Configuration for building the POCO.</param>
-    public NewPocoBuilder(ModelInspector inspector, PocoBuilderSettings? settings = null)
-    {
-        this._inspector = inspector ?? throw Error.ArgumentNull(nameof(inspector));
-        this._settings = settings;
-    }
-
     /// <summary>
     /// Build a POCO from an <see cref="ITypedElement"/>.
     /// </summary>
@@ -62,7 +50,7 @@ internal partial class NewPocoBuilder
 
         if (typeHint is null &&
             source.Annotation<IResourceTypeSupplier>()?.ResourceType is null &&
-            _inspector.FindClassMapping(source.Name) is { } rootMapping &&
+            inspector.FindClassMapping(source.Name) is { } rootMapping &&
             typeof(Base).IsAssignableFrom(rootMapping.NativeType))
         {
             return readFromElement(source, rootMapping);

--- a/src/Hl7.Fhir.Base/ElementModel/SourceNodeExtensions.Conversions.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/SourceNodeExtensions.Conversions.cs
@@ -15,140 +15,162 @@ namespace Hl7.Fhir.ElementModel;
 
 public static partial class SourceNodeExtensions
 {
-    public static Base ToPoco(this ISourceNode source, ModelInspector inspector, Type pocoType = null, PocoBuilderSettings settings = null) =>
-        new LegacyPocoBuilder(inspector, settings ?? new() { AllowUnrecognizedEnums = true, IgnoreUnknownMembers = true}).BuildFrom(source, pocoType);
-
-    public static T ToPoco<T>(this ISourceNode source, ModelInspector inspector, PocoBuilderSettings settings = null) where T : Base
+    /// <param name="source">The source node to convert.</param>
+    extension(ISourceNode source)
     {
-        if (source is PocoNode { Poco: T poco })
-            return poco;
+        public Base ToPoco(ModelInspector inspector, Type pocoType = null, PocoBuilderSettings settings = null) =>
+            source is PocoNode { Poco: { } poco } && (pocoType is null || pocoType.IsAssignableFrom(poco.GetType()))
+                ? poco
+                : new NewPocoBuilder(inspector, settings ?? new() { AllowUnrecognizedEnums = true, IgnoreUnknownMembers = true }).BuildFrom(source, pocoType);
 
-        return (T)source.ToPoco(inspector, typeof(T), settings);
+        public T ToPoco<T>(ModelInspector inspector, PocoBuilderSettings settings = null) where T : Base
+        {
+            if (source is PocoNode { Poco: T poco })
+                return poco;
+
+            return (T)source.ToPoco(inspector, typeof(T), settings);
+        }
+
+        /// <summary>
+        /// Converts a source node to a PocoNode without first building a TypedElement wrapper.
+        /// </summary>
+        /// <param name="inspector">The model inspector supplying version-specific metadata.</param>
+        /// <param name="rootName">Optional. The name to use for the root node.</param>
+        public PocoNode ToPocoNode(ModelInspector inspector, string rootName = null)
+        {
+            if (source is PocoNode pocoNode && (rootName is null || pocoNode.Name == rootName))
+                return pocoNode;
+
+            return source
+                .ToPoco(inspector, settings: new PocoBuilderSettings { IgnoreUnknownMembers = true, AllowUnrecognizedEnums = true })
+                .ToPocoNode(inspector, rootName ?? source.Name);
+        }
+
+        /// <summary>
+        /// Turns the <c>ISourceNode</c> into a <see cref="ITypedElement"/> by adding type information to it.
+        /// </summary>
+        /// <param name="provider">The provider which supplies type information.</param>
+        /// <param name="type">Optional. The type of the element at the root.</param>
+        /// <param name="settings"></param>
+        /// <returns>An <see cref="ITypedElement"/> that represents the data in the node, with type information
+        /// added to it.</returns>
+        /// <remarks>This extension method decorates the <c>ISourceNode</c> with a new instance of
+        /// an <see cref="TypedElementOnSourceNode"/>, passing on the parameters of this extension method.</remarks>
+        /// <seealso cref="ITypedElement"/>
+        public ITypedElement ToTypedElement(IStructureDefinitionSummaryProvider provider, string type = null, TypedElementSettings settings = null)
+            => source as ITypedElement ?? new TypedElementOnSourceNode(source, type, provider, settings: settings ?? new TypedElementSettings() { ErrorMode = TypedElementSettings.TypeErrorMode.Passthrough });
+
+        /// <summary>
+        /// Turns the <c>ISourceNode</c> into a <see cref="ITypedElement"/> by adding type information from <see cref="ModelInspector.Base"/>.
+        /// </summary>
+        /// <returns>An <see cref="ITypedElement"/> that represents the data in the node, with type information
+        /// added to it.</returns>
+        /// <remarks>This extension method decorates the <c>ISourceNode</c> with a new instance of
+        /// an <see cref="TypedElementOnSourceNode"/>, passing on the parameters of this extension method.</remarks>
+        /// <seealso cref="ITypedElement"/>
+        public ITypedElement ToTypedElement() => source.ToTypedElement(ModelInspector.Base);
+
+        /// <summary>
+        /// Adapting an <c>ISourceNode</c> to a <see cref="ITypedElement"/> without adding type information to it.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>In contrast to <see cref="ToTypedElement(ISourceNode, IStructureDefinitionSummaryProvider, string, TypedElementSettings)"/>,
+        /// this method simulates an <c>ITypedElement</c> on top of an <c>ISourceNode</c>, without adding type information to
+        /// it. This is used internally in a few places in the API, where the component using the <c>ITypedNode</c> is aware it
+        /// cannot depend on type information being present, but should normally not be used.
+        /// </remarks>
+        [Obsolete("WARNING! For internal API use only. Turning an untyped SourceNode into an ITypedElement without providing" +
+                  "type information (see other overload) will cause side-effects with components in the API that are not prepared to deal with" +
+                  "missing type information. Please don't use this overload unless you know what you are doing.")]
+        public ITypedElement ToTypedElementLegacy() =>
+            new SourceNodeToTypedElementAdapter(source);
     }
-
-    /// <summary>
-    /// Turns the <c>ISourceNode</c> into a <see cref="ITypedElement"/> by adding type information to it.
-    /// </summary>
-    /// <param name="node">The node containing the source information.</param>
-    /// <param name="provider">The provider which supplies type information.</param>
-    /// <param name="type">Optional. The type of the element at the root.</param>
-    /// <param name="settings"></param>
-    /// <returns>An <see cref="ITypedElement"/> that represents the data in the node, with type information
-    /// added to it.</returns>
-    /// <remarks>This extension method decorates the <c>ISourceNode</c> with a new instance of
-    /// an <see cref="TypedElementOnSourceNode"/>, passing on the parameters of this extension method.</remarks>
-    /// <seealso cref="ITypedElement"/>
-    public static ITypedElement ToTypedElement(this ISourceNode node, IStructureDefinitionSummaryProvider provider, string type = null, TypedElementSettings settings = null)
-        => node as ITypedElement ?? new TypedElementOnSourceNode(node, type, provider, settings: settings ?? new TypedElementSettings() { ErrorMode = TypedElementSettings.TypeErrorMode.Passthrough });
-    
-    /// <summary>
-    /// Turns the <c>ISourceNode</c> into a <see cref="ITypedElement"/> by adding type information from <see cref="ModelInspector.Base"/>.
-    /// </summary>
-    /// <param name="node">The node containing the source information.</param>
-    /// <returns>An <see cref="ITypedElement"/> that represents the data in the node, with type information
-    /// added to it.</returns>
-    /// <remarks>This extension method decorates the <c>ISourceNode</c> with a new instance of
-    /// an <see cref="TypedElementOnSourceNode"/>, passing on the parameters of this extension method.</remarks>
-    /// <seealso cref="ITypedElement"/>
-    public static ITypedElement ToTypedElement(this ISourceNode node) => node.ToTypedElement(ModelInspector.Base);
-    
-    /// <summary>
-    /// Adapting an <c>ISourceNode</c> to a <see cref="ITypedElement"/> without adding type information to it.
-    /// </summary>
-    /// <param name="node"></param>
-    /// <returns></returns>
-    /// <remarks>In contrast to <see cref="ToTypedElement(ISourceNode, IStructureDefinitionSummaryProvider, string, TypedElementSettings)"/>,
-    /// this method simulates an <c>ITypedElement</c> on top of an <c>ISourceNode</c>, without adding type information to
-    /// it. This is used internally in a few places in the API, where the component using the <c>ITypedNode</c> is aware it
-    /// cannot depend on type information being present, but should normally not be used.
-    /// </remarks>
-    [Obsolete("WARNING! For internal API use only. Turning an untyped SourceNode into an ITypedElement without providing" +
-              "type information (see other overload) will cause side-effects with components in the API that are not prepared to deal with" +
-              "missing type information. Please don't use this overload unless you know what you are doing.")]
-    public static ITypedElement ToTypedElementLegacy(this ISourceNode node) =>
-        new SourceNodeToTypedElementAdapter(node);
 
 
     #region Xml
+
+    /// <param name="source">The instance to serialize.</param>
+    extension(ISourceNode source)
+    {
         /// <summary>
-    /// Serializes an <see cref="ISourceNode"/> instance into a FHIR Xml string.
-    /// </summary>
-    /// <param name="source">The instance to serialize.</param>
-    /// <param name="pretty">Formats and indents the serialized Xml.</param>
-    /// <remarks>Since <see cref="ISourceNode"/> has no type information, this function will throw unless
-    /// the <see cref="ISourceNode"/> originated from parsing using <see cref="FhirXmlNode"/>.</remarks>
-    public static string ToXml(this ISourceNode source, bool pretty = false)
-        => SerializationUtil.WriteXmlToString(source.WriteTo, pretty);
+        /// Serializes an <see cref="ISourceNode"/> instance into a FHIR Xml string.
+        /// </summary>
+        /// <param name="pretty">Formats and indents the serialized Xml.</param>
+        /// <remarks>Since <see cref="ISourceNode"/> has no type information, this function will throw unless
+        /// the <see cref="ISourceNode"/> originated from parsing using <see cref="FhirXmlNode"/>.</remarks>
+        public string ToXml(bool pretty = false)
+            => SerializationUtil.WriteXmlToString(source.WriteTo, pretty);
 
-    /// <inheritdoc cref="ToXml(Hl7.Fhir.ElementModel.ISourceNode,bool)"/>
-    [Obsolete("Async support will be removed in the next major release, please use the non-async version instead")]
-    public static async Task<string> ToXmlAsync(this ISourceNode source, bool pretty = false)
-        => await SerializationUtil.WriteXmlToStringAsync(source.WriteToAsync, pretty).ConfigureAwait(false);
-    
-    /// <summary>
-    /// Serializes an <see cref="ISourceNode"/> instance into a <see cref="XDocument"/>.
-    /// </summary>
-    /// <param name="source">The instance to serialize.</param>
-    /// <remarks>Since <see cref="ISourceNode"/> has no type information, this function will throw unless
-    /// the <see cref="ISourceNode"/> originated from parsing using <see cref="FhirXmlNode"/>.</remarks>
-    public static XDocument ToXDocument(this ISourceNode source) =>
-        new FhirXmlBuilder().Build(source);
-    
-    /// <summary>
-    /// Serializes an <see cref="ISourceNode"/> instance into FHIR Xml.
-    /// </summary>
-    /// <param name="source">The instance to serialize.</param>
-    /// <param name="writer">The <see cref="XmlWriter"/> to write the serialized data to.</param>
-    /// <remarks>Since <see cref="ISourceNode"/> has no type information, this function will throw unless
-    /// the <see cref="ISourceNode"/> originated from parsing using <see cref="FhirXmlNode"/>.</remarks>
-    public static void WriteTo(this ISourceNode source, XmlWriter writer) =>
-        new FhirXmlBuilder().Build(source).writeTo(writer);
+        /// <inheritdoc cref="ToXml(Hl7.Fhir.ElementModel.ISourceNode,bool)"/>
+        [Obsolete("Async support will be removed in the next major release, please use the non-async version instead")]
+        public async Task<string> ToXmlAsync(bool pretty = false)
+            => await SerializationUtil.WriteXmlToStringAsync(source.WriteToAsync, pretty).ConfigureAwait(false);
 
-    /// <inheritdoc cref="WriteTo(Hl7.Fhir.ElementModel.ISourceNode,System.Xml.XmlWriter)"/>
-    public static async Task WriteToAsync(this ISourceNode source, XmlWriter destination) =>
-        await new FhirXmlBuilder().Build(source).writeToAsync(destination).ConfigureAwait(false);
+        /// <summary>
+        /// Serializes an <see cref="ISourceNode"/> instance into a <see cref="XDocument"/>.
+        /// </summary>
+        /// <remarks>Since <see cref="ISourceNode"/> has no type information, this function will throw unless
+        /// the <see cref="ISourceNode"/> originated from parsing using <see cref="FhirXmlNode"/>.</remarks>
+        public XDocument ToXDocument() =>
+            new FhirXmlBuilder().Build(source);
+
+        /// <summary>
+        /// Serializes an <see cref="ISourceNode"/> instance into FHIR Xml.
+        /// </summary>
+        /// <param name="writer">The <see cref="XmlWriter"/> to write the serialized data to.</param>
+        /// <remarks>Since <see cref="ISourceNode"/> has no type information, this function will throw unless
+        /// the <see cref="ISourceNode"/> originated from parsing using <see cref="FhirXmlNode"/>.</remarks>
+        public void WriteTo(XmlWriter writer) =>
+            new FhirXmlBuilder().Build(source).writeTo(writer);
+
+        /// <inheritdoc cref="WriteTo(Hl7.Fhir.ElementModel.ISourceNode,System.Xml.XmlWriter)"/>
+        public async Task WriteToAsync(XmlWriter destination) =>
+            await new FhirXmlBuilder().Build(source).writeToAsync(destination).ConfigureAwait(false);
+    }
+
     #endregion
 
     #region Json
 
-    /// <summary>
-    /// Serializes an <see cref="ISourceNode"/> instance into a FHIR Json string.
-    /// </summary>
     /// <param name="source">The instance to serialize.</param>
-    /// <param name="pretty">Formats and indents the serialized Json.</param>
-    /// <remarks>Since <see cref="ISourceNode"/> has no type information, this function will throw unless
-    /// the <see cref="ISourceNode"/> originated from parsing using <see cref="FhirJsonNode"/>.</remarks>
-    public static string ToJson(this ISourceNode source, bool pretty = false)
-        => SerializationUtil.WriteJsonToString(source.WriteTo, pretty);
+    extension(ISourceNode source)
+    {
+        /// <summary>
+        /// Serializes an <see cref="ISourceNode"/> instance into a FHIR Json string.
+        /// </summary>
+        /// <param name="pretty">Formats and indents the serialized Json.</param>
+        /// <remarks>Since <see cref="ISourceNode"/> has no type information, this function will throw unless
+        /// the <see cref="ISourceNode"/> originated from parsing using <see cref="FhirJsonNode"/>.</remarks>
+        public string ToJson(bool pretty = false)
+            => SerializationUtil.WriteJsonToString(source.WriteTo, pretty);
 
-    /// <inheritdoc cref="ToJson(Hl7.Fhir.ElementModel.ISourceNode,bool)"/>
-    [Obsolete("Async support will be removed in the next major release, please use the non-async version instead")]
-    public static async Task<string> ToJsonAsync(this ISourceNode source, bool pretty = false)
-        => await SerializationUtil.WriteJsonToStringAsync(source.WriteToAsync, pretty).ConfigureAwait(false);
+        /// <inheritdoc cref="ToJson(Hl7.Fhir.ElementModel.ISourceNode,bool)"/>
+        [Obsolete("Async support will be removed in the next major release, please use the non-async version instead")]
+        public async Task<string> ToJsonAsync(bool pretty = false)
+            => await SerializationUtil.WriteJsonToStringAsync(source.WriteToAsync, pretty).ConfigureAwait(false);
 
-    /// <summary>
-    /// Serializes an <see cref="ISourceNode"/> instance into a <see cref="JObject"/>.
-    /// </summary>
-    /// <param name="source">The instance to serialize.</param>
-    /// <param name="preserveWhiteSpaceInValues">Whether to preserve whitespace in string values when serializing</param>
-    /// <remarks>Since <see cref="ISourceNode"/> has no type information, this function will throw unless
-    /// the <see cref="ISourceNode"/> originated from parsing using <see cref="FhirJsonNode"/>.</remarks>
-    public static JObject ToJObject(this ISourceNode source, bool preserveWhiteSpaceInValues = false) => new FhirJsonBuilder(preserveWhiteSpaceInValues).Build(source);
-    
-    /// <summary>
-    /// Serializes an <see cref="ISourceNode"/> instance into FHIR Json.
-    /// </summary>
-    /// <param name="source">The instance to serialize.</param>
-    /// <param name="writer">The <see cref="JsonWriter"/> to write the serialized data to.</param>
-    /// <remarks>Since <see cref="ISourceNode"/> has no type information, this function will throw unless
-    /// the <see cref="ISourceNode"/> originated from parsing using <see cref="FhirJsonNode"/>.</remarks>
-    public static void WriteTo(this ISourceNode source, JsonWriter writer) =>
-        new FhirJsonBuilder().Build(source).writeTo(writer);
+        /// <summary>
+        /// Serializes an <see cref="ISourceNode"/> instance into a <see cref="JObject"/>.
+        /// </summary>
+        /// <param name="preserveWhiteSpaceInValues">Whether to preserve whitespace in string values when serializing</param>
+        /// <remarks>Since <see cref="ISourceNode"/> has no type information, this function will throw unless
+        /// the <see cref="ISourceNode"/> originated from parsing using <see cref="FhirJsonNode"/>.</remarks>
+        public JObject ToJObject(bool preserveWhiteSpaceInValues = false) => new FhirJsonBuilder(preserveWhiteSpaceInValues).Build(source);
 
-    /// <inheritdoc cref="WriteTo(Hl7.Fhir.ElementModel.ISourceNode,Newtonsoft.Json.JsonWriter)"/>
-    [Obsolete("Async support will be removed in the next major release, please use the non-async version instead")]
-    public static async Task WriteToAsync(this ISourceNode source, JsonWriter destination) =>
-        await new FhirJsonBuilder().Build(source).writeToAsync(destination).ConfigureAwait(false);
+        /// <summary>
+        /// Serializes an <see cref="ISourceNode"/> instance into FHIR Json.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write the serialized data to.</param>
+        /// <remarks>Since <see cref="ISourceNode"/> has no type information, this function will throw unless
+        /// the <see cref="ISourceNode"/> originated from parsing using <see cref="FhirJsonNode"/>.</remarks>
+        public void WriteTo(JsonWriter writer) =>
+            new FhirJsonBuilder().Build(source).writeTo(writer);
+
+        /// <inheritdoc cref="WriteTo(Hl7.Fhir.ElementModel.ISourceNode,Newtonsoft.Json.JsonWriter)"/>
+        [Obsolete("Async support will be removed in the next major release, please use the non-async version instead")]
+        public async Task WriteToAsync(JsonWriter destination) =>
+            await new FhirJsonBuilder().Build(source).writeToAsync(destination).ConfigureAwait(false);
+    }
 
     #endregion
 }

--- a/src/Hl7.Fhir.Base/Serialization/engine/ElementModelSerializationEngine.cs
+++ b/src/Hl7.Fhir.Base/Serialization/engine/ElementModelSerializationEngine.cs
@@ -54,7 +54,7 @@ internal class ElementModelSerializationEngine(
     {
         try
         {
-            return (Resource)deserializer().ToPoco(inspector, null, pocoSettings);
+            return (Resource)new LegacyPocoBuilder(inspector, pocoSettings).BuildFrom(deserializer(), (Type)null!);
         }
         catch (FormatException fe)
         {

--- a/src/Hl7.Fhir.Shims.STU3AndUp/ElementModel/VersionedConversionExtensions.cs
+++ b/src/Hl7.Fhir.Shims.STU3AndUp/ElementModel/VersionedConversionExtensions.cs
@@ -46,37 +46,31 @@ public static class VersionedConversionExtensions
     public static ITypedElement ToTypedElement(this Base @base, string? rootName = null) =>
         @base.ToTypedElement(ModelInfo.ModelInspector, rootName);
     
-    extension(ISourceNode source)
+    public static Base ToPoco(this ISourceNode source, Type? pocoType = null, PocoBuilderSettings? settings = null) =>
+        source.ToPoco(ModelInfo.ModelInspector, pocoType, settings);
+
+    public static T ToPoco<T>(this ISourceNode source, PocoBuilderSettings? settings = null) where T : Base
     {
-        public Base ToPoco(Type? pocoType = null, PocoBuilderSettings? settings = null) =>
-            source.ToPoco(ModelInfo.ModelInspector, pocoType, settings);
+        if (source is PocoNode { Poco: T poco })
+            return poco;
 
-        public T ToPoco<T>(PocoBuilderSettings? settings = null) where T : Base
-        {
-            if (source is PocoNode { Poco: T poco })
-                return poco;
-
-            return (T)source.ToPoco(ModelInfo.ModelInspector, typeof(T), settings);
-        }
-
-        public PocoNode ToPocoNode() =>
-            source.ToPocoNode(ModelInfo.ModelInspector, source.Name);
+        return (T)source.ToPoco(ModelInfo.ModelInspector, typeof(T), settings);
     }
 
-    extension(ITypedElement element)
+    public static PocoNode ToPocoNode(this ISourceNode source) =>
+        source.ToPocoNode(ModelInfo.ModelInspector, source.Name);
+
+    public static Base ToPoco(this ITypedElement element, Type? pocoType = null, PocoBuilderSettings? settings = null) =>
+        element.ToPoco(ModelInfo.ModelInspector, pocoType, settings);
+
+    public static T ToPoco<T>(this ITypedElement element, PocoBuilderSettings? settings = null) where T : Base
     {
-        public Base ToPoco(Type? pocoType = null, PocoBuilderSettings? settings = null) =>
-            element.ToPoco(ModelInfo.ModelInspector, pocoType, settings);
+        if (element is PocoNode { Poco: T {} poco })
+            return poco;
 
-        public T ToPoco<T>(PocoBuilderSettings? settings = null) where T : Base
-        {
-            if (element is PocoNode { Poco: T {} poco })
-                return poco;
-
-            return (T)element.ToPoco(ModelInfo.ModelInspector, typeof(T), settings);
-        }
-
-        public PocoNode ToPocoNode() =>
-            element.ToPocoNode(ModelInfo.ModelInspector, element.Name);
+        return (T)element.ToPoco(ModelInfo.ModelInspector, typeof(T), settings);
     }
+
+    public static PocoNode ToPocoNode(this ITypedElement element) =>
+        element.ToPocoNode(ModelInfo.ModelInspector, element.Name);
 }

--- a/src/Hl7.Fhir.Shims.STU3AndUp/ElementModel/VersionedConversionExtensions.cs
+++ b/src/Hl7.Fhir.Shims.STU3AndUp/ElementModel/VersionedConversionExtensions.cs
@@ -46,28 +46,37 @@ public static class VersionedConversionExtensions
     public static ITypedElement ToTypedElement(this Base @base, string? rootName = null) =>
         @base.ToTypedElement(ModelInfo.ModelInspector, rootName);
     
-    public static Base ToPoco(this ISourceNode source, Type? pocoType = null, PocoBuilderSettings? settings = null) =>
-        source.ToPoco(ModelInfo.ModelInspector, pocoType, settings);
-
-    public static T ToPoco<T>(this ISourceNode source, PocoBuilderSettings? settings = null) where T : Base
+    extension(ISourceNode source)
     {
-        if (source is PocoNode { Poco: T {} poco })
-            return poco;
+        public Base ToPoco(Type? pocoType = null, PocoBuilderSettings? settings = null) =>
+            source.ToPoco(ModelInfo.ModelInspector, pocoType, settings);
 
-        return (T)source.ToPoco(ModelInfo.ModelInspector, typeof(T), settings);
+        public T ToPoco<T>(PocoBuilderSettings? settings = null) where T : Base
+        {
+            if (source is PocoNode { Poco: T poco })
+                return poco;
+
+            return (T)source.ToPoco(ModelInfo.ModelInspector, typeof(T), settings);
+        }
+
+        public PocoNode ToPocoNode() =>
+            source.ToPocoNode(ModelInfo.ModelInspector, source.Name);
     }
 
-    public static Base ToPoco(this ITypedElement element, Type? pocoType = null, PocoBuilderSettings? settings = null) =>
-        element.ToPoco(ModelInfo.ModelInspector, pocoType, settings);
-
-    public static T ToPoco<T>(this ITypedElement element, PocoBuilderSettings? settings = null) where T : Base
+    extension(ITypedElement element)
     {
-        if (element is PocoNode { Poco: T {} poco })
-            return poco;
+        public Base ToPoco(Type? pocoType = null, PocoBuilderSettings? settings = null) =>
+            element.ToPoco(ModelInfo.ModelInspector, pocoType, settings);
 
-        return (T)element.ToPoco(ModelInfo.ModelInspector, typeof(T), settings);
+        public T ToPoco<T>(PocoBuilderSettings? settings = null) where T : Base
+        {
+            if (element is PocoNode { Poco: T {} poco })
+                return poco;
+
+            return (T)element.ToPoco(ModelInfo.ModelInspector, typeof(T), settings);
+        }
+
+        public PocoNode ToPocoNode() =>
+            element.ToPocoNode(ModelInfo.ModelInspector, element.Name);
     }
-
-    public static PocoNode ToPocoNode(this ITypedElement node) =>
-        node.ToPocoNode(ModelInfo.ModelInspector, node.Name);
 }

--- a/src/Hl7.Fhir.Shims.STU3AndUp/Serialization/JsonSerializationOptionsExtensions.cs
+++ b/src/Hl7.Fhir.Shims.STU3AndUp/Serialization/JsonSerializationOptionsExtensions.cs
@@ -44,5 +44,3 @@ namespace Hl7.Fhir.Serialization
             options.ForFhir(ModelInfo.ModelInspector, converterOptions);
     }
 }
-
-#nullable restore

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/SourceNodeToPocoTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/SourceNodeToPocoTests.cs
@@ -11,8 +11,10 @@
 using FluentAssertions;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Utility;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -116,6 +118,44 @@ public class SourceNodeToPocoTests
 
         patient.Name.Should().ContainSingle();
         patient.Name[0].Should().BeSameAs(name);
+    }
+
+    [TestMethod]
+    public void DirectSourceNodeToPocoThrowsOnUnknownMemberWhenNotIgnored()
+    {
+        var patient = SourceNode.Resource("Patient", "Patient",
+            SourceNode.Valued("unknownField", "value"));
+
+        var settings = new PocoBuilderSettings { IgnoreUnknownMembers = false };
+        var act = () => patient.ToPoco(ModelInfo.ModelInspector, typeof(Patient), settings);
+
+        act.Should().Throw<FormatException>()
+            .WithMessage("*unknownField*");
+    }
+
+    [TestMethod]
+    public void DirectSourceNodeToPocoThrowsOnInvalidEnumWhenNotAllowed()
+    {
+        var patient = SourceNode.Resource("Patient", "Patient",
+            SourceNode.Valued("gender", "not-a-valid-gender"));
+
+        var settings = new PocoBuilderSettings { AllowUnrecognizedEnums = false };
+        var act = () => patient.ToPoco(ModelInfo.ModelInspector, typeof(Patient), settings);
+
+        act.Should().Throw<FormatException>()
+            .WithMessage("*not-a-valid-gender*");
+    }
+
+    [TestMethod]
+    public void BuilderIgnoresAbstractResourceTypeHintAndBuildsConcreteType()
+    {
+        var source = SourceNode.Resource("Patient", "Patient",
+            SourceNode.Valued("active", "true"));
+
+        var poco = new NewPocoBuilder(ModelInfo.ModelInspector).BuildFrom(source, typeof(Resource));
+
+        poco.Should().BeOfType<Patient>()
+            .Which.Active.Should().Be(true);
     }
 
     private static SourceNode createPatientSourceNode() =>

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/SourceNodeToPocoTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/SourceNodeToPocoTests.cs
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+#nullable enable
+
+using FluentAssertions;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Utility;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Hl7.Fhir.Tests.Model;
+
+[TestClass]
+public class SourceNodeToPocoTests
+{
+    [TestMethod]
+    public void CanConvertSourceNodeToPocoNodeDirectly()
+    {
+        var patient = createPatientSourceNode();
+
+        var pocoNode = patient.ToPocoNode(ModelInfo.ModelInspector);
+
+        pocoNode.Name.Should().Be("Patient");
+        ((ISourceNode)pocoNode).Children("deceasedBoolean").Single().Text.Should().Be("true");
+    }
+
+    [TestMethod]
+    public void DirectSourceNodeToPocoNodeMatchesTypedElementBridge()
+    {
+        var patient = SourceNode.Resource("Patient", "Patient",
+            SourceNode.Valued("active", "true"),
+            SourceNode.Valued("deceasedBoolean", "true"),
+            SourceNode.Valued("newField", "hi"),
+            SourceNode.Node("newComplex", SourceNode.Valued("child", "hello")));
+
+        var direct = patient.ToPocoNode(ModelInfo.ModelInspector);
+        var bridged = patient.ToTypedElement(ModelInfo.ModelInspector).ToPocoNode(ModelInfo.ModelInspector);
+
+        direct.ToJson().Should().Be(bridged.ToJson());
+    }
+
+    [TestMethod]
+    public void DirectSourceNodeToPocoPreservesPositionAnnotations()
+    {
+        var integer = SourceNode.Valued("valueInteger", "1");
+        integer.AddAnnotation(new PositionInfo(1, 1));
+
+        var poco = integer.ToPoco(ModelInfo.ModelInspector, typeof(Integer));
+
+        poco.Should().BeOfType<Integer>().Which.Value.Should().Be(1);
+        poco.Annotation<PositionInfo>().Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void DirectSourceNodeToPocoKeepsUnknownMembersInOverflow()
+    {
+        var patient = SourceNode.Resource("Patient", "Patient",
+            SourceNode.Valued("newField", "hi"),
+            SourceNode.Node("newComplex", SourceNode.Valued("child", "hello")));
+
+        var poco = patient.ToPoco<Patient>();
+
+        poco.TryGetValue("newField", out var newField).Should().BeTrue();
+        newField.Should().BeOfType<DynamicPrimitive>().Which.JsonValue.Should().Be("hi");
+
+        poco.TryGetValue("newComplex", out var newComplex).Should().BeTrue();
+        var dynamicType = newComplex.Should().BeOfType<DynamicDataType>().Subject;
+        dynamicType.DynamicTypeName.Should().Be("newComplex");
+        dynamicType.TryGetValue("child", out var child).Should().BeTrue();
+        child.Should().BeOfType<DynamicPrimitive>().Which.JsonValue.Should().Be("hello");
+    }
+
+    [TestMethod]
+    public void ToPocoReturnsWrappedPocoWhenSourceNodeIsAlreadyPocoNode()
+    {
+        var patient = new Patient { Active = true };
+        ISourceNode source = patient.ToPocoNode(ModelInfo.ModelInspector);
+
+        var poco = source.ToPoco(ModelInfo.ModelInspector);
+
+        poco.Should().BeSameAs(patient);
+    }
+
+    [TestMethod]
+    public void BuilderReturnsWrappedPocoWhenSourceNodeIsAlreadyPocoNode()
+    {
+        var patient = new Patient { Active = true };
+        ISourceNode source = patient.ToPocoNode(ModelInfo.ModelInspector);
+
+        var poco = new NewPocoBuilder(ModelInfo.ModelInspector).BuildFrom(source, typeof(Resource));
+
+        poco.Should().BeSameAs(patient);
+    }
+
+    [TestMethod]
+    public void ToPocoReusesCompatiblePocoNodeChildrenInsideMixedSourceTree()
+    {
+        var name = new HumanName(family: "Doe", given: ["John"]);
+        ISourceNode root = new StubSourceNode(
+            name: "Patient",
+            resourceType: "Patient",
+            children:
+            [
+                name.ToPocoNode(ModelInfo.ModelInspector, "name")
+            ]);
+
+        var patient = root.ToPoco<Patient>();
+
+        patient.Name.Should().ContainSingle();
+        patient.Name[0].Should().BeSameAs(name);
+    }
+
+    private static SourceNode createPatientSourceNode() =>
+        SourceNode.Resource("Patient", "Patient",
+            SourceNode.Valued("active", "true"),
+            SourceNode.Valued("deceasedBoolean", "true"),
+            SourceNode.Node("name",
+                SourceNode.Valued("family", "Doe"),
+                SourceNode.Valued("given", "John")));
+
+    private sealed class StubSourceNode(string name, string? text = null, string? resourceType = null, IEnumerable<ISourceNode>? children = null)
+        : ISourceNode, IResourceTypeSupplier
+    {
+        private readonly IReadOnlyList<ISourceNode> _children = children?.ToList() ?? [];
+
+        public string Name { get; } = name;
+        public string Text { get; } = text!;
+        public string Location => Name;
+        public string? ResourceType { get; } = resourceType;
+
+        public IEnumerable<ISourceNode> Children(string? name = null) =>
+            name is null ? _children : _children.Where(c => c.Name == name);
+    }
+}
+
+


### PR DESCRIPTION
## Description

This pull request introduces a direct conversion from `ISourceNode` to `Poco`. For this, it refactors the implementation of the `NewPocoBuilder` for deserializing FHIR resources from `ISourceNode` (new) and `ITypedElement` (existing) trees, and updates the deserialization benchmarks to use and compare this new approach. The changes improve the flexibility, maintainability, and correctness of POCO construction from various node types, and add more comprehensive benchmarks for deserialization strategies.

**Core NewPocoBuilder Implementation:**

- Added a new partial, internal implementation of `NewPocoBuilder`, split into `NewPocoBuilder.Shared.cs`, `NewPocoBuilder.SourceNode.cs`, and `NewPocoBuilder.TypedElement.cs`, providing robust logic for constructing POCOs from both `ISourceNode` and `ITypedElement` trees, including dynamic type resolution, property assignment, and primitive normalization.
- Fixed a bug in `classMappingForElement` (`NewPocoBuilder.SourceNode.cs`) where `propertyMapping.ImplementingType` was used to look up the class mapping. For properties with an abstract `ImplementingType` but a single concrete `FhirType` (e.g. `Signature.who` in R4, typed as `DataType` but always holding a `Reference`), the code incorrectly fell through to `DynamicDataType`. The fix uses `propertyMapping.GetInstantiableType()` instead, which resolves to the single concrete type when only one is allowed. This fixes the `RoundtripSignature.WorksWithTypedElementSerializers` test failure that surfaced after the initial changes were merged.

**Refactoring and API Improvements:**

- Changed `NewPocoBuilder` from a single file to a partial class, encapsulating logic and making the constructor public for broader usability. Also removed unused usings and cleaned up the main file.

**Benchmark Enhancements:**

- Updated `DeserializationBenchmark.cs` to add new benchmark methods for the new POCO builder, comparing direct and bridge deserialization for both JSON and XML. Removed the `XmlReader` class field (which caused a name collision with `System.Xml.XmlReader`) and replaced it with a local `using var` declaration inside `XmlDictionaryDeserializer()`, also ensuring proper disposal.

**General Code Quality:**

- Improved naming conventions for internal variables and removed unused imports for clarity and maintainability.

These changes collectively modernize and enhance the deserialization pipeline, making it easier to extend and reason about, and providing a strong foundation for future improvements.

## Related issues

## Testing

Added unit tests and benchmark tests. The fix for `Signature.who` round-trip deserialization is verified by the `RoundtripSignature.WorksWithTypedElementSerializers` test, and all 16,233 R4 serialization tests pass.

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes

<!-- START COPILOT CODING AGENT TIPS -->
---

🔒 GitHub Advanced Security automatically protects Copilot coding agent pull requests. You can protect all pull requests by enabling Advanced Security for your repositories. [Learn more about Advanced Security.](https://gh.io/cca-advanced-security)