### PR TITLE
Support custom resources and datatypes in ClassMapping/ModelInspector

### DIFF
--- a/src/Hl7.Fhir.Base/ElementModel/PocoElementNode.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/PocoElementNode.cs
@@ -31,7 +31,7 @@ namespace Hl7.Fhir.ElementModel
         {
             Current = root;
             _inspector = inspector;
-            _myClassMapping = _inspector.FindOrImportClassMapping(root.GetType())!;
+            _myClassMapping = _inspector.FindOrImportClassMapping(root)!;
 
             InstanceType = ((IStructureDefinitionSummary)_myClassMapping).TypeName;
             Definition = ElementDefinitionSummary.ForRoot(_myClassMapping, rootName ?? root.TypeName);
@@ -46,10 +46,7 @@ namespace Hl7.Fhir.ElementModel
             Current = instance;
             _inspector = inspector;
 
-            var instanceType = definition.Choice != ChoiceType.None
-                ? instance.GetType()
-                : determineInstanceType(definition);
-            _myClassMapping = _inspector.FindOrImportClassMapping(instanceType)!;
+            _myClassMapping = determineInstanceMapping(instance, definition);
             InstanceType = ((IStructureDefinitionSummary)_myClassMapping).TypeName;
             Definition = definition;
 
@@ -58,9 +55,15 @@ namespace Hl7.Fhir.ElementModel
             ShortPath = shortPath;
         }
 
-        private Type determineInstanceType(PropertyMapping definition)
+        private ClassMapping determineInstanceMapping(Base instance, PropertyMapping definition)
         {
-            if (!definition.IsPrimitive) return definition.PropertyTypeMapping.NativeType;
+            // For a choice element, the instance determines the type. For other elements we use the
+            // declared type, which we already have as a mapping - note that going through the .NET
+            // type here instead would lose the identity of custom types, since these all share
+            // the same (dynamic) .NET type.
+            if (definition.Choice != ChoiceType.None)
+                return _inspector.FindOrImportClassMapping(instance)!;
+            if (!definition.IsPrimitive) return definition.PropertyTypeMapping;
             throw new NotSupportedException(
                 $"Encountered unexpected primitive type {Name} for PocoElementNode.InstanceType.");
         }

--- a/src/Hl7.Fhir.Base/Introspection/Attributes/AllowedTypesAttribute.cs
+++ b/src/Hl7.Fhir.Base/Introspection/Attributes/AllowedTypesAttribute.cs
@@ -32,15 +32,33 @@ public class AllowedTypesAttribute(params Type[] types) : ValidatingFhirModelAtt
     {
         OpenChoice = openChoice;
     }
-    
+
     public AllowedTypesAttribute(Type type) : this([type]) { }
-    
+
+    /// <summary>
+    /// Creates an attribute that validates against a list of allowed FHIR type names, rather
+    /// than .NET types. This is needed for custom types: these all share the same dynamic .NET
+    /// type, so a list of .NET types cannot faithfully express such choices.
+    /// </summary>
+    public AllowedTypesAttribute(string[] typeNames) : this(types: [])
+    {
+        TypeNames = typeNames;
+    }
+
     public bool OpenChoice { get; set; }
 
     /// <summary>
     /// The list of types that are allowed for the instance.
     /// </summary>
     public Type[]? Types { get; } = types;
+
+    /// <summary>
+    /// The list of FHIR type names (as registered with the <see cref="ModelInspector"/>) that are
+    /// allowed for the instance. A mapping's canonical is accepted as well.
+    /// </summary>
+    /// <remarks>Matching is by exact mapping name: unlike <see cref="Types"/>, name-based
+    /// matching does not take subtyping into account.</remarks>
+    public string[]? TypeNames { get; }
 
     /// <inheritdoc />
     public override IReadOnlyCollection<CodedValidationException> Validate(object? value, PocoValidationContext validationContext)
@@ -65,17 +83,48 @@ public class AllowedTypesAttribute(params Type[] types) : ValidatingFhirModelAtt
         return result;
     }
 
-    private IReadOnlyCollection<CodedValidationException> validateValue(object? item, PocoValidationContext context) =>
-        Types switch
-        {
-            { Length: > 1 } when item is not null && !Types.Any(t => t.IsInstanceOfType(item)) =>
-                [COVE.CHOICE_TYPE_NOT_ALLOWED(context, COVE.FhirTypeNameForObject(item))],
-            { Length: 1 } when !Types[0].IsInstanceOfType(item) =>
-                [COVE.FromTypes(Types[0], item, context)],
-            _ when this.OpenChoice => !context.ModelInspector.OpenTypes.Any(t => t.IsInstanceOfType(item) && item is not IDynamicType) 
-                ? [COVE.CHOICE_TYPE_NOT_ALLOWED(context, COVE.FhirTypeNameForObject(item))]
-                : [],
-            _ => []
-        };
+    private IReadOnlyCollection<CodedValidationException> validateValue(object? item, PocoValidationContext context)
+    {
+        // An attribute without any constraints (no types, no type names, not an open choice)
+        // validates nothing.
+        if (Types is not { Length: > 0 } && TypeNames is not { Length: > 0 } && !OpenChoice) return [];
 
+        if (item is null || isAllowedType(item, context)) return [];
+
+        // For a single-type constraint we report a type mismatch (just like the .NET type-based
+        // validation always did), everything else reports a non-allowed choice.
+        return Types is { Length: 1 } && TypeNames is null
+            ? [COVE.FromTypes(Types[0], item, context)]
+            : [COVE.CHOICE_TYPE_NOT_ALLOWED(context, COVE.FhirTypeNameForObject(item))];
+    }
+
+    private bool isAllowedType(object item, PocoValidationContext context)
+    {
+        // The .NET type-based check. Note that a dynamic instance matching a dynamic type in the
+        // list does not establish anything (all custom types share the same dynamic .NET type),
+        // so those matches do not count - dynamic instances are matched by name below.
+        if (Types is { Length: > 0 } &&
+            Types.Any(t => t.IsInstanceOfType(item) &&
+                           (item is not IDynamicType || !typeof(IDynamicType).IsAssignableFrom(t))))
+            return true;
+
+        // The name-based check: resolve the instance to its mapping (for dynamic instances this
+        // uses their DynamicTypeName) and match the mapping's name or canonical.
+        if (TypeNames is { Length: > 0 } && item is Base b &&
+            context.ModelInspector.FindClassMapping(b) is { } mapping &&
+            (TypeNames.Contains(mapping.Name) ||
+             (mapping.Canonical is { } canonical && TypeNames.Contains(canonical))))
+            return true;
+
+        if (OpenChoice)
+        {
+            // An open choice allows any of the model's open types. A dynamic instance is allowed
+            // when it resolves to a custom type that was registered with the inspector.
+            return item is IDynamicType
+                ? item is Base d && context.ModelInspector.FindClassMapping(d) is { IsCustomMapping: true }
+                : context.ModelInspector.OpenTypes.Any(t => t.IsInstanceOfType(item));
+        }
+
+        return false;
+    }
 }

--- a/src/Hl7.Fhir.Base/Introspection/Attributes/AllowedTypesAttribute.cs
+++ b/src/Hl7.Fhir.Base/Introspection/Attributes/AllowedTypesAttribute.cs
@@ -24,6 +24,13 @@ namespace Hl7.Fhir.Introspection;
 /// <summary>
 /// Validates the type of a property against the allowed type choices.
 /// </summary>
