### PR TITLE
Remove redundant null-checks and initialization logic from `setLink` method

### DIFF
--- a/src/Hl7.Fhir.Base/Model/Bundle.cs
+++ b/src/Hl7.Fhir.Base/Model/Bundle.cs
@@ -118,10 +118,6 @@ namespace Hl7.Fhir.Model
 
         private void setLink(string rel, Uri? uri)
         {
-            if (uri is null) throw new ArgumentNullException(nameof(uri));
-
-            if (Link == null) Link = new List<LinkComponent>();
-
             var entry = Link.FirstOrDefault(e => rel.Equals(e.Relation, StringComparison.OrdinalIgnoreCase));
 
             // Setting the link to null removes the entry


### PR DESCRIPTION
## Description
Stumbled on the logic when using the `Bundle.SelfLink` etc. helpers. Property claims the value is nullable, but it would throw `ArgumentNullException`. Then later down the code we had logic for actually removing the entry if the value is null.