### PR TITLE
fix: restore collection initializer support on Parameters class

### DIFF
--- a/src/Hl7.Fhir.Base/Model/Parameters.cs
+++ b/src/Hl7.Fhir.Base/Model/Parameters.cs
@@ -32,6 +32,7 @@
 
 using Hl7.Fhir.Utility;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -42,8 +43,13 @@ namespace Hl7.Fhir.Model;
 /// This is the Parameters partial class that adds all the specific functionality of a Parameters to the model
 /// </summary>
 [DebuggerDisplay(@"\{Count={_Parameter != null ? _Parameter.Count : 0}}")]
-public partial class Parameters
+public partial class Parameters : IEnumerable<Parameters.ParameterComponent>
 {
+    /// <inheritdoc/>
+    public IEnumerator<ParameterComponent> GetEnumerator() => Parameter.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => Parameter.GetEnumerator();
+
     public Parameters()
     {
         // Nothing

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/ModelTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/ModelTests.cs
@@ -438,6 +438,31 @@ public class ModelTests
         ];
         Assert.IsTrue(expected.SequenceEqual(children));
     }
+    [TestMethod]
+    public void ParametersSupportsCollectionInitializer()
+    {
+        // Verify that the collection initializer syntax works (issue #3447)
+        var p = new Parameters
+        {
+            { "param1", new FhirString("value1") },
+            { "param2", new FhirBoolean(true) }
+        };
+
+        p.Parameter.Should().HaveCount(2);
+        p.GetSingleValue<FhirString>("param1")!.Value.Should().Be("value1");
+        p.GetSingleValue<FhirBoolean>("param2")!.Value.Should().Be(true);
+    }
+
+    [TestMethod]
+    public void ParametersIsEnumerable()
+    {
+        var p = new Parameters();
+        p.Add("a", new FhirString("one"));
+        p.Add("b", new FhirString("two"));
+
+        var names = p.Select(pc => pc.Name).ToList();
+        names.Should().BeEquivalentTo(["a", "b"]);
+    }
 }
 
 #pragma warning restore CS0618 // Type or member is obsolete


### PR DESCRIPTION
 ## Summary
  - SDK 6 removed `IDictionary` from `Parameters`, breaking C# collection initializer syntax that worked in SDK 5
  - The `Add(string, Base?)` method was already present — the only missing piece was `IEnumerable<ParameterComponent>`
  - Added `IEnumerable<ParameterComponent>` to the `Parameters` partial class delegating to the underlying `Parameter` list

  ## Before (broken in SDK 6)
  ```csharp
  var p = new Parameters { { "value1", new FhirString("test") } }; // CS1061

  After (restored)

  var p = new Parameters { { "value1", new FhirString("test") } }; // works

  Changes

  - src/Hl7.Fhir.Base/Model/Parameters.cs — implement IEnumerable<ParameterComponent> + explicit IEnumerable
  - src/Hl7.Fhir.Support.Poco.Tests/Model/ModelTests.cs — two new tests covering collection initializer and enumeration

  Fixes #3447