### PR TITLE
Ensure PropertyMapping gets Code<T> for the PropertyTypeMapping

### DIFF
--- a/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
@@ -405,9 +405,11 @@ public class PropertyMapping : IElementDefinitionSummary
         if (typeof(Enum).IsAssignableFrom(implementingType))
             return typeof(Enum);
 
+        // To ensure CreateInstance indeed creates pocos that fit the expected property values, we need to return the
+        // implementing type, so PropertyMapping.PropertyTypeMapping will link to the exact ClassMapping needed
         // For all Code<T>, we use the mapping for Coding
-        if (implementingType.IsConstructedGenericType && implementingType.GetGenericTypeDefinition() == typeof(Code<>))
-            return typeof(Code);
+        // if (implementingType.IsConstructedGenericType && implementingType.GetGenericTypeDefinition() == typeof(Code<>))
+        //     return typeof(Code);
 
         // Otherwise, we simply use the mapping for the actual implementing type.
         return implementingType;

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
@@ -446,6 +446,26 @@ public partial class FhirJsonDeserializationTests
     }
 
     [TestMethod]
+    public void TestDeserializeCodeOfTIntoPoco()
+    {
+        const string json = """
+                            {
+                                "resourceType": "Observation",
+                                "status": "final",
+                                "code": { "text": "heart rate" }
+                            }
+                            """;
+
+        var parsed = FhirJsonDeserializer.DEFAULT.DeserializeResource(json)
+            .Should().BeOfType<Observation>().Subject;
+
+        // Observation.StatusElement is a Code<ObservationStatus>
+        parsed.StatusElement.Should().BeOfType<Code<ObservationStatus>>();
+        parsed.StatusElement!.JsonValue.Should().Be("final");
+        parsed.Status.Should().Be(ObservationStatus.Final);
+    }
+
+    [TestMethod]
     public void TestBase64Parsing()
     {
         var attachment = deserializeAttachment(new FhirJsonConverterOptions());

--- a/src/Hl7.Fhir.Support.Tests/Introspection/PropertyMappingTest.cs
+++ b/src/Hl7.Fhir.Support.Tests/Introspection/PropertyMappingTest.cs
@@ -113,9 +113,9 @@ public class ModelInspectorMembersTest
         ClassMapping.TryCreate(ModelInspector.Base, typeof(Canonical), out var canonicalMapping);
         canonicalMapping.FindMappedElementByName("value").PropertyTypeMapping.Name.Should().Be("System.String");
 
-        // ConcactPoint.System - a Code<T> -> Code
+        // ContactPoint.System - a Code<T>
         ClassMapping.TryCreate(ModelInspector.Base, typeof(ContactPoint), out var contactPointMapping);
-        contactPointMapping.FindMappedElementByName("system").PropertyTypeMapping.Name.Should().Be("code");
+        contactPointMapping.FindMappedElementByName("system").PropertyTypeMapping.Name.Should().Be("codeOfT<Hl7.Fhir.Model.ContactPoint+ContactPointSystem>");
 
         // ContactPoint.Value - a FhirString
         contactPointMapping.FindMappedElementByName("value").PropertyTypeMapping.Name.Should().Be("string");


### PR DESCRIPTION
## Description
This pull request updates how `Code<T>` types are handled in property mapping and serialization/deserialization, ensuring that the exact generic type is used rather than the base `Code` type.

**Property Mapping Improvements:**

* Updated `determineMappingType` in `PropertyMapping.cs` to return the exact generic type for `Code<T>` instead of the base `Code` type, ensuring proper class mapping and instance creation.

**Test Updates and Additions:**

* Added a new unit test `TestDeserializeCodeOfTIntoPoco` in `FhirJsonDeserializationTests.cs` to verify that deserialization of a resource with a `Code<T>` property results in the correct generic type and value.
* Updated `GetClassMappingForProperty` test in `PropertyMappingTest.cs` to expect the `PropertyTypeMapping.Name` for `ContactPoint.System` to be the specific generic type (`codeOfT<Hl7.Fhir.Model.ContactPoint+ContactPointSystem>`) instead of just `code`