### PR TITLE
Fixed incorrect merge logic in mergeCollectionWithSuppression that could result in suppression extension not being honoured

### DIFF
--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/ElementDefnMerger.cs
@@ -530,12 +530,22 @@ namespace Hl7.Fhir.Specification.Snapshot
                 var result = snap;
                 if (!diff.IsNullOrEmpty())
                 {
-                    if (snap.IsNullOrEmpty())
+                    if (snap.IsNullOrEmpty() || diff.IsExactly(snap))
                     {
-                        result = (List<T>)diff.DeepCopy();
-                        onConstraint(result);
+                        // If snap is empty or snap is exactly equal to diff, we still need to check for suppress extensions in diff
+                        
+                        result = new List<T>();
+
+                        foreach (var diffItem in diff)
+                        {
+                            if (!suppress(diffItem))
+                                result.Add(diffItem.DeepCopy());
+                        }
+
+                        if (snap.IsNullOrEmpty())
+                            onConstraint(result);
                     }
-                    else if (!diff.IsExactly(snap))
+                    else
                     {
                         // Start with inherited items from snapshot
                         result = new List<T>(snap.DeepCopy());

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/ElementDefnMerger.cs
@@ -530,22 +530,13 @@ namespace Hl7.Fhir.Specification.Snapshot
                 var result = snap;
                 if (!diff.IsNullOrEmpty())
                 {
-                    if (snap.IsNullOrEmpty() || diff.IsExactly(snap))
+                    if (snap.IsNullOrEmpty())
                     {
-                        // If snap is empty or snap is exactly equal to diff, we still need to check for suppress extensions in diff
-                        
-                        result = new List<T>();
-
-                        foreach (var diffItem in diff)
-                        {
-                            if (!suppress(diffItem))
-                                result.Add(diffItem.DeepCopy());
-                        }
-
-                        if (snap.IsNullOrEmpty())
-                            onConstraint(result);
+                        // If snap is empty we still need to check for suppress extensions in diff
+                        result = diff.Where(x => !x.HasSuppressExtension()).Select(x => x.DeepCopy()).ToList();
+                        onConstraint(result);
                     }
-                    else
+                    else if (!diff.IsExactly(snap))
                     {
                         // Start with inherited items from snapshot
                         result = new List<T>(snap.DeepCopy());
@@ -561,7 +552,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                             if (idx < 0)
                             {
                                 // New item from differential - add it (but only if not suppressed)
-                                if (!suppress(diffItem))
+                                if (!diffItem.HasSuppressExtension())
                                 {
                                     mergedItem = diffItem.DeepCopy();
                                     result.Add(mergedItem);
@@ -571,7 +562,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                             {
                                 // Matching item exists in snapshot
                                 // Check if diff item has suppress extension
-                                if (suppress(diffItem))
+                                if (diffItem.HasSuppressExtension())
                                 {
                                     // Tag the inherited item to be removed - it's being suppressed.
                                     // We cannot remove it immediately from the result list, because that will
@@ -597,27 +588,31 @@ namespace Hl7.Fhir.Specification.Snapshot
                             result.RemoveAt(idx);
                         }
                     }
+                    else
+                    {
+                        // If snap is exactly equal to diff we still need to check for suppress extensions in diff
+                        result = snap.Where(x => !x.HasSuppressExtension()).Select(x => x.DeepCopy()).ToList();
+                    }
                 }
                 return result;
-            }
-
-            bool suppress<T>(T item) where T : Element, IExtendable
-            {
-                return _generator.Settings.RespectSuppressExtension && item.HasSuppressExtension();
             }
 
             // Custom merge logic for mappings that respects the suppress extension
             // Inherit all mapping definitions from a parent resource unless someone added a suppress extension to it
             List<ElementDefinition.MappingComponent> mergeMappings(List<ElementDefinition.MappingComponent> snap, List<ElementDefinition.MappingComponent> diff)
             {
-                return mergeCollectionWithSuppression(snap, diff, (s, d) => IsEqualString(s.Identity, d.Identity) && IsEqualString(s.Map, d.Map));
+                return _generator.Settings.RespectSuppressExtension 
+                    ? mergeCollectionWithSuppression(snap, diff, (s, d) => IsEqualString(s.Identity, d.Identity) && IsEqualString(s.Map, d.Map)) 
+                    : mergeCollection(snap, diff, (s, d) => IsEqualString(s.Identity, d.Identity) && IsEqualString(s.Map, d.Map));
             }
 
             // Custom merge logic for examples that respects the suppress extension
             // Inherit all example definitions from a parent resource unless someone added a suppress extension to it
             List<ElementDefinition.ExampleComponent> mergeExamples(List<ElementDefinition.ExampleComponent> snap, List<ElementDefinition.ExampleComponent> diff)
             {
-                return mergeCollectionWithSuppression(snap, diff, (s, d) => IsEqualString(s.Label, d.Label));
+                return _generator.Settings.RespectSuppressExtension
+                    ? mergeCollectionWithSuppression(snap, diff, (s, d) => IsEqualString(s.Label, d.Label))
+                    : mergeCollection(snap, diff, (s, d) => IsEqualString(s.Label, d.Label));
             }
 
             // Merge two collections

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/ElementDefnMerger.cs
@@ -591,7 +591,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                     else
                     {
                         // If snap is exactly equal to diff we still need to check for suppress extensions
-                        result = snap.Where(x => !x.HasSuppressExtension()).ToList();
+                        result = snap.Where(x => !x.HasSuppressExtension()).Select(x => x.DeepCopy()).ToList();
                     }
                 }
                 return result;

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/ElementDefnMerger.cs
@@ -532,7 +532,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 {
                     if (snap.IsNullOrEmpty())
                     {
-                        // If snap is empty we still need to check for suppress extensions in diff
+                        // If snap is empty we still need to check for suppress extensions
                         result = diff.Where(x => !x.HasSuppressExtension()).Select(x => x.DeepCopy()).ToList();
                         onConstraint(result);
                     }
@@ -590,8 +590,8 @@ namespace Hl7.Fhir.Specification.Snapshot
                     }
                     else
                     {
-                        // If snap is exactly equal to diff we still need to check for suppress extensions in diff
-                        result = snap.Where(x => !x.HasSuppressExtension()).Select(x => x.DeepCopy()).ToList();
+                        // If snap is exactly equal to diff we still need to check for suppress extensions
+                        result = snap.Where(x => !x.HasSuppressExtension()).ToList();
                     }
                 }
                 return result;

--- a/src/Hl7.Fhir.STU3/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Snapshot/ElementDefnMerger.cs
@@ -526,12 +526,22 @@ namespace Hl7.Fhir.Specification.Snapshot
                 var result = snap;
                 if (!diff.IsNullOrEmpty())
                 {
-                    if (snap.IsNullOrEmpty())
+                    if (snap.IsNullOrEmpty() || diff.IsExactly(snap))
                     {
-                        result = (List<T>)diff.DeepCopy();
-                        onConstraint(result);
+                        // If snap is empty or snap is exactly equal to diff, we still need to check for suppress extensions
+
+                        result = new List<T>();
+
+                        foreach (var diffItem in diff)
+                        {
+                            if (!suppress(diffItem))
+                                result.Add(diffItem.DeepCopy());
+                        }
+
+                        if (snap.IsNullOrEmpty())
+                            onConstraint(result);
                     }
-                    else if (!diff.IsExactly(snap))
+                    else 
                     {
                         // Start with inherited items from snapshot
                         result = new List<T>(snap.DeepCopy());

--- a/src/Hl7.Fhir.STU3/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Snapshot/ElementDefnMerger.cs
@@ -528,7 +528,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 {
                     if (snap.IsNullOrEmpty())
                     {
-                        // If snap is empty we still need to check for suppress extensions in diff
+                        // If snap is empty we still need to check for suppress extensions
                         result = diff.Where(x => !x.HasSuppressExtension()).Select(x => x.DeepCopy()).ToList();
                         onConstraint(result);
                     }
@@ -586,8 +586,8 @@ namespace Hl7.Fhir.Specification.Snapshot
                     }
                     else
                     {
-                        // If snap is exactly equal to diff we still need to check for suppress extensions in diff
-                        result = snap.Where(x => !x.HasSuppressExtension()).Select(x => x.DeepCopy()).ToList();
+                        // If snap is exactly equal to diff we still need to check for suppress extensions
+                        result = snap.Where(x => !x.HasSuppressExtension()).ToList();
                     }
                 }
                 return result;

--- a/src/Hl7.Fhir.STU3/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Snapshot/ElementDefnMerger.cs
@@ -526,22 +526,13 @@ namespace Hl7.Fhir.Specification.Snapshot
                 var result = snap;
                 if (!diff.IsNullOrEmpty())
                 {
-                    if (snap.IsNullOrEmpty() || diff.IsExactly(snap))
+                    if (snap.IsNullOrEmpty())
                     {
-                        // If snap is empty or snap is exactly equal to diff, we still need to check for suppress extensions
-
-                        result = new List<T>();
-
-                        foreach (var diffItem in diff)
-                        {
-                            if (!suppress(diffItem))
-                                result.Add(diffItem.DeepCopy());
-                        }
-
-                        if (snap.IsNullOrEmpty())
-                            onConstraint(result);
+                        // If snap is empty we still need to check for suppress extensions in diff
+                        result = diff.Where(x => !x.HasSuppressExtension()).Select(x => x.DeepCopy()).ToList();
+                        onConstraint(result);
                     }
-                    else 
+                    else if (!diff.IsExactly(snap))
                     {
                         // Start with inherited items from snapshot
                         result = new List<T>(snap.DeepCopy());
@@ -557,7 +548,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                             if (idx < 0)
                             {
                                 // New item from differential - add it (but only if not suppressed)
-                                if (!suppress(diffItem))
+                                if (!diffItem.HasSuppressExtension())
                                 {
                                     mergedItem = diffItem.DeepCopy();
                                     result.Add(mergedItem);
@@ -567,7 +558,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                             {
                                 // Matching item exists in snapshot
                                 // Check if diff item has suppress extension
-                                if (suppress(diffItem))
+                                if (diffItem.HasSuppressExtension())
                                 {
                                     // Tag the inherited item to be removed - it's being suppressed.
                                     // We cannot remove it immediately from the result list, because that will
@@ -593,27 +584,31 @@ namespace Hl7.Fhir.Specification.Snapshot
                             result.RemoveAt(idx);
                         }
                     }
+                    else
+                    {
+                        // If snap is exactly equal to diff we still need to check for suppress extensions in diff
+                        result = snap.Where(x => !x.HasSuppressExtension()).Select(x => x.DeepCopy()).ToList();
+                    }
                 }
                 return result;
-            }
-
-            bool suppress<T>(T item) where T : Element, IExtendable
-            {
-                return _generator.Settings.RespectSuppressExtension && item.HasSuppressExtension();
             }
 
             // Custom merge logic for mappings that respects the suppress extension
             // Inherit all mapping definitions from a parent resource unless someone added a suppress extension to it
             List<ElementDefinition.MappingComponent> mergeMappings(List<ElementDefinition.MappingComponent> snap, List<ElementDefinition.MappingComponent> diff)
             {
-                return mergeCollectionWithSuppression(snap, diff, (s, d) => isEqualString(s.Identity, d.Identity) && isEqualString(s.Map, d.Map));
+                return _generator.Settings.RespectSuppressExtension
+                    ? mergeCollectionWithSuppression(snap, diff, (s, d) => isEqualString(s.Identity, d.Identity) && isEqualString(s.Map, d.Map))
+                    : mergeCollection(snap, diff, (s, d) => isEqualString(s.Identity, d.Identity) && isEqualString(s.Map, d.Map));
             }
 
             // Custom merge logic for examples that respects the suppress extension
             // Inherit all example definitions from a parent resource unless someone added a suppress extension to it
             List<ElementDefinition.ExampleComponent> mergeExamples(List<ElementDefinition.ExampleComponent> snap, List<ElementDefinition.ExampleComponent> diff)
             {
-                return mergeCollectionWithSuppression(snap, diff, (s, d) => isEqualString(s.Label, d.Label));
+                return _generator.Settings.RespectSuppressExtension
+                    ? mergeCollectionWithSuppression(snap, diff, (s, d) => isEqualString(s.Label, d.Label))
+                    : mergeCollection(snap, diff, (s, d) => isEqualString(s.Label, d.Label));
             }
 
 

--- a/src/Hl7.Fhir.STU3/Specification/Snapshot/ElementDefnMerger.cs
+++ b/src/Hl7.Fhir.STU3/Specification/Snapshot/ElementDefnMerger.cs
@@ -587,7 +587,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                     else
                     {
                         // If snap is exactly equal to diff we still need to check for suppress extensions
-                        result = snap.Where(x => !x.HasSuppressExtension()).ToList();
+                        result = snap.Where(x => !x.HasSuppressExtension()).Select(x => x.DeepCopy()).ToList();
                     }
                 }
                 return result;

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/SnapshotGeneratorMappingSuppressionTest.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/SnapshotGeneratorMappingSuppressionTest.cs
@@ -302,6 +302,69 @@ namespace Hl7.Fhir.Specification.Tests
                 Assert.HasCount(1, patientElement.Example, "Example with suppress extension should be inherited when suppression is not respected");
         }
 
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async System.Threading.Tasks.Task TestExampleSuppressionExtensionInBaseProfile(bool respectSuppressExtension)
+        {
+            // Create a base profile with suppressed examples
+            const string path = "Patient.birthDate";
+            var baseProfile = CreateTestProfileForExample("MyPatient", "Patient", path, "http://hl7.org/fhir/StructureDefinition/Patient", addSuppressedExample: true);
+            var diffExamples = baseProfile.Differential!.Element.FirstOrDefault(e => e.Path == path)!.Example;
+            var resolver = new CachedResolver(ZipSource.CreateValidationSource());
+
+            // Generate snapshot
+            var generator = new SnapshotGenerator(resolver, new SnapshotGeneratorSettings { RespectSuppressExtension = respectSuppressExtension });
+            await generator.UpdateAsync(baseProfile);
+            Assert.IsNotNull(baseProfile.Snapshot, "Should have snapshot");
+
+            // Verify that example is NOT inherited due to suppression when respectSuppressExtension is true, and is inherited when respectSuppressExtension is false
+            var rootElement = baseProfile.Snapshot.Element.FirstOrDefault(e => e.Path == path);
+            Assert.IsNotNull(rootElement, $"Should have {path} element");
+
+            foreach (var diffExample in diffExamples)
+            {
+                var snapExample = rootElement.Example.FirstOrDefault(e => e.Label == diffExample.Label);
+
+                if (respectSuppressExtension)
+                    snapExample.Should().BeNull("Example with suppress extension should not be in the snapshot when suppression is respected");
+                else
+                    snapExample.Should().NotBeNull("Example with suppress extension should be in the snapshot when suppression is not respected");
+            }
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async System.Threading.Tasks.Task TestExampleSuppressionExtensionInDerivedProfile(bool respectSuppressExtension)
+        {
+            // Create a base profile with no examples and a derived profile with suppressed examples
+            const string path = "Patient.birthDate";
+            var baseProfile = CreateTestProfileForExample("MyPatient", "Patient", path, "http://hl7.org/fhir/StructureDefinition/Patient", addSuppressedExample: false);
+            var derivedProfile = CreateTestProfileForExample("MyDerivedPatient", "Patient", path, "http://example.org/fhir/StructureDefinition/MyPatient", addSuppressedExample: true);
+            var diffExamples = derivedProfile.Differential!.Element.FirstOrDefault(e => e.Path == path)!.Example;
+            var resolver = new CachedResolver(new MultiResolver(new InMemoryResourceResolver(baseProfile), ZipSource.CreateValidationSource()));
+
+            // Generate snapshot
+            var generator = new SnapshotGenerator(resolver, new SnapshotGeneratorSettings { RespectSuppressExtension = respectSuppressExtension });
+            await generator.UpdateAsync(derivedProfile);
+            Assert.IsNotNull(derivedProfile.Snapshot, "Should have snapshot");
+
+            // Verify that example is NOT inherited due to suppression when respectSuppressExtension is true, and is inherited when respectSuppressExtension is false
+            var rootElement = derivedProfile.Snapshot.Element.FirstOrDefault(e => e.Path == path);
+            Assert.IsNotNull(rootElement, $"Should have {path} element");
+
+            foreach (var diffExample in diffExamples)
+            {
+                var snapExample = rootElement.Example.FirstOrDefault(e => e.Label == diffExample.Label);
+
+                if (respectSuppressExtension)
+                    snapExample.Should().BeNull("Example with suppress extension should not be in the snapshot when suppression is respected");
+                else
+                    snapExample.Should().NotBeNull("Example with suppress extension should be in the snapshot when suppression is not respected");
+            }
+        }
+
         private StructureDefinition CreateBaseProfileWithExample()
         {
             return new StructureDefinition()
@@ -405,6 +468,56 @@ namespace Hl7.Fhir.Specification.Tests
                     }
                 }
             };
+        }
+
+        private StructureDefinition CreateTestProfileForExample(string name, string type, string path, string baseUrl, bool addSuppressedExample)
+        {
+            var sd = new StructureDefinition
+            {
+                Id = name,
+                Url = $"http://example.org/fhir/StructureDefinition/{name}",
+                Name = name,
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Resource,
+                FhirVersion = ModelInfo.Version,
+                Abstract = false,
+                Type = type,
+                BaseDefinition = baseUrl,
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Differential = new StructureDefinition.DifferentialComponent { Element = [] }
+            };
+
+            if (addSuppressedExample)
+            {
+                sd.Differential.Element.Add(new ElementDefinition(path)
+                {
+                    Example =
+                    [
+                        new ElementDefinition.ExampleComponent
+                        {
+                            Label = "Test",
+                            Value = new FhirDateTime("2005"),
+                            Extension =
+                            [
+                                new Extension
+                                {
+                                    Url = SnapshotGeneratorExtensions.ELEMENTDEFINITION_SUPPRESS_EXT,
+                                    Value = new FhirBoolean(true)
+                                }
+                            ]
+                        }
+                    ]
+                });
+            }
+            else
+            {
+                sd.Differential.Element.Add(new ElementDefinition(path)
+                {
+                    Short = "Some constraint"
+                });
+            }
+
+            return sd;
         }
 
         [TestMethod]

--- a/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/SnapshotGeneratorMappingSuppressionTest.cs
+++ b/src/Hl7.Fhir.Specification.STU3.Tests/Snapshot/SnapshotGeneratorMappingSuppressionTest.cs
@@ -569,6 +569,253 @@ namespace Hl7.Fhir.Specification.Tests
             suppressedMapping.Should().BeNull("Duplicated suppressed mapping should not appear in snapshot");
         }
 
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async System.Threading.Tasks.Task TestExampleSuppressionWhenSnapEqualsDiff(bool respectSuppressExtension)
+        {
+            // Exercises the else branch: snap is non-empty and diff.IsExactly(snap) is true while
+            // some items carry the suppress extension (e.g. a snapshot previously generated without
+            // suppression is re-expanded with the same differential).
+            var suppressExt = new Extension { Url = SnapshotGeneratorExtensions.ELEMENTDEFINITION_SUPPRESS_EXT, Value = new FhirBoolean(true) };
+            var suppressedExample = new ElementDefinition.ExampleComponent
+            {
+                Label = "suppress-me",
+                Value = new FhirString("suppressed value"),
+                Extension = [suppressExt.DeepCopy()]
+            };
+            var keptExample = new ElementDefinition.ExampleComponent { Label = "keep-me", Value = new FhirString("kept value") };
+
+            var baseProfile = new StructureDefinition
+            {
+                Id = "base-snap-eq-diff",
+                Url = "http://example.org/fhir/StructureDefinition/BaseSnapEqDiff",
+                Name = "BaseSnapEqDiff",
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Resource,
+                FhirVersion = ModelInfo.Version,
+                Abstract = false,
+                Type = "Patient",
+                BaseDefinition = "http://hl7.org/fhir/StructureDefinition/Patient",
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Differential = new StructureDefinition.DifferentialComponent
+                {
+                    Element = [new ElementDefinition("Patient") { Short = "base" }]
+                },
+                Snapshot = new StructureDefinition.SnapshotComponent
+                {
+                    Element = [new ElementDefinition("Patient") { Example = [suppressedExample.DeepCopy(), keptExample.DeepCopy()] }]
+                }
+            };
+
+            // Derived differential re-states the identical examples (including the suppress extension),
+            // making diff.IsExactly(snap) true and triggering the else branch.
+            var derivedProfile = new StructureDefinition
+            {
+                Id = "derived-snap-eq-diff",
+                Url = "http://example.org/fhir/StructureDefinition/DerivedSnapEqDiff",
+                Name = "DerivedSnapEqDiff",
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Resource,
+                FhirVersion = ModelInfo.Version,
+                Abstract = false,
+                Type = "Patient",
+                BaseDefinition = baseProfile.Url,
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Differential = new StructureDefinition.DifferentialComponent
+                {
+                    Element = [new ElementDefinition("Patient") { Example = [suppressedExample.DeepCopy(), keptExample.DeepCopy()] }]
+                }
+            };
+
+            var mockResolver = new InMemoryResourceResolver();
+            mockResolver.Add(baseProfile);
+            var generator = new SnapshotGenerator(mockResolver, new SnapshotGeneratorSettings { RespectSuppressExtension = respectSuppressExtension });
+            await generator.UpdateAsync(derivedProfile);
+
+            var patientElement = derivedProfile.Snapshot!.Element.FirstOrDefault(e => e.Path == "Patient");
+            Assert.IsNotNull(patientElement);
+
+            if (respectSuppressExtension)
+            {
+                patientElement.Example.Should().NotContain(e => e.Label == "suppress-me", "suppress-extension example should be removed");
+                patientElement.Example.Should().Contain(e => e.Label == "keep-me", "unsuppressed example should be retained");
+            }
+            else
+            {
+                patientElement.Example.Should().Contain(e => e.Label == "suppress-me", "example should be kept when suppression is not respected");
+                patientElement.Example.Should().Contain(e => e.Label == "keep-me", "unsuppressed example should always be retained");
+            }
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async System.Threading.Tasks.Task TestMappingSuppressionWhenSnapIsEmpty(bool respectSuppressExtension)
+        {
+            // Exercises the snap-empty branch for mappings: base snapshot has no mappings,
+            // differential adds a mapping with a suppress extension.
+            var suppressExt = new Extension { Url = SnapshotGeneratorExtensions.ELEMENTDEFINITION_SUPPRESS_EXT, Value = new FhirBoolean(true) };
+
+            var baseProfile = new StructureDefinition
+            {
+                Id = "base-no-mappings",
+                Url = "http://example.org/fhir/StructureDefinition/BaseNoMappings",
+                Name = "BaseNoMappings",
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Resource,
+                FhirVersion = ModelInfo.Version,
+                Abstract = false,
+                Type = "Patient",
+                BaseDefinition = "http://hl7.org/fhir/StructureDefinition/Patient",
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Differential = new StructureDefinition.DifferentialComponent
+                {
+                    Element = [new ElementDefinition("Patient") { Short = "base" }]
+                },
+                Snapshot = new StructureDefinition.SnapshotComponent
+                {
+                    Element = [new ElementDefinition("Patient")]  // no mappings
+                }
+            };
+
+            var derivedProfile = new StructureDefinition
+            {
+                Id = "derived-suppressed-mapping",
+                Url = "http://example.org/fhir/StructureDefinition/DerivedSuppressedMapping",
+                Name = "DerivedSuppressedMapping",
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Resource,
+                FhirVersion = ModelInfo.Version,
+                Abstract = false,
+                Type = "Patient",
+                BaseDefinition = baseProfile.Url,
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Differential = new StructureDefinition.DifferentialComponent
+                {
+                    Element =
+                    [
+                        new ElementDefinition("Patient")
+                        {
+                            Mapping =
+                            [
+                                new ElementDefinition.MappingComponent
+                                {
+                                    Identity = "test-id",
+                                    Map = "Patient",
+                                    Extension = [suppressExt.DeepCopy()]
+                                },
+                                new ElementDefinition.MappingComponent { Identity = "keep-id", Map = "Patient.keep" }
+                            ]
+                        }
+                    ]
+                }
+            };
+
+            var mockResolver = new InMemoryResourceResolver();
+            mockResolver.Add(baseProfile);
+            var generator = new SnapshotGenerator(mockResolver, new SnapshotGeneratorSettings { RespectSuppressExtension = respectSuppressExtension });
+            await generator.UpdateAsync(derivedProfile);
+
+            var patientElement = derivedProfile.Snapshot!.Element.FirstOrDefault(e => e.Path == "Patient");
+            Assert.IsNotNull(patientElement);
+
+            if (respectSuppressExtension)
+            {
+                patientElement.Mapping.Should().NotContain(m => m.Identity == "test-id", "suppressed mapping should be filtered from new-item-in-snap-empty path");
+                patientElement.Mapping.Should().Contain(m => m.Identity == "keep-id", "unsuppressed mapping should be added");
+            }
+            else
+            {
+                patientElement.Mapping.Should().Contain(m => m.Identity == "test-id", "mapping should be kept when suppression is not respected");
+                patientElement.Mapping.Should().Contain(m => m.Identity == "keep-id", "unsuppressed mapping should always be added");
+            }
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async System.Threading.Tasks.Task TestPartialExampleSuppressionRetainsUnsuppressedItems(bool respectSuppressExtension)
+        {
+            // Snap is empty; diff has two examples — one suppressed, one not.
+            // With suppression on, only the unsuppressed item should appear in the snapshot.
+            var suppressExt = new Extension { Url = SnapshotGeneratorExtensions.ELEMENTDEFINITION_SUPPRESS_EXT, Value = new FhirBoolean(true) };
+
+            var baseProfile = new StructureDefinition
+            {
+                Id = "base-no-examples",
+                Url = "http://example.org/fhir/StructureDefinition/BaseNoExamples",
+                Name = "BaseNoExamples",
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Resource,
+                FhirVersion = ModelInfo.Version,
+                Abstract = false,
+                Type = "Patient",
+                BaseDefinition = "http://hl7.org/fhir/StructureDefinition/Patient",
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Differential = new StructureDefinition.DifferentialComponent
+                {
+                    Element = [new ElementDefinition("Patient") { Short = "base" }]
+                },
+                Snapshot = new StructureDefinition.SnapshotComponent
+                {
+                    Element = [new ElementDefinition("Patient")]  // no examples
+                }
+            };
+
+            var derivedProfile = new StructureDefinition
+            {
+                Id = "derived-partial-suppression",
+                Url = "http://example.org/fhir/StructureDefinition/DerivedPartialSuppression",
+                Name = "DerivedPartialSuppression",
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Resource,
+                FhirVersion = ModelInfo.Version,
+                Abstract = false,
+                Type = "Patient",
+                BaseDefinition = baseProfile.Url,
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Differential = new StructureDefinition.DifferentialComponent
+                {
+                    Element =
+                    [
+                        new ElementDefinition("Patient")
+                        {
+                            Example =
+                            [
+                                new ElementDefinition.ExampleComponent
+                                {
+                                    Label = "suppress-me",
+                                    Value = new FhirString("suppressed"),
+                                    Extension = [suppressExt.DeepCopy()]
+                                },
+                                new ElementDefinition.ExampleComponent { Label = "keep-me", Value = new FhirString("kept") }
+                            ]
+                        }
+                    ]
+                }
+            };
+
+            var mockResolver = new InMemoryResourceResolver();
+            mockResolver.Add(baseProfile);
+            var generator = new SnapshotGenerator(mockResolver, new SnapshotGeneratorSettings { RespectSuppressExtension = respectSuppressExtension });
+            await generator.UpdateAsync(derivedProfile);
+
+            var patientElement = derivedProfile.Snapshot!.Element.FirstOrDefault(e => e.Path == "Patient");
+            Assert.IsNotNull(patientElement);
+
+            if (respectSuppressExtension)
+            {
+                patientElement.Example.Should().NotContain(e => e.Label == "suppress-me", "suppressed example should be filtered out");
+                patientElement.Example.Should().Contain(e => e.Label == "keep-me", "unsuppressed example should be present");
+            }
+            else
+            {
+                patientElement.Example.Should().Contain(e => e.Label == "suppress-me", "example should be kept when suppression is not respected");
+                patientElement.Example.Should().Contain(e => e.Label == "keep-me", "unsuppressed example should always be present");
+            }
+        }
+
         private StructureDefinition CreateProfileWithDuplicateSuppressedMappings()
         {
             var suppressExtension = new Extension

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorMappingSuppressionTest.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorMappingSuppressionTest.cs
@@ -303,6 +303,69 @@ namespace Hl7.Fhir.Specification.Tests
                 Assert.HasCount(1, patientElement.Example, "Example with suppress extension should be inherited when suppression is not respected");
         }
 
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async System.Threading.Tasks.Task TestExampleSuppressionExtensionInBaseProfile(bool respectSuppressExtension)
+        {
+            // Create a base profile with suppressed examples
+            const string path = "Patient.birthDate";
+            var baseProfile = CreateTestProfileForExample("MyPatient", "Patient", path, "http://hl7.org/fhir/StructureDefinition/Patient", addSuppressedExample: true);
+            var diffExamples = baseProfile.Differential!.Element.FirstOrDefault(e => e.Path == path)!.Example;
+            var resolver = new CachedResolver(ZipSource.CreateValidationSource());
+
+            // Generate snapshot
+            var generator = new SnapshotGenerator(resolver, new SnapshotGeneratorSettings { RespectSuppressExtension = respectSuppressExtension });
+            await generator.UpdateAsync(baseProfile);
+            Assert.IsNotNull(baseProfile.Snapshot, "Should have snapshot");
+
+            // Verify that example is NOT inherited due to suppression when respectSuppressExtension is true, and is inherited when respectSuppressExtension is false
+            var rootElement = baseProfile.Snapshot.Element.FirstOrDefault(e => e.Path == path);
+            Assert.IsNotNull(rootElement, $"Should have {path} element");
+
+            foreach (var diffExample in diffExamples)
+            {
+                var snapExample = rootElement.Example.FirstOrDefault(e => e.Label == diffExample.Label);
+
+                if (respectSuppressExtension)
+                    snapExample.Should().BeNull("Example with suppress extension should not be in the snapshot when suppression is respected");
+                else
+                    snapExample.Should().NotBeNull("Example with suppress extension should be in the snapshot when suppression is not respected");
+            }
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async System.Threading.Tasks.Task TestExampleSuppressionExtensionInDerivedProfile(bool respectSuppressExtension)
+        {
+            // Create a base profile with no examples and a derived profile with suppressed examples
+            const string path = "Patient.birthDate";
+            var baseProfile = CreateTestProfileForExample("MyPatient", "Patient", path, "http://hl7.org/fhir/StructureDefinition/Patient", addSuppressedExample: false);
+            var derivedProfile = CreateTestProfileForExample("MyDerivedPatient", "Patient", path, "http://example.org/fhir/StructureDefinition/MyPatient", addSuppressedExample: true);
+            var diffExamples = derivedProfile.Differential!.Element.FirstOrDefault(e => e.Path == path)!.Example;
+            var resolver = new CachedResolver(new MultiResolver(new InMemoryResourceResolver(baseProfile), ZipSource.CreateValidationSource()));
+
+            // Generate snapshot
+            var generator = new SnapshotGenerator(resolver, new SnapshotGeneratorSettings { RespectSuppressExtension = respectSuppressExtension });
+            await generator.UpdateAsync(derivedProfile);
+            Assert.IsNotNull(derivedProfile.Snapshot, "Should have snapshot");
+
+            // Verify that example is NOT inherited due to suppression when respectSuppressExtension is true, and is inherited when respectSuppressExtension is false
+            var rootElement = derivedProfile.Snapshot.Element.FirstOrDefault(e => e.Path == path);
+            Assert.IsNotNull(rootElement, $"Should have {path} element");
+
+            foreach (var diffExample in diffExamples)
+            {
+                var snapExample = rootElement.Example.FirstOrDefault(e => e.Label == diffExample.Label);
+
+                if (respectSuppressExtension)
+                    snapExample.Should().BeNull("Example with suppress extension should not be in the snapshot when suppression is respected");
+                else
+                    snapExample.Should().NotBeNull("Example with suppress extension should be in the snapshot when suppression is not respected");
+            }
+        }
+
         private StructureDefinition CreateBaseProfileWithExample()
         {
             return new StructureDefinition()
@@ -406,6 +469,56 @@ namespace Hl7.Fhir.Specification.Tests
                     }
                 }
             };
+        }
+
+        private StructureDefinition CreateTestProfileForExample(string name, string type, string path, string baseUrl, bool addSuppressedExample)
+        {
+            var sd = new StructureDefinition
+            {
+                Id = name,
+                Url = $"http://example.org/fhir/StructureDefinition/{name}",
+                Name = name,
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Resource,
+                FhirVersion = EnumUtility.ParseLiteral<FHIRVersion>(ModelInfo.Version),
+                Abstract = false,
+                Type = type,
+                BaseDefinition = baseUrl,
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Differential = new StructureDefinition.DifferentialComponent { Element = [] }
+            };
+
+            if (addSuppressedExample)
+            {
+                sd.Differential.Element.Add(new ElementDefinition(path)
+                {
+                    Example =
+                    [
+                        new ElementDefinition.ExampleComponent
+                        {
+                            Label = "Test",
+                            Value = new FhirDateTime("2005"),
+                            Extension =
+                            [
+                                new Extension
+                                {
+                                    Url = SnapshotGeneratorExtensions.ELEMENTDEFINITION_SUPPRESS_EXT,
+                                    Value = new FhirBoolean(true)
+                                }
+                            ]
+                        }
+                    ]
+                });
+            }
+            else
+            {
+                sd.Differential.Element.Add(new ElementDefinition(path)
+                {
+                    Short = "Some constraint"
+                });
+            }
+
+            return sd;
         }
 
         [TestMethod]

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorMappingSuppressionTest.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorMappingSuppressionTest.cs
@@ -570,6 +570,253 @@ namespace Hl7.Fhir.Specification.Tests
             suppressedMapping.Should().BeNull("Duplicated suppressed mapping should not appear in snapshot");
         }
 
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async System.Threading.Tasks.Task TestExampleSuppressionWhenSnapEqualsDiff(bool respectSuppressExtension)
+        {
+            // Exercises the else branch: snap is non-empty and diff.IsExactly(snap) is true while
+            // some items carry the suppress extension (e.g. a snapshot previously generated without
+            // suppression is re-expanded with the same differential).
+            var suppressExt = new Extension { Url = SnapshotGeneratorExtensions.ELEMENTDEFINITION_SUPPRESS_EXT, Value = new FhirBoolean(true) };
+            var suppressedExample = new ElementDefinition.ExampleComponent
+            {
+                Label = "suppress-me",
+                Value = new FhirString("suppressed value"),
+                Extension = [suppressExt.DeepCopy()]
+            };
+            var keptExample = new ElementDefinition.ExampleComponent { Label = "keep-me", Value = new FhirString("kept value") };
+
+            var baseProfile = new StructureDefinition
+            {
+                Id = "base-snap-eq-diff",
+                Url = "http://example.org/fhir/StructureDefinition/BaseSnapEqDiff",
+                Name = "BaseSnapEqDiff",
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Resource,
+                FhirVersion = EnumUtility.ParseLiteral<FHIRVersion>(ModelInfo.Version),
+                Abstract = false,
+                Type = "Patient",
+                BaseDefinition = "http://hl7.org/fhir/StructureDefinition/Patient",
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Differential = new StructureDefinition.DifferentialComponent
+                {
+                    Element = [new ElementDefinition("Patient") { Short = "base" }]
+                },
+                Snapshot = new StructureDefinition.SnapshotComponent
+                {
+                    Element = [new ElementDefinition("Patient") { Example = [suppressedExample.DeepCopy(), keptExample.DeepCopy()] }]
+                }
+            };
+
+            // Derived differential re-states the identical examples (including the suppress extension),
+            // making diff.IsExactly(snap) true and triggering the else branch.
+            var derivedProfile = new StructureDefinition
+            {
+                Id = "derived-snap-eq-diff",
+                Url = "http://example.org/fhir/StructureDefinition/DerivedSnapEqDiff",
+                Name = "DerivedSnapEqDiff",
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Resource,
+                FhirVersion = EnumUtility.ParseLiteral<FHIRVersion>(ModelInfo.Version),
+                Abstract = false,
+                Type = "Patient",
+                BaseDefinition = baseProfile.Url,
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Differential = new StructureDefinition.DifferentialComponent
+                {
+                    Element = [new ElementDefinition("Patient") { Example = [suppressedExample.DeepCopy(), keptExample.DeepCopy()] }]
+                }
+            };
+
+            var mockResolver = new InMemoryResourceResolver();
+            mockResolver.Add(baseProfile);
+            var generator = new SnapshotGenerator(mockResolver, new SnapshotGeneratorSettings { RespectSuppressExtension = respectSuppressExtension });
+            await generator.UpdateAsync(derivedProfile);
+
+            var patientElement = derivedProfile.Snapshot!.Element.FirstOrDefault(e => e.Path == "Patient");
+            Assert.IsNotNull(patientElement);
+
+            if (respectSuppressExtension)
+            {
+                patientElement.Example.Should().NotContain(e => e.Label == "suppress-me", "suppress-extension example should be removed");
+                patientElement.Example.Should().Contain(e => e.Label == "keep-me", "unsuppressed example should be retained");
+            }
+            else
+            {
+                patientElement.Example.Should().Contain(e => e.Label == "suppress-me", "example should be kept when suppression is not respected");
+                patientElement.Example.Should().Contain(e => e.Label == "keep-me", "unsuppressed example should always be retained");
+            }
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async System.Threading.Tasks.Task TestMappingSuppressionWhenSnapIsEmpty(bool respectSuppressExtension)
+        {
+            // Exercises the snap-empty branch for mappings: base snapshot has no mappings,
+            // differential adds a mapping with a suppress extension.
+            var suppressExt = new Extension { Url = SnapshotGeneratorExtensions.ELEMENTDEFINITION_SUPPRESS_EXT, Value = new FhirBoolean(true) };
+
+            var baseProfile = new StructureDefinition
+            {
+                Id = "base-no-mappings",
+                Url = "http://example.org/fhir/StructureDefinition/BaseNoMappings",
+                Name = "BaseNoMappings",
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Resource,
+                FhirVersion = EnumUtility.ParseLiteral<FHIRVersion>(ModelInfo.Version),
+                Abstract = false,
+                Type = "Patient",
+                BaseDefinition = "http://hl7.org/fhir/StructureDefinition/Patient",
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Differential = new StructureDefinition.DifferentialComponent
+                {
+                    Element = [new ElementDefinition("Patient") { Short = "base" }]
+                },
+                Snapshot = new StructureDefinition.SnapshotComponent
+                {
+                    Element = [new ElementDefinition("Patient")]  // no mappings
+                }
+            };
+
+            var derivedProfile = new StructureDefinition
+            {
+                Id = "derived-suppressed-mapping",
+                Url = "http://example.org/fhir/StructureDefinition/DerivedSuppressedMapping",
+                Name = "DerivedSuppressedMapping",
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Resource,
+                FhirVersion = EnumUtility.ParseLiteral<FHIRVersion>(ModelInfo.Version),
+                Abstract = false,
+                Type = "Patient",
+                BaseDefinition = baseProfile.Url,
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Differential = new StructureDefinition.DifferentialComponent
+                {
+                    Element =
+                    [
+                        new ElementDefinition("Patient")
+                        {
+                            Mapping =
+                            [
+                                new ElementDefinition.MappingComponent
+                                {
+                                    Identity = "test-id",
+                                    Map = "Patient",
+                                    Extension = [suppressExt.DeepCopy()]
+                                },
+                                new ElementDefinition.MappingComponent { Identity = "keep-id", Map = "Patient.keep" }
+                            ]
+                        }
+                    ]
+                }
+            };
+
+            var mockResolver = new InMemoryResourceResolver();
+            mockResolver.Add(baseProfile);
+            var generator = new SnapshotGenerator(mockResolver, new SnapshotGeneratorSettings { RespectSuppressExtension = respectSuppressExtension });
+            await generator.UpdateAsync(derivedProfile);
+
+            var patientElement = derivedProfile.Snapshot!.Element.FirstOrDefault(e => e.Path == "Patient");
+            Assert.IsNotNull(patientElement);
+
+            if (respectSuppressExtension)
+            {
+                patientElement.Mapping.Should().NotContain(m => m.Identity == "test-id", "suppressed mapping should be filtered from new-item-in-snap-empty path");
+                patientElement.Mapping.Should().Contain(m => m.Identity == "keep-id", "unsuppressed mapping should be added");
+            }
+            else
+            {
+                patientElement.Mapping.Should().Contain(m => m.Identity == "test-id", "mapping should be kept when suppression is not respected");
+                patientElement.Mapping.Should().Contain(m => m.Identity == "keep-id", "unsuppressed mapping should always be added");
+            }
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async System.Threading.Tasks.Task TestPartialExampleSuppressionRetainsUnsuppressedItems(bool respectSuppressExtension)
+        {
+            // Snap is empty; diff has two examples — one suppressed, one not.
+            // With suppression on, only the unsuppressed item should appear in the snapshot.
+            var suppressExt = new Extension { Url = SnapshotGeneratorExtensions.ELEMENTDEFINITION_SUPPRESS_EXT, Value = new FhirBoolean(true) };
+
+            var baseProfile = new StructureDefinition
+            {
+                Id = "base-no-examples",
+                Url = "http://example.org/fhir/StructureDefinition/BaseNoExamples",
+                Name = "BaseNoExamples",
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Resource,
+                FhirVersion = EnumUtility.ParseLiteral<FHIRVersion>(ModelInfo.Version),
+                Abstract = false,
+                Type = "Patient",
+                BaseDefinition = "http://hl7.org/fhir/StructureDefinition/Patient",
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Differential = new StructureDefinition.DifferentialComponent
+                {
+                    Element = [new ElementDefinition("Patient") { Short = "base" }]
+                },
+                Snapshot = new StructureDefinition.SnapshotComponent
+                {
+                    Element = [new ElementDefinition("Patient")]  // no examples
+                }
+            };
+
+            var derivedProfile = new StructureDefinition
+            {
+                Id = "derived-partial-suppression",
+                Url = "http://example.org/fhir/StructureDefinition/DerivedPartialSuppression",
+                Name = "DerivedPartialSuppression",
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Resource,
+                FhirVersion = EnumUtility.ParseLiteral<FHIRVersion>(ModelInfo.Version),
+                Abstract = false,
+                Type = "Patient",
+                BaseDefinition = baseProfile.Url,
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Differential = new StructureDefinition.DifferentialComponent
+                {
+                    Element =
+                    [
+                        new ElementDefinition("Patient")
+                        {
+                            Example =
+                            [
+                                new ElementDefinition.ExampleComponent
+                                {
+                                    Label = "suppress-me",
+                                    Value = new FhirString("suppressed"),
+                                    Extension = [suppressExt.DeepCopy()]
+                                },
+                                new ElementDefinition.ExampleComponent { Label = "keep-me", Value = new FhirString("kept") }
+                            ]
+                        }
+                    ]
+                }
+            };
+
+            var mockResolver = new InMemoryResourceResolver();
+            mockResolver.Add(baseProfile);
+            var generator = new SnapshotGenerator(mockResolver, new SnapshotGeneratorSettings { RespectSuppressExtension = respectSuppressExtension });
+            await generator.UpdateAsync(derivedProfile);
+
+            var patientElement = derivedProfile.Snapshot!.Element.FirstOrDefault(e => e.Path == "Patient");
+            Assert.IsNotNull(patientElement);
+
+            if (respectSuppressExtension)
+            {
+                patientElement.Example.Should().NotContain(e => e.Label == "suppress-me", "suppressed example should be filtered out");
+                patientElement.Example.Should().Contain(e => e.Label == "keep-me", "unsuppressed example should be present");
+            }
+            else
+            {
+                patientElement.Example.Should().Contain(e => e.Label == "suppress-me", "example should be kept when suppression is not respected");
+                patientElement.Example.Should().Contain(e => e.Label == "keep-me", "unsuppressed example should always be present");
+            }
+        }
+
         private StructureDefinition CreateProfileWithDuplicateSuppressedMappings()
         {
             var suppressExtension = new Extension


### PR DESCRIPTION
## Description
Fixed incorrect merge logic in mergeCollectionWithSuppression that could result in suppression extension not being honoured.

## Testing
Added additional unit tests.

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes