### PR TITLE
Start development cycle 6.2.1

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,8 @@
 ## Intro:
 
-Fixes wrong logic for BaseTerminologyService filtering parameters for duplicates on requests that accept 0..* on some parameters
+Added `RespectSuppressExtension` setting to `SnapshotGeneratorSettings` (default `true`) so consumers can opt out of suppress-extension handling during snapshot generation.  
+Added `Base.ClearOverflow()` and corrected the `NoOverflow` docstring.  
+`ITypedElement` extension methods now carry `OverloadResolutionPriority(1)` so they are preferred over `ISourceNode` extensions for types that implement both (e.g. `PocoNode`).  
+Fixed a cache-key bug in `CachingTerminologyService` where resource or unrecognized parameter values could break the cache key.  
+Validation now includes canonicals in failed resolve attempts, and cardinality validation handles the case where the member name was not reported.  
+Bumped `System.Text.Json` and `Microsoft.Extensions.Caching.Memory` to 10.0.7.

--- a/src/firely-net-sdk.props
+++ b/src/firely-net-sdk.props
@@ -6,7 +6,7 @@
 
 	<!-- Solution-wide properties for NuGet packaging -->
 	<PropertyGroup>
-		<VersionPrefix>6.1.2</VersionPrefix>
+		<VersionPrefix>6.2.1</VersionPrefix>
 		<VersionSuffix></VersionSuffix>
 		<Authors>Firely (info@fire.ly) and contributors</Authors>
 		<Company>Firely (https://fire.ly)</Company>
@@ -37,7 +37,7 @@
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Configurations>Debug;Release;FullDebug</Configurations>
 		<EnablePackageValidation>true</EnablePackageValidation>
-		<PackageValidationBaselineVersion>6.1.1</PackageValidationBaselineVersion>
+		<PackageValidationBaselineVersion>6.2.0</PackageValidationBaselineVersion>
 		<!-- Error	CS4014	Because this call is not awaited, execution of the current method continues before the call is completed.
 		Consider applying the 'await' operator to the result of the call.	-->
 		<WarningsAsErrors>CS4014</WarningsAsErrors>

--- a/src/firely-net-sdk.props
+++ b/src/firely-net-sdk.props
@@ -6,7 +6,7 @@
 
 	<!-- Solution-wide properties for NuGet packaging -->
 	<PropertyGroup>
-		<VersionPrefix>6.1.2</VersionPrefix>
+		<VersionPrefix>6.2.0</VersionPrefix>
 		<VersionSuffix></VersionSuffix>
 		<Authors>Firely (info@fire.ly) and contributors</Authors>
 		<Company>Firely (https://fire.ly)</Company>


### PR DESCRIPTION
## Summary
- Merges release/6.2.0 back into develop after the 6.2.0 release.
- Bumps VersionPrefix to 6.2.1 and PackageValidationBaselineVersion to 6.2.0.
- No compatibility-suppression files needed (6.2.0 → 6.2.1 is API-compatible).

## Test plan
- [ ] CI passes on release/6.2.0
- [ ] Package validation against 6.2.0 baseline succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)