### PR TITLE
Support for custom resources in `ModelInspector` built from `IStructureDefinitionSummary`

### DIFF
--- a/src/Hl7.Fhir.Base/ElementModel/PocoElementNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/PocoElementNode.cs
@@ -31,7 +31,7 @@ namespace Hl7.Fhir.ElementModel
         {
             Current = root;
             _inspector = inspector;
-            _myClassMapping = _inspector.FindOrImportClassMapping(root.GetType())!;
+            _myClassMapping = _inspector.FindOrImportClassMapping(root)!;
 
             InstanceType = ((IStructureDefinitionSummary)_myClassMapping).TypeName;
             Definition = ElementDefinitionSummary.ForRoot(_myClassMapping, rootName ?? root.TypeName);
@@ -46,11 +46,12 @@ namespace Hl7.Fhir.ElementModel
             Current = instance;
             _inspector = inspector;
 
-            var instanceType = definition.Choice != ChoiceType.None
-                ? instance.GetType()
-                : determineInstanceType(definition);
-            _myClassMapping = _inspector.FindOrImportClassMapping(instanceType)!;
-            InstanceType = ((IStructureDefinitionSummary)_myClassMapping).TypeName;
+            if (definition.Choice != ChoiceType.None)
+                _myClassMapping = _inspector.FindOrImportClassMapping(instance);
+            else
+                _myClassMapping = _inspector.FindOrImportClassMapping(determineInstanceType(definition));
+
+            InstanceType = ((IStructureDefinitionSummary)_myClassMapping!).TypeName;
             Definition = definition;
 
             ExceptionHandler = parent.ExceptionHandler;

--- a/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
@@ -162,6 +162,30 @@ public class ClassMapping(
         return true;
     }
 
+    internal static bool TryCreate(ModelInspector parent, IStructureDefinitionSummary summary, string mappingName,
+        [NotNullWhen(true)] out ClassMapping? result, string? canonical = null)
+    {
+        if (summary is null) throw Error.ArgumentNull(nameof(summary));
+        if (mappingName is null) throw Error.ArgumentNull(nameof(mappingName));
+
+        result = new(parent, mappingName, determineNativeType(summary),
+            declaringClass => summary.GetElements().Select(element => PropertyMapping.CreateFromSummary(declaringClass, element)))
+        {
+            Canonical = canonical,
+            IsBackboneType = summary.TypeName is "BackboneElement" or "Element",
+            TypeNameOverride = summary.TypeName,
+            IsAbstractOverride = summary.IsAbstract,
+        };
+
+        return true;
+
+        static Type determineNativeType(IStructureDefinitionSummary summary) => summary switch
+        {
+            { IsResource: true } => typeof(DynamicResource),
+            _ => typeof(DynamicDataType)
+        };
+    }
+
     /// <summary>
     /// Is <c>true</c> when this class represents a Resource datatype.
     /// </summary>
@@ -268,8 +292,15 @@ public class ClassMapping(
     }
 
     #region IStructureDefinitionSummary members
+
+    /// <summary>
+    /// Override for logic from building ClassMapping from IStructureDefinitionSummary. 
+    /// </summary>
+    internal string? TypeNameOverride { get; init; }
+    
     /// <inheritdoc />
     string IStructureDefinitionSummary.TypeName =>
+        TypeNameOverride ??
         this switch
         {
             { IsCodeOfT: true } => "code",
@@ -279,9 +310,13 @@ public class ClassMapping(
             _ => Name
         };
 
+    /// <summary>
+    /// Override for logic from building ClassMapping from IStructureDefinitionSummary. 
+    /// </summary>
+    internal bool? IsAbstractOverride { get; init; }
+
     /// <inheritdoc />
-    bool IStructureDefinitionSummary.IsAbstract =>
-        ((IStructureDefinitionSummary)this).TypeName == "BackboneElement" || NativeType.IsAbstract;
+    bool IStructureDefinitionSummary.IsAbstract => IsAbstractOverride ?? (((IStructureDefinitionSummary)this).TypeName == "BackboneElement" || NativeType.IsAbstract);
 
     /// <inheritdoc />
     bool IStructureDefinitionSummary.IsResource => IsResource;

--- a/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
@@ -16,7 +16,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
-using System.Dynamic;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -162,30 +161,6 @@ public class ClassMapping(
         return true;
     }
 
-    internal static bool TryCreate(ModelInspector parent, IStructureDefinitionSummary summary, string mappingName,
-        [NotNullWhen(true)] out ClassMapping? result, string? canonical = null)
-    {
-        if (summary is null) throw Error.ArgumentNull(nameof(summary));
-        if (mappingName is null) throw Error.ArgumentNull(nameof(mappingName));
-
-        result = new(parent, mappingName, determineNativeType(summary),
-            declaringClass => summary.GetElements().Select(element => PropertyMapping.CreateFromSummary(declaringClass, element)))
-        {
-            Canonical = canonical,
-            IsBackboneType = summary.TypeName is "BackboneElement" or "Element",
-            TypeNameOverride = summary.TypeName,
-            IsAbstractOverride = summary.IsAbstract,
-        };
-
-        return true;
-
-        static Type determineNativeType(IStructureDefinitionSummary summary) => summary switch
-        {
-            { IsResource: true } => typeof(DynamicResource),
-            _ => typeof(DynamicDataType)
-        };
-    }
-
     /// <summary>
     /// Is <c>true</c> when this class represents a Resource datatype.
     /// </summary>
@@ -292,15 +267,9 @@ public class ClassMapping(
     }
 
     #region IStructureDefinitionSummary members
-
-    /// <summary>
-    /// Override for logic from building ClassMapping from IStructureDefinitionSummary. 
-    /// </summary>
-    internal string? TypeNameOverride { get; init; }
     
     /// <inheritdoc />
     string IStructureDefinitionSummary.TypeName =>
-        TypeNameOverride ??
         this switch
         {
             { IsCodeOfT: true } => "code",
@@ -313,10 +282,10 @@ public class ClassMapping(
     /// <summary>
     /// Override for logic from building ClassMapping from IStructureDefinitionSummary. 
     /// </summary>
-    internal bool? IsAbstractOverride { get; init; }
+    public bool? IsAbstract { get; init; }
 
     /// <inheritdoc />
-    bool IStructureDefinitionSummary.IsAbstract => IsAbstractOverride ?? (((IStructureDefinitionSummary)this).TypeName == "BackboneElement" || NativeType.IsAbstract);
+    bool IStructureDefinitionSummary.IsAbstract => IsAbstract ?? (((IStructureDefinitionSummary)this).TypeName == "BackboneElement" || NativeType.IsAbstract);
 
     /// <inheritdoc />
     bool IStructureDefinitionSummary.IsResource => IsResource;

--- a/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
@@ -273,6 +273,7 @@ public class ClassMapping(
         this switch
         {
             { IsCodeOfT: true } => "code",
+            { IsBackboneType: true, IsCustomMapping: true } => "BackboneElement",
             { IsBackboneType: true } => NativeType.CanBeTreatedAsType(typeof(BackboneElement)) ?
                 "BackboneElement"
                 : "Element",

--- a/src/Hl7.Fhir.Base/Introspection/ClassMappingCollection.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMappingCollection.cs
@@ -41,7 +41,7 @@ internal class ClassMappingCollection : ICollection<ClassMapping>
         // Multiple custom resources/backbones may share the same runtime type
         // (e.g. DynamicResource / DynamicDataType), so indexing them by type would
         // make later imports overwrite earlier ones and would make type-based lookup
-        // ambiguous. Will be solved in follow up task.
+        // ambiguous.
         if (!mapping.IsCustomMapping)
             _byType[mapping.NativeType] = mapping;
 

--- a/src/Hl7.Fhir.Base/Introspection/ClassMappingCollection.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMappingCollection.cs
@@ -84,8 +84,11 @@ internal class ClassMappingCollection : ICollection<ClassMapping>
                 _byType.TryRemove(kvp.Key, out _);
         }
 
-        if (item.Canonical is not null)
-            _byCanonical.TryRemove(item.Canonical, out _);
+        foreach (var kvp in _byCanonical)
+        {
+            if (ReferenceEquals(kvp.Value, item))
+                _byCanonical.TryRemove(kvp.Key, out _);
+        }
 
         return true;
     }
@@ -115,6 +118,17 @@ internal class ClassMappingCollection : ICollection<ClassMapping>
     public void RegisterTypeAlias(Type type, ClassMapping mapping)
     {
         _byType[type] = mapping;
+    }
+
+    /// <summary>
+    /// Registers a canonical alias for an existing <see cref="ClassMapping"/>.
+    /// Unlike <see cref="Add"/>, this only updates the canonical lookup and does not affect the
+    /// name or type dictionaries. This is used when a mapping is first imported by name and later
+    /// associated with a canonical identifier.
+    /// </summary>
+    public void RegisterCanonicalAlias(string canonical, ClassMapping mapping)
+    {
+        _byCanonical[canonical] = mapping;
     }
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/Introspection/ClassMappingCollection.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMappingCollection.cs
@@ -37,7 +37,13 @@ internal class ClassMappingCollection : ICollection<ClassMapping>
         var propKey = mapping.Name;
         _byName[propKey] = mapping;
 
-        _byType[mapping.NativeType] = mapping;
+        // Custom mappings intentionally do not participate in the type index.
+        // Multiple custom resources/backbones may share the same runtime type
+        // (e.g. DynamicResource / DynamicDataType), so indexing them by type would
+        // make later imports overwrite earlier ones and would make type-based lookup
+        // ambiguous. Will be solved in follow up task.
+        if (!mapping.IsCustomMapping)
+            _byType[mapping.NativeType] = mapping;
 
         var canonical = mapping.Canonical;
         if (canonical is not null)

--- a/src/Hl7.Fhir.Base/Introspection/ClassMappingCollection.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMappingCollection.cs
@@ -84,11 +84,8 @@ internal class ClassMappingCollection : ICollection<ClassMapping>
                 _byType.TryRemove(kvp.Key, out _);
         }
 
-        foreach (var kvp in _byCanonical)
-        {
-            if (ReferenceEquals(kvp.Value, item))
-                _byCanonical.TryRemove(kvp.Key, out _);
-        }
+        if (item.Canonical is not null)
+            _byCanonical.TryRemove(item.Canonical, out _);
 
         return true;
     }
@@ -118,17 +115,6 @@ internal class ClassMappingCollection : ICollection<ClassMapping>
     public void RegisterTypeAlias(Type type, ClassMapping mapping)
     {
         _byType[type] = mapping;
-    }
-
-    /// <summary>
-    /// Registers a canonical alias for an existing <see cref="ClassMapping"/>.
-    /// Unlike <see cref="Add"/>, this only updates the canonical lookup and does not affect the
-    /// name or type dictionaries. This is used when a mapping is first imported by name and later
-    /// associated with a canonical identifier.
-    /// </summary>
-    public void RegisterCanonicalAlias(string canonical, ClassMapping mapping)
-    {
-        _byCanonical[canonical] = mapping;
     }
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
@@ -402,8 +402,7 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
             FindClassMappingByCanonical(canonical)
             : FindClassMapping(canonical);
 
-    private static bool isCanonical(string value) =>
-        Uri.TryCreate(value, UriKind.Absolute, out _);
+    private static bool isCanonical(string value) => value.Contains('/');
 
     #region IModelInfo
 

--- a/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
@@ -30,7 +30,7 @@ namespace Hl7.Fhir.Introspection;
 public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
 {
     private static readonly ConcurrentDictionary<string, ModelInspector> _inspectedAssemblies = new();
-    
+
     // Cache for assembly-level FhirModelAssemblyAttribute to avoid repeated reflection calls
     private static readonly ConcurrentDictionary<Assembly, FhirModelAssemblyAttribute?> _assemblyAttributeCache = new();
 
@@ -249,39 +249,6 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
 
         var nestedClasses = nestedTypes.Where(t => t is { IsClass: true, IsEnum: false });
         extractBackbonesFromClasses(nestedClasses);
-
-        return newMapping;
-    }
-
-    /// <summary>
-    /// Imports FHIR metadata from a <see cref="IStructureDefinitionSummary"/>.
-    /// This is primarily intended for custom resources/types that are backed by dynamic POCOs.
-    /// </summary>
-    public ClassMapping Import(IStructureDefinitionSummary summary, string? canonical = null) =>
-        Import(summary, summary.TypeName, canonical);
-
-    internal ClassMapping Import(IStructureDefinitionSummary summary, string mappingName, string? canonical = null)
-    {
-        if (summary is null) throw Error.ArgumentNull(nameof(summary));
-        if (mappingName is null) throw Error.ArgumentNull(nameof(mappingName));
-
-        if (canonical is not null && FindClassMappingByCanonical(canonical) is { } existingByCanonical)
-            return existingByCanonical;
-
-        if (FindClassMapping(mappingName) is { } existingByName)
-        {
-            if (canonical is null)
-                return existingByName;
-
-            // register the canonical for the mapping as well
-            _classMappings.RegisterCanonicalAlias(canonical, existingByName);
-            return existingByName;
-        }
-
-        if (!ClassMapping.TryCreate(this, summary, mappingName, out var newMapping, canonical))
-            throw new InvalidOperationException($"Could not create a class mapping for summary '{mappingName}'.");
-
-        _classMappings.Add(newMapping);
 
         return newMapping;
     }

--- a/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
@@ -204,8 +204,8 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
     
     private ClassMapping? importType(Base instance)
     {
-        if (instance is IDynamicType { DynamicTypeName: {} typeName } && !string.IsNullOrWhiteSpace(typeName))
-            return FindClassMapping(typeName);
+        if (instance is IDynamicType { DynamicTypeName: {} typeName } && !string.IsNullOrWhiteSpace(typeName) && FindClassMapping(typeName) is {} cm)
+            return cm;
 
         return ImportType(instance.GetType());
     }

--- a/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
@@ -201,6 +201,14 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
             .Distinct()
             .ToList()!;
     }
+    
+    private ClassMapping? importType(Base instance)
+    {
+        if (instance is IDynamicType { DynamicTypeName: {} typeName } && !string.IsNullOrWhiteSpace(typeName))
+            return FindClassMapping(typeName);
+
+        return ImportType(instance.GetType());
+    }
 
     /// <summary>
     /// Extracts the FHIR metadata from a <see cref="Type"/> into a <see cref="ClassMapping"/> and
@@ -348,6 +356,13 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
     /// </summary>
     /// <returns>May return <c>null</c> if the type cannot be imported.</returns>
     public ClassMapping? FindOrImportClassMapping(Type nativeType) => ImportType(nativeType);
+    
+    /// <summary>
+    /// Tries to retrieve an already imported <see cref="ClassMapping"/> and will import
+    /// it when not found.
+    /// </summary>
+    /// <returns>May return <c>null</c> if the mapping is not know and type cannot be imported.</returns>
+    public ClassMapping? FindOrImportClassMapping(Base instance) => importType(instance);
 
     /// <summary>
     /// Retrieves an already imported <see cref="ClassMapping" /> given a FHIR type name.
@@ -355,6 +370,17 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
     /// <remarks>The search for the mapping by namem is case-insensitive.</remarks>
     public ClassMapping? FindClassMapping(string fhirTypeName) =>
         _classMappings.ByName.GetValueOrDefault(fhirTypeName);
+    
+    /// <summary>
+    /// Retrieves an already imported <see cref="ClassMapping" /> given an instance of a FHIR type.
+    /// </summary>
+    public ClassMapping? FindClassMapping(Base instance)
+    {
+        if(instance is IDynamicType { DynamicTypeName: {} typeName} && !string.IsNullOrWhiteSpace(typeName))
+            return FindClassMapping(typeName);
+        
+        return FindClassMapping(instance.GetType());
+    }
 
     /// <summary>
     /// Retrieves an already imported <see cref="ClassMapping" /> given a Type.

--- a/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
@@ -246,6 +246,32 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
     }
 
     /// <summary>
