### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/AddIssuesToProject.yml
+++ b/.github/workflows/AddIssuesToProject.yml
@@ -5,6 +5,10 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   add-to-project:
     name: Add issue to project


### PR DESCRIPTION
Potential fix for [https://github.com/FirelyTeam/firely-net-sdk/security/code-scanning/1](https://github.com/FirelyTeam/firely-net-sdk/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is constrained by default.  
Best single fix without changing functionality: define permissions at the workflow root (applies to all jobs unless overridden). For this workflow, minimal safe baseline is:

- `contents: read` (common read access for repository metadata/content)
- `issues: write` (the job handles issue-triggered/project assignment behavior)

Edit **`.github/workflows/AddIssuesToProject.yml`** by inserting the `permissions` block between the `on:` trigger section and `jobs:`.

No imports, methods, or external definitions are needed (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