+/// <remarks>The allowed types can be given as .NET types (<see cref="Types"/>), as FHIR type
+/// names (<see cref="TypeNames"/>), or both. The two lists are alternatives: a value is allowed
+/// when its .NET type matches one of <see cref="Types"/> (which takes inheritance into account),
+/// or when it resolves to a mapping whose name (or canonical) is listed in
+/// <see cref="TypeNames"/>. Note that custom types can only be matched by name: all custom types
+/// share the same dynamic .NET type, so a dynamic type listed in <see cref="Types"/> will never
+/// match.</remarks>
 [CLSCompliant(false)]
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
 public class AllowedTypesAttribute(params Type[] types) : ValidatingFhirModelAttribute
@@ -41,6 +48,16 @@ public class AllowedTypesAttribute(params Type[] types) : ValidatingFhirModelAtt
     /// type, so a list of .NET types cannot faithfully express such choices.
     /// </summary>
     public AllowedTypesAttribute(string[] typeNames) : this(types: [])
+    {
+        TypeNames = typeNames;
+    }
+
+    /// <summary>
+    /// Creates an attribute that validates against allowed types given both as .NET types and
+    /// as FHIR type names. The lists are alternatives: a value is allowed when it matches
+    /// either of them (see the remarks on this class).
+    /// </summary>
+    public AllowedTypesAttribute(Type[] types, string[] typeNames) : this(types)
     {
         TypeNames = typeNames;
     }

--- a/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
@@ -273,15 +273,24 @@ public class ClassMapping(
         this switch
         {
             { IsCodeOfT: true } => "code",
+            { IsBackboneType: true, IsCustomMapping: true } => "BackboneElement",
             { IsBackboneType: true } => NativeType.CanBeTreatedAsType(typeof(BackboneElement)) ?
                 "BackboneElement"
                 : "Element",
             _ => Name
         };
 
+    /// <summary>
+    /// Whether this type is an abstract type. Can only be set when the mapping is created;
+    /// when not set, this is derived from the <see cref="NativeType"/>. Mappings that are not
+    /// backed by a .NET type (e.g. mappings built from a StructureDefinition) should set this
+    /// explicitly, since their (dynamic) native type does not reflect the FHIR type's abstractness.
+    /// </summary>
+    public bool? IsAbstract { get; init; }
+
     /// <inheritdoc />
     bool IStructureDefinitionSummary.IsAbstract =>
-        ((IStructureDefinitionSummary)this).TypeName == "BackboneElement" || NativeType.IsAbstract;
+        IsAbstract ?? (((IStructureDefinitionSummary)this).TypeName == "BackboneElement" || NativeType.IsAbstract);
 
     /// <inheritdoc />
     bool IStructureDefinitionSummary.IsResource => IsResource;

--- a/src/Hl7.Fhir.Base/Introspection/ClassMappingCollection.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMappingCollection.cs
@@ -37,7 +37,12 @@ internal class ClassMappingCollection : ICollection<ClassMapping>
         var propKey = mapping.Name;
         _byName[propKey] = mapping;
 
-        _byType[mapping.NativeType] = mapping;
+        // Custom mappings intentionally do not participate in the type index: multiple custom
+        // types share the same runtime type (e.g. DynamicResource/DynamicDataType), so indexing
+        // them by type would make later additions overwrite earlier ones and make type-based
+        // lookup ambiguous. Custom mappings are found by name (or canonical) instead.
+        if (!mapping.IsCustomMapping)
+            _byType[mapping.NativeType] = mapping;
 
         var canonical = mapping.Canonical;
         if (canonical is not null)

--- a/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ModelInspector.cs
@@ -317,11 +317,34 @@ public class ModelInspector : IStructureDefinitionSummaryProvider, IModelInfo
     public ClassMapping? FindOrImportClassMapping(Type nativeType) => ImportType(nativeType);
 
     /// <summary>
+    /// Tries to retrieve an already imported <see cref="ClassMapping"/> for the type of the
+    /// given instance and will import its type when no mapping is found.
+    /// </summary>
+    /// <remarks>For dynamic types, the instance's <see cref="IDynamicType.DynamicTypeName"/> is used
+    /// to locate a (custom) mapping registered under that name, before falling back to the
+    /// runtime type of the instance.</remarks>
+    /// <returns>May return <c>null</c> if no mapping is found and the type cannot be imported.</returns>
+    public ClassMapping? FindOrImportClassMapping(Base instance) =>
+        FindClassMapping(instance) ?? ImportType(instance.GetType());
+
+    /// <summary>
     /// Retrieves an already imported <see cref="ClassMapping" /> given a FHIR type name.
     /// </summary>
     /// <remarks>The search for the mapping by namem is case-insensitive.</remarks>
     public ClassMapping? FindClassMapping(string fhirTypeName) =>
         _classMappings.ByName.GetValueOrDefault(fhirTypeName);
+
+    /// <summary>
+    /// Retrieves an already imported <see cref="ClassMapping" /> for the type of the given instance.
+    /// </summary>
+    /// <remarks>For dynamic types, the instance's <see cref="IDynamicType.DynamicTypeName"/> is used
+    /// to locate a (custom) mapping registered under that name, before falling back to the
+    /// runtime type of the instance.</remarks>
+    public ClassMapping? FindClassMapping(Base instance) =>
+        instance is IDynamicType { DynamicTypeName: { } typeName } && !string.IsNullOrWhiteSpace(typeName)
+            && FindClassMapping(typeName) is { } customMapping
+            ? customMapping
+            : FindClassMapping(instance.GetType());
 
     /// <summary>
     /// Retrieves an already imported <see cref="ClassMapping" /> given a Type.

--- a/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
@@ -53,19 +53,11 @@ public class PropertyMapping : IElementDefinitionSummary
     public PropertyMapping(ClassMapping declaringClass, string name, Type propertyType, Type[]? allowedTypes = null)
      : this(declaringClass, name, nativeProperty: null!)
     {
-        _ = ReflectionHelper.TryGetRepeatingElementType(propertyType, out var collectionItemType);
-
-        // Get to the actual (native) type representing this element
-        var implementingType = collectionItemType ?? propertyType;
-        if (Nullable.GetUnderlyingType(implementingType) is { } underlyingType) implementingType = underlyingType;
-
-        if (declaringClass.Inspector.FindOrImportClassMapping(implementingType) is not {} propertyTypeMapping)
-            throw new InvalidOperationException($"Custom property {name} is of type " +
-                                                $"{implementingType}, for which a classmapping cannot be found.");
+        var implementingType = unwrapPropertyType(propertyType, out var isCollection);
 
         Choice = allowedTypes is not null ? ChoiceType.DatatypeChoice : ChoiceType.None;
-        IsCollection = collectionItemType is not null;
-        PropertyTypeMapping = propertyTypeMapping;
+        IsCollection = isCollection;
+        PropertyTypeMapping = findMappingOrThrow(declaringClass, name, implementingType);
         FhirType = allowedTypes is not null ? allowedTypes.ToArray() : [implementingType];
         ImplementingType = implementingType;
         _propertyType = propertyType;
@@ -92,24 +84,18 @@ public class PropertyMapping : IElementDefinitionSummary
         if (typeMappings.Length == 0)
             throw new ArgumentException("At least one type mapping must be provided.", nameof(fhirTypes));
 
-        _ = ReflectionHelper.TryGetRepeatingElementType(propertyType, out var collectionItemType);
+        var implementingType = unwrapPropertyType(propertyType, out var isCollection);
 
-        // Get to the actual (native) type representing this element
-        var implementingType = collectionItemType ?? propertyType;
-        if (Nullable.GetUnderlyingType(implementingType) is { } underlyingType) implementingType = underlyingType;
+        Choice = typeMappings.Length > 1 ? ChoiceType.DatatypeChoice : ChoiceType.None;
+        IsCollection = isCollection;
 
         // For a single type, that type's mapping also serves as the property type mapping. For
         // choices, the property type mapping is the mapping for the declared (base) type of the
         // property, just like it is for reflected choice properties.
-        var propertyTypeMapping = typeMappings.Length == 1
+        PropertyTypeMapping = typeMappings.Length == 1
             ? typeMappings[0]
-            : declaringClass.Inspector.FindOrImportClassMapping(implementingType)
-              ?? throw new InvalidOperationException($"Custom property {name} is of type " +
-                                                     $"{implementingType}, for which a classmapping cannot be found.");
+            : findMappingOrThrow(declaringClass, name, implementingType);
 
-        Choice = typeMappings.Length > 1 ? ChoiceType.DatatypeChoice : ChoiceType.None;
-        IsCollection = collectionItemType is not null;
-        PropertyTypeMapping = propertyTypeMapping;
         FhirType = typeMappings.Select(tm => tm.NativeType).ToArray();
         ImplementingType = implementingType;
         _propertyType = propertyType;
@@ -122,6 +108,27 @@ public class PropertyMapping : IElementDefinitionSummary
             ? [new AllowedTypesAttribute(typeMappings.Select(tm => tm.Name).ToArray())]
             : [];
     }
+
+    /// <summary>
+    /// Derives the type representing the element from the declared type of a property,
+    /// unwrapping a repeating (List&lt;T&gt;) and/or nullable property type.
+    /// </summary>
+    private static Type unwrapPropertyType(Type propertyType, out bool isCollection)
+    {
+        _ = ReflectionHelper.TryGetRepeatingElementType(propertyType, out var collectionItemType);
+        isCollection = collectionItemType is not null;
+
+        // Get to the actual (native) type representing this element
+        var implementingType = collectionItemType ?? propertyType;
+        if (Nullable.GetUnderlyingType(implementingType) is { } underlyingType) implementingType = underlyingType;
+
+        return implementingType;
+    }
+
+    private static ClassMapping findMappingOrThrow(ClassMapping declaringClass, string name, Type implementingType) =>
+        declaringClass.Inspector.FindOrImportClassMapping(implementingType)
+            ?? throw new InvalidOperationException($"Custom property {name} is of type " +
+                                                   $"{implementingType}, for which a classmapping cannot be found.");
 
     /// <summary>
     /// Returns <c>true</c> when this class is a custom mapping, basically a dynamic resource/type with

--- a/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
@@ -72,6 +72,58 @@ public class PropertyMapping : IElementDefinitionSummary
     }
 
     /// <summary>