+    /// Imports FHIR metadata from a <see cref="IStructureDefinitionSummary"/>.
+    /// This is primarily intended for custom resources/types that are backed by dynamic POCOs.
+    /// </summary>
+    public ClassMapping Import(IStructureDefinitionSummary summary, string? canonical = null) =>
+        Import(summary, summary.TypeName, canonical);
+
+    internal ClassMapping Import(IStructureDefinitionSummary summary, string mappingName, string? canonical = null)
+    {
+        if (summary is null) throw Error.ArgumentNull(nameof(summary));
+        if (mappingName is null) throw Error.ArgumentNull(nameof(mappingName));
+
+        if (canonical is not null && FindClassMappingByCanonical(canonical) is { } existingByCanonical)
+            return existingByCanonical;
+
+        if (FindClassMapping(mappingName) is { } existingByName)
+            return existingByName;
+
+        if (!ClassMapping.TryCreate(this, summary, mappingName, out var newMapping, canonical))
+            throw new InvalidOperationException($"Could not create a class mapping for summary '{mappingName}'.");
+
+        _classMappings.Add(newMapping);
+
+        return newMapping;
+    }
+
+    /// <summary>
     /// Validates that a type being imported is compatible with this ModelInspector's FHIR release.
     /// </summary>
     /// <param name="type">The type being imported</param>

