### PR TITLE
Fix #3502: Detect wrong-cased element and resource type names at the model level

### DIFF
--- a/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
@@ -280,6 +280,52 @@ public class ClassMapping(
         }
     }
 
+    /// <summary>
+    /// Looks up the element that a (possibly choice-suffixed) serialized name refers to, matching
+    /// names case-insensitively, and reports how well the given name matches the definition.
+    /// </summary>
+    /// <param name="name">The name for the element as encountered in the serialized form.</param>
+    /// <returns>The result of the lookup, or <c>null</c> when the name does not match any element
+    /// of this class, not even when compared case-insensitively.</returns>
+    /// <remarks>This is the single source of truth for detecting case-sensitivity violations in
+    /// element names: FHIR names are case-sensitive, but this lookup will also find "near misses"
+    /// that differ from a defined element name only by casing. Callers decide, based on
+    /// <see cref="ElementLookupResult.IsExactCase"/> and <see cref="ElementLookupResult.MatchedByLegacyRules"/>,
+    /// whether to bind the data to the found element and/or to report an error.</remarks>
+    internal ElementLookupResult? TryFindElement(string name)
+    {
+        if (name == null) throw Error.ArgumentNull(nameof(name));
+
+        // Unsuffixed names: found via the (case-insensitive) name dictionary.
+        if (FindMappedElementByName(name) is { } byName)
+            return new ElementLookupResult(
+                byName,
+                byName.Name,
+                IsExactCase: string.Equals(name, byName.Name, StringComparison.Ordinal),
+                MatchedByLegacyRules: true);
+
+        // Choice elements: the name is the element name plus a type suffix.
+        if (FindMappedElementByChoiceName(name, ignoreCase: true) is { } byChoice)
+        {
+            var canonicalName = byChoice.Name + normalizeChoiceSuffix(name[byChoice.Name.Length..]);
+            return new ElementLookupResult(
+                byChoice,
+                canonicalName,
+                IsExactCase: string.Equals(name, canonicalName, StringComparison.Ordinal),
+                MatchedByLegacyRules: name.StartsWith(byChoice.Name, StringComparison.Ordinal));
+        }
+
+        return null;
+
+        // Resolves the suffix to its actual datatype mapping (case-insensitively) so the canonical
+        // name we suggest is correct even when the suffix casing is wrong. Suffixes that do not
+        // resolve to a known type carry no case information, so they are kept as-is.
+        string normalizeChoiceSuffix(string suffix) =>
+            suffix.Length > 0 && Inspector.FindClassMapping(suffix) is { } typeMapping
+                ? char.ToUpperInvariant(typeMapping.Name[0]) + typeMapping.Name[1..]
+                : suffix;
+    }
+
     #region IStructureDefinitionSummary members
     /// <inheritdoc />
     string IStructureDefinitionSummary.TypeName =>
@@ -422,3 +468,22 @@ public class ClassMapping(
     internal static ClassMapping DynamicDataType => _dynDataMapping ??= ModelInspector.Base.FindOrImportClassMapping(typeof(DynamicDataType)) ??
                                                     throw new InvalidOperationException($"{nameof(DynamicDataType)} mapping not found in Base.");
 }
+
+/// <summary>
+/// The result of looking up an element by a serialized name using <see cref="ClassMapping.TryFindElement(string)"/>.
+/// </summary>
+/// <param name="Mapping">The element that the name refers to (for choice elements: the unsuffixed choice element).</param>
+/// <param name="CanonicalName">The correctly-cased form of the given name, including a correctly-cased
+/// type suffix for choice elements. This is the name that should have been used in the serialized form.</param>
+/// <param name="IsExactCase">Whether the given name is exactly equal to <paramref name="CanonicalName"/>.
+/// When <c>false</c>, the name is a case-sensitivity violation ("near miss").</param>
+/// <param name="MatchedByLegacyRules">Whether this match would also have been found by the lookup rules
+/// used by the SDK before case-sensitivity violations were detected (SDK 6.2 and earlier): element names
+/// were compared case-insensitively, but the element-name part of a choice name was compared
+/// case-sensitively (only its type suffix was case-insensitive). Used to reproduce that legacy binding
+/// behaviour exactly when case-sensitivity violations are not treated as errors.</param>
+internal sealed record ElementLookupResult(
+    PropertyMapping Mapping,
+    string CanonicalName,
+    bool IsExactCase,
+    bool MatchedByLegacyRules);