+    /// Creates a custom PropertyMapping for an element whose FHIR type(s) are given as
+    /// <see cref="ClassMapping"/>s rather than .NET types. This is the constructor to use for
+    /// mappings that are not backed by a reflectable .NET property, e.g. mappings built from
+    /// a StructureDefinition: multiple custom types share the same (dynamic) .NET type, so
+    /// only their ClassMappings can faithfully express the type(s) of the element.
+    /// </summary>
+    /// <param name="declaringClass">The mapping for the class this property is a member of.</param>
+    /// <param name="name">The name of the element this property represents.</param>
+    /// <param name="propertyType">The actual type of the property, as it would have been declared
+    /// on a POCO (so this may be a List&lt;T&gt; or nullable type).</param>
+    /// <param name="fhirTypes">The mappings for the FHIR type(s) of this element: a single mapping
+    /// for a normal element, multiple mappings for a choice element.</param>
+    [SetsRequiredMembers]
+    public PropertyMapping(ClassMapping declaringClass, string name, Type propertyType, IEnumerable<ClassMapping> fhirTypes)
+        : this(declaringClass, name, nativeProperty: null!)
+    {
+        var typeMappings = fhirTypes.ToArray();
+        if (typeMappings.Length == 0)
+            throw new ArgumentException("At least one type mapping must be provided.", nameof(fhirTypes));
+
+        _ = ReflectionHelper.TryGetRepeatingElementType(propertyType, out var collectionItemType);
+
+        // Get to the actual (native) type representing this element
+        var implementingType = collectionItemType ?? propertyType;
+        if (Nullable.GetUnderlyingType(implementingType) is { } underlyingType) implementingType = underlyingType;
+
+        // For a single type, that type's mapping also serves as the property type mapping. For
+        // choices, the property type mapping is the mapping for the declared (base) type of the
+        // property, just like it is for reflected choice properties.
+        var propertyTypeMapping = typeMappings.Length == 1
+            ? typeMappings[0]
+            : declaringClass.Inspector.FindOrImportClassMapping(implementingType)
+              ?? throw new InvalidOperationException($"Custom property {name} is of type " +
+                                                     $"{implementingType}, for which a classmapping cannot be found.");
+
+        Choice = typeMappings.Length > 1 ? ChoiceType.DatatypeChoice : ChoiceType.None;
+        IsCollection = collectionItemType is not null;
+        PropertyTypeMapping = propertyTypeMapping;
+        FhirType = typeMappings.Select(tm => tm.NativeType).ToArray();
+        ImplementingType = implementingType;
+        _propertyType = propertyType;
+        _fhirTypeMappings = typeMappings;
+
+        // Type-based validation cannot distinguish between custom types (they share the same
+        // dynamic .NET type), so synthesize a name-based AllowedTypes validation from the
+        // given mappings. Callers can override this via the initializer if needed.
+        ValidationAttributes = typeMappings.Length > 1 || typeMappings.Any(tm => tm.IsCustomMapping)
+            ? [new AllowedTypesAttribute(typeMappings.Select(tm => tm.Name).ToArray())]
+            : [];
+    }
+
+    /// <summary>
     /// Returns <c>true</c> when this class is a custom mapping, basically a dynamic resource/type with
     /// its own name, not being the default "DynamicType" or "DynamicResource".
     /// </summary>
@@ -118,8 +170,46 @@ public class PropertyMapping : IElementDefinitionSummary
     /// or, if present, via a list of types in the [AllowedTypes] attribute. Finally,
     /// it the property type does not represent FHIR metadata, it is overridden using
     /// the [DeclaredType] attribute.
+    /// Note that for custom mappings, multiple FHIR types share the same (dynamic) .NET type,
+    /// so this property cannot distinguish between them. Use <see cref="FhirTypeMappings"/>
+    /// instead, which is the authoritative list of types for this element.
     /// </remark>
     public required Type[] FhirType { get; init; }