--- a/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
@@ -261,7 +261,14 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
             return existingByCanonical;
 
         if (FindClassMapping(mappingName) is { } existingByName)
+        {
+            if (canonical is null)
+                return existingByName;
+
+            // register the canonical for the mapping as well
+            _classMappings.RegisterCanonicalAlias(canonical, existingByName);
             return existingByName;
+        }
 
         if (!ClassMapping.TryCreate(this, summary, mappingName, out var newMapping, canonical))
             throw new InvalidOperationException($"Could not create a class mapping for summary '{mappingName}'.");
@@ -398,9 +405,12 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
 
     /// <inheritdoc cref="IStructureDefinitionSummaryProvider.Provide(string)"/>
     public IStructureDefinitionSummary? Provide(string canonical) =>
-        canonical.Contains('/') ?
+        isCanonical(canonical) ?
             FindClassMappingByCanonical(canonical)
             : FindClassMapping(canonical);
+
+    private static bool isCanonical(string value) =>
+        Uri.TryCreate(value, UriKind.Absolute, out _);
 
     #region IModelInfo
 

--- a/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
@@ -370,10 +370,12 @@ public class PropertyMapping : IElementDefinitionSummary
         }
 
         ClassMapping resolveExistingMapping(string typeName) =>
-            (typeName.Contains('/')
+            (isCanonical(typeName)
                 ? declaringClass.Inspector.FindClassMappingByCanonical(typeName)
                 : declaringClass.Inspector.FindClassMapping(typeName))
             ?? throw new InvalidOperationException($"Cannot find a class mapping for summary type '{typeName}' on element '{declaringClass.Name}.{elementSummary.ElementName}'.");
+
+        static bool isCanonical(string value) => Uri.TryCreate(value, UriKind.Absolute, out _);
 
         static Type determineImplementingType(Type[] nativeTypes, ChoiceType choice) => choice switch
         {

--- a/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
@@ -71,6 +71,17 @@ public class PropertyMapping : IElementDefinitionSummary
         _propertyType = propertyType;
     }
 
+    [SetsRequiredMembers]
+    private PropertyMapping(ClassMapping declaringClass, string name, Type propertyType, ClassMapping propertyTypeMapping,
+        Type implementingType, Type[] fhirTypes)
+        : this(declaringClass, name, nativeProperty: null!)
+    {
+        PropertyTypeMapping = propertyTypeMapping;
+        ImplementingType = implementingType;
+        FhirType = fhirTypes;
+        _propertyType = propertyType;
+    }
+
     /// <summary>
     /// Returns <c>true</c> when this class is a custom mapping, basically a dynamic resource/type with
     /// its own name, not being the default "DynamicType" or "DynamicResource".
@@ -127,6 +138,8 @@ public class PropertyMapping : IElementDefinitionSummary
     /// <remarks>This is effectively the ClassMapping for the <see cref="ImplementingType" /> unless a
     /// <see cref="AllowedTypesAttribute" /> specifies otherwise.</remarks>
     public required ClassMapping PropertyTypeMapping { get; init; }
+
+    private ITypeSerializationInfo[]? TypeSerializationInfos { get; init; }
 
     /// <summary>
     /// Whether the element can repeat.
@@ -200,6 +213,10 @@ public class PropertyMapping : IElementDefinitionSummary
     /// For a bound element, this is the name of the binding.
     /// </summary>
     public string? BindingName { get; init; }
+
+    internal string? DefaultTypeNameOverride { get; init; }
+
+    internal string? NonDefaultNamespaceOverride { get; init; }
 
     /// <summary>
     /// The <see cref="ModelInspector"/> for which this mapping was created.
@@ -277,6 +294,95 @@ public class PropertyMapping : IElementDefinitionSummary
         };
 
         return true;
