### PR TITLE
Fix small bug in the CachingTerminologyService 

### DIFF
--- a/src/Hl7.Fhir.Base/Specification/Terminology/CachingTerminologyService.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/CachingTerminologyService.cs
@@ -139,8 +139,6 @@ internal static class ParametersExtensions
         {
             if (parameter.getPartHashCode() is { } hashPart)
                 hash.Add(hashPart);
-            else
-                return null;
         }
         return hash.ToHashCode();
     }
@@ -157,8 +155,6 @@ internal static class ParametersExtensions
         {
             if(subpart.getPartHashCode() is { } subpartHash)
                 hash.Add(subpartHash);
-            else
-                return null;
         }
         return hash.ToHashCode();
     }

--- a/src/Hl7.Fhir.Base/Specification/Terminology/CachingTerminologyService.cs
+++ b/src/Hl7.Fhir.Base/Specification/Terminology/CachingTerminologyService.cs
@@ -150,7 +150,7 @@ internal static class ParametersExtensions
         if(part.Value != null)
             hash.Add(getTerminologyValueHashCode(part.Value));
         if(part.Resource != null)
-            return null;
+            return part.Resource.GetHashCode();
         foreach (var subpart in part.Part)
         {
             if(subpart.getPartHashCode() is { } subpartHash)
@@ -199,7 +199,7 @@ internal static class ParametersExtensions
                 hash.Add(dt.Value);
                 break;
             default:
-                return null;
+                return parameterValue.GetHashCode();
         }
         
         return hash.ToHashCode();

--- a/src/Hl7.Fhir.Support.Tests/Specification/CachingTerminologyServiceTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/Specification/CachingTerminologyServiceTests.cs
@@ -74,10 +74,16 @@ public class CachingTerminologyServiceTests
     }
 
     [TestMethod]
-    public async Task ParametersWithResource_DoesNotCache()
+    public async Task ParametersWithResource_DoesntBreakCache_CachedPerObject()
     {
         // Arrange
         var parametersWithResource = new Parameters();
+        parametersWithResource.Parameter.Add(new Parameters.ParameterComponent
+        {
+            Name = "resource",
+            Resource = new Bundle()
+        });
+        var parametersWithAnotherResource = new Parameters();
         parametersWithResource.Parameter.Add(new Parameters.ParameterComponent
         {
             Name = "resource",
@@ -90,9 +96,12 @@ public class CachingTerminologyServiceTests
         // Act
         await _cachingService.ValueSetValidateCode(parametersWithResource);
         await _cachingService.ValueSetValidateCode(parametersWithResource);
+        await _cachingService.ValueSetValidateCode(parametersWithAnotherResource);
+        await _cachingService.ValueSetValidateCode(parametersWithAnotherResource);
 
-        // Assert - Should call underlying service twice since resource parameters aren't cached
-        await _mockService.Received(2).ValueSetValidateCode(parametersWithResource, null, false);
+        // Assert - Should call underlying service once, but a different resource should result in a different cache key
+        await _mockService.Received(1).ValueSetValidateCode(parametersWithResource, null, false);
+        await _mockService.Received(1).ValueSetValidateCode(parametersWithAnotherResource, null, false);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Description
Old behavior would exit out of hashcode building on a `Resource` or an unrecognized primitive type, breaking cache key.