### PR TITLE
Fix serialization base64 size limits

### DIFF
--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonSerializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonSerializer.cs
@@ -14,8 +14,10 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Utility;
 using System;
 using System.Buffers;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 
 namespace Hl7.Fhir.Serialization;
@@ -187,7 +189,7 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
                     writeStartArray(elementName, numNullsMissed, writer);
                 }
 
-                SerializePrimitiveValue(value.JsonValue, writer);
+                SerializePrimitiveValue(value, writer);
             }
             else
             {
@@ -253,18 +255,22 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
         {
             // Write a property with 'elementName'
             writer.WritePropertyName(elementName);
-
-            // due to System.Text.Json limitations described in https://github.com/FirelyTeam/firely-net-sdk/issues/3501
-            // Base64 strings need to be < 125MB, but the overload accepting byte array does not carry such limitation
-            // so we pass the underlying array down
-            var serializableValue = value is Base64Binary { Value.Length: > 0 } bin ? bin.Value : value.JsonValue;
-            
-            SerializePrimitiveValue(serializableValue, writer);
+            SerializePrimitiveValue(value, writer);
         }
 
         if (!value.EnumerateElements().Any()) return;
         
         deferSerializeForFilter(elementName, value, writer, filter);
+    }
+    
+    private static void tryWriteBase64(Utf8JsonWriter writer, string text)
+    {
+        var maxSize = Base64.GetMaxDecodedFromUtf8Length(text.Length);
+        using var pool = MemoryPool<byte>.Shared.Rent(maxSize);
+        if (Convert.TryFromBase64Chars(text, pool.Memory.Span, out var written))
+            writer.WriteBase64StringValue(pool.Memory.Span[..written]);
+        else
+            writer.WriteStringValue(text);
     }
 
     private void deferSerializeForFilter(string elementName, PrimitiveType value, Utf8JsonWriter writer, SerializationFilter? filter)
@@ -298,13 +304,17 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
     /// to be written that fit in .NET's <see cref="decimal"/> type, which may be less
     /// precision than required by the FHIR specification (http://hl7.org/fhir/json.html#primitive).
     /// </remarks>
-    protected virtual void SerializePrimitiveValue(object? value, Utf8JsonWriter writer)
+    protected virtual void SerializePrimitiveValue(PrimitiveType value, Utf8JsonWriter writer)
     {
-        switch (value)
+        
+        switch (value.JsonValue)
         {
             case int i32: writer.WriteNumberValue(i32); break;
             case decimal dec: writer.WriteNumberValue(dec); break;
-            case byte[] bytes: writer.WriteBase64StringValue(bytes); break;
+            // due to System.Text.Json limitations described in https://github.com/FirelyTeam/firely-net-sdk/issues/3501
+            // Base64 strings need to be < 125MB, but the overload accepting byte array does not carry such limitation
+            // Accessing the Value property might result in CodedValidationException, so we need to 
+            case string s when value is Base64Binary: tryWriteBase64(writer, s); break;
             // A little note about trimming and whitespaces. The spec says:
             // "(...) In JSON and Turtle whitespace in string values is always significant. Primitive types other than
             // string SHALL NOT have leading or trailing whitespace."

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonSerializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonSerializer.cs
@@ -17,7 +17,6 @@ using System.Buffers;
 using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Text.Json;
 
 namespace Hl7.Fhir.Serialization;
@@ -189,7 +188,7 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
                     writeStartArray(elementName, numNullsMissed, writer);
                 }
 
-                SerializePrimitiveValue(value, writer);
+                SerializePrimitiveInternal(value, writer);
             }
             else
             {
@@ -255,7 +254,7 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
         {
             // Write a property with 'elementName'
             writer.WritePropertyName(elementName);
-            SerializePrimitiveValue(value, writer);
+            SerializePrimitiveInternal(value, writer);
         }
 
         if (!value.EnumerateElements().Any()) return;
@@ -291,6 +290,17 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
         writer.WriteRawValue(buffer.WrittenSpan, skipInputValidation: true);
     }
 