+    }
+
+    internal static PropertyMapping CreateFromSummary(ClassMapping declaringClass, IElementDefinitionSummary elementSummary)
+    {
+        if (declaringClass is null) throw Error.ArgumentNull(nameof(declaringClass));
+        if (elementSummary is null) throw Error.ArgumentNull(nameof(elementSummary));
+
+        var resolvedTypes = elementSummary.Type.Select(resolveTypeInfo).ToArray();
+
+        if (resolvedTypes.Length == 0)
+            throw new InvalidOperationException($"Element '{declaringClass.Name}.{elementSummary.ElementName}' does not declare any types.");
+
+        var choice = elementSummary.IsResource
+            ? ChoiceType.ResourceChoice
+            : elementSummary.IsChoiceElement
+                ? ChoiceType.DatatypeChoice
+                : ChoiceType.None;
+
+        var implementingType = determineImplementingType(resolvedTypes.Select(rt => rt.Mapping.NativeType).Distinct().ToArray(), choice);
+        var propertyTypeMapping = choice == ChoiceType.None
+            ? resolvedTypes[0].Mapping
+            : declaringClass.Inspector.FindOrImportClassMapping(implementingType)
+                ?? throw new InvalidOperationException($"Cannot find a class mapping for summary element '{declaringClass.Name}.{elementSummary.ElementName}' implementing type '{implementingType.Name}'.");
+
+        var propertyType = elementSummary.IsCollection
+            ? typeof(List<>).MakeGenericType(implementingType)
+            : implementingType;
+
+        return new(
+            declaringClass,
+            elementSummary.ElementName,
+            propertyType,
+            propertyTypeMapping,
+            implementingType,
+            resolvedTypes.Select(rt => rt.Mapping.NativeType).Distinct().ToArray())
+        {
+            Choice = choice,
+            IsCollection = elementSummary.IsCollection,
+            IsMandatoryElement = elementSummary.IsRequired,
+            InSummary = elementSummary.InSummary,
+            IsModifier = elementSummary.IsModifier,
+            SerializationHint = elementSummary.Representation,
+            Order = elementSummary.Order,
+            TypeSerializationInfos = resolvedTypes.Select(rt => rt.TypeInfo).ToArray(),
+            DefaultTypeNameOverride = elementSummary.DefaultTypeName,
+            NonDefaultNamespaceOverride = elementSummary.NonDefaultNamespace,
+        };
+
+        ResolvedTypeInfo resolveTypeInfo(ITypeSerializationInfo typeInfo) => typeInfo switch
+        {
+            IStructureDefinitionSummary summary => importSummaryType(summary),
+            IStructureDefinitionReference reference => importReferencedType(reference),
+            _ => throw Error.NotSupported($"Don't know how to derive property type information from type {typeInfo.GetType()}")
+        };
+
+        ResolvedTypeInfo importSummaryType(IStructureDefinitionSummary summary)
+        {
+            var mappingName = summary.TypeName is "BackboneElement" or "Element"
+                ? $"{declaringClass.Name}.{elementSummary.ElementName}"
+                : summary.TypeName;
+
+            var mapping = declaringClass.Inspector.Import(summary, mappingName, canonical: null);
+            var exportedTypeInfo = mapping.IsBackboneType
+                ? (ITypeSerializationInfo)mapping
+                : new PocoTypeReferenceInfo(((IStructureDefinitionSummary)mapping).TypeName);
+
+            return new ResolvedTypeInfo(mapping, exportedTypeInfo);
+        }
+
+        ResolvedTypeInfo importReferencedType(IStructureDefinitionReference reference)
+        {
+            var mapping = resolveExistingMapping(reference.ReferredType);
+            return new ResolvedTypeInfo(mapping, new PocoTypeReferenceInfo(reference.ReferredType));
+        }
+
+        ClassMapping resolveExistingMapping(string typeName) =>
+            (typeName.Contains('/')
+                ? declaringClass.Inspector.FindClassMappingByCanonical(typeName)
+                : declaringClass.Inspector.FindClassMapping(typeName))
+            ?? throw new InvalidOperationException($"Cannot find a class mapping for summary type '{typeName}' on element '{declaringClass.Name}.{elementSummary.ElementName}'.");
+
+        static Type determineImplementingType(Type[] nativeTypes, ChoiceType choice) => choice switch
+        {
+            ChoiceType.ResourceChoice => typeof(Resource),
+            ChoiceType.DatatypeChoice => nativeTypes.All(t => typeof(PrimitiveType).IsAssignableFrom(t))
+                ? typeof(PrimitiveType)
+                : typeof(Model.DataType),
+            _ => nativeTypes[0]
+        };
     }
 
     private static Type determineMappingType(Type[]? overridingTypes, Type implementingType, FhirElementAttribute felem, string parentTypeName)
@@ -421,12 +527,13 @@ public class PropertyMapping : IElementDefinitionSummary
 
     bool IElementDefinitionSummary.IsResource => this.Choice == ChoiceType.ResourceChoice;
 
-    string? IElementDefinitionSummary.DefaultTypeName => null;
+    string? IElementDefinitionSummary.DefaultTypeName => DefaultTypeNameOverride;
 
     ITypeSerializationInfo[] IElementDefinitionSummary.Type
     {
         get
         {
+            if (TypeSerializationInfos is not null) return TypeSerializationInfos;
             LazyInitializer.EnsureInitialized(ref _types, buildTypes);
             return _types!;
         }
@@ -434,7 +541,7 @@ public class PropertyMapping : IElementDefinitionSummary
 
     private ITypeSerializationInfo[]? _types;
 
-    string? IElementDefinitionSummary.NonDefaultNamespace => null;
+    string? IElementDefinitionSummary.NonDefaultNamespace => NonDefaultNamespaceOverride;
 
     XmlRepresentation IElementDefinitionSummary.Representation =>
         SerializationHint != XmlRepresentation.None ?
@@ -467,6 +574,8 @@ public class PropertyMapping : IElementDefinitionSummary
                                                   $"be a valid FHIR type POCO.");
         }
     }
+
+    private readonly record struct ResolvedTypeInfo(ClassMapping Mapping, ITypeSerializationInfo TypeInfo);
 
     private readonly struct PocoTypeReferenceInfo(string canonical) : IStructureDefinitionReference
     {

--- a/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
@@ -71,14 +71,19 @@ public class PropertyMapping : IElementDefinitionSummary
         _propertyType = propertyType;
     }
 
+    /// <summary>
+    /// Creates a PropertyMapping from pre-computed type information, typically when building
+    /// mappings from a <see cref="Hl7.Fhir.Specification.IElementDefinitionSummary"/>.
+    /// </summary>
     [SetsRequiredMembers]
-    private PropertyMapping(ClassMapping declaringClass, string name, Type propertyType, ClassMapping propertyTypeMapping,
-        Type implementingType, Type[] fhirTypes)
+    public PropertyMapping(ClassMapping declaringClass, string name, Type propertyType, ClassMapping propertyTypeMapping,
+        Type implementingType, Type[] fhirTypes, IEnumerable<ITypeSerializationInfo>? typeInfos = null)
         : this(declaringClass, name, nativeProperty: null!)
     {
         PropertyTypeMapping = propertyTypeMapping;
         ImplementingType = implementingType;
         FhirType = fhirTypes;
+        TypeSerializationInfos = typeInfos?.ToArray();
         _propertyType = propertyType;
     }
 
@@ -214,10 +219,6 @@ public class PropertyMapping : IElementDefinitionSummary
     /// </summary>
     public string? BindingName { get; init; }
 
-    internal string? DefaultTypeNameOverride { get; init; }
-
-    internal string? NonDefaultNamespaceOverride { get; init; }
-
     /// <summary>
     /// The <see cref="ModelInspector"/> for which this mapping was created.
     /// </summary>
@@ -294,97 +295,6 @@ public class PropertyMapping : IElementDefinitionSummary
         };
 
         return true;
