### PR TITLE
R6 related fixes

### DIFF
--- a/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
+++ b/src/Hl7.Fhir.Base/CompatibilitySuppressions.xml
@@ -1,3 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
-<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+<Suppressions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Hl7.Fhir.Model.FHIRVersion.N6_0_0Ballo1</Target>
+    <Left>lib/net8.0/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/net8.0/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Hl7.Fhir.Model.FHIRVersion.N6_0_0Ballo1</Target>
+    <Left>lib/netstandard2.1/Hl7.Fhir.Base.dll</Left>
+    <Right>lib/netstandard2.1/Hl7.Fhir.Base.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/src/Hl7.Fhir.Base/Model/Generated/Template-Bindings.cs
+++ b/src/Hl7.Fhir.Base/Model/Generated/Template-Bindings.cs
@@ -400,8 +400,8 @@ namespace Hl7.Fhir.Model
     /// R6 1st Draft Ballot.
     /// (system: http://hl7.org/fhir/FHIR-version)
     /// </summary>
-    [EnumLiteral("6.0.0-ballo1"), Description("6.0.0-ballot1")]
-    N6_0_0Ballo1,
+    [EnumLiteral("6.0.0-ballot1"), Description("6.0.0-ballot1")]
+    N6_0_0Ballot1,
     /// <summary>
     /// R6 2nd Draft Ballot.
     /// (system: http://hl7.org/fhir/FHIR-version)

--- a/src/Hl7.Fhir.Base/Utility/FhirReleaseParser.cs
+++ b/src/Hl7.Fhir.Base/Utility/FhirReleaseParser.cs
@@ -63,6 +63,9 @@ namespace Hl7.Fhir.Utility
                 //Official R5 versions (and technical corrections) => 5.0.x
                 string s when s.StartsWith("5.0") => FhirRelease.R5,
 
+                //All R6 versions
+                string s when s.StartsWith("6.0") => FhirRelease.R6,
+
                 _ => null
             };
 
@@ -85,6 +88,7 @@ namespace Hl7.Fhir.Utility
                 FhirRelease.R4 => "4.0.1",
                 FhirRelease.R4B => "4.3.0",
                 FhirRelease.R5 => "5.0.0",
+                FhirRelease.R6 => "6.0.0-ballot3", // This is the version the SDK currently supports
                 _ => throw new NotSupportedException($"Unknown FHIR version {fhirRelease}")
             };
         }
@@ -118,6 +122,7 @@ namespace Hl7.Fhir.Utility
                 // this discussion.
                 "4.3" => FhirRelease.R4B,
                 "5.0" => FhirRelease.R5,
+                "6.0" => FhirRelease.R6,
                 _ => null
             };
 
@@ -143,6 +148,7 @@ namespace Hl7.Fhir.Utility
                 // this discussion.
                 FhirRelease.R4B => "4.3",
                 FhirRelease.R5 => "5.0",
+                FhirRelease.R6 => "6.0",
                 _ => throw new NotSupportedException($"Unknown FHIR version {fhirRelease}")
             };
         }
@@ -172,6 +178,7 @@ namespace Hl7.Fhir.Utility
                 "hl7.fhir.r4.core" => FhirRelease.R4,
                 "hl7.fhir.r4b.core" => FhirRelease.R4B,
                 "hl7.fhir.r5.core" => FhirRelease.R5,
+                "hl7.fhir.r6.core-ballot3" => FhirRelease.R6, // This is the version the SDK currently supports
                 _ => null
             };
 
@@ -192,6 +199,7 @@ namespace Hl7.Fhir.Utility
                 FhirRelease.R4 => "hl7.fhir.r4.core",
                 FhirRelease.R4B => "hl7.fhir.r4b.core",
                 FhirRelease.R5 => "hl7.fhir.r5.core",
+                FhirRelease.R6 => "hl7.fhir.r6.core-ballot3", // This is the version the SDK currently supports
                 _ => throw new NotSupportedException($"Unknown FHIR version {fhirRelease}")
             };
         }

--- a/src/Hl7.Fhir.Support.Tests/Utility/FhirVersionTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/Utility/FhirVersionTests.cs
@@ -27,10 +27,18 @@ namespace Hl7.Fhir.Utility.Tests
             Assert.AreEqual(FhirRelease.R4, FhirReleaseParser.Parse("4.0.0"));
             Assert.AreEqual(FhirRelease.R4, FhirReleaseParser.Parse("4.0.1"));
 
+            Assert.AreEqual(FhirRelease.R4B, FhirReleaseParser.Parse("4.1.0"));
+            Assert.AreEqual(FhirRelease.R4B, FhirReleaseParser.Parse("4.3.0"));
+
             Assert.AreEqual(FhirRelease.R5, FhirReleaseParser.Parse("4.2.0"));
             Assert.AreEqual(FhirRelease.R5, FhirReleaseParser.Parse("4.5.0"));