--- a/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
@@ -243,7 +243,19 @@ public class ClassMapping(
     /// so for where there is no suffix. In this case, however, <see cref="FindMappedElementByName(string)"/>
     /// is faster.
     /// </remarks>
-    public PropertyMapping? FindMappedElementByChoiceName(string name, bool ignoreCase = false)
+    public PropertyMapping? FindMappedElementByChoiceName(string name) => FindMappedElementByChoiceName(name, ignoreCase: false);
+
+    /// <summary>
+    /// Returns the mapping for an element of this class by a name that
+    /// might be suffixed by a type name (e.g. for choice elements).
+    /// </summary>
+    /// <param name="name">The (possibly suffixed) name to look up.</param>
+    /// <param name="ignoreCase">If <c>true</c>, the choice prefix is matched case-insensitively.</param>
+    /// <remarks>Will also return properties for which the name is exactly the same,
+    /// so for where there is no suffix. In this case, however, <see cref="FindMappedElementByName(string)"/>
+    /// is faster.
+    /// </remarks>
+    public PropertyMapping? FindMappedElementByChoiceName(string name, bool ignoreCase)
     {
         if (name == null) throw Error.ArgumentNull(nameof(name));
 

--- a/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
@@ -282,7 +282,7 @@ public class ClassMapping(
 
     /// <summary>
     /// Looks up the element that a (possibly choice-suffixed) serialized name refers to, matching
-    /// names case-insensitively, and reports how well the given name matches the definition.
+    /// names case-insensitively, and reports whether the given name matches the definition exactly.
     /// </summary>
     /// <param name="name">The name for the element as encountered in the serialized form.</param>
     /// <returns>The result of the lookup, or <c>null</c> when the name does not match any element
@@ -290,8 +290,8 @@ public class ClassMapping(
     /// <remarks>This is the single source of truth for detecting case-sensitivity violations in
     /// element names: FHIR names are case-sensitive, but this lookup will also find "near misses"
     /// that differ from a defined element name only by casing. Callers decide, based on
-    /// <see cref="ElementLookupResult.IsExactCase"/> and <see cref="ElementLookupResult.MatchedByLegacyRules"/>,
-    /// whether to bind the data to the found element and/or to report an error.</remarks>
+    /// <see cref="ElementLookupResult.IsExactCase"/>, whether to bind the data to the found
+    /// element and/or to report an error.</remarks>
     internal ElementLookupResult? TryFindElement(string name)
     {
         if (name == null) throw Error.ArgumentNull(nameof(name));
@@ -301,8 +301,7 @@ public class ClassMapping(
             return new ElementLookupResult(
                 byName,
                 byName.Name,
-                IsExactCase: string.Equals(name, byName.Name, StringComparison.Ordinal),
-                MatchedByLegacyRules: true);
+                IsExactCase: string.Equals(name, byName.Name, StringComparison.Ordinal));
 
         // Choice elements: the name is the element name plus a type suffix.
         if (FindMappedElementByChoiceName(name, ignoreCase: true) is { } byChoice)
@@ -311,8 +310,7 @@ public class ClassMapping(
             return new ElementLookupResult(
                 byChoice,
                 canonicalName,
-                IsExactCase: string.Equals(name, canonicalName, StringComparison.Ordinal),
-                MatchedByLegacyRules: name.StartsWith(byChoice.Name, StringComparison.Ordinal));
+                IsExactCase: string.Equals(name, canonicalName, StringComparison.Ordinal));
         }
 
         return null;
@@ -477,13 +475,7 @@ public class ClassMapping(
 /// type suffix for choice elements. This is the name that should have been used in the serialized form.</param>
 /// <param name="IsExactCase">Whether the given name is exactly equal to <paramref name="CanonicalName"/>.
 /// When <c>false</c>, the name is a case-sensitivity violation ("near miss").</param>
-/// <param name="MatchedByLegacyRules">Whether this match would also have been found by the lookup rules
-/// used by the SDK before case-sensitivity violations were detected (SDK 6.2 and earlier): element names
-/// were compared case-insensitively, but the element-name part of a choice name was compared
-/// case-sensitively (only its type suffix was case-insensitive). Used to reproduce that legacy binding
-/// behaviour exactly when case-sensitivity violations are not treated as errors.</param>
 internal sealed record ElementLookupResult(
     PropertyMapping Mapping,
     string CanonicalName,
-    bool IsExactCase,
-    bool MatchedByLegacyRules);
+    bool IsExactCase);

--- a/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
@@ -243,7 +243,7 @@ public class ClassMapping(
     /// so for where there is no suffix. In this case, however, <see cref="FindMappedElementByName(string)"/>
     /// is faster.
     /// </remarks>
-    public PropertyMapping? FindMappedElementByChoiceName(string name)
+    public PropertyMapping? FindMappedElementByChoiceName(string name, bool ignoreCase = false)
     {
         if (name == null) throw Error.ArgumentNull(nameof(name));
 
@@ -251,8 +251,9 @@ public class ClassMapping(
         if (FindMappedElementByName(name) is { } pm) return pm;
 
         // Now, check the choice elements for a match.
+        var comparisonType = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
         var matches = PropertyMappingsInternal.ChoiceProperties
-            .Where(m => name.StartsWith(m.Name)).ToList();
+            .Where(m => name.StartsWith(m.Name, comparisonType)).ToList();
 
         // Loop through possible matches and return the longest match.
         if (matches.Any())

--- a/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
@@ -241,29 +241,22 @@ public class ClassMapping(
     /// </summary>
     /// <remarks>Will also return properties for which the name is exactly the same,
     /// so for where there is no suffix. In this case, however, <see cref="FindMappedElementByName(string)"/>
-    /// is faster.
+    /// is faster. The element-name part of the name is matched case-sensitively (the type suffix is
+    /// matched case-insensitively by the callers that resolve it).
     /// </remarks>
-    public PropertyMapping? FindMappedElementByChoiceName(string name) => FindMappedElementByChoiceName(name, ignoreCase: false);
-
-    /// <summary>
-    /// Returns the mapping for an element of this class by a name that
-    /// might be suffixed by a type name (e.g. for choice elements).
-    /// </summary>
-    /// <param name="name">The (possibly suffixed) name to look up.</param>
-    /// <param name="ignoreCase">If <c>true</c>, the choice prefix is matched case-insensitively.</param>
-    /// <remarks>Will also return properties for which the name is exactly the same,
-    /// so for where there is no suffix. In this case, however, <see cref="FindMappedElementByName(string)"/>
-    /// is faster.
-    /// </remarks>
-    public PropertyMapping? FindMappedElementByChoiceName(string name, bool ignoreCase)
+    public PropertyMapping? FindMappedElementByChoiceName(string name)
     {
         if (name == null) throw Error.ArgumentNull(nameof(name));
 
         // Returns correct mapping for unsuffixed names.
         if (FindMappedElementByName(name) is { } pm) return pm;
 
-        // Now, check the choice elements for a match.
-        var comparisonType = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        return findChoiceMatch(name, StringComparison.Ordinal);
+    }
+
+    private PropertyMapping? findChoiceMatch(string name, StringComparison comparisonType)
+    {
+        // Check the choice elements for a prefix match.
         var matches = PropertyMappingsInternal.ChoiceProperties
             .Where(m => name.StartsWith(m.Name, comparisonType)).ToList();
 
@@ -303,8 +296,9 @@ public class ClassMapping(
                 byName.Name,
                 IsExactCase: string.Equals(name, byName.Name, StringComparison.Ordinal));
 
-        // Choice elements: the name is the element name plus a type suffix.
-        if (FindMappedElementByChoiceName(name, ignoreCase: true) is { } byChoice)
+        // Choice elements: the name is the element name plus a type suffix. The name dictionary
+        // was already consulted above, so only the choice-prefix scan remains to be done here.
+        if (findChoiceMatch(name, StringComparison.OrdinalIgnoreCase) is { } byChoice)
         {
             var canonicalName = byChoice.Name + normalizeChoiceSuffix(name[byChoice.Name.Length..]);
             return new ElementLookupResult(

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonDeserializer.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Json;
+using COVE = Hl7.Fhir.Validation.CodedValidationException;
 using ERR = Hl7.Fhir.Serialization.FhirJsonException;
 
 #nullable enable
@@ -55,6 +56,20 @@ public class BaseFhirJsonDeserializer
     public DeserializerSettings Settings { get; set; }
 
     private readonly ModelInspector _inspector;
+
+    // Caches DeserializerSettings.UsesStrictCaseBinding(), which is invoked for every element, per
+    // settings instance. The settings' relevant properties are init-only, so as long as the same
+    // instance is assigned to Settings, the cached answer remains valid.
+    private (DeserializerSettings settings, bool strict)? _caseBindingCache;
+
+    private bool usesStrictCaseBinding()
+    {
+        if (_caseBindingCache is { } cached && ReferenceEquals(cached.settings, Settings)) return cached.strict;
+
+        var strict = Settings.UsesStrictCaseBinding();
+        _caseBindingCache = (Settings, strict);
+        return strict;
+    }
 
     /// <summary>
     /// Deserialize the FHIR Json from the reader and create a new POCO object containing the data from the reader.
@@ -253,12 +268,14 @@ public class BaseFhirJsonDeserializer
         var result = deserializeRhs(existingValue, ref reader, propertyName, metadata, state);
         target.SetValue(elementName, result);
 
-        doPropertyValidation(target, result, metadata, state, line, pos);
+        // Pass the name as encountered in the serialized form (without the '_' prefix), so the
+        // validator can also detect names that only differ from the defined name by casing.
+        doPropertyValidation(target, usesUnderscore ? propertyName[1..] : propertyName, result, metadata, state, line, pos);
 
         state.ExitElement();
     }
 
-    private void doPropertyValidation(Base target, object propertyValue, PropertyValueMapping metadata, PocoDeserializerState state, long line, long pos)
+    private void doPropertyValidation(Base target, string serializedName, object propertyValue, PropertyValueMapping metadata, PocoDeserializerState state, long line, long pos)
     {
         if (Settings.Validator is null) return;
 
@@ -283,7 +300,7 @@ public class BaseFhirJsonDeserializer
         void runPropertyValidation()
         {
             var c = context;
-            state.Errors.Add(Settings.Validator.ValidateProperty(metadata.PropertyMapping.Name, propertyValue, metadata.PropertyMapping,
+            state.Errors.Add(Settings.Validator.ValidateProperty(serializedName, propertyValue, metadata.PropertyMapping,
                 c));
         }
     }
@@ -656,8 +673,14 @@ public class BaseFhirJsonDeserializer
         if (resourceMapping is null or { IsResource: false })
             return new ClassMapping(_inspector, resourceType, typeof(DynamicResource));
 
-        if (!string.Equals(resourceMapping.Name, resourceType, StringComparison.Ordinal))
-            state.Errors.Add(ERR.RESOURCE_TYPE_WRONG_CASE(ref reader, state.Path.GetInstancePath(), resourceType, resourceMapping.Name));
+        // The inspector finds resource types case-insensitively, so the data can still be parsed
+        // into the correct POCO, but a wrong-cased resource type name violates the spec and is
+        // reported. This is a model-level validation, so it is skipped when the validator is off.
+        if (Settings.Validator is not null && !string.Equals(resourceMapping.Name, resourceType, StringComparison.Ordinal))
+        {
+            var (line, pos) = reader.GetLocation();
+            state.Errors.Add(COVE.WRONG_CASED_RESOURCE_TYPE(state.Path.GetInstancePath(), line, pos, resourceType, resourceMapping.Name));
+        }
 
         return resourceMapping;
     }
@@ -727,40 +750,29 @@ public class BaseFhirJsonDeserializer
         bool isUnexpectedValueProperty = parentMapping.IsFhirPrimitive && propNameWithoutUnderscore == "value";
 
         var localMapping = state.GetObjectContext().LocalPropertyMappings.GetValueOrDefault(propNameWithoutUnderscore);
-        PropertyMapping? byNameMapping = null;
-        PropertyMapping? byChoiceMapping = null;
-        string? caseMismatchExpectedName = null;
+        PropertyMapping? definedMapping = null;
 
-        if (localMapping is null && !isUnexpectedValueProperty)
+        if (localMapping is null && !isUnexpectedValueProperty
+            && parentMapping.TryFindElement(propNameWithoutUnderscore) is { } lookup)
         {
-            byNameMapping = parentMapping.FindMappedElementByName(propNameWithoutUnderscore);
-            if (byNameMapping is not null && !string.Equals(byNameMapping.Name, propNameWithoutUnderscore, StringComparison.Ordinal))
-                caseMismatchExpectedName = byNameMapping.Name;
-            else
-            {
-                byChoiceMapping = parentMapping.FindMappedElementByChoiceName(propNameWithoutUnderscore, ignoreCase: true);
-                if (byChoiceMapping is not null)
-                {
-                    var actualPrefix = propNameWithoutUnderscore[..byChoiceMapping.Name.Length];
-                    if (!string.Equals(byChoiceMapping.Name, actualPrefix, StringComparison.Ordinal))
-                    {
-                        var actualSuffix = propNameWithoutUnderscore[byChoiceMapping.Name.Length..];
-                        caseMismatchExpectedName = byChoiceMapping.Name + normalizeChoiceSuffix(actualSuffix);
-                    }
-                }
-            }
+            // The lookup also finds names that differ from a defined element name only by casing.
+            // Whether such a wrong-cased name is still bound to the element it nearly matches is
+            // decided by DeserializerSettings.UsesStrictCaseBinding (see there for the rationale):
+            // - lenient: bind using exactly the matching rules of SDK 6.2 and earlier, so behaviour
+            //   is unchanged for callers that tolerate wrong-case errors;
+            // - strict: only bind exactly-cased names. A wrong-cased name falls through to
+            //   getUnknownPropMapping() below, so the data is preserved under its original name in
+            //   the overflow, and the validator reports it (WRONG_CASED_ELEMENT + UNKNOWN_ELEMENT).
+            if (usesStrictCaseBinding() ? lookup.IsExactCase : lookup.MatchedByLegacyRules)
+                definedMapping = lookup.Mapping;
         }
 
         var propertyMapping = localMapping
-            ?? byNameMapping
-            ?? byChoiceMapping
+            ?? definedMapping
             ?? getUnknownPropMapping(ref reader, startsWithUnderscore);
 
         // Simulate us moving into the element, so we get an error at the right location
         state.EnterElement(propertyMapping.Name);
-
-        if (caseMismatchExpectedName is not null)
-            state.Errors.Add(ERR.PROPERTY_NAME_WRONG_CASE(ref reader, state.Path.GetInstancePath(), propNameWithoutUnderscore, caseMismatchExpectedName));
 
         var propertyValueMapping = propertyMapping.Choice switch
         {
@@ -780,13 +792,6 @@ public class BaseFhirJsonDeserializer
 
         return new PropertyValueMapping(propertyMapping, propertyValueMapping);
 
-        // Resolves the suffix to its actual datatype mapping (case-insensitively) so the casing
-        // suggested in a wrong-case-prefix error is correct even when the suffix is also wrong-case.
-        string normalizeChoiceSuffix(string suffix) =>
-            parentMapping.Inspector.FindClassMapping(suffix) is { } typeMapping
-                ? char.ToUpperInvariant(typeMapping.Name[0]) + typeMapping.Name[1..]
-                : suffix;
-
         ClassMapping getChoiceClassMapping(ref Utf8JsonReader r)
         {
             string typeSuffix = propNameWithoutUnderscore[propertyMapping.Name.Length..];
@@ -799,12 +804,6 @@ public class BaseFhirJsonDeserializer
                 {
                     var guessedDynamicType = getUnknownPropMapping(ref r, startsWithUnderscore).ImplementingType;
                     foundChoiceMapping = new ClassMapping(_inspector, typeSuffix, guessedDynamicType);
-                }
-                else
-                {
-                    var expectedSuffix = char.ToUpperInvariant(foundChoiceMapping.Name[0]) + foundChoiceMapping.Name[1..];
-                    if (!string.Equals(typeSuffix, expectedSuffix, StringComparison.Ordinal))
-                        state.Errors.Add(ERR.CHOICE_TYPE_SUFFIX_WRONG_CASE(ref r, state.Path.GetInstancePath(), typeSuffix, expectedSuffix));
                 }
 
                 return foundChoiceMapping;

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonDeserializer.cs
@@ -652,11 +652,14 @@ public class BaseFhirJsonDeserializer
         var resourceType = scanForResourceType(ref reader, state);
         if (resourceType is null) return makeUnnamedResourceMapping(state.Path.GetInstancePath());
 
-        return _inspector.FindClassMapping(resourceType) switch
-        {
-            null or { IsResource: false } => new ClassMapping(_inspector, resourceType, typeof(DynamicResource)),
-            { } resourceMapping => resourceMapping,
-        };
+        var resourceMapping = _inspector.FindClassMapping(resourceType);
+        if (resourceMapping is null or { IsResource: false })
+            return new ClassMapping(_inspector, resourceType, typeof(DynamicResource));
+
+        if (!string.Equals(resourceMapping.Name, resourceType, StringComparison.Ordinal))
+            state.Errors.Add(ERR.RESOURCE_TYPE_WRONG_CASE(ref reader, state.Path.GetInstancePath(), resourceType, resourceMapping.Name));
+
+        return resourceMapping;
     }
 
     private const string UNNAMED_RESOURCE_NAME_PREFIX = "UnnamedResource_";
@@ -723,12 +726,16 @@ public class BaseFhirJsonDeserializer
         // separate "value" property in Json. If it does, treat it like an unknown property.
         bool isUnexpectedValueProperty = parentMapping.IsFhirPrimitive && propNameWithoutUnderscore == "value";
 
+        bool caseMismatch = false;
         var propertyMapping = state.GetObjectContext().LocalPropertyMappings.GetValueOrDefault(propNameWithoutUnderscore)
                               ?? (isUnexpectedValueProperty ? null : lookupPropertyInDefinition())
                               ?? getUnknownPropMapping(ref reader, startsWithUnderscore);
 
         // Simulate us moving into the element, so we get an error at the right location
         state.EnterElement(propertyMapping.Name);
+
+        if (caseMismatch)
+            state.Errors.Add(ERR.ELEMENT_NAME_WRONG_CASE(ref reader, state.Path.GetInstancePath(), propNameWithoutUnderscore, propertyMapping.Name));
 
         var propertyValueMapping = propertyMapping.Choice switch
         {
@@ -748,9 +755,17 @@ public class BaseFhirJsonDeserializer
 
         return new PropertyValueMapping(propertyMapping, propertyValueMapping);
 
-        PropertyMapping? lookupPropertyInDefinition() =>
-            parentMapping.FindMappedElementByName(propNameWithoutUnderscore)
-            ?? parentMapping.FindMappedElementByChoiceName(propNameWithoutUnderscore);
+        PropertyMapping? lookupPropertyInDefinition()
+        {
+            var byName = parentMapping.FindMappedElementByName(propNameWithoutUnderscore);
+            if (byName is not null)
+            {
+                if (!string.Equals(byName.Name, propNameWithoutUnderscore, StringComparison.Ordinal))
+                    caseMismatch = true;
+                return byName;
+            }
+            return parentMapping.FindMappedElementByChoiceName(propNameWithoutUnderscore);
+        }
 
         ClassMapping getChoiceClassMapping(ref Utf8JsonReader r)
         {
@@ -764,6 +779,12 @@ public class BaseFhirJsonDeserializer
                 {
                     var guessedDynamicType = getUnknownPropMapping(ref r, startsWithUnderscore).ImplementingType;
                     foundChoiceMapping = new ClassMapping(_inspector, typeSuffix, guessedDynamicType);
+                }
+                else
+                {
+                    var expectedSuffix = char.ToUpperInvariant(foundChoiceMapping.Name[0]) + foundChoiceMapping.Name[1..];
+                    if (!string.Equals(typeSuffix, expectedSuffix, StringComparison.Ordinal))
+                        state.Errors.Add(ERR.CHOICE_TYPE_SUFFIX_WRONG_CASE(ref r, state.Path.GetInstancePath(), typeSuffix, expectedSuffix));
                 }
 
                 return foundChoiceMapping;

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonDeserializer.cs
@@ -739,9 +739,15 @@ public class BaseFhirJsonDeserializer
             else
             {
                 byChoiceMapping = parentMapping.FindMappedElementByChoiceName(propNameWithoutUnderscore, ignoreCase: true);
-                if (byChoiceMapping is not null &&
-                    !string.Equals(byChoiceMapping.Name, propNameWithoutUnderscore[..byChoiceMapping.Name.Length], StringComparison.Ordinal))
-                    caseMismatchExpectedName = byChoiceMapping.Name + propNameWithoutUnderscore[byChoiceMapping.Name.Length..];
+                if (byChoiceMapping is not null)
+                {
+                    var actualPrefix = propNameWithoutUnderscore[..byChoiceMapping.Name.Length];
+                    if (!string.Equals(byChoiceMapping.Name, actualPrefix, StringComparison.Ordinal))
+                    {
+                        var actualSuffix = propNameWithoutUnderscore[byChoiceMapping.Name.Length..];
+                        caseMismatchExpectedName = byChoiceMapping.Name + normalizeChoiceSuffix(actualSuffix);
+                    }
+                }
             }
         }
 
@@ -773,6 +779,13 @@ public class BaseFhirJsonDeserializer
         state.ExitElement();
 
         return new PropertyValueMapping(propertyMapping, propertyValueMapping);
+
+        // Resolves the suffix to its actual datatype mapping (case-insensitively) so the casing
+        // suggested in a wrong-case-prefix error is correct even when the suffix is also wrong-case.
+        string normalizeChoiceSuffix(string suffix) =>
+            parentMapping.Inspector.FindClassMapping(suffix) is { } typeMapping
+                ? char.ToUpperInvariant(typeMapping.Name[0]) + typeMapping.Name[1..]
+                : suffix;
 
         ClassMapping getChoiceClassMapping(ref Utf8JsonReader r)
         {

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonDeserializer.cs
@@ -726,16 +726,35 @@ public class BaseFhirJsonDeserializer
         // separate "value" property in Json. If it does, treat it like an unknown property.
         bool isUnexpectedValueProperty = parentMapping.IsFhirPrimitive && propNameWithoutUnderscore == "value";
 
-        bool caseMismatch = false;
-        var propertyMapping = state.GetObjectContext().LocalPropertyMappings.GetValueOrDefault(propNameWithoutUnderscore)
-                              ?? (isUnexpectedValueProperty ? null : lookupPropertyInDefinition())
-                              ?? getUnknownPropMapping(ref reader, startsWithUnderscore);
+        var localMapping = state.GetObjectContext().LocalPropertyMappings.GetValueOrDefault(propNameWithoutUnderscore);
+        PropertyMapping? byNameMapping = null;
+        PropertyMapping? byChoiceMapping = null;
+        string? caseMismatchExpectedName = null;
+
+        if (localMapping is null && !isUnexpectedValueProperty)
+        {
+            byNameMapping = parentMapping.FindMappedElementByName(propNameWithoutUnderscore);
+            if (byNameMapping is not null && !string.Equals(byNameMapping.Name, propNameWithoutUnderscore, StringComparison.Ordinal))
+                caseMismatchExpectedName = byNameMapping.Name;
+            else
+            {
+                byChoiceMapping = parentMapping.FindMappedElementByChoiceName(propNameWithoutUnderscore, ignoreCase: true);
+                if (byChoiceMapping is not null &&
+                    !string.Equals(byChoiceMapping.Name, propNameWithoutUnderscore[..byChoiceMapping.Name.Length], StringComparison.Ordinal))
+                    caseMismatchExpectedName = byChoiceMapping.Name + propNameWithoutUnderscore[byChoiceMapping.Name.Length..];
+            }
+        }
+
+        var propertyMapping = localMapping
+            ?? byNameMapping
+            ?? byChoiceMapping
+            ?? getUnknownPropMapping(ref reader, startsWithUnderscore);
 
         // Simulate us moving into the element, so we get an error at the right location
         state.EnterElement(propertyMapping.Name);
 
-        if (caseMismatch)
-            state.Errors.Add(ERR.ELEMENT_NAME_WRONG_CASE(ref reader, state.Path.GetInstancePath(), propNameWithoutUnderscore, propertyMapping.Name));
+        if (caseMismatchExpectedName is not null)
+            state.Errors.Add(ERR.PROPERTY_NAME_WRONG_CASE(ref reader, state.Path.GetInstancePath(), propNameWithoutUnderscore, caseMismatchExpectedName));
 
         var propertyValueMapping = propertyMapping.Choice switch
         {
@@ -754,18 +773,6 @@ public class BaseFhirJsonDeserializer
         state.ExitElement();
 
         return new PropertyValueMapping(propertyMapping, propertyValueMapping);
-
-        PropertyMapping? lookupPropertyInDefinition()
-        {
-            var byName = parentMapping.FindMappedElementByName(propNameWithoutUnderscore);
-            if (byName is not null)
-            {
-                if (!string.Equals(byName.Name, propNameWithoutUnderscore, StringComparison.Ordinal))
-                    caseMismatch = true;
-                return byName;
-            }
-            return parentMapping.FindMappedElementByChoiceName(propNameWithoutUnderscore);
-        }
 
         ClassMapping getChoiceClassMapping(ref Utf8JsonReader r)
         {

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirJsonDeserializer.cs
@@ -758,12 +758,11 @@ public class BaseFhirJsonDeserializer
             // The lookup also finds names that differ from a defined element name only by casing.
             // Whether such a wrong-cased name is still bound to the element it nearly matches is
             // decided by DeserializerSettings.UsesStrictCaseBinding (see there for the rationale):
-            // - lenient: bind using exactly the matching rules of SDK 6.2 and earlier, so behaviour
-            //   is unchanged for callers that tolerate wrong-case errors;
+            // - lenient: bind, so the data ends up in the typed property where it is most useful;
             // - strict: only bind exactly-cased names. A wrong-cased name falls through to
             //   getUnknownPropMapping() below, so the data is preserved under its original name in
             //   the overflow, and the validator reports it (WRONG_CASED_ELEMENT + UNKNOWN_ELEMENT).
-            if (usesStrictCaseBinding() ? lookup.IsExactCase : lookup.MatchedByLegacyRules)
+            if (lookup.IsExactCase || !usesStrictCaseBinding())
                 definedMapping = lookup.Mapping;
         }
 

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Xml;
+using COVE = Hl7.Fhir.Validation.CodedValidationException;
 using ERR = Hl7.Fhir.Serialization.FhirXmlException;
 using NotSupportedException = System.NotSupportedException;
 
@@ -57,6 +58,20 @@ public class BaseFhirXmlDeserializer
     public DeserializerSettings Settings { get; set; }
 
     private readonly ModelInspector _inspector;
+
+    // Caches DeserializerSettings.UsesStrictCaseBinding(), which is invoked for every element, per
+    // settings instance. The settings' relevant properties are init-only, so as long as the same
+    // instance is assigned to Settings, the cached answer remains valid.
+    private (DeserializerSettings settings, bool strict)? _caseBindingCache;
+
+    private bool usesStrictCaseBinding()
+    {
+        if (_caseBindingCache is { } cached && ReferenceEquals(cached.settings, Settings)) return cached.strict;
+
+        var strict = Settings.UsesStrictCaseBinding();
+        _caseBindingCache = (Settings, strict);
+        return strict;
+    }
 
     /// <summary>
     /// Deserialize the FHIR xml from the reader and create a new POCO resource containing the data from the reader.
@@ -560,7 +575,7 @@ public class BaseFhirXmlDeserializer
     /// Returns the <see cref="ClassMapping" /> for the object to be deserialized using the root property.
     /// </summary>
     /// <remarks>Assumes the reader is on the start of an object.</remarks>
-    private static ClassMapping determineClassMappingFromInstance(XmlReader reader, ModelInspector inspector, PocoDeserializerState state)
+    private ClassMapping determineClassMappingFromInstance(XmlReader reader, ModelInspector inspector, PocoDeserializerState state)
     {
         var resourceType = reader.LocalName;
 
@@ -568,8 +583,14 @@ public class BaseFhirXmlDeserializer
         if (resourceMapping is null or { IsResource: false })
             return new ClassMapping(inspector, resourceType, typeof(DynamicResource));
 
-        if (!string.Equals(resourceMapping.Name, resourceType, StringComparison.Ordinal))
-            state.Errors.Add(ERR.RESOURCE_TYPE_WRONG_CASE(reader, state.Path.GetInstancePath(), resourceType, resourceMapping.Name));
+        // The inspector finds resource types case-insensitively, so the data can still be parsed
+        // into the correct POCO, but a wrong-cased resource type name violates the spec and is
+        // reported. This is a model-level validation, so it is skipped when the validator is off.
+        if (Settings.Validator is not null && !string.Equals(resourceMapping.Name, resourceType, StringComparison.Ordinal))
+        {
+            var (line, pos) = reader.GenerateLineInfo();
+            state.Errors.Add(COVE.WRONG_CASED_RESOURCE_TYPE(state.Path.GetInstancePath(), line, pos, resourceType, resourceMapping.Name));
+        }
 
         return resourceMapping;
     }
@@ -587,32 +608,23 @@ public class BaseFhirXmlDeserializer
         PocoDeserializerState state,
         XmlReader reader)
     {
-        var byNameMapping = parentMapping.FindMappedElementByName(elementName);
-        string? caseMismatchExpectedName = null;
+        PropertyMapping? definedMapping = null;
 
-        PropertyMapping? byChoiceMapping = null;
-        if (byNameMapping is not null)
+        if (parentMapping.TryFindElement(elementName) is { } lookup)
         {
-            if (!string.Equals(byNameMapping.Name, elementName, StringComparison.Ordinal))
-                caseMismatchExpectedName = byNameMapping.Name;
-        }
-        else
-        {
-            byChoiceMapping = parentMapping.FindMappedElementByChoiceName(elementName, ignoreCase: true);
-            if (byChoiceMapping is not null)
-            {
-                var actualPrefix = elementName[..byChoiceMapping.Name.Length];
-                if (!string.Equals(byChoiceMapping.Name, actualPrefix, StringComparison.Ordinal))
-                {
-                    var actualSuffix = elementName[byChoiceMapping.Name.Length..];
-                    caseMismatchExpectedName = byChoiceMapping.Name + normalizeChoiceSuffix(actualSuffix);
-                }
-            }
+            // The lookup also finds names that differ from a defined element name only by casing.
+            // Whether such a wrong-cased name is still bound to the element it nearly matches is
+            // decided by DeserializerSettings.UsesStrictCaseBinding (see there for the rationale):
+            // - lenient: bind using exactly the matching rules of SDK 6.2 and earlier, so behaviour
+            //   is unchanged for callers that tolerate wrong-case errors;
+            // - strict: only bind exactly-cased names. A wrong-cased name falls through to
+            //   getUnknownPropMapping() below, so the data is preserved under its original name in
+            //   the overflow, and the validator reports it (WRONG_CASED_ELEMENT + UNKNOWN_ELEMENT).
+            if (usesStrictCaseBinding() ? lookup.IsExactCase : lookup.MatchedByLegacyRules)
+                definedMapping = lookup.Mapping;
         }
 
-        var propertyMapping = byNameMapping
-                              ?? byChoiceMapping
-                              ?? getUnknownPropMapping();
+        var propertyMapping = definedMapping ?? getUnknownPropMapping();
 
         ClassMapping propertyValueMapping = propertyMapping.Choice switch
         {
@@ -628,17 +640,7 @@ public class BaseFhirXmlDeserializer
             _ => throw new NotSupportedException($"ChoiceType '{propertyMapping.Choice}' is not supported.")
         };
 
-        if (caseMismatchExpectedName is not null)
-            state.Errors.Add(ERR.ELEMENT_NAME_WRONG_CASE(reader, state.Path.GetInstancePath(), elementName, caseMismatchExpectedName));
-
         return new PropertyValueMapping(propertyMapping, propertyValueMapping);
-
-        // Resolves the suffix to its actual datatype mapping (case-insensitively) so the casing
-        // suggested in a wrong-case-prefix error is correct even when the suffix is also wrong-case.
-        string normalizeChoiceSuffix(string suffix) =>
-            parentMapping.Inspector.FindClassMapping(suffix) is { } typeMapping
-                ? char.ToUpperInvariant(typeMapping.Name[0]) + typeMapping.Name[1..]
-                : suffix;
 
         ClassMapping getChoiceClassMapping()
         {
@@ -651,12 +653,6 @@ public class BaseFhirXmlDeserializer
                 if (foundChoiceMapping is null)
                 {
                     foundChoiceMapping = new ClassMapping(_inspector, typeSuffix, getDynamicTypeMapping());
-                }
-                else
-                {
-                    var expectedSuffix = char.ToUpperInvariant(foundChoiceMapping.Name[0]) + foundChoiceMapping.Name[1..];
-                    if (!string.Equals(typeSuffix, expectedSuffix, StringComparison.Ordinal))
-                        state.Errors.Add(ERR.CHOICE_TYPE_SUFFIX_WRONG_CASE(reader, state.Path.GetInstancePath(), typeSuffix, expectedSuffix));
                 }
 
                 return foundChoiceMapping;

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
@@ -564,11 +564,14 @@ public class BaseFhirXmlDeserializer
     {
         var resourceType = reader.LocalName;
 
-        return inspector.FindClassMapping(resourceType) switch
-        {
-            null or { IsResource: false } => new ClassMapping(inspector, resourceType, typeof(DynamicResource)),
-            { } resourceMapping => resourceMapping,
-        };
+        var resourceMapping = inspector.FindClassMapping(resourceType);
+        if (resourceMapping is null or { IsResource: false })
+            return new ClassMapping(inspector, resourceType, typeof(DynamicResource));
+
+        if (!string.Equals(resourceMapping.Name, resourceType, StringComparison.Ordinal))
+            state.Errors.Add(ERR.RESOURCE_TYPE_WRONG_CASE(reader, state.Path.GetInstancePath(), resourceType, resourceMapping.Name));
+
+        return resourceMapping;
     }
 
     /// <summary>
@@ -584,9 +587,11 @@ public class BaseFhirXmlDeserializer
         PocoDeserializerState state,
         XmlReader reader)
     {
-        var propertyMapping = parentMapping.FindMappedElementByName(elementName)
-                                    ?? parentMapping.FindMappedElementByChoiceName(elementName)
-                                    ?? getUnknownPropMapping();
+        var byNameMapping = parentMapping.FindMappedElementByName(elementName);
+        bool propCaseMismatch = byNameMapping is not null && !string.Equals(byNameMapping.Name, elementName, StringComparison.Ordinal);
+        var propertyMapping = byNameMapping
+                              ?? parentMapping.FindMappedElementByChoiceName(elementName)
+                              ?? getUnknownPropMapping();
 
         ClassMapping propertyValueMapping = propertyMapping.Choice switch
         {
@@ -602,6 +607,9 @@ public class BaseFhirXmlDeserializer
             _ => throw new NotSupportedException($"ChoiceType '{propertyMapping.Choice}' is not supported.")
         };
 
+        if (propCaseMismatch)
+            state.Errors.Add(ERR.ELEMENT_NAME_WRONG_CASE(reader, state.Path.GetInstancePath(), elementName, byNameMapping!.Name));
+
         return new PropertyValueMapping(propertyMapping, propertyValueMapping);
 
         ClassMapping getChoiceClassMapping()
@@ -615,6 +623,12 @@ public class BaseFhirXmlDeserializer
                 if (foundChoiceMapping is null)
                 {
                     foundChoiceMapping = new ClassMapping(_inspector, typeSuffix, getDynamicTypeMapping());
+                }
+                else
+                {
+                    var expectedSuffix = char.ToUpperInvariant(foundChoiceMapping.Name[0]) + foundChoiceMapping.Name[1..];
+                    if (!string.Equals(typeSuffix, expectedSuffix, StringComparison.Ordinal))
+                        state.Errors.Add(ERR.CHOICE_TYPE_SUFFIX_WRONG_CASE(reader, state.Path.GetInstancePath(), typeSuffix, expectedSuffix));
                 }
 
                 return foundChoiceMapping;

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
@@ -588,9 +588,24 @@ public class BaseFhirXmlDeserializer
         XmlReader reader)
     {
         var byNameMapping = parentMapping.FindMappedElementByName(elementName);
-        bool propCaseMismatch = byNameMapping is not null && !string.Equals(byNameMapping.Name, elementName, StringComparison.Ordinal);
+        string? caseMismatchExpectedName = null;
+
+        PropertyMapping? byChoiceMapping = null;
+        if (byNameMapping is not null)
+        {
+            if (!string.Equals(byNameMapping.Name, elementName, StringComparison.Ordinal))
+                caseMismatchExpectedName = byNameMapping.Name;
+        }
+        else
+        {
+            byChoiceMapping = parentMapping.FindMappedElementByChoiceName(elementName, ignoreCase: true);
+            if (byChoiceMapping is not null &&
+                !string.Equals(byChoiceMapping.Name, elementName[..byChoiceMapping.Name.Length], StringComparison.Ordinal))
+                caseMismatchExpectedName = byChoiceMapping.Name + elementName[byChoiceMapping.Name.Length..];
+        }
+
         var propertyMapping = byNameMapping
-                              ?? parentMapping.FindMappedElementByChoiceName(elementName)
+                              ?? byChoiceMapping
                               ?? getUnknownPropMapping();
 
         ClassMapping propertyValueMapping = propertyMapping.Choice switch
@@ -607,8 +622,8 @@ public class BaseFhirXmlDeserializer
             _ => throw new NotSupportedException($"ChoiceType '{propertyMapping.Choice}' is not supported.")
         };
 
-        if (propCaseMismatch)
-            state.Errors.Add(ERR.ELEMENT_NAME_WRONG_CASE(reader, state.Path.GetInstancePath(), elementName, byNameMapping!.Name));
+        if (caseMismatchExpectedName is not null)
+            state.Errors.Add(ERR.ELEMENT_NAME_WRONG_CASE(reader, state.Path.GetInstancePath(), elementName, caseMismatchExpectedName));
 
         return new PropertyValueMapping(propertyMapping, propertyValueMapping);
 

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
@@ -615,12 +615,11 @@ public class BaseFhirXmlDeserializer
             // The lookup also finds names that differ from a defined element name only by casing.
             // Whether such a wrong-cased name is still bound to the element it nearly matches is
             // decided by DeserializerSettings.UsesStrictCaseBinding (see there for the rationale):
-            // - lenient: bind using exactly the matching rules of SDK 6.2 and earlier, so behaviour
-            //   is unchanged for callers that tolerate wrong-case errors;
+            // - lenient: bind, so the data ends up in the typed property where it is most useful;
             // - strict: only bind exactly-cased names. A wrong-cased name falls through to
             //   getUnknownPropMapping() below, so the data is preserved under its original name in
             //   the overflow, and the validator reports it (WRONG_CASED_ELEMENT + UNKNOWN_ELEMENT).
-            if (usesStrictCaseBinding() ? lookup.IsExactCase : lookup.MatchedByLegacyRules)
+            if (lookup.IsExactCase || !usesStrictCaseBinding())
                 definedMapping = lookup.Mapping;
         }
 

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
@@ -599,9 +599,15 @@ public class BaseFhirXmlDeserializer
         else
         {
             byChoiceMapping = parentMapping.FindMappedElementByChoiceName(elementName, ignoreCase: true);
-            if (byChoiceMapping is not null &&
-                !string.Equals(byChoiceMapping.Name, elementName[..byChoiceMapping.Name.Length], StringComparison.Ordinal))
-                caseMismatchExpectedName = byChoiceMapping.Name + elementName[byChoiceMapping.Name.Length..];
+            if (byChoiceMapping is not null)
+            {
+                var actualPrefix = elementName[..byChoiceMapping.Name.Length];
+                if (!string.Equals(byChoiceMapping.Name, actualPrefix, StringComparison.Ordinal))
+                {
+                    var actualSuffix = elementName[byChoiceMapping.Name.Length..];
+                    caseMismatchExpectedName = byChoiceMapping.Name + normalizeChoiceSuffix(actualSuffix);
+                }
+            }
         }
 
         var propertyMapping = byNameMapping
@@ -626,6 +632,13 @@ public class BaseFhirXmlDeserializer
             state.Errors.Add(ERR.ELEMENT_NAME_WRONG_CASE(reader, state.Path.GetInstancePath(), elementName, caseMismatchExpectedName));
 
         return new PropertyValueMapping(propertyMapping, propertyValueMapping);
+
+        // Resolves the suffix to its actual datatype mapping (case-insensitively) so the casing
+        // suggested in a wrong-case-prefix error is correct even when the suffix is also wrong-case.
+        string normalizeChoiceSuffix(string suffix) =>
+            parentMapping.Inspector.FindClassMapping(suffix) is { } typeMapping
+                ? char.ToUpperInvariant(typeMapping.Name[0]) + typeMapping.Name[1..]
+                : suffix;
 
         ClassMapping getChoiceClassMapping()
         {

--- a/src/Hl7.Fhir.Base/Serialization/CodedExceptionFilters.cs
+++ b/src/Hl7.Fhir.Base/Serialization/CodedExceptionFilters.cs
@@ -16,12 +16,25 @@ namespace Hl7.Fhir.Serialization;
 public static class CodedExceptionFilters
 {
     /// <summary>
+    /// A predicate that returns true if a <see cref="CodedException"/> is a case-sensitivity issue.
+    /// These issues are only reported in <see cref="DeserializationMode.Strict"/> mode.
+    /// </summary>
+    internal static readonly Predicate<CodedException> FilterCaseSensitivityIssues =
+        new[]
+        {
+            FhirJsonException.PROPERTY_NAME_WRONG_CASE_CODE,
+            FhirJsonException.RESOURCE_TYPE_WRONG_CASE_CODE,
+            FhirXmlException.ELEMENT_NAME_WRONG_CASE_CODE
+        }.IsInList();
+
+    /// <summary>
     /// A predicate that returns true if a <see cref="CodedException"/> is recoverable,
     /// which means that all data is represented in the POCO, so there is no data loss.
     /// See <see cref="DeserializationMode.Recoverable"/>.
     /// </summary>
     public static readonly Predicate<CodedException> FilterRecoverableIssues =
-        ce => ce is ExtendedCodedException ece && ece.IssueSeverity != OperationOutcome.IssueSeverity.Fatal;
+        ce => (ce is ExtendedCodedException ece && ece.IssueSeverity != OperationOutcome.IssueSeverity.Fatal)
+              || FilterCaseSensitivityIssues(ce);
 
     /// <summary>
     /// A predicate that returns true if an error recoverable and also does not require
@@ -30,21 +43,15 @@ public static class CodedExceptionFilters
     public static readonly Predicate<CodedException> FilterNoOverflowIssues =
         ce => FilterRecoverableIssues(ce) &&
               !CodedValidationException.ISSUES_CAUSED_BY_OVERFLOW.Contains(ce.ErrorCode);
+
     /// <summary>
     /// A predicate that returns true if a <see cref="CodedException"/> signifies a backwards compatibility issue.
     /// See <see cref="DeserializationMode.BackwardsCompatible"/>.
     /// </summary>
     public static readonly Predicate<CodedException> FilterBackwardsCompatibilityIssues =
         ce => FhirJsonException.BACKWARDS_COMPATIBILITY_ALLOWED_ISSUES.Contains(ce.ErrorCode) ||
-              FhirXmlException.BACKWARDS_COMPATIBILITY_ALLOWED_ISSUES.Contains(ce.ErrorCode);
-
-    /// <summary>
-    /// A predicate that returns true if a <see cref="CodedException"/> is a case-sensitivity issue.
-    /// These issues are only reported in <see cref="DeserializationMode.Strict"/> mode.
-    /// </summary>
-    internal static readonly Predicate<CodedException> FilterCaseSensitivityIssues =
-        new[] { FhirJsonException.ELEMENT_NAME_WRONG_CASE_CODE, FhirXmlException.ELEMENT_NAME_WRONG_CASE_CODE }
-            .IsInList();
+              FhirXmlException.BACKWARDS_COMPATIBILITY_ALLOWED_ISSUES.Contains(ce.ErrorCode) ||
+              FilterCaseSensitivityIssues(ce);
 
     /// <summary>
     /// Combines two predicates for a <see cref="CodedException"/> with a logical AND.

--- a/src/Hl7.Fhir.Base/Serialization/CodedExceptionFilters.cs
+++ b/src/Hl7.Fhir.Base/Serialization/CodedExceptionFilters.cs
@@ -19,12 +19,15 @@ public static class CodedExceptionFilters
     /// A predicate that returns true if a <see cref="CodedException"/> is a case-sensitivity issue.
     /// These issues are only reported in <see cref="DeserializationMode.Strict"/> mode.
     /// </summary>
+    /// <remarks>Whether a filter ignores or reports these issues does not only determine whether they
+    /// are returned to the caller: the deserializers also use it to decide whether a wrong-cased name is
+    /// still bound to the element it (nearly) matches, see
+    /// <see cref="DeserializerSettings.UsesStrictCaseBinding"/>.</remarks>
     internal static readonly Predicate<CodedException> FilterCaseSensitivityIssues =
         new[]
         {
-            FhirJsonException.PROPERTY_NAME_WRONG_CASE_CODE,
-            FhirJsonException.RESOURCE_TYPE_WRONG_CASE_CODE,
-            FhirXmlException.ELEMENT_NAME_WRONG_CASE_CODE
+            CodedValidationException.WRONG_CASED_ELEMENT_CODE,
+            CodedValidationException.WRONG_CASED_RESOURCE_TYPE_CODE
         }.IsInList();
 
     /// <summary>
@@ -33,8 +36,7 @@ public static class CodedExceptionFilters
     /// See <see cref="DeserializationMode.Recoverable"/>.
     /// </summary>
     public static readonly Predicate<CodedException> FilterRecoverableIssues =
-        ce => (ce is ExtendedCodedException ece && ece.IssueSeverity != OperationOutcome.IssueSeverity.Fatal)
-              || FilterCaseSensitivityIssues(ce);
+        ce => ce is ExtendedCodedException ece && ece.IssueSeverity != OperationOutcome.IssueSeverity.Fatal;
 
     /// <summary>
     /// A predicate that returns true if an error recoverable and also does not require

--- a/src/Hl7.Fhir.Base/Serialization/CodedExceptionFilters.cs
+++ b/src/Hl7.Fhir.Base/Serialization/CodedExceptionFilters.cs
@@ -39,6 +39,14 @@ public static class CodedExceptionFilters
               FhirXmlException.BACKWARDS_COMPATIBILITY_ALLOWED_ISSUES.Contains(ce.ErrorCode);
 
     /// <summary>
+    /// A predicate that returns true if a <see cref="CodedException"/> is a case-sensitivity issue.
+    /// These issues are only reported in <see cref="DeserializationMode.Strict"/> mode.
+    /// </summary>
+    internal static readonly Predicate<CodedException> FilterCaseSensitivityIssues =
+        new[] { FhirJsonException.ELEMENT_NAME_WRONG_CASE_CODE, FhirXmlException.ELEMENT_NAME_WRONG_CASE_CODE }
+            .IsInList();
+
+    /// <summary>
     /// Combines two predicates for a <see cref="CodedException"/> with a logical AND.
     /// </summary>
     [return: NotNullIfNotNull(nameof(a))]

--- a/src/Hl7.Fhir.Base/Serialization/DeserializerModes.cs
+++ b/src/Hl7.Fhir.Base/Serialization/DeserializerModes.cs
@@ -14,6 +14,10 @@ public enum DeserializationMode
     /// <summary>
     /// Do not ignore any errors (default behaviour for most implementations). Will report all errors.
     /// </summary>
+    /// <remarks>
+    /// The set of issues reported in Strict mode may expand across releases as new validations are added.
+    /// Do not rely on a fixed set of error codes being raised in this mode.
+    /// </remarks>
     Strict,
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/Serialization/DeserializerSettings.cs
+++ b/src/Hl7.Fhir.Base/Serialization/DeserializerSettings.cs
@@ -41,7 +41,8 @@ public record DeserializerSettings
         init => _exceptionFilter = value;
     }
 
-    private readonly Predicate<CodedException>? _exceptionFilter;
+    private readonly Predicate<CodedException>? _exceptionFilter
+        = CodedExceptionFilters.FilterCaseSensitivityIssues;
 
     /// <summary>
     /// During parsing any contained resources (such as those in a bundle) that encounter some form of parse/validation exception
@@ -120,12 +121,14 @@ public record DeserializerSettings
             },
             DeserializationMode.BackwardsCompatible => this with
             {
-                ExceptionFilter = CodedExceptionFilters.FilterBackwardsCompatibilityIssues,
+                ExceptionFilter = CodedExceptionFilters.FilterBackwardsCompatibilityIssues
+                                  .Or(CodedExceptionFilters.FilterCaseSensitivityIssues),
                 NarrativeValidation = nvk ?? NarrativeValidationKind.None
             },
             DeserializationMode.Recoverable => this with
             {
-                ExceptionFilter = CodedExceptionFilters.FilterRecoverableIssues,
+                ExceptionFilter = CodedExceptionFilters.FilterRecoverableIssues
+                                  .Or(CodedExceptionFilters.FilterCaseSensitivityIssues),
                 NarrativeValidation = nvk ?? NarrativeValidationKind.None
             },
             DeserializationMode.SyntaxOnly => this with
@@ -136,7 +139,8 @@ public record DeserializerSettings
             },
             DeserializationMode.NoOverflow => this with
             {
-                ExceptionFilter = CodedExceptionFilters.FilterNoOverflowIssues,
+                ExceptionFilter = CodedExceptionFilters.FilterNoOverflowIssues
+                                  .Or(CodedExceptionFilters.FilterCaseSensitivityIssues),
                 NarrativeValidation = nvk ?? NarrativeValidationKind.None
             },
             DeserializationMode.Ostrich => this with

--- a/src/Hl7.Fhir.Base/Serialization/DeserializerSettings.cs
+++ b/src/Hl7.Fhir.Base/Serialization/DeserializerSettings.cs
@@ -64,8 +64,8 @@ public record DeserializerSettings
     /// deserialization will fail because of them - and a failing parse should faithfully preserve the
     /// input rather than silently correct the name, so we bind strictly. If the filter <em>ignores</em>
     /// these errors (the default, and all other modes), the caller has chosen to tolerate them, and we
-    /// keep the lenient legacy binding so the data ends up in the typed properties where it is most
-    /// useful. This way the reported errors always accurately describe what happened to the data, and
+    /// bind the name to the element it nearly matches, so the data ends up in the typed properties
+    /// where it is most useful. This way the reported errors always accurately describe what happened to the data, and
     /// case strictness follows the chosen mode - or can be controlled explicitly with
     /// <see cref="Enforcing"/> / <see cref="Ignoring"/> and the wrong-case error codes - without a
     /// dedicated setting.</para>

--- a/src/Hl7.Fhir.Base/Serialization/DeserializerSettings.cs
+++ b/src/Hl7.Fhir.Base/Serialization/DeserializerSettings.cs
@@ -41,8 +41,52 @@ public record DeserializerSettings
         init => _exceptionFilter = value;
     }
 
+    // By default (i.e. when no mode or explicit filter is chosen), case-sensitivity issues are
+    // ignored, so that the default behaviour of the deserializers is the same as in previous
+    // versions of the SDK, which did not detect these issues at all.
     private readonly Predicate<CodedException>? _exceptionFilter
         = CodedExceptionFilters.FilterCaseSensitivityIssues;
+
+    /// <summary>
+    /// Determines whether the deserializers should treat names that differ from a defined element or
+    /// resource type name only by casing ("wrong-cased names") as unknown, rather than binding the data
+    /// to the defined element like previous versions of the SDK did.
+    /// </summary>
+    /// <returns><c>true</c> when wrong-cased element names must be treated as unknown elements, so that
+    /// the data is preserved under its original name in the overflow dictionary and the validator reports
+    /// <see cref="CodedValidationException.WRONG_CASED_ELEMENT_CODE"/>. <c>false</c> when wrong-cased
+    /// names are bound to the element they nearly match, so the data remains available in the typed
+    /// POCO properties (the behaviour of SDK 6.2 and earlier).</returns>
+    /// <remarks>
+    /// <para>This decision is <b>intentionally derived from the <see cref="ExceptionFilter"/></b> in effect,
+    /// rather than from a separate setting. The reasoning: if the configured filter <em>reports</em>
+    /// wrong-case errors (as <see cref="DeserializationMode.Strict"/> does, since it reports everything),
+    /// deserialization will fail because of them - and a failing parse should faithfully preserve the
+    /// input rather than silently correct the name, so we bind strictly. If the filter <em>ignores</em>
+    /// these errors (the default, and all other modes), the caller has chosen to tolerate them, and we
+    /// keep the lenient legacy binding so the data ends up in the typed properties where it is most
+    /// useful. This way the reported errors always accurately describe what happened to the data, and
+    /// case strictness follows the chosen mode - or can be controlled explicitly with
+    /// <see cref="Enforcing"/> / <see cref="Ignoring"/> and the wrong-case error codes - without a
+    /// dedicated setting.</para>
+    /// <para>When <see cref="Validator"/> is <c>null</c> (<see cref="DeserializationMode.SyntaxOnly"/>
+    /// and <see cref="DeserializationMode.Ostrich"/>), all model validation is off. Wrong-case detection
+    /// is a model-level check, not a syntax check, so no wrong-case errors will be raised at all and
+    /// lenient binding is used.</para>
+    /// <para>The check works by asking the filter how it would treat a representative
+    /// <see cref="CodedValidationException.WRONG_CASED_ELEMENT_CODE"/> error. Custom filters therefore
+    /// participate automatically: a filter that reports this code gets strict binding, a filter that
+    /// ignores it gets lenient binding.</para>
+    /// </remarks>
+    internal bool UsesStrictCaseBinding() =>
+        Validator is not null &&
+        (ExceptionFilter is not { } filter || !filter(WRONG_CASE_PROBE));
+
+    // A representative wrong-case error, used only to ask the ExceptionFilter whether it would
+    // report or ignore errors with this code. Never surfaces to users.
+    private static readonly CodedValidationException WRONG_CASE_PROBE =
+        new(CodedValidationException.WRONG_CASED_ELEMENT_CODE,
+            "This is a probe instance, used to determine how the exception filter treats wrong-case errors. It should never be reported.");
 
     /// <summary>
     /// During parsing any contained resources (such as those in a bundle) that encounter some form of parse/validation exception

--- a/src/Hl7.Fhir.Base/Serialization/DeserializerSettings.cs
+++ b/src/Hl7.Fhir.Base/Serialization/DeserializerSettings.cs
@@ -121,14 +121,12 @@ public record DeserializerSettings
             },
             DeserializationMode.BackwardsCompatible => this with
             {
-                ExceptionFilter = CodedExceptionFilters.FilterBackwardsCompatibilityIssues
-                                  .Or(CodedExceptionFilters.FilterCaseSensitivityIssues),
+                ExceptionFilter = CodedExceptionFilters.FilterBackwardsCompatibilityIssues,
                 NarrativeValidation = nvk ?? NarrativeValidationKind.None
             },
             DeserializationMode.Recoverable => this with
             {
-                ExceptionFilter = CodedExceptionFilters.FilterRecoverableIssues
-                                  .Or(CodedExceptionFilters.FilterCaseSensitivityIssues),
+                ExceptionFilter = CodedExceptionFilters.FilterRecoverableIssues,
                 NarrativeValidation = nvk ?? NarrativeValidationKind.None
             },
             DeserializationMode.SyntaxOnly => this with
@@ -139,8 +137,7 @@ public record DeserializerSettings
             },
             DeserializationMode.NoOverflow => this with
             {
-                ExceptionFilter = CodedExceptionFilters.FilterNoOverflowIssues
-                                  .Or(CodedExceptionFilters.FilterCaseSensitivityIssues),
+                ExceptionFilter = CodedExceptionFilters.FilterNoOverflowIssues,
                 NarrativeValidation = nvk ?? NarrativeValidationKind.None
             },
             DeserializationMode.Ostrich => this with

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
@@ -50,8 +50,6 @@ public class FhirJsonException(
     public const string UNEXPECTED_OBJECT_VALUE_FOR_PRIMITIVE_CODE = "JSON132";
     public const string USE_OF_UNDERSCORE_WITH_NON_PRIMITIVE_CODE = "JSON133";
     public const string UNDERSCORE_SHOULD_BE_OBJECT_CODE = "JSON134";
-    public const string PROPERTY_NAME_WRONG_CASE_CODE = "JSON135";
-    public const string RESOURCE_TYPE_WRONG_CASE_CODE = "JSON136";
 
     // Fatal errors - there is dataloss so processing should not continue.
     internal static FhirJsonException DUPLICATE_PROPERTY(ref Utf8JsonReader reader, string instancePath, string propName) => Initialize(ref reader, instancePath, DUPLICATE_PROPERTY_CODE, $"Encountered duplicate property '{propName}'.", "Duplicate property", OO_Sev.Fatal);
@@ -87,11 +85,6 @@ public class FhirJsonException(
 
     // This will use a DynamicXXX, so no data loss.
     internal static FhirJsonException CHOICE_ELEMENTS_MUST_HAVE_SUFFIX(ref Utf8JsonReader reader, string instancePath, string elementName) => Initialize(ref reader, instancePath, CHOICE_ELEMENT_MUST_HAVE_SUFFIX_CODE, $"Choice element '{elementName}' should be suffixed by a type.", "Expected type suffix", OO_Sev.Error);
-
-    // Data is still captured correctly using the case-insensitive lookup, but the name violates the spec.
-    internal static FhirJsonException PROPERTY_NAME_WRONG_CASE(ref Utf8JsonReader reader, string instancePath, string given, string expected) => Initialize(ref reader, instancePath, PROPERTY_NAME_WRONG_CASE_CODE, $"Property '{given}' has incorrect casing, expected '{expected}'.", "Property has wrong case", OO_Sev.Error);
-    internal static FhirJsonException CHOICE_TYPE_SUFFIX_WRONG_CASE(ref Utf8JsonReader reader, string instancePath, string given, string expected) => Initialize(ref reader, instancePath, PROPERTY_NAME_WRONG_CASE_CODE, $"Property type suffix '{given}' has incorrect casing, expected '{expected}'.", "Choice type suffix has wrong case", OO_Sev.Error);
-    internal static FhirJsonException RESOURCE_TYPE_WRONG_CASE(ref Utf8JsonReader reader, string instancePath, string given, string expected) => Initialize(ref reader, instancePath, RESOURCE_TYPE_WRONG_CASE_CODE, $"Resource type '{given}' has incorrect casing, expected '{expected}'.", "Resource type has wrong case", OO_Sev.Error);
 
     // Will store the data as a DynamicResource
     internal static FhirJsonException RESOURCETYPE_SHOULD_BE_STRING(ref Utf8JsonReader reader, string instancePath, JsonTokenType valueToken, string value) => Initialize(ref reader, instancePath, RESOURCETYPE_SHOULD_BE_STRING_CODE, $"Property 'resourceType' should be a string, but found token {valueToken} with value {value}.", "Invalid resource type", OO_Sev.Error);

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
@@ -50,7 +50,8 @@ public class FhirJsonException(
     public const string UNEXPECTED_OBJECT_VALUE_FOR_PRIMITIVE_CODE = "JSON132";
     public const string USE_OF_UNDERSCORE_WITH_NON_PRIMITIVE_CODE = "JSON133";
     public const string UNDERSCORE_SHOULD_BE_OBJECT_CODE = "JSON134";
-    public const string ELEMENT_NAME_WRONG_CASE_CODE = "JSON135";
+    public const string PROPERTY_NAME_WRONG_CASE_CODE = "JSON135";
+    public const string RESOURCE_TYPE_WRONG_CASE_CODE = "JSON136";
 
     // Fatal errors - there is dataloss so processing should not continue.
     internal static FhirJsonException DUPLICATE_PROPERTY(ref Utf8JsonReader reader, string instancePath, string propName) => Initialize(ref reader, instancePath, DUPLICATE_PROPERTY_CODE, $"Encountered duplicate property '{propName}'.", "Duplicate property", OO_Sev.Fatal);
@@ -88,9 +89,9 @@ public class FhirJsonException(
     internal static FhirJsonException CHOICE_ELEMENTS_MUST_HAVE_SUFFIX(ref Utf8JsonReader reader, string instancePath, string elementName) => Initialize(ref reader, instancePath, CHOICE_ELEMENT_MUST_HAVE_SUFFIX_CODE, $"Choice element '{elementName}' should be suffixed by a type.", "Expected type suffix", OO_Sev.Error);
 
     // Data is still captured correctly using the case-insensitive lookup, but the name violates the spec.
-    internal static FhirJsonException ELEMENT_NAME_WRONG_CASE(ref Utf8JsonReader reader, string instancePath, string given, string expected) => Initialize(ref reader, instancePath, ELEMENT_NAME_WRONG_CASE_CODE, $"Element '{given}' has incorrect casing, expected '{expected}'.", "Element name has wrong case", OO_Sev.Error);
-    internal static FhirJsonException CHOICE_TYPE_SUFFIX_WRONG_CASE(ref Utf8JsonReader reader, string instancePath, string given, string expected) => Initialize(ref reader, instancePath, ELEMENT_NAME_WRONG_CASE_CODE, $"Choice type suffix '{given}' has incorrect casing, expected '{expected}'.", "Choice type suffix has wrong case", OO_Sev.Error);
-    internal static FhirJsonException RESOURCE_TYPE_WRONG_CASE(ref Utf8JsonReader reader, string instancePath, string given, string expected) => Initialize(ref reader, instancePath, ELEMENT_NAME_WRONG_CASE_CODE, $"Resource type '{given}' has incorrect casing, expected '{expected}'.", "Resource type has wrong case", OO_Sev.Error);
+    internal static FhirJsonException PROPERTY_NAME_WRONG_CASE(ref Utf8JsonReader reader, string instancePath, string given, string expected) => Initialize(ref reader, instancePath, PROPERTY_NAME_WRONG_CASE_CODE, $"Property '{given}' has incorrect casing, expected '{expected}'.", "Property has wrong case", OO_Sev.Error);
+    internal static FhirJsonException CHOICE_TYPE_SUFFIX_WRONG_CASE(ref Utf8JsonReader reader, string instancePath, string given, string expected) => Initialize(ref reader, instancePath, PROPERTY_NAME_WRONG_CASE_CODE, $"Property type suffix '{given}' has incorrect casing, expected '{expected}'.", "Choice type suffix has wrong case", OO_Sev.Error);
+    internal static FhirJsonException RESOURCE_TYPE_WRONG_CASE(ref Utf8JsonReader reader, string instancePath, string given, string expected) => Initialize(ref reader, instancePath, RESOURCE_TYPE_WRONG_CASE_CODE, $"Resource type '{given}' has incorrect casing, expected '{expected}'.", "Resource type has wrong case", OO_Sev.Error);
 
     // Will store the data as a DynamicResource
     internal static FhirJsonException RESOURCETYPE_SHOULD_BE_STRING(ref Utf8JsonReader reader, string instancePath, JsonTokenType valueToken, string value) => Initialize(ref reader, instancePath, RESOURCETYPE_SHOULD_BE_STRING_CODE, $"Property 'resourceType' should be a string, but found token {valueToken} with value {value}.", "Invalid resource type", OO_Sev.Error);

--- a/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirJsonException.cs
@@ -50,6 +50,7 @@ public class FhirJsonException(
     public const string UNEXPECTED_OBJECT_VALUE_FOR_PRIMITIVE_CODE = "JSON132";
     public const string USE_OF_UNDERSCORE_WITH_NON_PRIMITIVE_CODE = "JSON133";
     public const string UNDERSCORE_SHOULD_BE_OBJECT_CODE = "JSON134";
+    public const string ELEMENT_NAME_WRONG_CASE_CODE = "JSON135";
 
     // Fatal errors - there is dataloss so processing should not continue.
     internal static FhirJsonException DUPLICATE_PROPERTY(ref Utf8JsonReader reader, string instancePath, string propName) => Initialize(ref reader, instancePath, DUPLICATE_PROPERTY_CODE, $"Encountered duplicate property '{propName}'.", "Duplicate property", OO_Sev.Fatal);
@@ -85,6 +86,11 @@ public class FhirJsonException(
 
     // This will use a DynamicXXX, so no data loss.
     internal static FhirJsonException CHOICE_ELEMENTS_MUST_HAVE_SUFFIX(ref Utf8JsonReader reader, string instancePath, string elementName) => Initialize(ref reader, instancePath, CHOICE_ELEMENT_MUST_HAVE_SUFFIX_CODE, $"Choice element '{elementName}' should be suffixed by a type.", "Expected type suffix", OO_Sev.Error);
+
+    // Data is still captured correctly using the case-insensitive lookup, but the name violates the spec.
+    internal static FhirJsonException ELEMENT_NAME_WRONG_CASE(ref Utf8JsonReader reader, string instancePath, string given, string expected) => Initialize(ref reader, instancePath, ELEMENT_NAME_WRONG_CASE_CODE, $"Element '{given}' has incorrect casing, expected '{expected}'.", "Element name has wrong case", OO_Sev.Error);
+    internal static FhirJsonException CHOICE_TYPE_SUFFIX_WRONG_CASE(ref Utf8JsonReader reader, string instancePath, string given, string expected) => Initialize(ref reader, instancePath, ELEMENT_NAME_WRONG_CASE_CODE, $"Choice type suffix '{given}' has incorrect casing, expected '{expected}'.", "Choice type suffix has wrong case", OO_Sev.Error);
+    internal static FhirJsonException RESOURCE_TYPE_WRONG_CASE(ref Utf8JsonReader reader, string instancePath, string given, string expected) => Initialize(ref reader, instancePath, ELEMENT_NAME_WRONG_CASE_CODE, $"Resource type '{given}' has incorrect casing, expected '{expected}'.", "Resource type has wrong case", OO_Sev.Error);
 
     // Will store the data as a DynamicResource
     internal static FhirJsonException RESOURCETYPE_SHOULD_BE_STRING(ref Utf8JsonReader reader, string instancePath, JsonTokenType valueToken, string value) => Initialize(ref reader, instancePath, RESOURCETYPE_SHOULD_BE_STRING_CODE, $"Property 'resourceType' should be a string, but found token {valueToken} with value {value}.", "Invalid resource type", OO_Sev.Error);

--- a/src/Hl7.Fhir.Base/Serialization/FhirXmlException.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirXmlException.cs
@@ -46,6 +46,7 @@ public class FhirXmlException(
     public const string ELEMENT_SHOULD_HAVE_BEEN_AN_ATTRIBUTE_CODE = "XML124";
     public const string ATTRIBUTE_SHOULD_HAVE_BEEN_AN_ELEMENT_CODE = "XML125";
     public const string STRING_SHOULD_NOT_HAVE_LEADING_OR_TRAILING_WHITESPACE = "XML126";
+    public const string ELEMENT_NAME_WRONG_CASE_CODE = "XML127";
 
     // Fatal errors - there is dataloss so processing should not continue.
     internal static FhirXmlException MULTIPLE_ELEMENTS_IN_RESOURCE_CONTAINER(XmlReader reader, string instancePath) => Initialize(reader, instancePath, MULTIPLE_ELEMENTS_IN_RESOURCE_CONTAINER_CODE, $"Encountered multiple elements in a resource container. Only a single resource is allowed.", "Multiple resources in contained", OO_Sev.Fatal);
@@ -80,7 +81,12 @@ public class FhirXmlException(
     
     // XML strings do not accept leading or trailing whitespaces and will become trimmed during parsing
     internal static FhirXmlException STRING_SHOULD_NOT_HAVE_LEADING_TRAILING_WHITESPACE(XmlReader reader, string instancePath, string attributeName) => Initialize(reader, instancePath, STRING_SHOULD_NOT_HAVE_LEADING_OR_TRAILING_WHITESPACE, $"Attribute '{attributeName}' should not contain leading or trailing whitespace.", "Invalid whitespace", OO_Sev.Warning);
-    
+
+    // Data is still captured correctly using the case-insensitive lookup, but the name violates the spec.
+    internal static FhirXmlException ELEMENT_NAME_WRONG_CASE(XmlReader reader, string instancePath, string given, string expected) => Initialize(reader, instancePath, ELEMENT_NAME_WRONG_CASE_CODE, $"Element '{given}' has incorrect casing, expected '{expected}'.", "Element name has wrong case", OO_Sev.Error);
+    internal static FhirXmlException CHOICE_TYPE_SUFFIX_WRONG_CASE(XmlReader reader, string instancePath, string given, string expected) => Initialize(reader, instancePath, ELEMENT_NAME_WRONG_CASE_CODE, $"Choice type suffix '{given}' has incorrect casing, expected '{expected}'.", "Choice type suffix has wrong case", OO_Sev.Error);
+    internal static FhirXmlException RESOURCE_TYPE_WRONG_CASE(XmlReader reader, string instancePath, string given, string expected) => Initialize(reader, instancePath, ELEMENT_NAME_WRONG_CASE_CODE, $"Resource type '{given}' has incorrect casing, expected '{expected}'.", "Resource type has wrong case", OO_Sev.Error);
+
     /// <summary>
     /// An issue is allowable for backwards compatibility if it could be caused because an older parser encounters data coming from a newer
     /// FHIR release. This means allowing unknown elements, attributes, codes and types in a choice element. Note that the POCO model cannot capture

--- a/src/Hl7.Fhir.Base/Serialization/FhirXmlException.cs
+++ b/src/Hl7.Fhir.Base/Serialization/FhirXmlException.cs
@@ -46,7 +46,6 @@ public class FhirXmlException(
     public const string ELEMENT_SHOULD_HAVE_BEEN_AN_ATTRIBUTE_CODE = "XML124";
     public const string ATTRIBUTE_SHOULD_HAVE_BEEN_AN_ELEMENT_CODE = "XML125";
     public const string STRING_SHOULD_NOT_HAVE_LEADING_OR_TRAILING_WHITESPACE = "XML126";
-    public const string ELEMENT_NAME_WRONG_CASE_CODE = "XML127";
 
     // Fatal errors - there is dataloss so processing should not continue.
     internal static FhirXmlException MULTIPLE_ELEMENTS_IN_RESOURCE_CONTAINER(XmlReader reader, string instancePath) => Initialize(reader, instancePath, MULTIPLE_ELEMENTS_IN_RESOURCE_CONTAINER_CODE, $"Encountered multiple elements in a resource container. Only a single resource is allowed.", "Multiple resources in contained", OO_Sev.Fatal);
@@ -81,11 +80,6 @@ public class FhirXmlException(
     
     // XML strings do not accept leading or trailing whitespaces and will become trimmed during parsing
     internal static FhirXmlException STRING_SHOULD_NOT_HAVE_LEADING_TRAILING_WHITESPACE(XmlReader reader, string instancePath, string attributeName) => Initialize(reader, instancePath, STRING_SHOULD_NOT_HAVE_LEADING_OR_TRAILING_WHITESPACE, $"Attribute '{attributeName}' should not contain leading or trailing whitespace.", "Invalid whitespace", OO_Sev.Warning);
-
-    // Data is still captured correctly using the case-insensitive lookup, but the name violates the spec.
-    internal static FhirXmlException ELEMENT_NAME_WRONG_CASE(XmlReader reader, string instancePath, string given, string expected) => Initialize(reader, instancePath, ELEMENT_NAME_WRONG_CASE_CODE, $"Element '{given}' has incorrect casing, expected '{expected}'.", "Element name has wrong case", OO_Sev.Error);
-    internal static FhirXmlException CHOICE_TYPE_SUFFIX_WRONG_CASE(XmlReader reader, string instancePath, string given, string expected) => Initialize(reader, instancePath, ELEMENT_NAME_WRONG_CASE_CODE, $"Choice type suffix '{given}' has incorrect casing, expected '{expected}'.", "Choice type suffix has wrong case", OO_Sev.Error);
-    internal static FhirXmlException RESOURCE_TYPE_WRONG_CASE(XmlReader reader, string instancePath, string given, string expected) => Initialize(reader, instancePath, ELEMENT_NAME_WRONG_CASE_CODE, $"Resource type '{given}' has incorrect casing, expected '{expected}'.", "Resource type has wrong case", OO_Sev.Error);
 
     /// <summary>
     /// An issue is allowable for backwards compatibility if it could be caused because an older parser encounters data coming from a newer

--- a/src/Hl7.Fhir.Base/Validation/CodedValidationException.cs
+++ b/src/Hl7.Fhir.Base/Validation/CodedValidationException.cs
@@ -51,12 +51,18 @@ public class CodedValidationException : ExtendedCodedException
     public const string UNKNOWN_ELEMENT_CODE = "PVAL128";
     public const string ELEMENT_CANNOT_BE_EMPTY_CODE = "PVAL129";
     public const string UNKNOWN_RESOURCE_TYPE_CODE = "PVAL130";
+    public const string WRONG_CASED_ELEMENT_CODE = "PVAL131";
+    public const string WRONG_CASED_RESOURCE_TYPE_CODE = "PVAL132";
 
     // A list of all issues that would throw an exception if the user used the
     // properties on the POCOs (and specifically the Value prop on datatypes).
     // Otherwise said, if none of these are raised, the user should be able to
     // use the POCOs without us throwing validation exceptions and should not be
     // required to check the <see cref="Base.Overflow"/> for unknown elements.
+    // Note: WRONG_CASED_ELEMENT_CODE is deliberately NOT in this list. When a wrong-cased
+    // element ends up in the overflow (strict case binding), the parser raises UNKNOWN_ELEMENT
+    // alongside it, which is in this list - so DeserializationMode.NoOverflow keeps rejecting
+    // exactly the inputs it rejected before wrong-case detection was introduced.
     internal static readonly HashSet<string> ISSUES_CAUSED_BY_OVERFLOW =
     [
         INVALID_CODED_VALUE_CODE,
@@ -99,6 +105,22 @@ public class CodedValidationException : ExtendedCodedException
 
     internal static COVE UNKNOWN_RESOURCE_TYPE(PocoValidationContext? context, string resourceName) =>
         Initialize(context, UNKNOWN_RESOURCE_TYPE_CODE, $"Encountered unknown resource type '{resourceName}'.", "Unknown resource", OO_Sev.Error, OO_Typ.Value);
+
+    internal static COVE WRONG_CASED_ELEMENT(PocoValidationContext? context, string name, string canonicalName) =>
+        Initialize(context, WRONG_CASED_ELEMENT_CODE, wrongCasedElementMessage(name, canonicalName), "Element name has wrong case", OO_Sev.Error, OO_Typ.Value);
+
+    // Overload for use by the deserializers, which detect wrong-cased names at a point where no
+    // PocoValidationContext is available, but the exact source location is.
+    internal static COVE WRONG_CASED_ELEMENT(string instancePath, long? lineNumber, long? position, string name, string canonicalName) =>
+        new(WRONG_CASED_ELEMENT_CODE, wrongCasedElementMessage(name, canonicalName), "Element name has wrong case", instancePath, lineNumber, position, OO_Sev.Error, OO_Typ.Value, null);
+
+    // Overload for use by the deserializers, which detect wrong-cased resource type names at a point
+    // where no PocoValidationContext is available, but the exact source location is.
+    internal static COVE WRONG_CASED_RESOURCE_TYPE(string instancePath, long? lineNumber, long? position, string name, string canonicalName) =>
+        new(WRONG_CASED_RESOURCE_TYPE_CODE, $"Resource type '{name}' has incorrect casing, expected '{canonicalName}'.", "Resource type has wrong case", instancePath, lineNumber, position, OO_Sev.Error, OO_Typ.Value, null);
+
+    private static string wrongCasedElementMessage(string name, string canonicalName) =>
+        $"Element '{name}' has incorrect casing, expected '{canonicalName}'.";
 
     private static string niceValue(object? v)
     {

--- a/src/Hl7.Fhir.Base/Validation/CodedValidationException.cs
+++ b/src/Hl7.Fhir.Base/Validation/CodedValidationException.cs
@@ -59,11 +59,13 @@ public class CodedValidationException : ExtendedCodedException
     // Otherwise said, if none of these are raised, the user should be able to
     // use the POCOs without us throwing validation exceptions and should not be
     // required to check the <see cref="Base.Overflow"/> for unknown elements.
-    // Note: WRONG_CASED_ELEMENT_CODE is deliberately NOT in this list. A wrong-cased element
-    // only ends up in the overflow under strict case binding, and there UNKNOWN_ELEMENT (which
-    // is in this list) always accompanies it. Under lenient case binding (which is what
-    // DeserializationMode.NoOverflow uses) the data is bound to the typed property, so no
-    // overflow arises.
+    // Note: WRONG_CASED_ELEMENT_CODE is deliberately NOT in this list. Under lenient case
+    // binding (which is what DeserializationMode.NoOverflow uses) a wrong-cased element is bound
+    // to the typed property, so no overflow arises and the error is correctly ignorable. The
+    // data only ends up in the overflow under strict case binding - and strict binding is, by
+    // construction, only used when the ExceptionFilter reports WRONG_CASED_ELEMENT (see
+    // DeserializerSettings.UsesStrictCaseBinding), so such a parse always fails on that error
+    // itself and cannot silently leave data in the overflow.
     internal static readonly HashSet<string> ISSUES_CAUSED_BY_OVERFLOW =
     [
         INVALID_CODED_VALUE_CODE,

--- a/src/Hl7.Fhir.Base/Validation/CodedValidationException.cs
+++ b/src/Hl7.Fhir.Base/Validation/CodedValidationException.cs
@@ -59,10 +59,11 @@ public class CodedValidationException : ExtendedCodedException
     // Otherwise said, if none of these are raised, the user should be able to
     // use the POCOs without us throwing validation exceptions and should not be
     // required to check the <see cref="Base.Overflow"/> for unknown elements.
-    // Note: WRONG_CASED_ELEMENT_CODE is deliberately NOT in this list. When a wrong-cased
-    // element ends up in the overflow (strict case binding), the parser raises UNKNOWN_ELEMENT
-    // alongside it, which is in this list - so DeserializationMode.NoOverflow keeps rejecting
-    // exactly the inputs it rejected before wrong-case detection was introduced.
+    // Note: WRONG_CASED_ELEMENT_CODE is deliberately NOT in this list. A wrong-cased element
+    // only ends up in the overflow under strict case binding, and there UNKNOWN_ELEMENT (which
+    // is in this list) always accompanies it. Under lenient case binding (which is what
+    // DeserializationMode.NoOverflow uses) the data is bound to the typed property, so no
+    // overflow arises.
     internal static readonly HashSet<string> ISSUES_CAUSED_BY_OVERFLOW =
     [
         INVALID_CODED_VALUE_CODE,

--- a/src/Hl7.Fhir.Base/Validation/FhirAttributeValidator.cs
+++ b/src/Hl7.Fhir.Base/Validation/FhirAttributeValidator.cs
@@ -47,16 +47,14 @@ public class FhirAttributeValidator : IPocoValidator
                 : "element";
 
             // If the unknown name is a case-insensitive near miss of a defined element, the reason
-            // it is unknown is its incorrect casing. Report the casing violation alongside the
-            // unknown element, so both the cause and the fact that the data ended up in the
-            // overflow are visible.
+            // it is unknown is its incorrect casing - report the casing violation instead of the
+            // generic unknown element. So, a name always produces at most one of these errors:
+            // WRONG_CASED_ELEMENT when it nearly matches a defined element, UNKNOWN_ELEMENT when
+            // it does not match anything at all.
             var declaringMapping = propertyMapping?.DeclaringClass
                 ?? context.ModelInspector.FindOrImportClassMapping(context.ObjectInstance);
             if (declaringMapping?.TryFindElement(name) is { IsExactCase: false } nearMiss)
-                return [
-                    CodedValidationException.WRONG_CASED_ELEMENT(context, name, nearMiss.CanonicalName),
-                    CodedValidationException.UNKNOWN_ELEMENT(context, name, serializedForm)
-                ];
+                return [CodedValidationException.WRONG_CASED_ELEMENT(context, name, nearMiss.CanonicalName)];
 
             return [CodedValidationException.UNKNOWN_ELEMENT(context, name, serializedForm)];
         }

--- a/src/Hl7.Fhir.Base/Validation/FhirAttributeValidator.cs
+++ b/src/Hl7.Fhir.Base/Validation/FhirAttributeValidator.cs
@@ -12,6 +12,7 @@ using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Utility;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -44,8 +45,31 @@ public class FhirAttributeValidator : IPocoValidator
             var serializedForm = propertyValue is Base b && b.Annotation<XmlRepresentationAnnotation>() is not null
                 ? "attribute"
                 : "element";
+
+            // If the unknown name is a case-insensitive near miss of a defined element, the reason
+            // it is unknown is its incorrect casing. Report the casing violation alongside the
+            // unknown element, so both the cause and the fact that the data ended up in the
+            // overflow are visible.
+            var declaringMapping = propertyMapping?.DeclaringClass
+                ?? context.ModelInspector.FindOrImportClassMapping(context.ObjectInstance);
+            if (declaringMapping?.TryFindElement(name) is { IsExactCase: false } nearMiss)
+                return [
+                    CodedValidationException.WRONG_CASED_ELEMENT(context, name, nearMiss.CanonicalName),
+                    CodedValidationException.UNKNOWN_ELEMENT(context, name, serializedForm)
+                ];
+
             return [CodedValidationException.UNKNOWN_ELEMENT(context, name, serializedForm)];
         }
+
+        // The name - as encountered in the serialized form, or used as a key in the dictionary
+        // interface - may differ from the element's defined name only by casing (for choice
+        // elements: including the casing of the type suffix). The value is still validated against
+        // the element it nearly matches, but the casing violation itself is reported as well.
+        CodedValidationException[] caseErrors =
+            !string.Equals(name, propertyMapping.Name, StringComparison.Ordinal)
+            && propertyMapping.DeclaringClass.TryFindElement(name) is { IsExactCase: false } wrongCased
+                ? [CodedValidationException.WRONG_CASED_ELEMENT(context, name, wrongCased.CanonicalName)]
+                : [];
 
         // if context doesn't have MemberName, set it explicitly
         context.MemberName ??= propertyMapping.NativeProperty?.Name;
@@ -54,12 +78,16 @@ public class FhirAttributeValidator : IPocoValidator
         if (!propertyMapping.PropertyType.IsInstanceOfType(propertyValue))
         {
             return [
+                ..caseErrors,
                 CodedValidationException.FromTypes(propertyMapping.PropertyType, propertyValue, context, propertyMapping.NativeProperty?.Name ?? propertyMapping.Name),
                 ..runAttributeValidation(propertyValue, propertyMapping.ValidationAttributes, context)
             ];
         }
 
-        return runAttributeValidation(propertyValue, propertyMapping.ValidationAttributes, context);
+        if (caseErrors.Length == 0)
+            return runAttributeValidation(propertyValue, propertyMapping.ValidationAttributes, context);
+
+        return [.. caseErrors, .. runAttributeValidation(propertyValue, propertyMapping.ValidationAttributes, context)];
     }
 
    /// <inheritdoc />

--- a/src/Hl7.Fhir.Support.Poco.Tests/PocoValidationTests/ValidatableObjectTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/PocoValidationTests/ValidatableObjectTests.cs
@@ -60,13 +60,14 @@ public class ValidatableObjectTests
     public void WrongCasedChoiceDictionaryKey_IsReportedByValidation()
     {
         // Same for a suffixed choice-element key: it is unknown to the POCO, but validation
-        // detects that it only differs from a correct choice name by casing.
+        // detects that it only differs from a correct choice name by casing, and reports the
+        // casing violation instead of a generic unknown element.
         var patient = new Patient();
         patient.SetValue("DeceasedBoolean", new FhirBoolean(true));
 
         var errors = patient.Validate();
         errors.Should().Contain(e => e.ErrorCode == COVE.WRONG_CASED_ELEMENT_CODE && e.Message.Contains("'deceasedBoolean'"));
-        errors.Should().Contain(e => e.ErrorCode == COVE.UNKNOWN_ELEMENT_CODE);
+        errors.Should().NotContain(e => e.ErrorCode == COVE.UNKNOWN_ELEMENT_CODE);
     }
 
     [TestMethod]

--- a/src/Hl7.Fhir.Support.Poco.Tests/PocoValidationTests/ValidatableObjectTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/PocoValidationTests/ValidatableObjectTests.cs
@@ -44,6 +44,41 @@ public class ValidatableObjectTests
         Assert.ThrowsExactly<COVE>(() => _ = c.Value);
     }
 
+    [TestMethod]
+    public void WrongCasedDictionaryKey_IsReportedByValidation()
+    {
+        // A wrong-cased element name used with the dictionary interface does not match the POCO
+        // property, so the data ends up in the overflow. Validation reports the casing violation.
+        var patient = new Patient();
+        patient.SetValue("Active", new FhirBoolean(true));
+
+        var errors = patient.Validate();
+        errors.Should().Contain(e => e.ErrorCode == COVE.WRONG_CASED_ELEMENT_CODE && e.Message.Contains("'active'"));
+    }
+
+    [TestMethod]
+    public void WrongCasedChoiceDictionaryKey_IsReportedByValidation()
+    {
+        // Same for a suffixed choice-element key: it is unknown to the POCO, but validation
+        // detects that it only differs from a correct choice name by casing.
+        var patient = new Patient();
+        patient.SetValue("DeceasedBoolean", new FhirBoolean(true));
+
+        var errors = patient.Validate();
+        errors.Should().Contain(e => e.ErrorCode == COVE.WRONG_CASED_ELEMENT_CODE && e.Message.Contains("'deceasedBoolean'"));
+        errors.Should().Contain(e => e.ErrorCode == COVE.UNKNOWN_ELEMENT_CODE);
+    }
+
+    [TestMethod]
+    public void CorrectlyCasedDictionaryKey_NoCaseError()
+    {
+        var patient = new Patient();
+        patient.SetValue("active", new FhirBoolean(true));
+
+        var errors = patient.Validate();
+        errors.Should().NotContain(e => e.ErrorCode == COVE.WRONG_CASED_ELEMENT_CODE);
+    }
+
     private static void assertValid(Base o, string? errorCode = null)
     {
         var validationResult = o.Validate();

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
@@ -1008,6 +1008,64 @@ public partial class FhirJsonDeserializationTests
         JsonAssert.AreSame("parsed", json, serialized);
     }
 
+    [TestMethod]
+    public void WrongCaseNames_DefaultMode_NoErrors()
+    {
+        // In the default (non-Strict) mode, case-sensitivity issues are filtered and should not surface.
+        var settings = new DeserializerSettings();
+        var deserializer = new FhirJsonDeserializer(settings);
+
+        // Wrong-case property name
+        var json = """{"resourceType":"Patient","Id":"test"}""";
+        var result = deserializer.DeserializeResource(json);
+        result.Should().BeOfType<Patient>().Which.Id.Should().Be("test");
+
+        // Wrong-case resource type
+        json = """{"resourceType":"patient","id":"test"}""";
+        result = deserializer.DeserializeResource(json);
+        result.Should().BeOfType<Patient>().Which.Id.Should().Be("test");
+    }
+
+    [TestMethod]
+    public void WrongCaseNames_BackwardsCompatibleMode_NoErrors()
+    {
+        // BackwardsCompatible mode must also suppress case-sensitivity errors.
+        var settings = new DeserializerSettings().UsingMode(DeserializationMode.BackwardsCompatible);
+        var deserializer = new FhirJsonDeserializer(settings);
+
+        var json = """{"resourceType":"patient","Id":"test"}""";
+        var result = deserializer.DeserializeResource(json);
+        result.Should().BeOfType<Patient>().Which.Id.Should().Be("test");
+    }
+
+    [TestMethod]
+    [DataRow("""{"resourceType":"Patient","Id":"test"}""", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_PropertyName")]
+    [DataRow("""{"resourceType":"patient","id":"test"}""", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_ResourceType")]
+    [DataRow("""{"resourceType":"Patient","deceasedDatetime":"2022-05"}""", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_ChoiceTypeSuffix")]
+    public void WrongCaseNames_StrictMode_ReportsError(string json, string expectedErrorCode)
+    {
+        var settings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);
+        var deserializer = new FhirJsonDeserializer(settings);
+
+        var act = () => deserializer.DeserializeResource(json);
+        act.Should().Throw<DeserializationFailedException>()
+            .Which.Exceptions.Should().Contain(e => e.ErrorCode == expectedErrorCode);
+    }
+
+    [TestMethod]
+    // Also verifies that a multi-word type suffix like "CodeableConcept" does not produce a false positive.
+    [DataRow("""{"resourceType":"Patient","id":"test","deceasedDateTime":"2022-05"}""", DisplayName = "Correct_DateTimeChoice")]
+    [DataRow("""{"resourceType":"Observation","id":"test","status":"final","code":{"text":"t"},"valueCodeableConcept":{"text":"x"}}""", DisplayName = "Correct_CodeableConceptChoice")]
+    public void CorrectCaseNames_StrictMode_NoError(string json)
+    {
+        var settings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);
+        var deserializer = new FhirJsonDeserializer(settings);
+
+        // Should not throw: no JSON135 errors on correct casing.
+        var act = () => deserializer.DeserializeResource(json);
+        act.Should().NotThrow();
+    }
+
 // This test is only relevant when we have getter/setter codegen enabled. - See PropertyMapping's
 // Getter and Setter, which are also excluded by this preprocessor directive.
 #if USE_GETTER_SETTER_AND_CODEGEN

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
@@ -1039,6 +1039,21 @@ public partial class FhirJsonDeserializationTests
     }
 
     [TestMethod]
+    public void WrongCaseChoicePrefix_LenientModes_BindsToChoiceElement()
+    {
+        // SDK 6.2 and earlier matched the element-name part of a choice name case-sensitively, so
+        // "DeceasedBoolean" was treated as an unknown element. We consider that a bug: in lenient
+        // modes, all wrong-cased names bind to the element they nearly match.
+        var settings = new DeserializerSettings();
+        var deserializer = new FhirJsonDeserializer(settings);
+
+        var json = """{"resourceType":"Patient","DeceasedBoolean":true}""";
+        var result = deserializer.DeserializeResource(json);
+        result.Should().BeOfType<Patient>().Which.Deceased.Should().BeOfType<FhirBoolean>()
+            .Which.Value.Should().Be(true);
+    }
+
+    [TestMethod]
     [DataRow("""{"resourceType":"Patient","Id":"test"}""", COVE.WRONG_CASED_ELEMENT_CODE, DisplayName = "WrongCase_PropertyName")]
     [DataRow("""{"resourceType":"patient","id":"test"}""", COVE.WRONG_CASED_RESOURCE_TYPE_CODE, DisplayName = "WrongCase_ResourceType")]
     [DataRow("""{"resourceType":"Patient","deceasedDatetime":"2022-05"}""", COVE.WRONG_CASED_ELEMENT_CODE, DisplayName = "WrongCase_ChoiceTypeSuffix")]

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
@@ -1039,9 +1039,10 @@ public partial class FhirJsonDeserializationTests
     }
 
     [TestMethod]
-    [DataRow("""{"resourceType":"Patient","Id":"test"}""", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_PropertyName")]
-    [DataRow("""{"resourceType":"patient","id":"test"}""", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_ResourceType")]
-    [DataRow("""{"resourceType":"Patient","deceasedDatetime":"2022-05"}""", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_ChoiceTypeSuffix")]
+    [DataRow("""{"resourceType":"Patient","Id":"test"}""", ERR.PROPERTY_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_PropertyName")]
+    [DataRow("""{"resourceType":"patient","id":"test"}""", ERR.RESOURCE_TYPE_WRONG_CASE_CODE, DisplayName = "WrongCase_ResourceType")]
+    [DataRow("""{"resourceType":"Patient","deceasedDatetime":"2022-05"}""", ERR.PROPERTY_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_ChoiceTypeSuffix")]
+    [DataRow("""{"resourceType":"Observation","status":"final","code":{"text":"t"},"ValueString":"hello"}""", ERR.PROPERTY_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_ChoicePrefix")]
     public void WrongCaseNames_StrictMode_ReportsError(string json, string expectedErrorCode)
     {
         var settings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
@@ -1054,6 +1054,22 @@ public partial class FhirJsonDeserializationTests
     }
 
     [TestMethod]
+    public void WrongCase_ChoicePrefixAndSuffix_SuggestsFullyCorrectedName()
+    {
+        // When both the choice prefix ("Value") and the type suffix ("Datetime") have wrong casing,
+        // the suggested name in the error message should be fully corrected ("valueDateTime"), not
+        // just have its prefix fixed ("valueDatetime").
+        var settings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);
+        var deserializer = new FhirJsonDeserializer(settings);
+
+        var json = """{"resourceType":"Observation","status":"final","code":{"text":"t"},"ValueDatetime":"2022-05"}""";
+        var act = () => deserializer.DeserializeResource(json);
+        act.Should().Throw<DeserializationFailedException>()
+            .Which.Exceptions.Should().Contain(e => e.ErrorCode == ERR.PROPERTY_NAME_WRONG_CASE_CODE
+                                                     && e.Message.Contains("valueDateTime"));
+    }
+
+    [TestMethod]
     // Also verifies that a multi-word type suffix like "CodeableConcept" does not produce a false positive.
     [DataRow("""{"resourceType":"Patient","id":"test","deceasedDateTime":"2022-05"}""", DisplayName = "Correct_DateTimeChoice")]
     [DataRow("""{"resourceType":"Observation","id":"test","status":"final","code":{"text":"t"},"valueCodeableConcept":{"text":"x"}}""", DisplayName = "Correct_CodeableConceptChoice")]

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
@@ -1039,10 +1039,10 @@ public partial class FhirJsonDeserializationTests
     }
 
     [TestMethod]
-    [DataRow("""{"resourceType":"Patient","Id":"test"}""", ERR.PROPERTY_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_PropertyName")]
-    [DataRow("""{"resourceType":"patient","id":"test"}""", ERR.RESOURCE_TYPE_WRONG_CASE_CODE, DisplayName = "WrongCase_ResourceType")]
-    [DataRow("""{"resourceType":"Patient","deceasedDatetime":"2022-05"}""", ERR.PROPERTY_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_ChoiceTypeSuffix")]
-    [DataRow("""{"resourceType":"Observation","status":"final","code":{"text":"t"},"ValueString":"hello"}""", ERR.PROPERTY_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_ChoicePrefix")]
+    [DataRow("""{"resourceType":"Patient","Id":"test"}""", COVE.WRONG_CASED_ELEMENT_CODE, DisplayName = "WrongCase_PropertyName")]
+    [DataRow("""{"resourceType":"patient","id":"test"}""", COVE.WRONG_CASED_RESOURCE_TYPE_CODE, DisplayName = "WrongCase_ResourceType")]
+    [DataRow("""{"resourceType":"Patient","deceasedDatetime":"2022-05"}""", COVE.WRONG_CASED_ELEMENT_CODE, DisplayName = "WrongCase_ChoiceTypeSuffix")]
+    [DataRow("""{"resourceType":"Observation","status":"final","code":{"text":"t"},"ValueString":"hello"}""", COVE.WRONG_CASED_ELEMENT_CODE, DisplayName = "WrongCase_ChoicePrefix")]
     public void WrongCaseNames_StrictMode_ReportsError(string json, string expectedErrorCode)
     {
         var settings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);
@@ -1051,6 +1051,64 @@ public partial class FhirJsonDeserializationTests
         var act = () => deserializer.DeserializeResource(json);
         act.Should().Throw<DeserializationFailedException>()
             .Which.Exceptions.Should().Contain(e => e.ErrorCode == expectedErrorCode);
+    }
+
+    [TestMethod]
+    public void WrongCaseNames_StrictMode_PreservesDataInOverflow()
+    {
+        // In strict mode, a wrong-cased element is not silently corrected: it is treated as an
+        // unknown element, so the original data is preserved (and roundtrippable) in the overflow.
+        var settings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);
+        var deserializer = new FhirJsonDeserializer(settings);
+
+        var json = """{"resourceType":"Patient","Active":true}""";
+        var act = () => deserializer.DeserializeResource(json);
+        var ex = act.Should().Throw<DeserializationFailedException>().Which;
+
+        // Both the casing violation and the resulting unknown element are reported.
+        ex.Exceptions.Should().Contain(e => e.ErrorCode == COVE.WRONG_CASED_ELEMENT_CODE);
+        ex.Exceptions.Should().Contain(e => e.ErrorCode == COVE.UNKNOWN_ELEMENT_CODE);
+
+        // The data is in the overflow under its original name, not in the typed property.
+        var patient = ex.PartialResult.Should().BeOfType<Patient>().Subject;
+        patient.ActiveElement.Should().BeNull();
+        patient.TryGetValue("Active", out _).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void WrongCaseResourceType_StrictMode_StillBindsToPocoType()
+    {
+        // Unlike elements, a wrong-cased resource type is still deserialized into the matching
+        // POCO type: falling back to a DynamicResource would degrade the entire resource to
+        // overflow data, which is disproportionate. The violation is reported with its own code.
+        var settings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);
+        var deserializer = new FhirJsonDeserializer(settings);
+
+        var json = """{"resourceType":"patient","id":"test"}""";
+        var act = () => deserializer.DeserializeResource(json);
+        var ex = act.Should().Throw<DeserializationFailedException>().Which;
+
+        ex.Exceptions.Should().ContainSingle(e => e.ErrorCode == COVE.WRONG_CASED_RESOURCE_TYPE_CODE);
+        ex.PartialResult.Should().BeOfType<Patient>().Which.Id.Should().Be("test");
+    }
+
+    [TestMethod]
+    public void WrongCaseNames_RecoverableModeWithEnforcedCaseErrors_UsesStrictBinding()
+    {
+        // Case-strict parsing can be turned on in any mode by enforcing the wrong-case error
+        // codes: the deserializer derives its binding behaviour from the ExceptionFilter
+        // (see DeserializerSettings.UsesStrictCaseBinding).
+        var settings = new DeserializerSettings()
+            .UsingMode(DeserializationMode.Recoverable)
+            .Enforcing([COVE.WRONG_CASED_ELEMENT_CODE]);
+        var deserializer = new FhirJsonDeserializer(settings);
+
+        var json = """{"resourceType":"Patient","Active":true}""";
+        var act = () => deserializer.DeserializeResource(json);
+        var ex = act.Should().Throw<DeserializationFailedException>().Which;
+
+        ex.Exceptions.Should().Contain(e => e.ErrorCode == COVE.WRONG_CASED_ELEMENT_CODE);
+        ex.PartialResult.Should().BeOfType<Patient>().Which.ActiveElement.Should().BeNull();
     }
 
     [TestMethod]
@@ -1065,7 +1123,7 @@ public partial class FhirJsonDeserializationTests
         var json = """{"resourceType":"Observation","status":"final","code":{"text":"t"},"ValueDatetime":"2022-05"}""";
         var act = () => deserializer.DeserializeResource(json);
         act.Should().Throw<DeserializationFailedException>()
-            .Which.Exceptions.Should().Contain(e => e.ErrorCode == ERR.PROPERTY_NAME_WRONG_CASE_CODE
+            .Which.Exceptions.Should().Contain(e => e.ErrorCode == COVE.WRONG_CASED_ELEMENT_CODE
                                                      && e.Message.Contains("valueDateTime"));
     }
 
@@ -1078,7 +1136,7 @@ public partial class FhirJsonDeserializationTests
         var settings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);
         var deserializer = new FhirJsonDeserializer(settings);
 
-        // Should not throw: no JSON135 errors on correct casing.
+        // Should not throw: no wrong-case errors on correct casing.
         var act = () => deserializer.DeserializeResource(json);
         act.Should().NotThrow();
     }

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirJsonDeserializationTests.cs
@@ -1080,9 +1080,10 @@ public partial class FhirJsonDeserializationTests
         var act = () => deserializer.DeserializeResource(json);
         var ex = act.Should().Throw<DeserializationFailedException>().Which;
 
-        // Both the casing violation and the resulting unknown element are reported.
-        ex.Exceptions.Should().Contain(e => e.ErrorCode == COVE.WRONG_CASED_ELEMENT_CODE);
-        ex.Exceptions.Should().Contain(e => e.ErrorCode == COVE.UNKNOWN_ELEMENT_CODE);
+        // The casing violation is reported - and only that: a near miss is never additionally
+        // reported as an unknown element.
+        ex.Exceptions.Should().ContainSingle(e => e.ErrorCode == COVE.WRONG_CASED_ELEMENT_CODE);
+        ex.Exceptions.Should().NotContain(e => e.ErrorCode == COVE.UNKNOWN_ELEMENT_CODE);
 
         // The data is in the overflow under its original name, not in the typed property.
         var patient = ex.PartialResult.Should().BeOfType<Patient>().Subject;

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirXmlDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirXmlDeserializationTests.cs
@@ -712,6 +712,23 @@ public partial class FhirXmlDeserializationTests
     }
 
     [TestMethod]
+    public void WrongCaseChoicePrefix_LenientModes_BindsToChoiceElement()
+    {
+        // SDK 6.2 and earlier matched the element-name part of a choice name case-sensitively, so
+        // "DeceasedBoolean" was treated as an unknown element. We consider that a bug: in lenient
+        // modes, all wrong-cased names bind to the element they nearly match.
+        var settings = new DeserializerSettings();
+        var deserializer = getTestDeserializer(settings);
+
+        var content = "<Patient xmlns=\"http://hl7.org/fhir\"><DeceasedBoolean value=\"true\"/></Patient>";
+        var reader = constructReader(content);
+        reader.Read();
+        var result = deserializer.DeserializeResource(reader);
+        result.Should().BeOfType<Patient>().Which.Deceased.Should().BeOfType<FhirBoolean>()
+            .Which.Value.Should().Be(true);
+    }
+
+    [TestMethod]
     [DataRow("<Patient xmlns=\"http://hl7.org/fhir\"><Id value=\"test\"/></Patient>", COVE.WRONG_CASED_ELEMENT_CODE, DisplayName = "WrongCase_PropertyName")]
     [DataRow("<patient xmlns=\"http://hl7.org/fhir\"><id value=\"test\"/></patient>", COVE.WRONG_CASED_RESOURCE_TYPE_CODE, DisplayName = "WrongCase_ResourceType")]
     [DataRow("<Patient xmlns=\"http://hl7.org/fhir\"><deceasedDatetime value=\"2022-05\"/></Patient>", COVE.WRONG_CASED_ELEMENT_CODE, DisplayName = "WrongCase_ChoiceTypeSuffix")]

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirXmlDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirXmlDeserializationTests.cs
@@ -759,9 +759,10 @@ public partial class FhirXmlDeserializationTests
         var state = new PocoDeserializerState();
         var resource = deserializer.DeserializeResourceInternal(reader, state);
 
-        // Both the casing violation and the resulting unknown element are reported.
-        state.Errors.Should().Contain(e => e.ErrorCode == COVE.WRONG_CASED_ELEMENT_CODE);
-        state.Errors.Should().Contain(e => e.ErrorCode == COVE.UNKNOWN_ELEMENT_CODE);
+        // The casing violation is reported - and only that: a near miss is never additionally
+        // reported as an unknown element.
+        state.Errors.Should().ContainSingle(e => e.ErrorCode == COVE.WRONG_CASED_ELEMENT_CODE);
+        state.Errors.Should().NotContain(e => e.ErrorCode == COVE.UNKNOWN_ELEMENT_CODE);
 
         // The data is in the overflow under its original name, not in the typed property.
         var patient = resource.Should().BeOfType<Patient>().Subject;

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirXmlDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirXmlDeserializationTests.cs
@@ -682,4 +682,63 @@ public partial class FhirXmlDeserializationTests
         var serialized = serializer.SerializeToString(parsed);
         XmlAssert.AreSame("parsed", json, serialized);
     }
+
+    [TestMethod]
+    public void WrongCaseNames_DefaultMode_NoErrors()
+    {
+        // In the default (non-Strict) mode, case-sensitivity issues are filtered and should not surface.
+        var settings = new DeserializerSettings();
+        var deserializer = getTestDeserializer(settings);
+
+        var content = "<Patient xmlns=\"http://hl7.org/fhir\"><Id value=\"test\"/></Patient>";
+        var reader = constructReader(content);
+        reader.Read();
+        var result = deserializer.DeserializeResource(reader);
+        result.Should().BeOfType<Patient>().Which.Id.Should().Be("test");
+    }
+
+    [TestMethod]
+    public void WrongCaseNames_BackwardsCompatibleMode_NoErrors()
+    {
+        // BackwardsCompatible mode must also suppress case-sensitivity errors.
+        var settings = new DeserializerSettings().UsingMode(DeserializationMode.BackwardsCompatible);
+        var deserializer = getTestDeserializer(settings);
+
+        var content = "<patient xmlns=\"http://hl7.org/fhir\"><Id value=\"test\"/></patient>";
+        var reader = constructReader(content);
+        reader.Read();
+        var result = deserializer.DeserializeResource(reader);
+        result.Should().BeOfType<Patient>().Which.Id.Should().Be("test");
+    }
+
+    [TestMethod]
+    [DataRow("<Patient xmlns=\"http://hl7.org/fhir\"><Id value=\"test\"/></Patient>", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_PropertyName")]
+    [DataRow("<patient xmlns=\"http://hl7.org/fhir\"><id value=\"test\"/></patient>", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_ResourceType")]
+    [DataRow("<Patient xmlns=\"http://hl7.org/fhir\"><deceasedDatetime value=\"2022-05\"/></Patient>", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_ChoiceTypeSuffix")]
+    public void WrongCaseNames_StrictMode_ReportsError(string xmlContent, string expectedErrorCode)
+    {
+        var settings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);
+        var deserializer = getTestDeserializer(settings);
+        var reader = constructReader(xmlContent);
+        reader.Read();
+
+        var state = new PocoDeserializerState();
+        _ = deserializer.DeserializeResourceInternal(reader, state);
+        state.Errors.Should().Contain(e => e.ErrorCode == expectedErrorCode);
+    }
+
+    [TestMethod]
+    // Also verifies that a multi-word type suffix like "CodeableConcept" does not produce a false positive.
+    [DataRow("<Patient xmlns=\"http://hl7.org/fhir\"><id value=\"test\"/><deceasedDateTime value=\"2022-05\"/></Patient>", DisplayName = "Correct_DateTimeChoice")]
+    [DataRow("<Observation xmlns=\"http://hl7.org/fhir\"><id value=\"test\"/><status value=\"final\"/><code><text value=\"t\"/></code><valueCodeableConcept><text value=\"x\"/></valueCodeableConcept></Observation>", DisplayName = "Correct_CodeableConceptChoice")]
+    public void CorrectCaseNames_StrictMode_NoError(string content)
+    {
+        var settings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);
+        var deserializer = getTestDeserializer(settings);
+        var reader = constructReader(content);
+        reader.Read();
+        var state = new PocoDeserializerState();
+        _ = deserializer.DeserializeResourceInternal(reader, state);
+        state.Errors.Should().NotContain(e => e.ErrorCode == ERR.ELEMENT_NAME_WRONG_CASE_CODE);
+    }
 }

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirXmlDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirXmlDeserializationTests.cs
@@ -712,10 +712,10 @@ public partial class FhirXmlDeserializationTests
     }
 
     [TestMethod]
-    [DataRow("<Patient xmlns=\"http://hl7.org/fhir\"><Id value=\"test\"/></Patient>", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_PropertyName")]
-    [DataRow("<patient xmlns=\"http://hl7.org/fhir\"><id value=\"test\"/></patient>", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_ResourceType")]
-    [DataRow("<Patient xmlns=\"http://hl7.org/fhir\"><deceasedDatetime value=\"2022-05\"/></Patient>", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_ChoiceTypeSuffix")]
-    [DataRow("<Observation xmlns=\"http://hl7.org/fhir\"><status value=\"final\"/><code><text value=\"t\"/></code><ValueString value=\"hello\"/></Observation>", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_ChoicePrefix")]
+    [DataRow("<Patient xmlns=\"http://hl7.org/fhir\"><Id value=\"test\"/></Patient>", COVE.WRONG_CASED_ELEMENT_CODE, DisplayName = "WrongCase_PropertyName")]
+    [DataRow("<patient xmlns=\"http://hl7.org/fhir\"><id value=\"test\"/></patient>", COVE.WRONG_CASED_RESOURCE_TYPE_CODE, DisplayName = "WrongCase_ResourceType")]
+    [DataRow("<Patient xmlns=\"http://hl7.org/fhir\"><deceasedDatetime value=\"2022-05\"/></Patient>", COVE.WRONG_CASED_ELEMENT_CODE, DisplayName = "WrongCase_ChoiceTypeSuffix")]
+    [DataRow("<Observation xmlns=\"http://hl7.org/fhir\"><status value=\"final\"/><code><text value=\"t\"/></code><ValueString value=\"hello\"/></Observation>", COVE.WRONG_CASED_ELEMENT_CODE, DisplayName = "WrongCase_ChoicePrefix")]
     public void WrongCaseNames_StrictMode_ReportsError(string xmlContent, string expectedErrorCode)
     {
         var settings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);
@@ -726,6 +726,48 @@ public partial class FhirXmlDeserializationTests
         var state = new PocoDeserializerState();
         _ = deserializer.DeserializeResourceInternal(reader, state);
         state.Errors.Should().Contain(e => e.ErrorCode == expectedErrorCode);
+    }
+
+    [TestMethod]
+    public void WrongCaseNames_StrictMode_PreservesDataInOverflow()
+    {
+        // In strict mode, a wrong-cased element is not silently corrected: it is treated as an
+        // unknown element, so the original data is preserved (and roundtrippable) in the overflow.
+        var settings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);
+        var deserializer = getTestDeserializer(settings);
+        var content = "<Patient xmlns=\"http://hl7.org/fhir\"><Active value=\"true\"/></Patient>";
+        var reader = constructReader(content);
+        reader.Read();
+
+        var state = new PocoDeserializerState();
+        var resource = deserializer.DeserializeResourceInternal(reader, state);
+
+        // Both the casing violation and the resulting unknown element are reported.
+        state.Errors.Should().Contain(e => e.ErrorCode == COVE.WRONG_CASED_ELEMENT_CODE);
+        state.Errors.Should().Contain(e => e.ErrorCode == COVE.UNKNOWN_ELEMENT_CODE);
+
+        // The data is in the overflow under its original name, not in the typed property.
+        var patient = resource.Should().BeOfType<Patient>().Subject;
+        patient.ActiveElement.Should().BeNull();
+        patient.TryGetValue("Active", out _).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void WrongCaseResourceType_StrictMode_StillBindsToPocoType()
+    {
+        // Unlike elements, a wrong-cased resource type is still deserialized into the matching
+        // POCO type: falling back to a DynamicResource would degrade the entire resource to
+        // overflow data, which is disproportionate. The violation is reported with its own code.
+        var settings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);
+        var deserializer = getTestDeserializer(settings);
+        var reader = constructReader("<patient xmlns=\"http://hl7.org/fhir\"><id value=\"test\"/></patient>");
+        reader.Read();
+
+        var state = new PocoDeserializerState();
+        var resource = deserializer.DeserializeResourceInternal(reader, state);
+
+        state.Errors.Should().ContainSingle(e => e.ErrorCode == COVE.WRONG_CASED_RESOURCE_TYPE_CODE);
+        resource.Should().BeOfType<Patient>().Which.Id.Should().Be("test");
     }
 
     [TestMethod]
@@ -742,7 +784,7 @@ public partial class FhirXmlDeserializationTests
 
         var state = new PocoDeserializerState();
         _ = deserializer.DeserializeResourceInternal(reader, state);
-        state.Errors.Should().Contain(e => e.ErrorCode == ERR.ELEMENT_NAME_WRONG_CASE_CODE
+        state.Errors.Should().Contain(e => e.ErrorCode == COVE.WRONG_CASED_ELEMENT_CODE
                                             && e.Message.Contains("valueDateTime"));
     }
 
@@ -758,6 +800,7 @@ public partial class FhirXmlDeserializationTests
         reader.Read();
         var state = new PocoDeserializerState();
         _ = deserializer.DeserializeResourceInternal(reader, state);
-        state.Errors.Should().NotContain(e => e.ErrorCode == ERR.ELEMENT_NAME_WRONG_CASE_CODE);
+        state.Errors.Should().NotContain(e => e.ErrorCode == COVE.WRONG_CASED_ELEMENT_CODE
+                                              || e.ErrorCode == COVE.WRONG_CASED_RESOURCE_TYPE_CODE);
     }
 }

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirXmlDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirXmlDeserializationTests.cs
@@ -715,6 +715,7 @@ public partial class FhirXmlDeserializationTests
     [DataRow("<Patient xmlns=\"http://hl7.org/fhir\"><Id value=\"test\"/></Patient>", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_PropertyName")]
     [DataRow("<patient xmlns=\"http://hl7.org/fhir\"><id value=\"test\"/></patient>", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_ResourceType")]
     [DataRow("<Patient xmlns=\"http://hl7.org/fhir\"><deceasedDatetime value=\"2022-05\"/></Patient>", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_ChoiceTypeSuffix")]
+    [DataRow("<Observation xmlns=\"http://hl7.org/fhir\"><status value=\"final\"/><code><text value=\"t\"/></code><ValueString value=\"hello\"/></Observation>", ERR.ELEMENT_NAME_WRONG_CASE_CODE, DisplayName = "WrongCase_ChoicePrefix")]
     public void WrongCaseNames_StrictMode_ReportsError(string xmlContent, string expectedErrorCode)
     {
         var settings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirXmlDeserializationTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirXmlDeserializationTests.cs
@@ -729,6 +729,24 @@ public partial class FhirXmlDeserializationTests
     }
 
     [TestMethod]
+    public void WrongCase_ChoicePrefixAndSuffix_SuggestsFullyCorrectedName()
+    {
+        // When both the choice prefix ("Value") and the type suffix ("Datetime") have wrong casing,
+        // the suggested name in the error message should be fully corrected ("valueDateTime"), not
+        // just have its prefix fixed ("valueDatetime").
+        var settings = new DeserializerSettings().UsingMode(DeserializationMode.Strict);
+        var deserializer = getTestDeserializer(settings);
+        var content = "<Observation xmlns=\"http://hl7.org/fhir\"><status value=\"final\"/><code><text value=\"t\"/></code><ValueDatetime value=\"2022-05\"/></Observation>";
+        var reader = constructReader(content);
+        reader.Read();
+
+        var state = new PocoDeserializerState();
+        _ = deserializer.DeserializeResourceInternal(reader, state);
+        state.Errors.Should().Contain(e => e.ErrorCode == ERR.ELEMENT_NAME_WRONG_CASE_CODE
+                                            && e.Message.Contains("valueDateTime"));
+    }
+
+    [TestMethod]
     // Also verifies that a multi-word type suffix like "CodeableConcept" does not produce a false positive.
     [DataRow("<Patient xmlns=\"http://hl7.org/fhir\"><id value=\"test\"/><deceasedDateTime value=\"2022-05\"/></Patient>", DisplayName = "Correct_DateTimeChoice")]
     [DataRow("<Observation xmlns=\"http://hl7.org/fhir\"><id value=\"test\"/><status value=\"final\"/><code><text value=\"t\"/></code><valueCodeableConcept><text value=\"x\"/></valueCodeableConcept></Observation>", DisplayName = "Correct_CodeableConceptChoice")]


### PR DESCRIPTION
## Summary

FHIR names are case-sensitive per spec, but the SDK's lookup dictionaries use `OrdinalIgnoreCase`, silently normalizing wrong-case input. This PR detects and reports these violations — and after review feedback, the detection now lives **in the model/validation layer rather than in the parsers**, since a wrong-cased name is a model violation, not a syntax error.

The rule is now a single sentence: **lenient modes bind every wrong-cased name to the element it nearly matches and stay silent; strict mode binds none, preserves the wire form in the overflow, and fails with exactly one wrong-case error.**

### Design

- **One detection primitive**: `ClassMapping.TryFindElement(name)` (internal) performs the case-insensitive lookup and reports the mapping, the canonical (correctly-cased) name — including a normalized choice-type suffix — and whether the match is case-exact. Both parsers and the validator consume it; the previously duplicated per-parser detection blocks are gone.
- **Two model-level error codes** replace the three format-specific ones: `PVAL131` (`WRONG_CASED_ELEMENT`) and `PVAL132` (`WRONG_CASED_RESOURCE_TYPE`). They apply to JSON and XML alike (a wrong-cased XML root element is a resource type violation, so it raises PVAL132).
- **Exactly one error per failed name**: `PVAL131` when the name differs from a defined element only by casing, `PVAL128` (`UNKNOWN_ELEMENT`) only when it matches nothing at all. Never both.
- **No new settings — binding policy is derived from the `ExceptionFilter`** (see the documented `DeserializerSettings.UsesStrictCaseBinding`):
  - If the active filter *ignores* wrong-case errors (the default, `Recoverable`, `BackwardsCompatible`, `NoOverflow`, `Ostrich`), wrong-cased names are bound to the element they nearly match — data stays in the typed properties.
  - If the filter *reports* them (`Strict`, or any filter via `Enforcing([PVAL131])`), a wrong-cased element is treated as unknown: the data is preserved under its original name in the overflow (and roundtrips), and validation reports `PVAL131`. A failing parse never silently corrects the input.
  - This also guarantees no filter combination can silently strand data in the overflow: data only reaches the overflow under strict binding, which by construction only happens when the filter reports `PVAL131` — so such a parse always fails. This is why `PVAL131` is not in `ISSUES_CAUSED_BY_OVERFLOW` (reasoning recorded in a comment there).
  - `SyntaxOnly`/`Ostrich` set `Validator = null`: case checks are model validation, so nothing is reported and binding stays lenient.
- **The dictionary interface is covered too**: `patient.SetValue("Active", ...)` puts the value in the overflow; `Validate()` now reports `PVAL131` with the correct-casing suggestion — for plain names and choice-suffixed keys alike.

### Behaviour changes vs 6.2 (deliberate)

- **Wrong-cased choice prefixes now bind in lenient modes.** ≤6.2 matched plain names and choice *suffixes* case-insensitively but choice *prefixes* ordinally, so `"DeceasedBoolean"` was an unknown element (default mode: parse failed; `Recoverable`: data hidden in overflow). We consider that asymmetry a bug: it now binds to `Deceased` like any other near miss. This is the only lenient-mode change, and it is in the lenient direction (previously-rejected input now parses).
- **Strict mode reports new errors** — covered by the `<remarks>` on `DeserializationMode.Strict` stating the issue set may expand.
- **A wrong-cased `resourceType` still binds to the matching POCO type, even in Strict** (reported as `PVAL132`). Falling back to `DynamicResource` would degrade the entire resource to overflow data, which seems disproportionate. Candidate to revisit in SDK7.

### Backwards compatibility

- All other lenient-mode behaviour is unchanged from 6.2; correctly-cased input is unaffected everywhere.
- No public API removed relative to `develop`; `FindMappedElementByChoiceName(string, bool)` remains.

## Test plan
- [x] `dotnet build Hl7.Fhir.sln` — clean
- [x] `Hl7.Fhir.Support.Poco.Tests` — 595/595 passed (incl. new tests: strict overflow preservation with single-error assertion, lenient choice-prefix binding, resourceType strict binding, `Enforcing()` opt-in strict binding in Recoverable, dictionary-key detection for plain and choice names)
- [x] `Hl7.Fhir.Serialization.R4.Tests` — 16234/16234 passed (roundtrip corpus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