-    }
-
-    internal static PropertyMapping CreateFromSummary(ClassMapping declaringClass, IElementDefinitionSummary elementSummary)
-    {
-        if (declaringClass is null) throw Error.ArgumentNull(nameof(declaringClass));
-        if (elementSummary is null) throw Error.ArgumentNull(nameof(elementSummary));
-
-        var resolvedTypes = elementSummary.Type.Select(resolveTypeInfo).ToArray();
-
-        if (resolvedTypes.Length == 0)
-            throw new InvalidOperationException($"Element '{declaringClass.Name}.{elementSummary.ElementName}' does not declare any types.");
-
-        var choice = elementSummary.IsResource
-            ? ChoiceType.ResourceChoice
-            : elementSummary.IsChoiceElement
-                ? ChoiceType.DatatypeChoice
-                : ChoiceType.None;
-
-        var implementingType = determineImplementingType(resolvedTypes.Select(rt => rt.Mapping.NativeType).Distinct().ToArray(), choice);
-        var propertyTypeMapping = choice == ChoiceType.None
-            ? resolvedTypes[0].Mapping
-            : declaringClass.Inspector.FindOrImportClassMapping(implementingType)
-                ?? throw new InvalidOperationException($"Cannot find a class mapping for summary element '{declaringClass.Name}.{elementSummary.ElementName}' implementing type '{implementingType.Name}'.");
-
-        var propertyType = elementSummary.IsCollection
-            ? typeof(List<>).MakeGenericType(implementingType)
-            : implementingType;
-
-        return new(
-            declaringClass,
-            elementSummary.ElementName,
-            propertyType,
-            propertyTypeMapping,
-            implementingType,
-            resolvedTypes.Select(rt => rt.Mapping.NativeType).Distinct().ToArray())
-        {
-            Choice = choice,
-            IsCollection = elementSummary.IsCollection,
-            IsMandatoryElement = elementSummary.IsRequired,
-            InSummary = elementSummary.InSummary,
-            IsModifier = elementSummary.IsModifier,
-            SerializationHint = elementSummary.Representation,
-            Order = elementSummary.Order,
-            TypeSerializationInfos = resolvedTypes.Select(rt => rt.TypeInfo).ToArray(),
-            DefaultTypeNameOverride = elementSummary.DefaultTypeName,
-            NonDefaultNamespaceOverride = elementSummary.NonDefaultNamespace,
-        };
-
-        ResolvedTypeInfo resolveTypeInfo(ITypeSerializationInfo typeInfo) => typeInfo switch
-        {
-            IStructureDefinitionSummary summary => importSummaryType(summary),
-            IStructureDefinitionReference reference => importReferencedType(reference),
-            _ => throw Error.NotSupported($"Don't know how to derive property type information from type {typeInfo.GetType()}")
-        };
-
-        ResolvedTypeInfo importSummaryType(IStructureDefinitionSummary summary)
-        {
-            var mappingName = summary.TypeName is "BackboneElement" or "Element"
-                ? $"{declaringClass.Name}.{elementSummary.ElementName}"
-                : summary.TypeName;
-
-            var mapping = declaringClass.Inspector.Import(summary, mappingName, canonical: null);
-            var exportedTypeInfo = mapping.IsBackboneType
-                ? (ITypeSerializationInfo)mapping
-                : new PocoTypeReferenceInfo(((IStructureDefinitionSummary)mapping).TypeName);
-
-            return new ResolvedTypeInfo(mapping, exportedTypeInfo);
-        }
-
-        ResolvedTypeInfo importReferencedType(IStructureDefinitionReference reference)
-        {
-            var mapping = resolveExistingMapping(reference.ReferredType);
-            return new ResolvedTypeInfo(mapping, new PocoTypeReferenceInfo(reference.ReferredType));
-        }
-
-        ClassMapping resolveExistingMapping(string typeName) =>
-            (isCanonical(typeName)
-                ? declaringClass.Inspector.FindClassMappingByCanonical(typeName)
-                : declaringClass.Inspector.FindClassMapping(typeName))
-            ?? throw new InvalidOperationException($"Cannot find a class mapping for summary type '{typeName}' on element '{declaringClass.Name}.{elementSummary.ElementName}'.");
-
-        static bool isCanonical(string value) => Uri.TryCreate(value, UriKind.Absolute, out _);
-
-        static Type determineImplementingType(Type[] nativeTypes, ChoiceType choice) => choice switch
-        {
-            ChoiceType.ResourceChoice => typeof(Resource),
-            ChoiceType.DatatypeChoice => nativeTypes.All(t => typeof(PrimitiveType).IsAssignableFrom(t))
-                ? typeof(PrimitiveType)
-                : typeof(Model.DataType),
-            _ => nativeTypes[0]
-        };
     }
 
     private static Type determineMappingType(Type[]? overridingTypes, Type implementingType, FhirElementAttribute felem, string parentTypeName)
@@ -529,7 +439,11 @@ public class PropertyMapping : IElementDefinitionSummary
 
     bool IElementDefinitionSummary.IsResource => this.Choice == ChoiceType.ResourceChoice;
 
-    string? IElementDefinitionSummary.DefaultTypeName => DefaultTypeNameOverride;
+
+    /// <inheritdoc cref="IElementDefinitionSummary.DefaultTypeName" />
+    public string? DefaultTypeName { get; init; }
+    
+    string? IElementDefinitionSummary.DefaultTypeName => this.DefaultTypeName;
 
     ITypeSerializationInfo[] IElementDefinitionSummary.Type
     {
@@ -543,7 +457,11 @@ public class PropertyMapping : IElementDefinitionSummary
 
     private ITypeSerializationInfo[]? _types;
 
-    string? IElementDefinitionSummary.NonDefaultNamespace => NonDefaultNamespaceOverride;
+
+    /// <inheritdoc cref="IElementDefinitionSummary.NonDefaultNamespace" />
+    public string? NonDefaultNamespace { get; init; }
+    
+    string? IElementDefinitionSummary.NonDefaultNamespace => this.NonDefaultNamespace;
 
     XmlRepresentation IElementDefinitionSummary.Representation =>
         SerializationHint != XmlRepresentation.None ?
@@ -575,13 +493,6 @@ public class PropertyMapping : IElementDefinitionSummary
                                                   $"'{QualifiedPropName}', but it does not seem to" +
                                                   $"be a valid FHIR type POCO.");
         }
-    }
-
-    private readonly record struct ResolvedTypeInfo(ClassMapping Mapping, ITypeSerializationInfo TypeInfo);
-
-    private readonly struct PocoTypeReferenceInfo(string canonical) : IStructureDefinitionReference
-    {
-        public string ReferredType { get; } = canonical;
     }
 
     #endregion

--- a/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
@@ -83,7 +83,7 @@ public class PropertyMapping : IElementDefinitionSummary
         PropertyTypeMapping = propertyTypeMapping;
         ImplementingType = implementingType;
         FhirType = fhirTypes;
-        TypeSerializationInfos = typeInfos?.ToArray();
+        _types = typeInfos?.ToArray();
         _propertyType = propertyType;
     }
 