+
+    /// <summary>
+    /// The list of possible FHIR types for this element, listed as their <see cref="ClassMapping"/>s.
+    /// For non-choice elements this is a single mapping, for choice elements the mappings of
+    /// the allowed choice types.
+    /// </summary>
+    /// <remarks>This is the authoritative representation of the element's types: unlike
+    /// <see cref="FhirType"/> it can distinguish between custom types that share the
+    /// same (dynamic) .NET type. For mappings created by reflection, the list is resolved
+    /// lazily from <see cref="FhirType"/>.</remarks>
+    public IReadOnlyList<ClassMapping> FhirTypeMappings
+    {
+        get
+        {
+            LazyInitializer.EnsureInitialized(ref _fhirTypeMappings, buildFhirTypeMappings);
+            return _fhirTypeMappings!;
+        }
+    }
+
+    private ClassMapping[]? _fhirTypeMappings;
+
+    private ClassMapping[] buildFhirTypeMappings()
+    {
+        // For backbone properties, the (single) type is the backbone's own mapping.
+        if (PropertyTypeMapping.IsBackboneType)
+            return [PropertyTypeMapping];
+
+        return FhirType.Select(resolve).ToArray();
+
+        ClassMapping resolve(Type ft) =>
+            Inspector.FindOrImportClassMapping(ft) ??
+            throw new NotSupportedException($"Type '{ft.Name}' is listed as an allowed type for property " +
+                                            $"'{QualifiedPropName}', but it does not seem to " +
+                                            $"be a valid FHIR type POCO.");
+    }
 
     /// <summary>
     /// The <see cref="ClassMapping" /> that represents the type of this property.
@@ -326,8 +416,8 @@ public class PropertyMapping : IElementDefinitionSummary
             return ImplementingType;
 
         // Ok, so we're in abstract type land, maybe FhirType can help us
-        if (FhirType.Length == 1)
-            return FhirType[0];
+        if (FhirTypeMappings.Count == 1)
+            return FhirTypeMappings[0].NativeType;
 
         // No, just return ImplementingType then.
         return ImplementingType;
@@ -399,10 +489,12 @@ public class PropertyMapping : IElementDefinitionSummary
 
     public PropertyMapping PromoteToList()
     {
-        if(FhirType.Length > 1) throw new InvalidOperationException("Cannot promote a choice element to a list");
+        if(FhirTypeMappings.Count > 1) throw new InvalidOperationException("Cannot promote a choice element to a list");
 
+        // Carry over the type mappings, so the promoted list keeps referring to the same
+        // (possibly custom) type as the original element.
         var listType = typeof(List<>).MakeGenericType(ImplementingType);
-        return new PropertyMapping(DeclaringClass, Name, listType);
+        return new PropertyMapping(DeclaringClass, Name, listType, FhirTypeMappings);
     }
 
     #region IElementDefinitionSummary members
@@ -444,33 +536,27 @@ public class PropertyMapping : IElementDefinitionSummary
 
     private ITypeSerializationInfo[] buildTypes()
     {
-        if (PropertyTypeMapping.IsBackboneType)
-            return [PropertyTypeMapping];
-
         if (IsPrimitive)
         {
             throw new NotSupportedException(
                 $"Encountered unexpected primitive type {Name} for ITypedElement.InstanceType.");
         }
 
-        var names = FhirType.Select(getFhirTypeName);
-        return names.Select(n => (ITypeSerializationInfo)new PocoTypeReferenceInfo(n)).ToArray();
-
-        string getFhirTypeName(Type ft)
-        {
-            // The special case where the mapping name is a backbone element name can safely
-            // be ignored here, since that is handled by the first case in the if statement above.
-            return Inspector.FindOrImportClassMapping(ft) is {} tm
-                ? ((IStructureDefinitionSummary)tm).TypeName
-                : throw new NotSupportedException($"Type '{ft.Name}' is listed as an allowed type for property " +
-                                                  $"'{QualifiedPropName}', but it does not seem to" +
-                                                  $"be a valid FHIR type POCO.");
-        }
+        // Backbone mappings are themselves the IStructureDefinitionSummary for the type, all
+        // other types are returned as a reference by type name. Note that this is always the
+        // type NAME (also for custom types, which are registered by name with the inspector),
+        // never a canonical: consumers match these references against type names, e.g. when
+        // matching the type suffix of a choice element.
+        return FhirTypeMappings
+            .Select(tm => tm.IsBackboneType
+                ? (ITypeSerializationInfo)tm
+                : new PocoTypeReferenceInfo(((IStructureDefinitionSummary)tm).TypeName))
+            .ToArray();
     }
 
-    private readonly struct PocoTypeReferenceInfo(string canonical) : IStructureDefinitionReference
+    private readonly struct PocoTypeReferenceInfo(string typeName) : IStructureDefinitionReference
     {
-        public string ReferredType { get; } = canonical;
+        public string ReferredType { get; } = typeName;
     }
 
     #endregion

--- a/src/Hl7.Fhir.Base/Model/PocoNode.TypedElement.cs
+++ b/src/Hl7.Fhir.Base/Model/PocoNode.TypedElement.cs
@@ -44,10 +44,10 @@ public partial record PocoNode
 
             // we could get definitions with FindOrImportClassMapping, but then we're modifying inspector mappings
             // which either should already have the type, or is expected to be immutable!
-            if (this.Parent is {} node && inspector.FindClassMapping(node.Poco.GetType()) is {} classMapping)
+            if (this.Parent is {} node && inspector.FindClassMapping(node.Poco) is {} classMapping)
                 return classMapping.FindMappedElementByName(Name);
 
-            if (inspector.FindClassMapping(Poco.GetType()) is {} cm)
+            if (inspector.FindClassMapping(Poco) is {} cm)
                 return ElementDefinitionSummary.ForRoot(cm, Name);
 
             return null;
@@ -92,7 +92,7 @@ public partial record PocoNode
         if (name is null) return Children().SelectMany(node => node);
         
         var trueElementName = this.FindInspector()?
