### PR TITLE
Fix: store 'instant' as canonical string when building a POCO from an untyped source

### DIFF
--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.Shared.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.Shared.cs
@@ -175,6 +175,11 @@ internal partial class NewPocoBuilder
         ET.Time => value.ToString()!,
         ET.Date => value.ToString()!,
 
+        // 'instant' is the only FHIR primitive whose POCO value property is a System.DateTimeOffset
+        // (rather than a string), so converting its literal yields a DateTimeOffset that must also be
+        // stored as the canonical string form, just like the CQL date/time types above.
+        DateTimeOffset dto => ET.DateTime.FromDateTimeOffset(dto).ToString()!,
+
         // Integer64 uses string in the POCOs.
         long l => new ET.Long(l).ToString(),
 

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/SourceNodeToPocoTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/SourceNodeToPocoTests.cs
@@ -158,6 +158,24 @@ public class SourceNodeToPocoTests
             .Which.Active.Should().Be(true);
     }
 
+    [TestMethod]
+    public void ConvertsInstantValueWhenBuildingFromSourceNode()
+    {
+        // 'instant' is the only FHIR primitive whose POCO value property is a System.DateTimeOffset
+        // (rather than a string). When built from an (untyped) source node, its literal must still be
+        // stored as the canonical string form in JsonValue, otherwise the string-backed instant
+        // validation rejects the value when it is read back.
+        const string lastUpdated = "2026-06-24T15:21:58.865+00:00";
+        var patient = SourceNode.Resource("Patient", "Patient",
+            SourceNode.Node("meta",
+                SourceNode.Valued("lastUpdated", lastUpdated)));
+
+        var poco = patient.ToPoco<Patient>(ModelInfo.ModelInspector);
+
+        poco.Meta!.LastUpdatedElement!.JsonValue.Should().BeOfType<string>();
+        poco.Meta.LastUpdated.Should().Be(DateTimeOffset.Parse(lastUpdated));
+    }
+
     private static SourceNode createPatientSourceNode() =>
         SourceNode.Resource("Patient", "Patient",
             SourceNode.Valued("active", "true"),


### PR DESCRIPTION
## Problem

When a POCO is built from an **untyped source node** (`ISourceNode → POCO`, e.g. `ToPoco<T>()` / `NewPocoBuilder.BuildFrom(ISourceNode)`), an `instant` value ends up stored as a `System.DateTimeOffset` in the primitive's `JsonValue`. Because `instant` is now string-backed, reading the value back fails validation:

```
CodedValidationException: value '2026-06-24T15:21:58.865+00:00' of type 'System.DateTimeOffset' is not the right type of literal for a instant.
```

`instant` is the only FHIR primitive whose generated POCO value property is `DateTimeOffset?` (every other primitive — `date`/`dateTime`/`time`/etc. — uses a `string`-backed value property). In `convertSourceNodeValue`, `PrimitiveTypeConverter.ConvertTo(text, PrimitiveValueProperty.ImplementingType)` therefore yields a `System.DateTimeOffset`, and `normalizePrimitiveValueForPocoStorage` had no case for `DateTimeOffset`, so it was stored unchanged.

This surfaces in any consumer that builds resources from untyped source-node trees and then reads `meta.lastUpdated` (search/history/transaction response bundles, deletion tombstones, etc.).

## Fix

Add a `DateTimeOffset` arm to `normalizePrimitiveValueForPocoStorage` that converts to the canonical `instant` string, mirroring the existing handling of the CQL date/time types.

## Test

`SourceNodeToPocoTests.ConvertsInstantValueWhenBuildingFromSourceNode` builds a `Patient` with a `meta.lastUpdated` from a source node and asserts the stored `JsonValue` is a string and that `Meta.LastUpdated` reads back correctly. It fails without the fix and passes with it.

Note: the `ITypedElement → POCO` path was checked and is **not** affected (its dynamic-primitive values are already handled), so no change there.