@@ -143,8 +143,6 @@ public class PropertyMapping : IElementDefinitionSummary
     /// <remarks>This is effectively the ClassMapping for the <see cref="ImplementingType" /> unless a
     /// <see cref="AllowedTypesAttribute" /> specifies otherwise.</remarks>
     public required ClassMapping PropertyTypeMapping { get; init; }
-
-    private ITypeSerializationInfo[]? TypeSerializationInfos { get; init; }
 
     /// <summary>
     /// Whether the element can repeat.
@@ -449,7 +447,6 @@ public class PropertyMapping : IElementDefinitionSummary
     {
         get
         {
-            if (TypeSerializationInfos is not null) return TypeSerializationInfos;
             LazyInitializer.EnsureInitialized(ref _types, buildTypes);
             return _types!;
         }

--- a/src/Hl7.Fhir.Base/Model/PocoNode.TypedElement.cs
+++ b/src/Hl7.Fhir.Base/Model/PocoNode.TypedElement.cs
@@ -44,7 +44,7 @@ public partial record PocoNode
 
             // we could get definitions with FindOrImportClassMapping, but then we're modifying inspector mappings
             // which either should already have the type, or is expected to be immutable!
-            if (this.Parent is {} node && inspector.FindClassMapping(node.Poco.GetType()) is {} classMapping)
+            if (this.Parent is {} node && inspector.FindClassMapping(node.Poco) is {} classMapping)
                 return classMapping.FindMappedElementByName(Name);
 
             if (inspector.FindClassMapping(Poco.GetType()) is {} cm)
@@ -92,7 +92,7 @@ public partial record PocoNode
         if (name is null) return Children().SelectMany(node => node);
         
         var trueElementName = this.FindInspector()?
-            .FindOrImportClassMapping(Poco.GetType())?
+            .FindOrImportClassMapping(Poco)?
             .FindMappedElementByChoiceName(name)?.Name;
         
         return Child(trueElementName ?? name) ?? Enumerable.Empty<ISourceNode>();

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonSerializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonSerializer.cs
@@ -84,7 +84,7 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
             writer.WriteString("resourceType", r.TypeName);
 
         // Only throw if we don't have a mapping where we are expected to: when this is a subclass of Base.
-        if (Inspector.FindOrImportClassMapping(element.GetType()) is not {} mapping)
+        if (Inspector.FindOrImportClassMapping(element) is not {} mapping)
             throw new InvalidOperationException($"Encountered type {element.GetType()}, which is a support POCO for FHIR, but does not " +
                                                 $"have sufficient metadata to be used by the serializer.");
 

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlSerializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlSerializer.cs
@@ -75,7 +75,7 @@ public class BaseFhirXmlSerializer(ModelInspector inspector)
             writer.WriteStartElement(r.TypeName, XmlNs.FHIR);
 
         // Only throw if we don't have a mapping where we are expected to: when this is a subclass of Base.
-        if (Inspector.FindOrImportClassMapping(element.GetType()) is not {} mapping)
+        if (Inspector.FindOrImportClassMapping(element) is not {} mapping)
             throw new InvalidOperationException($"Encountered type {element.GetType()}, which is a support POCO for FHIR, but does not " +
                                                 $"have sufficient metadata to be used by the serializer.");
 

--- a/src/Hl7.Fhir.Base/Validation/PocoValidationExtensions.cs
+++ b/src/Hl7.Fhir.Base/Validation/PocoValidationExtensions.cs
@@ -61,7 +61,7 @@ public static class PocoValidationExtensions
     {
         var errors = new List<CodedValidationException>();
 
-        var classMapping = validationContext.ModelInspector.FindOrImportClassMapping(value.GetType());
+        var classMapping = validationContext.ModelInspector.FindOrImportClassMapping(value);
         if (classMapping is null) return [];
 
         // Step 1: Validate the object properties.

--- a/src/Hl7.Fhir.ElementModel.Shared.Tests/ElementNodeTests.cs
+++ b/src/Hl7.Fhir.ElementModel.Shared.Tests/ElementNodeTests.cs
@@ -121,6 +121,39 @@ namespace Hl7.FhirPath.Tests
         }
 
         [TestMethod]
+        public async Tasks.Task CanBuildClassMappingFromCustomResourceStructureDefinition()
+        {
+            var provider = new StructureDefinitionSummaryProvider(new CustomResourceResolver());
+            var summary = await provider.ProvideAsync("http://hl7.org/fhir/StructureDefinition/MyCustomResource");
+
+            summary.Should().NotBeNull();
+
+            var inspector = new ModelInspector(FhirRelease.STU3);
+            inspector.Import(typeof(Resource).Assembly);
+
+            var mapping = inspector.Import(summary!, "http://hl7.org/fhir/StructureDefinition/MyCustomResource");
+
+            mapping.Name.Should().Be("MyCustomResource");
+            mapping.NativeType.Should().Be(typeof(DynamicResource));
+            inspector.FindClassMapping("MyCustomResource").Should().BeSameAs(mapping);
+            inspector.FindClassMappingByCanonical("http://hl7.org/fhir/StructureDefinition/MyCustomResource").Should().BeSameAs(mapping);
+
+            var upperCaseElement = mapping.FindMappedElementByName("UpperCaseElement");
+            upperCaseElement.Should().NotBeNull();
+            upperCaseElement!.PropertyTypeMapping.Name.Should().Be("boolean");
+            upperCaseElement.PropertyTypeMapping.IsFhirPrimitive.Should().BeTrue();
+
+            var lowerCaseElement = mapping.FindMappedElementByName("lowerCaseElement");
+            lowerCaseElement.Should().NotBeNull();
+            lowerCaseElement!.PropertyTypeMapping.Name.Should().Be("boolean");
+            lowerCaseElement.PropertyTypeMapping.IsFhirPrimitive.Should().BeTrue();
+
+            var instance = mapping.CreateInstance();
+            instance.Should().BeOfType<DynamicResource>();
+            ((DynamicResource)instance).DynamicTypeName.Should().Be("MyCustomResource");
+        }
+
+        [TestMethod]
         public void TestAutoDeriveTypeForPolymorphicElement()
         {
             // Explicit types will be passed through on polymorphic elements

--- a/src/Hl7.Fhir.Support.Tests/Introspection/ModelInspectorTest.cs
+++ b/src/Hl7.Fhir.Support.Tests/Introspection/ModelInspectorTest.cs
@@ -14,6 +14,7 @@ using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Specification;
 using Hl7.Fhir.Specification.Terminology;
 using Hl7.Fhir.Utility;
+using Hl7.Fhir.Serialization;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -295,6 +296,65 @@ namespace Hl7.Fhir.Tests.Introspection
             value!.PropertyTypeMapping.Should().BeSameAs(inspector.FindClassMappingByCanonical(referencedSummary.Canonical));
             serializedType.Should().BeAssignableTo<IStructureDefinitionReference>();
             ((IStructureDefinitionReference)serializedType).ReferredType.Should().Be(referencedSummary.Canonical);
+        }
+
+        [TestMethod]
+        public void SerializingCustomDynamicResourceShouldUseImportedChoiceMapping()
+        {
+            var inspector = new ModelInspector(FhirRelease.STU3);
+            inspector.Import(typeof(Resource).GetTypeInfo().Assembly);
+
+            var resourceSummary = new TestStructureDefinitionSummary(
+                "CustomChoiceResource",
+                isAbstract: false,
+                isResource: true,
+                elements:
+                [
+                    new TestElementDefinitionSummary(
+                        "value",
+                        [new TestStructureDefinitionReference("string"), new TestStructureDefinitionReference("boolean")],
+                        isChoiceElement: true,
+                        order: 10)
+                ]);
+
+            var mapping = inspector.Import(resourceSummary, "http://example.org/fhir/StructureDefinition/CustomChoiceResource");
+            var instance = (DynamicResource)mapping.CreateInstance();
+            instance.SetValue("value", new FhirBoolean(true));
+
+            var json = new BaseFhirJsonSerializer(inspector).SerializeToString(instance);
+
+            json.Should().Contain("\"resourceType\":\"CustomChoiceResource\"");
+            json.Should().Contain("\"valueBoolean\":true",
+                "the imported custom ClassMapping declares value[x], so the serializer should suffix the property name using that mapping");
+            json.Should().NotContain("\"value\":true",
+                "falling back to the generic DynamicResource mapping drops the choice metadata even though DynamicTypeName is correct");
+        }
+
+        [TestMethod]
+        public void ToTypedElementLegacyShouldExposeImportedCustomDefinition()
+        {
+            var inspector = new ModelInspector(FhirRelease.STU3);
+            inspector.Import(typeof(Resource).GetTypeInfo().Assembly);
+
+            var resourceSummary = new TestStructureDefinitionSummary(
+                "LegacyCustomResource",
+                isAbstract: false,
+                isResource: true,
+                elements:
+                [
+                    new TestElementDefinitionSummary("flag", [new TestStructureDefinitionReference("boolean")], order: 10)
+                ]);
+
+            var mapping = inspector.Import(resourceSummary, "http://example.org/fhir/StructureDefinition/LegacyCustomResource");
+            var instance = (DynamicResource)mapping.CreateInstance();
+            instance.SetValue("flag", new FhirBoolean(true));
+
+            var typed = instance.ToTypedElementLegacy(inspector);
+
+            typed.InstanceType.Should().Be("LegacyCustomResource",
+                "legacy POCO-to-typed-element conversion should preserve the imported custom mapping identity instead of falling back to DynamicResource");
+            typed.Children("flag").Single().InstanceType.Should().Be("boolean",
+                "child definitions should come from the imported custom mapping so custom elements remain navigable");
         }
     }
 