+    internal void SerializePrimitiveInternal(PrimitiveType value, Utf8JsonWriter writer)
+    {
+        // due to System.Text.Json limitations described in https://github.com/FirelyTeam/firely-net-sdk/issues/3501
+        // Base64 strings need to be < 125MB, but the overload accepting byte array does not carry such limitation
+        // Accessing the Value property might result in CodedValidationException, so we need to 
+        if (value is Base64Binary { JsonValue: string { Length: > 0 } text })
+            tryWriteBase64(writer, text);
+        else
+            SerializePrimitiveValue(value.JsonValue, writer);
+    }
+
     /// <summary>
     /// Serialize a primitive .NET value that may occur in the POCOs into Json.
     /// </summary>
@@ -304,17 +314,12 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
     /// to be written that fit in .NET's <see cref="decimal"/> type, which may be less
     /// precision than required by the FHIR specification (http://hl7.org/fhir/json.html#primitive).
     /// </remarks>
-    protected virtual void SerializePrimitiveValue(PrimitiveType value, Utf8JsonWriter writer)
+    protected virtual void SerializePrimitiveValue(object? value, Utf8JsonWriter writer)
     {
-        
-        switch (value.JsonValue)
+        switch (value)
         {
             case int i32: writer.WriteNumberValue(i32); break;
             case decimal dec: writer.WriteNumberValue(dec); break;
-            // due to System.Text.Json limitations described in https://github.com/FirelyTeam/firely-net-sdk/issues/3501
-            // Base64 strings need to be < 125MB, but the overload accepting byte array does not carry such limitation
-            // Accessing the Value property might result in CodedValidationException, so we need to 
-            case string s when value is Base64Binary: tryWriteBase64(writer, s); break;
             // A little note about trimming and whitespaces. The spec says:
             // "(...) In JSON and Turtle whitespace in string values is always significant. Primitive types other than
             // string SHALL NOT have leading or trailing whitespace."

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonSerializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonSerializer.cs
@@ -253,7 +253,13 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
         {
             // Write a property with 'elementName'
             writer.WritePropertyName(elementName);
-            SerializePrimitiveValue(value.JsonValue, writer);
+
+            // due to System.Text.Json limitations described in https://github.com/FirelyTeam/firely-net-sdk/issues/3501
+            // Base64 strings need to be < 125MB, but the overload accepting byte array does not carry such limitation
+            // so we pass the underlying array down
+            var serializableValue = value is Base64Binary { Value.Length: > 0 } bin ? bin.Value : value.JsonValue;
+            
+            SerializePrimitiveValue(serializableValue, writer);
         }
 
         if (!value.EnumerateElements().Any()) return;
@@ -298,6 +304,7 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
         {
             case int i32: writer.WriteNumberValue(i32); break;
             case decimal dec: writer.WriteNumberValue(dec); break;
+            case byte[] bytes: writer.WriteBase64StringValue(bytes); break;
             // A little note about trimming and whitespaces. The spec says:
             // "(...) In JSON and Turtle whitespace in string values is always significant. Primitive types other than
             // string SHALL NOT have leading or trailing whitespace."

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonSerializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonSerializer.cs
@@ -188,7 +188,7 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
                     writeStartArray(elementName, numNullsMissed, writer);
                 }
 
-                SerializePrimitiveInternal(value, writer);
+                SerializePrimitiveValue(value, writer);
             }
             else
             {
@@ -254,7 +254,7 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
         {
             // Write a property with 'elementName'
             writer.WritePropertyName(elementName);
-            SerializePrimitiveInternal(value, writer);
+            SerializePrimitiveValue(value, writer);
         }
 
         if (!value.EnumerateElements().Any()) return;
@@ -290,7 +290,27 @@ public class BaseFhirJsonSerializer(ModelInspector inspector)
         writer.WriteRawValue(buffer.WrittenSpan, skipInputValidation: true);
     }
 
-    internal void SerializePrimitiveInternal(PrimitiveType value, Utf8JsonWriter writer)
+    /// <summary>
+    /// Serialize a primitive POCO into Json.
+    /// </summary>
+    /// <remarks>
+    /// For <see cref="Base64Binary"/> values, this method decodes the stored base64 string into a
+    /// pooled byte buffer and writes it via <see cref="Utf8JsonWriter.WriteBase64StringValue(ReadOnlySpan{byte})"/>,
+    /// bypassing the ~125 MB string-size limit in System.Text.Json (see
+    /// https://github.com/FirelyTeam/firely-net-sdk/issues/3501). If the stored value is not valid
+    /// base64, it falls back to writing the raw string so that error information is preserved.
+    /// All other primitive types are delegated to <see cref="SerializePrimitiveValue(object?, Utf8JsonWriter)"/>.
+    ///
+    /// To allow for future additions to the POCOs the list of primitives supported here
+    /// is larger than the set used by the current POCOs. Note that <c>DateTimeOffset</c> and
+    /// <c>byte[]</c> are considered to be "primitive" values here (used as the value in
+    /// <see cref="Instant"/> and <see cref="Base64Binary"/>).
+    ///
+    /// Note that the current version of System.Text.Json only allows numbers
+    /// to be written that fit in .NET's <see cref="decimal"/> type, which may be less
+    /// precision than required by the FHIR specification (http://hl7.org/fhir/json.html#primitive).
+    /// </remarks>
+    protected virtual void SerializePrimitiveValue(PrimitiveType value, Utf8JsonWriter writer)
     {
         // due to System.Text.Json limitations described in https://github.com/FirelyTeam/firely-net-sdk/issues/3501
         // Base64 strings need to be < 125MB, but the overload accepting byte array does not carry such limitation

--- a/src/Hl7.Fhir.Serialization.Shared.Tests/RoundTripAttachments.cs
+++ b/src/Hl7.Fhir.Serialization.Shared.Tests/RoundTripAttachments.cs
@@ -5,8 +5,8 @@ using Hl7.Fhir.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Text.Json;
-using ERR = Hl7.Fhir.Serialization.FhirJsonException;
 using COVE = Hl7.Fhir.Validation.CodedValidationException;
 
 namespace Hl7.Fhir.Serialization.Tests;
@@ -97,5 +97,22 @@ public class RoundTripAttachments
 #endif
 
         }
+    }
+
+    [TestMethod]
+    public void RoundTripLargeBase64Binary()
+    {
+        // Exercises the byte[] code path with a 128 MB payload to guard against regressions
+        // introduced by the System.Text.Json base64 string size limit fix (~125 MB limit on strings).
+        var data = new byte[128 * 1024 * 1024];
+        new Random(42).NextBytes(data);
+        var attachment = new Attachment { DataElement = new Base64Binary(data) };
+
+        var serializer = new FhirJsonSerializer();
+        var json = serializer.SerializeToString(attachment);
+
+        var parser = new FhirJsonDeserializer();
+        var roundTripped = parser.Deserialize<Attachment>(json)!;
+        roundTripped.DataElement!.Value.Should().Equal(data);
     }
 }


### PR DESCRIPTION
## Description

This pull request addresses an issue with serializing large Base64 strings in FHIR primitives by improving how binary data is handled during JSON serialization. The main focus is to avoid limitations in `System.Text.Json` when serializing large Base64 strings.

**Improvements to FHIR primitive serialization:**

* Updated `serializeFhirPrimitive` in `BaseFhirJsonSerializer.cs` to pass the underlying byte array of `Base64Binary` values directly to the serializer, bypassing the 125MB limitation of `System.Text.Json` for strings.
* Enhanced `SerializePrimitiveValue` to handle `byte[]` values by writing them as Base64 strings using `WriteBase64StringValue`, ensuring proper serialization of binary data.

## Related issues
Fixes #3501