+            Assert.AreEqual(FhirRelease.R5, FhirReleaseParser.Parse("5.0.0-ballot"));
             Assert.AreEqual(FhirRelease.R5, FhirReleaseParser.Parse("5.0.0"));
+
+            Assert.AreEqual(FhirRelease.R6, FhirReleaseParser.Parse("6.0.0-ballot3"));
+            Assert.AreEqual(FhirRelease.R6, FhirReleaseParser.Parse("6.0.0"));
         }
+        
         [TestMethod]
         public void TestTryParseFhirReleaseFromVersion()
         {
@@ -43,8 +51,12 @@ namespace Hl7.Fhir.Utility.Tests
             Assert.AreEqual(FhirRelease.STU3, version);
             Assert.IsTrue(FhirReleaseParser.TryParse("4.0.0", out version));
             Assert.AreEqual(FhirRelease.R4, version);
+            Assert.IsTrue(FhirReleaseParser.TryParse("4.3.0", out version));
+            Assert.AreEqual(FhirRelease.R4B, version);
             Assert.IsTrue(FhirReleaseParser.TryParse("5.0.0", out version));
             Assert.AreEqual(FhirRelease.R5, version);
+            Assert.IsTrue(FhirReleaseParser.TryParse("6.0.0-ballot3", out version));
+            Assert.AreEqual(FhirRelease.R6, version);
 
             Assert.IsFalse(FhirReleaseParser.TryParse("0.0.0.0.1", out version));
             Assert.IsNull(version);
@@ -60,6 +72,7 @@ namespace Hl7.Fhir.Utility.Tests
             Assert.AreEqual("4.0.1", FhirReleaseParser.FhirVersionFromRelease(FhirRelease.R4));
             Assert.AreEqual("4.3.0", FhirReleaseParser.FhirVersionFromRelease(FhirRelease.R4B));
             Assert.AreEqual("5.0.0", FhirReleaseParser.FhirVersionFromRelease(FhirRelease.R5));
+            Assert.AreEqual("6.0.0-ballot3", FhirReleaseParser.FhirVersionFromRelease(FhirRelease.R6));
         }
 
         [TestMethod]
@@ -69,7 +82,9 @@ namespace Hl7.Fhir.Utility.Tests
             Assert.AreEqual("1.0", FhirReleaseParser.MimeVersionFromFhirRelease(FhirRelease.DSTU2));
             Assert.AreEqual("3.0", FhirReleaseParser.MimeVersionFromFhirRelease(FhirRelease.STU3));
             Assert.AreEqual("4.0", FhirReleaseParser.MimeVersionFromFhirRelease(FhirRelease.R4));
+            Assert.AreEqual("4.3", FhirReleaseParser.MimeVersionFromFhirRelease(FhirRelease.R4B));
             Assert.AreEqual("5.0", FhirReleaseParser.MimeVersionFromFhirRelease(FhirRelease.R5));
+            Assert.AreEqual("6.0", FhirReleaseParser.MimeVersionFromFhirRelease(FhirRelease.R6));
         }
 
         [TestMethod]
@@ -79,7 +94,9 @@ namespace Hl7.Fhir.Utility.Tests
             Assert.AreEqual(FhirRelease.DSTU2, FhirReleaseParser.FhirReleaseFromMimeVersion("1.0"));
             Assert.AreEqual(FhirRelease.STU3, FhirReleaseParser.FhirReleaseFromMimeVersion("3.0"));
             Assert.AreEqual(FhirRelease.R4, FhirReleaseParser.FhirReleaseFromMimeVersion("4.0"));
+            Assert.AreEqual(FhirRelease.R4B, FhirReleaseParser.FhirReleaseFromMimeVersion("4.3"));
             Assert.AreEqual(FhirRelease.R5, FhirReleaseParser.FhirReleaseFromMimeVersion("5.0"));
+            Assert.AreEqual(FhirRelease.R6, FhirReleaseParser.FhirReleaseFromMimeVersion("6.0"));
         }
 
         [TestMethod]
@@ -94,8 +111,12 @@ namespace Hl7.Fhir.Utility.Tests
             Assert.AreEqual(FhirRelease.STU3, version);
             Assert.IsTrue(FhirReleaseParser.TryGetFhirReleaseFromMimeVersion("4.0", out version));
             Assert.AreEqual(FhirRelease.R4, version);
+            Assert.IsTrue(FhirReleaseParser.TryGetFhirReleaseFromMimeVersion("4.3", out version));
+            Assert.AreEqual(FhirRelease.R4B, version);
             Assert.IsTrue(FhirReleaseParser.TryGetFhirReleaseFromMimeVersion("5.0", out version));
             Assert.AreEqual(FhirRelease.R5, version);