--- a/src/Hl7.Fhir.Support.Tests/Introspection/ModelInspectorTest.cs
+++ b/src/Hl7.Fhir.Support.Tests/Introspection/ModelInspectorTest.cs
@@ -14,6 +14,8 @@ using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Specification;
 using Hl7.Fhir.Specification.Terminology;
 using Hl7.Fhir.Utility;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Hl7.Fhir.Tests.Introspection
 {
@@ -151,6 +153,151 @@ namespace Hl7.Fhir.Tests.Introspection
             inspector.FindClassMapping(typeof(ValidateCodeParameters)).Should().BeNull(
                 "alias entries for derived types must be cleaned up when the base mapping is removed");
         }
+
+        [TestMethod]
+        public void CanImportCustomClassMappingFromStructureDefinitionSummary()
+        {
+            var inspector = new ModelInspector(FhirRelease.STU3);
+            inspector.Import(typeof(Resource).GetTypeInfo().Assembly);
+
+            var componentSummary = new TestStructureDefinitionSummary(
+                "BackboneElement",
+                isAbstract: true,
+                isResource: false,
+                elements:
+                [
+                    new TestElementDefinitionSummary("value", [new TestStructureDefinitionReference("string")], order: 10)
+                ]);
+
+            var resourceSummary = new TestStructureDefinitionSummary(
+                "CustomResource",
+                isAbstract: false,
+                isResource: true,
+                elements:
+                [
+                    new TestElementDefinitionSummary("identifier", [new TestStructureDefinitionReference("string")], isRequired: true, order: 10),
+                    new TestElementDefinitionSummary("component", [componentSummary], isCollection: true, order: 20),
+                    new TestElementDefinitionSummary("value", [new TestStructureDefinitionReference("string"), new TestStructureDefinitionReference("boolean")], isChoiceElement: true, order: 30)
+                ]);
+
+            var mapping = inspector.Import(resourceSummary, "http://example.org/fhir/StructureDefinition/CustomResource");
+
+            mapping.Name.Should().Be("CustomResource");
+            mapping.NativeType.Should().Be(typeof(DynamicResource));
+            inspector.FindClassMapping("CustomResource").Should().BeSameAs(mapping);
+            inspector.FindClassMappingByCanonical("http://example.org/fhir/StructureDefinition/CustomResource").Should().BeSameAs(mapping);
+            inspector.Provide("CustomResource").Should().BeSameAs(mapping);
+
+            var instance = mapping.CreateInstance();
+            instance.Should().BeOfType<DynamicResource>();
+            ((DynamicResource)instance).DynamicTypeName.Should().Be("CustomResource");
+
+            ((IStructureDefinitionSummary)mapping).TypeName.Should().Be("CustomResource");
+            ((IStructureDefinitionSummary)mapping).IsAbstract.Should().BeFalse();
+
+            var identifier = mapping.FindMappedElementByName("identifier");
+            identifier.Should().NotBeNull();
+            identifier!.IsMandatoryElement.Should().BeTrue();
+            identifier.SerializationHint.Should().Be(XmlRepresentation.XmlElement);
+
+            var component = mapping.FindMappedElementByName("component");
+            component.Should().NotBeNull();
+            component!.IsCollection.Should().BeTrue();
+            component.PropertyTypeMapping.Name.Should().Be("CustomResource.component");
+            component.PropertyTypeMapping.NativeType.Should().Be(typeof(DynamicDataType));
+            ((IStructureDefinitionSummary)component.PropertyTypeMapping).TypeName.Should().Be("BackboneElement");
+            ((IStructureDefinitionSummary)component.PropertyTypeMapping).IsAbstract.Should().BeTrue();
+            ((IElementDefinitionSummary)component).Type.Single().Should().BeSameAs(component.PropertyTypeMapping);
+
+            var choice = (IElementDefinitionSummary)mapping.FindMappedElementByName("value")!;
+            choice.IsChoiceElement.Should().BeTrue();
+            choice.Type.Should().OnlyContain(t => t is IStructureDefinitionReference);
+            choice.Type.Cast<IStructureDefinitionReference>().Select(t => t.ReferredType)
+                .Should().BeEquivalentTo(["string", "boolean"]);
+        }
+
+        [TestMethod]
+        public void ImportingCustomStructureDefinitionMappingDoesNotOverwriteDynamicRuntimeTypeLookup()
+        {
+            var inspector = new ModelInspector(FhirRelease.STU3);
+            inspector.Import(typeof(Resource).GetTypeInfo().Assembly);
+
+            var dynamicResourceMapping = inspector.FindClassMapping(typeof(DynamicResource));
+            dynamicResourceMapping.Should().NotBeNull();
+
+            var resourceSummary = new TestStructureDefinitionSummary(
+                "AnotherCustomResource",
+                isAbstract: false,
+                isResource: true,
+                elements: []);
+
+            var imported = inspector.Import(resourceSummary);
+
+            inspector.FindClassMapping("AnotherCustomResource").Should().BeSameAs(imported);
+            inspector.FindClassMapping(typeof(DynamicResource)).Should().BeSameAs(dynamicResourceMapping,
+                "custom mappings should be registered by name/canonical, not by ambiguous runtime type");
+        }
+    }
+
+    internal sealed class TestStructureDefinitionSummary : IStructureDefinitionSummary
+    {
+        private readonly IReadOnlyCollection<IElementDefinitionSummary> _elements;
+
+        public TestStructureDefinitionSummary(string typeName, bool isAbstract, bool isResource, IReadOnlyCollection<IElementDefinitionSummary> elements)
+        {
+            TypeName = typeName;
+            IsAbstract = isAbstract;
+            IsResource = isResource;
+            _elements = elements;
+        }
+
+        public string TypeName { get; }
+
+        public bool IsAbstract { get; }
+
+        public bool IsResource { get; }
+
+        public IReadOnlyCollection<IElementDefinitionSummary> GetElements() => _elements;
+    }
+
+    internal sealed class TestElementDefinitionSummary : IElementDefinitionSummary
+    {
+        public TestElementDefinitionSummary(string elementName, ITypeSerializationInfo[] type, bool isCollection = false,
+            bool isRequired = false, bool inSummary = false, bool isChoiceElement = false, bool isResource = false,
+            bool isModifier = false, string defaultTypeName = null, string nonDefaultNamespace = null,
+            XmlRepresentation representation = XmlRepresentation.XmlElement, int order = 0)
+        {
+            ElementName = elementName;
+            Type = type;
+            IsCollection = isCollection;
+            IsRequired = isRequired;
+            InSummary = inSummary;
+            IsChoiceElement = isChoiceElement;
+            IsResource = isResource;
+            IsModifier = isModifier;
+            DefaultTypeName = defaultTypeName;
+            NonDefaultNamespace = nonDefaultNamespace;
+            Representation = representation;
+            Order = order;
+        }
+
+        public string ElementName { get; }
+        public bool IsCollection { get; }
+        public bool IsRequired { get; }
+        public bool InSummary { get; }
+        public bool IsChoiceElement { get; }
+        public bool IsResource { get; }
+        public bool IsModifier { get; }
+        public ITypeSerializationInfo[] Type { get; }
+        public string DefaultTypeName { get; }
+        public string NonDefaultNamespace { get; }
+        public XmlRepresentation Representation { get; }
+        public int Order { get; }
+    }
+
+    internal sealed class TestStructureDefinitionReference(string referredType) : IStructureDefinitionReference
+    {
+        public string ReferredType { get; } = referredType;
     }
 
     [FhirEnumeration("SomeEnum")]

