### PR TITLE
Add Version interface to R5 NamingSystem

### DIFF
--- a/src/Hl7.Fhir.R5/Model/IConformanceResource.cs
+++ b/src/Hl7.Fhir.R5/Model/IConformanceResource.cs
@@ -41,7 +41,7 @@ public partial class CompartmentDefinition : IVersionableConformanceResource;
 
 public partial class ConceptMap : IVersionableConformanceResource;
 
-public partial class NamingSystem : IConformanceResource;
+public partial class NamingSystem : IVersionableConformanceResource;
 public partial class StructureMap : IVersionableConformanceResource;
 public partial class GraphDefinition : IVersionableConformanceResource;
 


### PR DESCRIPTION
## Description
The NamingSystem in R5 does carry a Version, so it can implement the more specialized `IVersionableConformanceResource`, since that interface implies the `IConformanceResource` anyway

## Related issues
Resolves #3515