### PR TITLE
Fix DebuggerDisplay attribute for Url property on Extension.cs

### DIFF
--- a/src/Hl7.Fhir.Base/Model/Extension.cs
+++ b/src/Hl7.Fhir.Base/Model/Extension.cs
@@ -38,7 +38,7 @@ namespace Hl7.Fhir.Model;
 /// <summary>
 /// Optional Extensions Element
 /// </summary>
-[System.Diagnostics.DebuggerDisplay(@"\{Value={Value} Url={_url}}")]
+[System.Diagnostics.DebuggerDisplay(@"\{Value={Value} Url={Url}}")]
 public partial class Extension : ICoded
 {
     public Extension()


### PR DESCRIPTION
## Description
Fix DebuggerDisplay attribute for Url property on Extension.cs

<img width="751" height="94" alt="image" src="https://github.com/user-attachments/assets/e112acf7-8483-42a3-a530-235643e29103" />

## Related issues

## Testing

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes