### PR TITLE
Add ClearOverflow() to Base and fix misleading NoOverflow docstring

### DIFF
--- a/src/Hl7.Fhir.Base/Model/Base.cs
+++ b/src/Hl7.Fhir.Base/Model/Base.cs
@@ -56,6 +56,12 @@ public abstract partial class Base : IAnnotatable, INotifyPropertyChanged
     public bool HasOverflow => _overflow?.Count > 0;
 
     /// <summary>
+    /// Removes all overflow elements from this object.
+    /// </summary>
+    /// <remarks>This does not recursively clear overflow on child elements.</remarks>
+    public void ClearOverflow() => _overflow?.Clear();
+
+    /// <summary>
     /// A dictionary containing all elements that are not explicitly defined in the class.
     /// </summary>
     protected Dictionary<string, object> Overflow =>

--- a/src/Hl7.Fhir.Base/Serialization/DeserializerModes.cs
+++ b/src/Hl7.Fhir.Base/Serialization/DeserializerModes.cs
@@ -17,11 +17,18 @@ public enum DeserializationMode
     Strict,
 
     /// <summary>
-    /// In this mode, the deserializer will ignore <see cref="Recoverable"/> errors, as long as the data can
-    /// be captured in the POCO model without using "overflow". This means that in this mode, after deserialization,
-    /// all properties and primitive `Value` properties are guaranteed not to throw because of incorrect data.
-    /// Also, no unknown elements will be not be allowed, so <see cref="Base.Overflow"/> can be ignored.
+    /// In this mode, the deserializer will ignore <see cref="Recoverable"/> errors, but will still report
+    /// errors that would cause data to end up in overflow (such as unknown elements or type mismatches).
+    /// This means that if deserialization succeeds without throwing, all properties and primitive <c>Value</c>
+    /// properties are guaranteed not to throw, and <see cref="Base.HasOverflow"/> is guaranteed to be
+    /// <c>false</c> on the returned POCO.
     /// </summary>
+    /// <remarks>
+    /// Note that overflow data is still captured during parsing even in this mode. If an overflow-causing
+    /// error is encountered, an exception is thrown, but the partial result — including any overflow — can
+    /// be retrieved from the exception. Use <see cref="Recoverable"/> or <see cref="BackwardsCompatible"/>
+    /// if you want unknown elements to be silently accepted into overflow without throwing.
+    /// </remarks>
     NoOverflow,
 
     /// <summary>


### PR DESCRIPTION
Fixes #3478

## Summary
- Add `public void ClearOverflow()` to `Base` so callers can discard overflow elements after parsing
- Fix the `DeserializationMode.NoOverflow` docstring, which incorrectly implied overflow would be empty after parsing — the actual guarantee is that a successful `Deserialize()` call means `HasOverflow` is `false`; overflow is still captured during parsing and available via the exception's partial result

## Test plan
- [ ] Verify `ClearOverflow()` sets `HasOverflow` to `false`
- [ ] Review updated docstring for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)