-            .FindOrImportClassMapping(Poco.GetType())?
+            .FindOrImportClassMapping(Poco)?
             .FindMappedElementByChoiceName(name)?.Name;
         
         return Child(trueElementName ?? name) ?? Enumerable.Empty<ISourceNode>();

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonDeserializer.cs
@@ -732,6 +732,10 @@ public class BaseFhirJsonDeserializer
 
         var propertyValueMapping = propertyMapping.Choice switch
         {
+            // A custom type mapping is used directly: resolving it via the .NET type (below) would
+            // lose the identity of the custom type, since custom types share the same dynamic .NET type.
+            ChoiceType.None or ChoiceType.ResourceChoice when propertyMapping.PropertyTypeMapping is { IsCustomMapping: true } customType =>
+                customType,
             ChoiceType.None or ChoiceType.ResourceChoice =>
                 parentMapping.Inspector.FindOrImportClassMapping(propertyMapping.GetInstantiableType()) ??
                     throw new InvalidOperationException($"Encountered property type {propertyMapping.GetInstantiableType()} for which" +

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonSerializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonSerializer.cs
@@ -84,7 +84,7 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
             writer.WriteString("resourceType", r.TypeName);
 
         // Only throw if we don't have a mapping where we are expected to: when this is a subclass of Base.
-        if (Inspector.FindOrImportClassMapping(element.GetType()) is not {} mapping)
+        if (Inspector.FindOrImportClassMapping(element) is not {} mapping)
             throw new InvalidOperationException($"Encountered type {element.GetType()}, which is a support POCO for FHIR, but does not " +
                                                 $"have sufficient metadata to be used by the serializer.");
 

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
@@ -590,6 +590,10 @@ public class BaseFhirXmlDeserializer
 
         ClassMapping propertyValueMapping = propertyMapping.Choice switch
         {
+            // A custom type mapping is used directly: resolving it via the .NET type (below) would
+            // lose the identity of the custom type, since custom types share the same dynamic .NET type.
+            ChoiceType.None or ChoiceType.ResourceChoice when propertyMapping.PropertyTypeMapping is { IsCustomMapping: true } customType =>
+                customType,
             ChoiceType.None or ChoiceType.ResourceChoice =>
                 parentMapping.Inspector.FindOrImportClassMapping(propertyMapping.GetInstantiableType()) ??
                 throw new InvalidOperationException($"Encountered property type {propertyMapping.GetInstantiableType()} for which" +

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlSerializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlSerializer.cs
@@ -75,7 +75,7 @@ public class BaseFhirXmlSerializer(ModelInspector inspector)
             writer.WriteStartElement(r.TypeName, XmlNs.FHIR);
 
         // Only throw if we don't have a mapping where we are expected to: when this is a subclass of Base.
-        if (Inspector.FindOrImportClassMapping(element.GetType()) is not {} mapping)
+        if (Inspector.FindOrImportClassMapping(element) is not {} mapping)
             throw new InvalidOperationException($"Encountered type {element.GetType()}, which is a support POCO for FHIR, but does not " +
                                                 $"have sufficient metadata to be used by the serializer.");
 

--- a/src/Hl7.Fhir.Base/Validation/FhirAttributeValidator.cs
+++ b/src/Hl7.Fhir.Base/Validation/FhirAttributeValidator.cs
@@ -33,6 +33,12 @@ public class FhirAttributeValidator : IPocoValidator
         PropertyMapping? propertyMapping,
         PocoValidationContext context)
     {
+        // An element is unknown when there is no mapping for it at all, or when its mapping was
+        // fabricated on the fly by the deserializer for an element it did not recognize (an
+        // "ad-hoc" mapping). Note that the latter can also happen on a custom class: custom
+        // properties that are a member of their declaring class are known and validated normally,
+        // but an unrecognized element on such a class gets an ad-hoc mapping too, and must still
+        // be reported here.
         if (propertyMapping is null || propertyMapping.IsPrimitive || isAdHocMapping(propertyMapping))
         {
             var serializedForm = propertyValue is Base b && b.Annotation<XmlRepresentationAnnotation>() is not null

--- a/src/Hl7.Fhir.Base/Validation/FhirAttributeValidator.cs
+++ b/src/Hl7.Fhir.Base/Validation/FhirAttributeValidator.cs
@@ -33,22 +33,22 @@ public class FhirAttributeValidator : IPocoValidator
         PropertyMapping? propertyMapping,
         PocoValidationContext context)
     {
-        if (propertyMapping?.NativeProperty is null || propertyMapping.IsPrimitive)
+        if (propertyMapping is null || propertyMapping.IsPrimitive || isAdHocMapping(propertyMapping))
         {
             var serializedForm = propertyValue is Base b && b.Annotation<XmlRepresentationAnnotation>() is not null
                 ? "attribute"
                 : "element";
             return [CodedValidationException.UNKNOWN_ELEMENT(context, name, serializedForm)];
         }
-        
+
         // if context doesn't have MemberName, set it explicitly
-        context.MemberName ??= propertyMapping.NativeProperty.Name;
+        context.MemberName ??= propertyMapping.NativeProperty?.Name;
 
         // check whether the value is assignable to the property, we'll complain in runAttributeValidation about other issues
         if (!propertyMapping.PropertyType.IsInstanceOfType(propertyValue))
         {
             return [
-                CodedValidationException.FromTypes(propertyMapping.PropertyType, propertyValue, context, propertyMapping.NativeProperty.Name),
+                CodedValidationException.FromTypes(propertyMapping.PropertyType, propertyValue, context, propertyMapping.NativeProperty?.Name ?? propertyMapping.Name),
                 ..runAttributeValidation(propertyValue, propertyMapping.ValidationAttributes, context)
             ];
         }
@@ -61,10 +61,11 @@ public class FhirAttributeValidator : IPocoValidator
     {
         var errors = new List<CodedValidationException>();
 
-        // For now, if we encounter a dynamic resource, we'll report that we have encountered an unknown
-        // resource type. In a future version, users will able to register custom dynamic types that are
-        // "known" to the validator, in which case those would not be reported here.
-        if (instance is DynamicResource dr && !BaseFhirJsonDeserializer.IsUnnamedResourceMapping(classMapping))
+        // If we encounter a dynamic resource that is not backed by a custom mapping registered
+        // with the inspector, we'll report that we have encountered an unknown resource type.
+        if (instance is DynamicResource dr
+            && !BaseFhirJsonDeserializer.IsUnnamedResourceMapping(classMapping)
+            && !isRegisteredCustomMapping(classMapping, context))
             errors.Add(CodedValidationException.UNKNOWN_RESOURCE_TYPE(context, dr.DynamicTypeName ?? "(unnamed)"));
 
         // Make sure we detect missing values - go over all members that have cardinality constraints
@@ -102,4 +103,21 @@ public class FhirAttributeValidator : IPocoValidator
         ValidatingFhirModelAttribute[] attributes,
         PocoValidationContext validationContext) =>
         attributes.SelectMany(vfma => vfma.Validate(candidateValue, validationContext)).ToArray();
+
+    /// <summary>
+    /// Whether this is an ad-hoc mapping, created on the fly (e.g. by the deserializer) for a
+    /// property that is not part of its declaring class. Custom mappings that are a member of
+    /// their declaring class represent known elements and should be validated normally.
+    /// </summary>
+    private static bool isAdHocMapping(PropertyMapping propertyMapping) =>
+        propertyMapping.NativeProperty is null &&
+        !ReferenceEquals(propertyMapping.DeclaringClass.FindMappedElementByName(propertyMapping.Name), propertyMapping);
+
+    /// <summary>
+    /// Whether this is a custom mapping that has been registered with the inspector, as opposed
+    /// to an ad-hoc mapping created by the deserializer for an unknown resource type.
+    /// </summary>
+    private static bool isRegisteredCustomMapping(ClassMapping classMapping, PocoValidationContext context) =>
+        classMapping.IsCustomMapping &&
+        ReferenceEquals(context.ModelInspector.FindClassMapping(classMapping.Name), classMapping);
 }

--- a/src/Hl7.Fhir.Base/Validation/PocoValidationExtensions.cs
+++ b/src/Hl7.Fhir.Base/Validation/PocoValidationExtensions.cs
@@ -61,7 +61,7 @@ public static class PocoValidationExtensions
     {
         var errors = new List<CodedValidationException>();
 
-        var classMapping = validationContext.ModelInspector.FindOrImportClassMapping(value.GetType());
+        var classMapping = validationContext.ModelInspector.FindOrImportClassMapping(value);
         if (classMapping is null) return [];
 
         // Step 1: Validate the object properties.

--- a/src/Hl7.Fhir.Support.Tests/Introspection/CustomClassMappingTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/Introspection/CustomClassMappingTests.cs
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2026, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+using FluentAssertions;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Introspection;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Hl7.Fhir.Specification;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Hl7.Fhir.Tests.Introspection
+{
+    /// <summary>
+    /// Builds a small custom model, expressed purely in terms of ClassMappings and
+    /// PropertyMappings (as an external user, e.g. a server hosting custom resources, would):
+    /// a custom datatype, and a custom resource with a backbone element and a choice element
+    /// for which one of the choices is the custom datatype.
+    /// </summary>
+    internal static class CustomTestModel
+    {
+        public const string DATATYPE_CANONICAL = "http://example.org/fhir/StructureDefinition/MyCustomDatatype";
+        public const string RESOURCE_CANONICAL = "http://example.org/fhir/StructureDefinition/MyCustomResource";
+
+        public static ModelInspector Create()
+        {
+            var inspector = new ModelInspector(FhirRelease.STU3);
+            inspector.Import(typeof(Resource).GetTypeInfo().Assembly);
+
+            var stringMapping = inspector.FindClassMapping("string")!;
+            var booleanMapping = inspector.FindClassMapping("boolean")!;
+            var integerMapping = inspector.FindClassMapping("integer")!;
+
+            var datatype = new ClassMapping(inspector, "MyCustomDatatype", typeof(DynamicDataType), dt =>
+            [
+                new PropertyMapping(dt, "unit", typeof(FhirString), [stringMapping]) { Order = 10 },
+                new PropertyMapping(dt, "score", typeof(Integer), [integerMapping]) { Order = 20 }
+            ])
+            {
+                Canonical = DATATYPE_CANONICAL,
+                IsAbstract = false
+            };
+
+            ClassMapping component = null!;
+            component = new ClassMapping(inspector, "MyCustomResource.component", typeof(DynamicDataType), c =>
+            [
+                new PropertyMapping(c, "flag", typeof(FhirBoolean), [booleanMapping]) { Order = 10 },
+                new PropertyMapping(c, "data", typeof(DynamicDataType), [datatype]) { Order = 20 }
+            ])
+            {
+                IsBackboneType = true
+            };
+
+            var resource = new ClassMapping(inspector, "MyCustomResource", typeof(DynamicResource), r =>
+            [
+                new PropertyMapping(r, "identifier", typeof(FhirString), [stringMapping])
+                {
+                    Order = 10,
+                    IsMandatoryElement = true,
+                    ValidationAttributes = [new CardinalityAttribute { Min = 1 }]
+                },
+                new PropertyMapping(r, "component", typeof(List<DynamicDataType>), [component]) { Order = 20 },
+                new PropertyMapping(r, "value", typeof(DataType), [stringMapping, datatype]) { Order = 30 }
+            ])
+            {
+                Canonical = RESOURCE_CANONICAL
+            };
+
+            inspector.ClassMappings.Add(datatype);
+            inspector.ClassMappings.Add(component);
+            inspector.ClassMappings.Add(resource);
+
+            return inspector;
+        }
+
+        public static DynamicResource CreateValidInstance(ModelInspector inspector)
+        {
+            var datatype = inspector.FindClassMapping("MyCustomDatatype")!;
+            var component = inspector.FindClassMapping("MyCustomResource.component")!;
+            var resource = inspector.FindClassMapping("MyCustomResource")!;
+
+            var data = (DynamicDataType)datatype.CreateInstance();
+            data.SetValue("unit", new FhirString("kg"));
+            data.SetValue("score", new Integer(5));
+
+            var comp = (DynamicDataType)component.CreateInstance();
+            comp.SetValue("flag", new FhirBoolean(true));
+            comp.SetValue("data", data);
+
+            var choiceValue = (DynamicDataType)datatype.CreateInstance();
+            choiceValue.SetValue("unit", new FhirString("g"));
+            choiceValue.SetValue("score", new Integer(3));
+
+            var instance = (DynamicResource)resource.CreateInstance();
+            instance.SetValue("identifier", new FhirString("id-1"));
+            instance.SetValue("component", new List<DynamicDataType> { comp });
+            instance.SetValue("value", choiceValue);
+
+            return instance;
+        }
+    }
+
+    [TestClass]
+    public class CustomClassMappingTests
+    {
+        [TestMethod]
+        public void CustomMappingsExposeCorrectStructureDefinitionSummaries()
+        {
+            var inspector = CustomTestModel.Create();
+
+            var resource = inspector.FindClassMapping("MyCustomResource");
+            resource.Should().NotBeNull();
+            inspector.FindClassMappingByCanonical(CustomTestModel.RESOURCE_CANONICAL).Should().BeSameAs(resource);
+            inspector.Provide("MyCustomResource").Should().BeSameAs(resource);
+
+            // Custom mappings must not hijack the type-based lookup for the shared dynamic types.
+            inspector.FindClassMapping(typeof(DynamicResource))!.Name.Should().Be("DynamicResource");
+            inspector.FindClassMapping(typeof(DynamicDataType))!.Name.Should().Be("DynamicDataType");
+
+            var summary = (IStructureDefinitionSummary)resource!;
+            summary.TypeName.Should().Be("MyCustomResource");
+            summary.IsAbstract.Should().BeFalse();
+            summary.IsResource.Should().BeTrue();
+
+            var elements = summary.GetElements();
+            elements.Select(e => e.ElementName).Should().Equal("identifier", "component", "value");
+
+            var identifier = elements.Single(e => e.ElementName == "identifier");
+            identifier.IsRequired.Should().BeTrue();
+            identifier.Type.Single().Should().BeAssignableTo<IStructureDefinitionReference>()
+                .Which.ReferredType.Should().Be("string");
+
+            var component = elements.Single(e => e.ElementName == "component");
+            component.IsCollection.Should().BeTrue();
+            var componentSummary = component.Type.Single().Should().BeAssignableTo<IStructureDefinitionSummary>().Subject;
+            componentSummary.Should().BeSameAs(inspector.FindClassMapping("MyCustomResource.component"));
+            componentSummary.TypeName.Should().Be("BackboneElement");
+            componentSummary.IsAbstract.Should().BeTrue();
+            componentSummary.GetElements().Select(e => e.ElementName).Should().Equal("flag", "data");
+
+            var choice = elements.Single(e => e.ElementName == "value");
+            choice.IsChoiceElement.Should().BeTrue();
+            // Type references are always by type name (never by canonical), since consumers
+            // match them against e.g. the type suffix of a choice element.
+            choice.Type.Cast<IStructureDefinitionReference>().Select(t => t.ReferredType)
+                .Should().Equal("string", "MyCustomDatatype");
+        }
+
+        [TestMethod]
+        public void CustomChoicePropertyExposesFhirTypeMappings()
+        {
+            var inspector = CustomTestModel.Create();
+            var resource = inspector.FindClassMapping("MyCustomResource")!;
+
+            var choice = resource.FindMappedElementByName("value")!;
+            choice.Choice.Should().Be(ChoiceType.DatatypeChoice);
+            choice.FhirTypeMappings.Select(tm => tm.Name).Should().Equal("string", "MyCustomDatatype");
+
+            // The legacy .NET type based view degrades to the native (dynamic) types.
+            choice.FhirType.Should().Equal(typeof(FhirString), typeof(DynamicDataType));
+
+            // A name-based AllowedTypes validation has been synthesized from the mappings.
+            choice.ValidationAttributes.OfType<AllowedTypesAttribute>().Single()
+                .TypeNames.Should().Equal("string", "MyCustomDatatype");
+        }
+
+        [TestMethod]
+        public void ReflectedPropertyExposesFhirTypeMappings()
+        {
+            var inspector = CustomTestModel.Create();
+
+            var coding = inspector.FindClassMapping("Coding")!;
+            var system = coding.FindMappedElementByName("system")!;
+            system.FhirTypeMappings.Single().Should().BeSameAs(inspector.FindClassMapping("uri"));
+            system.FhirType.Should().Equal(typeof(FhirUri));
+
+            // The open choice on Extension.value still presents itself as a "DataType" reference.
+            var extension = inspector.FindClassMapping("Extension")!;
+            var value = (IElementDefinitionSummary)extension.FindMappedElementByName("value")!;
+            value.Type.Single().Should().BeAssignableTo<IStructureDefinitionReference>()
+                .Which.ReferredType.Should().Be("DataType");
+        }
+
+        [TestMethod]
+        public void CustomResourceRoundtripsThroughJson()
+        {
+            var inspector = CustomTestModel.Create();
+            var instance = CustomTestModel.CreateValidInstance(inspector);
+
+            var json = new BaseFhirJsonSerializer(inspector).SerializeToString(instance);
+
+            json.Should().Contain("\"resourceType\":\"MyCustomResource\"");
+            json.Should().Contain("\"valueMyCustomDatatype\":");
+
+            var parsed = new BaseFhirJsonDeserializer(inspector).DeserializeResource(json);
+            assertParsedCustomResource(parsed);
+
+            new BaseFhirJsonSerializer(inspector).SerializeToString(parsed).Should().Be(json);
+        }
+
+        [TestMethod]
+        public void CustomResourceRoundtripsThroughXml()
+        {
+            var inspector = CustomTestModel.Create();
+            var instance = CustomTestModel.CreateValidInstance(inspector);
+
+            var xml = new BaseFhirXmlSerializer(inspector).SerializeToString(instance);
+
+            xml.Should().Contain("<MyCustomResource");
+            xml.Should().Contain("<valueMyCustomDatatype");
+
+            var parsed = new BaseFhirXmlDeserializer(inspector).DeserializeResource(xml);
+            assertParsedCustomResource(parsed);
+
+            new BaseFhirXmlSerializer(inspector).SerializeToString(parsed).Should().Be(xml);
+        }
+
+        private static void assertParsedCustomResource(Resource parsed)
+        {
+            var custom = parsed.Should().BeOfType<DynamicResource>().Subject;
+            custom.DynamicTypeName.Should().Be("MyCustomResource");
+
+            custom.TryGetValue("value", out var choiceValue).Should().BeTrue();
+            choiceValue.Should().BeOfType<DynamicDataType>()
+                .Which.DynamicTypeName.Should().Be("MyCustomDatatype");
+
+            custom.TryGetValue("component", out var components).Should().BeTrue();
+            var component = ((IEnumerable<Base>)components!).Single();
+            component.TryGetValue("data", out var data).Should().BeTrue();
+            data.Should().BeOfType<DynamicDataType>()
+                .Which.DynamicTypeName.Should().Be("MyCustomDatatype",
+                    "a non-choice element of a custom type should keep the custom type identity when parsed");
+        }
+
+        [TestMethod]
+        public void TypedElementOnCustomPocoExposesCustomTypes()
+        {
+            var inspector = CustomTestModel.Create();
+            var instance = CustomTestModel.CreateValidInstance(inspector);
+
+            var typed = instance.ToTypedElementLegacy(inspector);
+
+            typed.InstanceType.Should().Be("MyCustomResource");
+
+            var component = typed.Children("component").Single();
+            component.InstanceType.Should().Be("BackboneElement");
+            component.Children("data").Single().InstanceType.Should().Be("MyCustomDatatype",
+                "non-choice elements should take their instance type from the declared custom mapping");
+
+            typed.Children("value").Single().InstanceType.Should().Be("MyCustomDatatype",
+                "choice elements should take their instance type from the instance's dynamic type");
+        }
+    }
+}

--- a/src/Hl7.Fhir.Support.Tests/Introspection/CustomMappingValidationTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/Introspection/CustomMappingValidationTests.cs
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+using FluentAssertions;
+using Hl7.Fhir.Introspection;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Validation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace Hl7.Fhir.Tests.Introspection
+{
+    /// <summary>
+    /// Tests attribute-based validation of instances of custom types, using the custom model
+    /// from <see cref="CustomTestModel"/>.
+    /// </summary>
+    [TestClass]
+    public class CustomMappingValidationTests
+    {
+        [TestMethod]
+        public void ValidCustomResourceInstanceValidatesCleanly()
+        {
+            var inspector = CustomTestModel.Create();
+            var instance = CustomTestModel.CreateValidInstance(inspector);
+
+            instance.Validate(inspector).Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void ChoiceAcceptsCoreTypeFromTheChoiceList()
+        {
+            var inspector = CustomTestModel.Create();
+            var instance = CustomTestModel.CreateValidInstance(inspector);
+
+            instance.SetValue("value", new FhirString("plain"));
+            instance.Validate(inspector).Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void ChoiceRejectsOtherRegisteredCustomType()
+        {
+            var inspector = CustomTestModel.Create();
+            var stringMapping = inspector.FindClassMapping("string")!;
+            var other = new ClassMapping(inspector, "OtherCustomDatatype", typeof(DynamicDataType), dt =>
+            [
+                new PropertyMapping(dt, "note", typeof(FhirString), [stringMapping]) { Order = 10 }
+            ]);
+            inspector.ClassMappings.Add(other);
+
+            var otherInstance = other.CreateInstance();
+            otherInstance.SetValue("note", new FhirString("hi"));
+
+            var instance = CustomTestModel.CreateValidInstance(inspector);
+            instance.SetValue("value", otherInstance);
+
+            instance.Validate(inspector).Should().ContainSingle()
+                .Which.ErrorCode.Should().Be(CodedValidationException.CHOICE_TYPE_NOT_ALLOWED_CODE);
+        }
+
+        [TestMethod]
+        public void ChoiceRejectsUnregisteredDynamicType()
+        {
+            var inspector = CustomTestModel.Create();
+            var instance = CustomTestModel.CreateValidInstance(inspector);
+
+            instance.SetValue("value", new DynamicDataType { DynamicTypeName = "NotRegistered" });
+
+            // The instance itself will report more issues (it is unregistered, so its contents
+            // cannot be valid either way) - we just verify the choice validation rejected it.
+            instance.Validate(inspector).Select(e => e.ErrorCode)
+                .Should().Contain(CodedValidationException.CHOICE_TYPE_NOT_ALLOWED_CODE);
+        }
+
+        [TestMethod]
+        public void MissingMandatoryElementIsReported()
+        {
+            var inspector = CustomTestModel.Create();
+            var instance = CustomTestModel.CreateValidInstance(inspector);
+
+            instance.SetValue("identifier", null);
+
+            instance.Validate(inspector).Should().ContainSingle()
+                .Which.ErrorCode.Should().Be(CodedValidationException.MANDATORY_ELEMENT_MUST_BE_PRESENT_CODE);
+        }
+
+        [TestMethod]
+        public void UnknownElementOnCustomResourceIsReported()
+        {
+            var inspector = CustomTestModel.Create();
+            var instance = CustomTestModel.CreateValidInstance(inspector);
+
+            instance.SetValue("bogus", new FhirString("nope"));
+
+            instance.Validate(inspector).Should().ContainSingle()
+                .Which.ErrorCode.Should().Be(CodedValidationException.UNKNOWN_ELEMENT_CODE);
+        }
+
+        [TestMethod]
+        public void UnregisteredDynamicResourceIsStillReportedAsUnknown()
+        {
+            var inspector = CustomTestModel.Create();
+            var stray = new DynamicResource { DynamicTypeName = "NotRegisteredResource" };
+
+            stray.Validate(inspector).Select(e => e.ErrorCode)
+                .Should().Contain(CodedValidationException.UNKNOWN_RESOURCE_TYPE_CODE);
+        }
+
+        [TestMethod]
+        public void OpenChoiceAcceptsRegisteredCustomTypeAndOpenTypes()
+        {
+            var inspector = CustomTestModel.Create();
+            var openResource = addOpenChoiceResource(inspector);
+            var custom = inspector.FindClassMapping("MyCustomDatatype")!.CreateInstance();
+            custom.SetValue("unit", new FhirString("kg"));
+
+            var instance = (DynamicResource)openResource.CreateInstance();
+            instance.SetValue("anything", custom);
+            instance.Validate(inspector).Should().BeEmpty();
+
+            instance.SetValue("anything", new FhirBoolean(true));
+            instance.Validate(inspector).Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void OpenChoiceRejectsUnregisteredDynamicType()
+        {
+            var inspector = CustomTestModel.Create();
+            var openResource = addOpenChoiceResource(inspector);
+
+            var instance = (DynamicResource)openResource.CreateInstance();
+            instance.SetValue("anything", new DynamicDataType { DynamicTypeName = "NotRegistered" });
+
+            instance.Validate(inspector).Select(e => e.ErrorCode)
+                .Should().Contain(CodedValidationException.CHOICE_TYPE_NOT_ALLOWED_CODE);
+        }
+
+        [TestMethod]
+        public void ReflectedAllowedTypesValidationIsUnchanged()
+        {
+            var inspector = CustomTestModel.Create();
+
+            var ext = new Extension { Url = "http://example.org/ext", Value = new FhirBoolean(true) };
+            ext.Validate(inspector).Should().BeEmpty();
+        }
+
+        private static ClassMapping addOpenChoiceResource(ModelInspector inspector)
+        {
+            var openResource = new ClassMapping(inspector, "OpenChoiceResource", typeof(DynamicResource), r =>
+            [
+                new PropertyMapping(r, "anything", typeof(DataType), [inspector.FindClassMapping("DataType")!])
+                {
+                    Order = 10,
+                    Choice = ChoiceType.DatatypeChoice,
+                    ValidationAttributes = [new AllowedTypesAttribute(true)]
+                }
+            ]);
+            inspector.ClassMappings.Add(openResource);
+
+            return openResource;
+        }
+    }
+}

--- a/src/Hl7.Fhir.Support.Tests/Introspection/CustomMappingValidationTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/Introspection/CustomMappingValidationTests.cs
@@ -140,6 +140,39 @@ namespace Hl7.Fhir.Tests.Introspection
         }
 
         [TestMethod]
+        public void MixedTypeAndNameBasedAllowedTypesActAsUnion()
+        {
+            var inspector = CustomTestModel.Create();
+            var mixedResource = new ClassMapping(inspector, "MixedChoiceResource", typeof(DynamicResource), r =>
+            [
+                new PropertyMapping(r, "value", typeof(DataType), [inspector.FindClassMapping("DataType")!])
+                {
+                    Order = 10,
+                    Choice = ChoiceType.DatatypeChoice,
+                    ValidationAttributes = [new AllowedTypesAttribute([typeof(FhirString)], ["MyCustomDatatype"])]
+                }
+            ]);
+            inspector.ClassMappings.Add(mixedResource);
+
+            var instance = (DynamicResource)mixedResource.CreateInstance();
+
+            // matched by the .NET type list
+            instance.SetValue("value", new FhirString("plain"));
+            instance.Validate(inspector).Should().BeEmpty();
+
+            // matched by the type name list
+            var custom = inspector.FindClassMapping("MyCustomDatatype")!.CreateInstance();
+            custom.SetValue("unit", new FhirString("kg"));
+            instance.SetValue("value", custom);
+            instance.Validate(inspector).Should().BeEmpty();
+
+            // matched by neither list
+            instance.SetValue("value", new FhirBoolean(true));
+            instance.Validate(inspector).Should().ContainSingle()
+                .Which.ErrorCode.Should().Be(CodedValidationException.CHOICE_TYPE_NOT_ALLOWED_CODE);
+        }
+
+        [TestMethod]
         public void ReflectedAllowedTypesValidationIsUnchanged()
         {
             var inspector = CustomTestModel.Create();


### PR DESCRIPTION
## Summary

Enables registering `ClassMapping`s for custom resources and datatypes (backed by `DynamicResource`/`DynamicDataType`) with the `ModelInspector`, expressed purely in the domain language of the mapping classes (`Type`, `ClassMapping`, `PropertyMapping`). Supersedes #3489, which leaked `ITypeSerializationInfo` into the public mapping API.

The core modeling change: with custom types, a .NET `Type` no longer identifies a FHIR type (all custom types share the same dynamic .NET type), so:

- `PropertyMapping` gains **`FhirTypeMappings`**, the authoritative (lazily resolved) list of the element''s types as `ClassMapping`s. The legacy `FhirType` (`Type[]`) remains as a compatibility facade, but degrades to the native dynamic types for custom choices (documented on the property). `buildTypes`/`GetInstantiableType`/`PromoteToList` now work off `FhirTypeMappings`.
- A new constructor builds a custom `PropertyMapping` from the property `Type` and the `ClassMapping`s of its (choice) types - no serialization-infrastructure types in the signature, and the `IElementDefinitionSummary.Type` cache stays a cache.
- Custom mappings register by **name/canonical only**, never in the by-type index. `ModelInspector` gains instance-aware `FindClassMapping(Base)`/`FindOrImportClassMapping(Base)` honoring `IDynamicType.DynamicTypeName`.
- `ClassMapping.IsAbstract` can be set explicitly for mappings whose native type does not reflect the FHIR type''s abstractness.

## Consumer fixes (so custom type identity survives end-to-end)

- The JSON/XML (de)serializers, `PocoElementNode`, `PocoNode` and the poco validator resolve mappings instance-aware, or directly from the declared `PropertyTypeMapping` instead of roundtripping through the .NET type (which silently degraded custom types to their generic dynamic mapping).
- `IElementDefinitionSummary.Type` references are always by type *name* (never canonical), since consumers match them against choice-element type suffixes.

## Validation

- `AllowedTypesAttribute` gains name-based matching (`TypeNames`), since `Type[]` cannot express custom choice types; `Types` and `TypeNames` act as a union when combined. Choice `PropertyMapping`s built from custom types synthesize this validation automatically, so the metadata and the validation rule cannot drift apart.
- The attribute validator now validates custom properties normally and accepts registered custom resources and open-choice custom datatypes, while still reporting unknown elements (including unrecognized elements *on* a custom class) and unregistered dynamic resources.

## Testing

- New tests build a custom datatype plus a custom resource with a backbone and a choice element (one choice being the custom datatype) through the public API only, then assert the `IStructureDefinitionSummary` surface, full JSON **and** XML parse/serialize roundtrips (including dynamic type identity of parsed values), typed-element navigation, and a validation matrix (allowed/disallowed/unregistered choice types, open choices, cardinality, unknown elements, unknown resource types, mixed `Types`+`TypeNames`).
- Regression sweeps green: Hl7.Fhir.Support.Tests (500), Hl7.Fhir.Support.Poco.Tests (552), Hl7.Fhir.ElementModel.STU3.Tests (70), R4 validation tests (41), full Hl7.Fhir.Serialization.STU3.Tests (13,404).

## Out of scope

- The StructureDefinition-summary -> ClassMapping translation lives downstream (Firely Server) on top of this API. Note for that implementation: set `Order` on every custom `PropertyMapping`, since XML serialization orders elements by it.
- Type hierarchies for custom types (`baseDefinition`) and `urn:` canonicals.

Closes #2850

🤖 Generated with [Claude Code](https://claude.com/claude-code)