--- a/src/Hl7.Fhir.Support.Tests/Introspection/ModelInspectorTest.cs
+++ b/src/Hl7.Fhir.Support.Tests/Introspection/ModelInspectorTest.cs
@@ -237,6 +237,65 @@ namespace Hl7.Fhir.Tests.Introspection
             inspector.FindClassMapping(typeof(DynamicResource)).Should().BeSameAs(dynamicResourceMapping,
                 "custom mappings should be registered by name/canonical, not by ambiguous runtime type");
         }
+
+        [TestMethod]
+        public void ImportingExistingSummaryByCanonicalRegistersCanonicalAlias()
+        {
+            var inspector = new ModelInspector(FhirRelease.STU3);
+            inspector.Import(typeof(Resource).GetTypeInfo().Assembly);
+
+            var resourceSummary = new TestStructureDefinitionSummary(
+                "CanonicalUpgradeResource",
+                isAbstract: false,
+                isResource: true,
+                elements: []);
+
+            var importedByName = inspector.Import(resourceSummary);
+            var importedByCanonical = inspector.Import(resourceSummary, "http://example.org/fhir/StructureDefinition/CanonicalUpgradeResource");
+
+            importedByCanonical.Should().BeSameAs(importedByName);
+            inspector.FindClassMapping("CanonicalUpgradeResource").Should().BeSameAs(importedByName);
+            inspector.FindClassMappingByCanonical("http://example.org/fhir/StructureDefinition/CanonicalUpgradeResource")
+                .Should().BeSameAs(importedByName);
+            inspector.Provide("http://example.org/fhir/StructureDefinition/CanonicalUpgradeResource")
+                .Should().BeSameAs(importedByName);
+        }
+
+        [TestMethod]
+        public void CanResolveSummaryPropertyTypeByUrnCanonical()
+        {
+            var inspector = new ModelInspector(FhirRelease.STU3);
+            inspector.Import(typeof(Resource).GetTypeInfo().Assembly);
+
+            var referencedSummary = new TestStructureDefinitionSummary(
+                "CanonicalDatatype",
+                isAbstract: false,
+                isResource: false,
+                elements: [])
+            {
+                Canonical = "urn:uuid:0f8fad5b-d9cb-469f-a165-70867728950e"
+            };
+
+            inspector.Import(referencedSummary, referencedSummary.Canonical);
+
+            var resourceSummary = new TestStructureDefinitionSummary(
+                "UrnReferenceResource",
+                isAbstract: false,
+                isResource: true,
+                elements:
+                [
+                    new TestElementDefinitionSummary("value", [new TestStructureDefinitionReference(referencedSummary.Canonical)], order: 10)
+                ]);
+
+            var mapping = inspector.Import(resourceSummary, "http://example.org/fhir/StructureDefinition/UrnReferenceResource");
+            var value = mapping.FindMappedElementByName("value");
+            var serializedType = ((IElementDefinitionSummary)value!).Type.Single();
+
+            value.Should().NotBeNull();
+            value!.PropertyTypeMapping.Should().BeSameAs(inspector.FindClassMappingByCanonical(referencedSummary.Canonical));
+            serializedType.Should().BeAssignableTo<IStructureDefinitionReference>();
+            ((IStructureDefinitionReference)serializedType).ReferredType.Should().Be(referencedSummary.Canonical);
+        }
     }
 
     internal sealed class TestStructureDefinitionSummary : IStructureDefinitionSummary
@@ -252,6 +311,8 @@ namespace Hl7.Fhir.Tests.Introspection
         }
 
         public string TypeName { get; }
+
+        public string Canonical { get; init; }
 
         public bool IsAbstract { get; }
 


### PR DESCRIPTION
## Summary
- add support for importing `ClassMapping` metadata directly from `IStructureDefinitionSummary`, so custom resources and datatypes can be registered in `ModelInspector` without reflected POCO types
- build `PropertyMapping` instances from summary element metadata, including nested backbone elements, collection metadata, and choice typing
- register custom summary-backed mappings by name/canonical without overwriting the shared runtime-type index for `DynamicResource` and `DynamicDataType`

## Additional fixes
- preserve canonical lookup when a mapping is imported by name first and later imported with a canonical
- resolve summary property references by canonical using absolute URI detection instead of the previous slash-based heuristic, so `urn:` identifiers work too

## Testing
- added unit coverage for importing custom class mappings from synthetic `IStructureDefinitionSummary` inputs
- added integration coverage for building a mapping from a real custom resource `StructureDefinition`
- added regression coverage for delayed canonical registration and `urn:` canonical resolution

## Out of scope
- NewPocoBuilder needs to be reviewed for any changes needed, would be good to have #3472 merged before too

Closes #2891