+            Assert.IsTrue(FhirReleaseParser.TryGetFhirReleaseFromMimeVersion("6.0", out version));
+            Assert.AreEqual(FhirRelease.R6, version);
 
             Assert.IsFalse(FhirReleaseParser.TryGetFhirReleaseFromMimeVersion("0.0.0.0.1", out version));
             Assert.IsNull(version);
@@ -104,29 +125,41 @@ namespace Hl7.Fhir.Utility.Tests
         [TestMethod]
         public void TestFhirCorePackageFromFhirVersion()
         {
+            Assert.AreEqual("hl7.fhir.r2.core", FhirReleaseParser.CorePackageNameFromFhirRelease(FhirRelease.DSTU2));
             Assert.AreEqual("hl7.fhir.r3.core", FhirReleaseParser.CorePackageNameFromFhirRelease(FhirRelease.STU3));
             Assert.AreEqual("hl7.fhir.r4.core", FhirReleaseParser.CorePackageNameFromFhirRelease(FhirRelease.R4));
+            Assert.AreEqual("hl7.fhir.r4b.core", FhirReleaseParser.CorePackageNameFromFhirRelease(FhirRelease.R4B));
             Assert.AreEqual("hl7.fhir.r5.core", FhirReleaseParser.CorePackageNameFromFhirRelease(FhirRelease.R5));
+            Assert.AreEqual("hl7.fhir.r6.core-ballot3", FhirReleaseParser.CorePackageNameFromFhirRelease(FhirRelease.R6));
         }
 
         [TestMethod]
         public void FhirReleaseFromCorePackageName()
         {
+            Assert.AreEqual(FhirRelease.DSTU2, FhirReleaseParser.FhirReleaseFromCorePackageName("hl7.fhir.r2.core"));
             Assert.AreEqual(FhirRelease.STU3, FhirReleaseParser.FhirReleaseFromCorePackageName("hl7.fhir.r3.core"));
             Assert.AreEqual(FhirRelease.R4, FhirReleaseParser.FhirReleaseFromCorePackageName("hl7.fhir.r4.core"));
+            Assert.AreEqual(FhirRelease.R4B, FhirReleaseParser.FhirReleaseFromCorePackageName("hl7.fhir.r4b.core"));
             Assert.AreEqual(FhirRelease.R5, FhirReleaseParser.FhirReleaseFromCorePackageName("hl7.fhir.r5.core"));
+            Assert.AreEqual(FhirRelease.R6, FhirReleaseParser.FhirReleaseFromCorePackageName("hl7.fhir.r6.core-ballot3"));
         }
 
         [TestMethod]
         public void TestTryFhirReleaseFromCorePackageName()
         {
             FhirRelease? version = null;
+            Assert.IsTrue(FhirReleaseParser.TryGetFhirReleaseFromCorePackageName("hl7.fhir.r2.core", out version));
+            Assert.AreEqual(FhirRelease.DSTU2, version);
             Assert.IsTrue(FhirReleaseParser.TryGetFhirReleaseFromCorePackageName("hl7.fhir.r3.core", out version));
             Assert.AreEqual(FhirRelease.STU3, version);
             Assert.IsTrue(FhirReleaseParser.TryGetFhirReleaseFromCorePackageName("hl7.fhir.r4.core", out version));
             Assert.AreEqual(FhirRelease.R4, version);
+            Assert.IsTrue(FhirReleaseParser.TryGetFhirReleaseFromCorePackageName("hl7.fhir.r4b.core", out version));
+            Assert.AreEqual(FhirRelease.R4B, version);
             Assert.IsTrue(FhirReleaseParser.TryGetFhirReleaseFromCorePackageName("hl7.fhir.r5.core", out version));
             Assert.AreEqual(FhirRelease.R5, version);
+            Assert.IsTrue(FhirReleaseParser.TryGetFhirReleaseFromCorePackageName("hl7.fhir.r6.core-ballot3", out version));
+            Assert.AreEqual(FhirRelease.R6, version);
 
             Assert.IsFalse(FhirReleaseParser.TryGetFhirReleaseFromCorePackageName("hl7.fhir.core.r3", out version));
             Assert.IsNull(version);
@@ -143,6 +176,7 @@ namespace Hl7.Fhir.Utility.Tests
                 FhirRelease.R4,
                 FhirRelease.R4B,
                 FhirRelease.R5,
+                FhirRelease.R6
             };
             listOfReleases.Should().BeInAscendingOrder();
         }


### PR DESCRIPTION
## Description
Fixed wrong N6_0_0Ballo1 enum name and literal. Added R6 support to FhirReleaseParser and updated unit tests.
