### PR TITLE
Retain XML comments in the POCO-based parser

### DIFF
--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
@@ -83,7 +83,7 @@ public class BaseFhirXmlDeserializer
     /// <remarks>The <see cref="ParserSettings.ExceptionFilter"/> influences which issues are returned.</remarks>
     public bool TryDeserializeResource(XmlReader reader, [NotNullWhen(true)] out Resource? instance, out IEnumerable<CodedException> issues)
     {
-        PocoDeserializerState state = new() { Comments = Settings.RetainComments ? new() : null };
+        var state = createState();
 
         // If the stream has just been opened, move to the first token. (skip processing instructions, comments, whitespaces etc.)
         reader.MoveToContent(state);
@@ -95,7 +95,7 @@ public class BaseFhirXmlDeserializer
 
         // Whatever is left after the root element has been read are the comments trailing the document.
         if (instance is not null)
-            addSourceComments(instance, documentEnd: state.Comments?.Take());
+            addSourceComments(instance, documentEnd: state.Comments?.Consume());
 
         issues = Settings.ExceptionFilter is { } filter
             ? state.Errors.Remove(filter)
@@ -115,7 +115,7 @@ public class BaseFhirXmlDeserializer
     /// <remarks>The <see cref="ParserSettings.ExceptionFilter"/> influences which issues are returned.</remarks>
     public bool TryDeserializeElement(Type targetType, XmlReader reader, [NotNullWhen(true)] out Base? instance, out IEnumerable<CodedException> issues)
     {
-        PocoDeserializerState state = new() { Comments = Settings.RetainComments ? new() : null };
+        var state = createState();
 
         // If the stream has just been opened, move to the first token. (skip processing instructions, comments, whitespaces etc.)
         reader.MoveToContent(state);
@@ -126,7 +126,7 @@ public class BaseFhirXmlDeserializer
         instance = DeserializeElementInternal(targetType, reader, state);
 
         // Whatever is left after the root element has been read are the comments trailing the document.
-        addSourceComments(instance, documentEnd: state.Comments?.Take());
+        addSourceComments(instance, documentEnd: state.Comments?.Consume());
 
         issues = Settings.ExceptionFilter is { } filter
             ? state.Errors.Remove(filter)
@@ -134,6 +134,8 @@ public class BaseFhirXmlDeserializer
 
         return !issues.Any();
     }
+
+    private PocoDeserializerState createState() => new() { Comments = Settings.RetainComments ? new() : null };
 
     internal Resource? DeserializeResourceInternal(XmlReader reader, PocoDeserializerState state)
     {
@@ -203,7 +205,7 @@ public class BaseFhirXmlDeserializer
         var hasValueAttribute = reader.GetAttribute("value") != null;
 
         // The comments collected since the previous element was closed are the ones preceding this element.
-        var commentsBefore = state.Comments?.Take();
+        var commentsBefore = state.Comments?.Consume();
 
         if (Settings.AnnotateLineInfo)
             target.AddAnnotation(new XmlSerializationDetails { LineNumber = lineNumber, LinePosition = position });
@@ -252,7 +254,7 @@ public class BaseFhirXmlDeserializer
             // We are on the closing tag now, so anything collected after the last child closes this element.
             // This has to be taken here, before the read at the end of this method moves past the closing tag
             // and starts collecting the comments that precede our next sibling.
-            closingComments = state.Comments?.Take();
+            closingComments = state.Comments?.Consume();
         }
 
         addSourceComments(target, commentsBefore, closingComments);
@@ -426,7 +428,7 @@ public class BaseFhirXmlDeserializer
 
             // Take the comments preceding the xhtml before reading on: readXhtml() moves past the div,
             // and the comments it collects while doing so belong to whatever comes after it.
-            var commentsBefore = state.Comments?.Take();
+            var commentsBefore = state.Comments?.Consume();
 
             var xhtml = readXhtml(reader, state);
             if (Settings.AnnotateLineInfo)
@@ -467,7 +469,7 @@ public class BaseFhirXmlDeserializer
 
             // Comments between the resource and the closing tag of its container would otherwise leak into
             // the element following the container, so treat them as closing the resource itself.
-            if (state.Comments?.Take() is { } trailing && result.Count > 0)
+            if (state.Comments?.Consume() is { } trailing && result.Count > 0)
                 addSourceComments(result[^1], closing: trailing);
         }
 

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
@@ -83,10 +83,10 @@ public class BaseFhirXmlDeserializer
     /// <remarks>The <see cref="ParserSettings.ExceptionFilter"/> influences which issues are returned.</remarks>
     public bool TryDeserializeResource(XmlReader reader, [NotNullWhen(true)] out Resource? instance, out IEnumerable<CodedException> issues)
     {
-        PocoDeserializerState state = new() { RetainComments = Settings.RetainComments };
+        PocoDeserializerState state = new() { Comments = Settings.RetainComments ? new() : null };
 
         // If the stream has just been opened, move to the first token. (skip processing instructions, comments, whitespaces etc.)
-        reader.MoveToContentCapturingComments(state);
+        reader.MoveToContent(state);
 
         if (reader.Settings is not null && reader.Settings.DtdProcessing != DtdProcessing.Prohibit)
             reader.Settings.DtdProcessing = DtdProcessing.Prohibit;
@@ -95,7 +95,7 @@ public class BaseFhirXmlDeserializer
 
         // Whatever is left after the root element has been read are the comments trailing the document.
         if (instance is not null)
-            addSourceComments(instance, documentEnd: state.TakePendingComments());
+            addSourceComments(instance, documentEnd: state.Comments?.Take());
 
         issues = Settings.ExceptionFilter is { } filter
             ? state.Errors.Remove(filter)
@@ -115,10 +115,10 @@ public class BaseFhirXmlDeserializer
     /// <remarks>The <see cref="ParserSettings.ExceptionFilter"/> influences which issues are returned.</remarks>
     public bool TryDeserializeElement(Type targetType, XmlReader reader, [NotNullWhen(true)] out Base? instance, out IEnumerable<CodedException> issues)
     {
-        PocoDeserializerState state = new() { RetainComments = Settings.RetainComments };
+        PocoDeserializerState state = new() { Comments = Settings.RetainComments ? new() : null };
 
         // If the stream has just been opened, move to the first token. (skip processing instructions, comments, whitespaces etc.)
-        reader.MoveToContentCapturingComments(state);
+        reader.MoveToContent(state);
 
         if (reader.Settings is not null && reader.Settings.DtdProcessing != DtdProcessing.Prohibit)
             reader.Settings.DtdProcessing = DtdProcessing.Prohibit;
@@ -126,7 +126,7 @@ public class BaseFhirXmlDeserializer
         instance = DeserializeElementInternal(targetType, reader, state);
 
         // Whatever is left after the root element has been read are the comments trailing the document.
-        addSourceComments(instance, documentEnd: state.TakePendingComments());
+        addSourceComments(instance, documentEnd: state.Comments?.Take());
 
         issues = Settings.ExceptionFilter is { } filter
             ? state.Errors.Remove(filter)
@@ -203,7 +203,7 @@ public class BaseFhirXmlDeserializer
         var hasValueAttribute = reader.GetAttribute("value") != null;
 
         // The comments collected since the previous element was closed are the ones preceding this element.
-        var commentsBefore = state.TakePendingComments();
+        var commentsBefore = state.Comments?.Take();
 
         if (Settings.AnnotateLineInfo)
             target.AddAnnotation(new XmlSerializationDetails { LineNumber = lineNumber, LinePosition = position });
@@ -252,7 +252,7 @@ public class BaseFhirXmlDeserializer
             // We are on the closing tag now, so anything collected after the last child closes this element.
             // This has to be taken here, before the read at the end of this method moves past the closing tag
             // and starts collecting the comments that precede our next sibling.
-            closingComments = state.TakePendingComments();
+            closingComments = state.Comments?.Take();
         }
 
         addSourceComments(target, commentsBefore, closingComments);
@@ -368,7 +368,7 @@ public class BaseFhirXmlDeserializer
     private static XHtml readXhtml(XmlReader reader, PocoDeserializerState state)
     {
         var xhtml = reader.ReadOuterXml();
-        reader.MoveToContentCapturingComments(state);
+        reader.MoveToContent(state);
         return new XHtml(xhtml);
     }
 
@@ -426,7 +426,7 @@ public class BaseFhirXmlDeserializer
 
             // Take the comments preceding the xhtml before reading on: readXhtml() moves past the div,
             // and the comments it collects while doing so belong to whatever comes after it.
-            var commentsBefore = state.TakePendingComments();
+            var commentsBefore = state.Comments?.Take();
 
             var xhtml = readXhtml(reader, state);
             if (Settings.AnnotateLineInfo)
@@ -467,7 +467,7 @@ public class BaseFhirXmlDeserializer
 
             // Comments between the resource and the closing tag of its container would otherwise leak into
             // the element following the container, so treat them as closing the resource itself.
-            if (state.TakePendingComments() is { } trailing && result.Count > 0)
+            if (state.Comments?.Take() is { } trailing && result.Count > 0)
                 addSourceComments(result[^1], closing: trailing);
         }
 

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlDeserializer.cs
@@ -83,15 +83,20 @@ public class BaseFhirXmlDeserializer
     /// <remarks>The <see cref="ParserSettings.ExceptionFilter"/> influences which issues are returned.</remarks>
     public bool TryDeserializeResource(XmlReader reader, [NotNullWhen(true)] out Resource? instance, out IEnumerable<CodedException> issues)
     {
-        PocoDeserializerState state = new();
+        PocoDeserializerState state = new() { RetainComments = Settings.RetainComments };
 
         // If the stream has just been opened, move to the first token. (skip processing instructions, comments, whitespaces etc.)
-        reader.MoveToContent();
+        reader.MoveToContentCapturingComments(state);
 
         if (reader.Settings is not null && reader.Settings.DtdProcessing != DtdProcessing.Prohibit)
             reader.Settings.DtdProcessing = DtdProcessing.Prohibit;
 
         instance = DeserializeResourceInternal(reader, state);
+
+        // Whatever is left after the root element has been read are the comments trailing the document.
+        if (instance is not null)
+            addSourceComments(instance, documentEnd: state.TakePendingComments());
+
         issues = Settings.ExceptionFilter is { } filter
             ? state.Errors.Remove(filter)
             : state.Errors;
@@ -110,15 +115,19 @@ public class BaseFhirXmlDeserializer
     /// <remarks>The <see cref="ParserSettings.ExceptionFilter"/> influences which issues are returned.</remarks>
     public bool TryDeserializeElement(Type targetType, XmlReader reader, [NotNullWhen(true)] out Base? instance, out IEnumerable<CodedException> issues)
     {
-        PocoDeserializerState state = new();
+        PocoDeserializerState state = new() { RetainComments = Settings.RetainComments };
 
         // If the stream has just been opened, move to the first token. (skip processing instructions, comments, whitespaces etc.)
-        reader.MoveToContent();
+        reader.MoveToContentCapturingComments(state);
 
         if (reader.Settings is not null && reader.Settings.DtdProcessing != DtdProcessing.Prohibit)
             reader.Settings.DtdProcessing = DtdProcessing.Prohibit;
 
         instance = DeserializeElementInternal(targetType, reader, state);
+
+        // Whatever is left after the root element has been read are the comments trailing the document.
+        addSourceComments(instance, documentEnd: state.TakePendingComments());
+
         issues = Settings.ExceptionFilter is { } filter
             ? state.Errors.Remove(filter)
             : state.Errors;
@@ -192,7 +201,10 @@ public class BaseFhirXmlDeserializer
     {
         var (lineNumber, position) = reader.GenerateLineInfo();
         var hasValueAttribute = reader.GetAttribute("value") != null;
-        
+
+        // The comments collected since the previous element was closed are the ones preceding this element.
+        var commentsBefore = state.TakePendingComments();
+
         if (Settings.AnnotateLineInfo)
             target.AddAnnotation(new XmlSerializationDetails { LineNumber = lineNumber, LinePosition = position });
 
@@ -202,6 +214,8 @@ public class BaseFhirXmlDeserializer
         validateNameSpace(reader, state);
 
         readAttributes(target, mapping, reader, state);
+
+        string[]? closingComments = null;
 
         //Empty elements have no children e.g. <foo value="bar/>)
         if (!reader.IsEmptyElement)
@@ -234,7 +248,14 @@ public class BaseFhirXmlDeserializer
                         state.ExitElement();
                 }
             }
+
+            // We are on the closing tag now, so anything collected after the last child closes this element.
+            // This has to be taken here, before the read at the end of this method moves past the closing tag
+            // and starts collecting the comments that precede our next sibling.
+            closingComments = state.TakePendingComments();
         }
+
+        addSourceComments(target, commentsBefore, closingComments);
 
         if (Settings.Validator is not null)
         {
@@ -344,11 +365,37 @@ public class BaseFhirXmlDeserializer
         return result;
     }
 
-    private static XHtml readXhtml(XmlReader reader)
+    private static XHtml readXhtml(XmlReader reader, PocoDeserializerState state)
     {
         var xhtml = reader.ReadOuterXml();
-        reader.MoveToContent();
+        reader.MoveToContentCapturingComments(state);
         return new XHtml(xhtml);
+    }
+
+    /// <summary>
+    /// Annotates the comments found around <paramref name="target"/> in the source data onto it, merging
+    /// them into the annotation when one is already present.
+    /// </summary>
+    /// <remarks>Only used when <see cref="DeserializerSettings.RetainComments"/> is on - without it there
+    /// are no comments to annotate, since none are collected.</remarks>
+    private static void addSourceComments(Base? target, string[]? before = null, string[]? closing = null, string[]? documentEnd = null)
+    {
+        if (target is null || (before is null && closing is null && documentEnd is null)) return;
+
+        var comments = target.Annotation<SourceComments>();
+
+        if (comments is null)
+        {
+            comments = new SourceComments();
+            target.AddAnnotation(comments);
+        }
+
+        if (before is not null) comments.CommentsBefore = combine(comments.CommentsBefore, before);
+        if (closing is not null) comments.ClosingComments = combine(comments.ClosingComments, closing);
+        if (documentEnd is not null) comments.DocumentEndComments = combine(comments.DocumentEndComments, documentEnd);
+
+        static string[] combine(string[]? existing, string[] added) =>
+            existing is not { Length: > 0 } ? added : [.. existing, .. added];
     }
 
     private static void addToList(IList target, object oneOrMoreThings)
@@ -377,10 +424,16 @@ public class BaseFhirXmlDeserializer
                 state.Errors.Add(ERR.INCORRECT_XHTML_NAMESPACE(reader, state.Path.GetInstancePath()));
             }
 
-            var xhtml = readXhtml(reader);
+            // Take the comments preceding the xhtml before reading on: readXhtml() moves past the div,
+            // and the comments it collects while doing so belong to whatever comes after it.
+            var commentsBefore = state.TakePendingComments();
+
+            var xhtml = readXhtml(reader, state);
             if (Settings.AnnotateLineInfo)
                 xhtml.AddAnnotation(new XmlSerializationDetails { LineNumber = lineNumber, LinePosition = position });
-            
+
+            addSourceComments(xhtml, commentsBefore);
+
             return [xhtml];
         }
 
@@ -411,6 +464,11 @@ public class BaseFhirXmlDeserializer
                 var containedResource = DeserializeResourceInternal(reader, state);
                 if(containedResource is not null) result.Add(containedResource);
             }
+
+            // Comments between the resource and the closing tag of its container would otherwise leak into
+            // the element following the container, so treat them as closing the resource itself.
+            if (state.TakePendingComments() is { } trailing && result.Count > 0)
+                addSourceComments(result[^1], closing: trailing);
         }
 
         switch (result.Count)

--- a/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlSerializer.cs
+++ b/src/Hl7.Fhir.Base/Serialization/BaseFhirXmlSerializer.cs
@@ -51,7 +51,13 @@ public class BaseFhirXmlSerializer(ModelInspector inspector)
         if (filter is not null)
             instance = SerializationUtil.MakeSubsettedClone(instance);
 
+        // Comments around the root element are not written by the loop over the members (there is no
+        // parent element to write them into), so they are handled here.
+        var rootComments = instance.Annotation<SourceComments>();
+
         writer.WriteStartDocument();
+
+        writeComments(rootComments?.CommentsBefore, writer);
 
         // Wrap the instance with a named element if either a root name is given,
         // or we are serializing a datatype (=a subtree).
@@ -63,6 +69,12 @@ public class BaseFhirXmlSerializer(ModelInspector inspector)
         serializeInternal(instance, writer, filter);
 
         if (rootName is not null) writer.WriteEndElement();
+
+        // Only write these once the root element is actually closed - for a datatype without a root name
+        // the wrapping element above is left open for WriteEndDocument() to close.
+        if (rootName is not null || instance is Resource)
+            writeComments(rootComments?.DocumentEndComments, writer);
+
         writer.WriteEndDocument();
     }
 
@@ -138,6 +150,24 @@ public class BaseFhirXmlSerializer(ModelInspector inspector)
 
             filter?.LeaveMember(mKey, serializeValue, propertyMapping);
         }
+
+        // Comments that were the last content of this element in the source data. Written after the children,
+        // so they end up just before the closing tag written by our caller.
+        writeComments(element.Annotation<SourceComments>()?.ClosingComments, writer);
+    }
+
+    /// <summary>
+    /// Writes the comments retained from the source data (see <see cref="DeserializerSettings.RetainComments"/>).
+    /// </summary>
+    /// <remarks>May only be called when the writer is not writing the attributes of a start tag: a comment
+    /// cannot be written into a start tag. Since a comment is only ever annotated onto an element that was
+    /// itself serialized as an element, that is guaranteed by writing them at the element branches only.</remarks>
+    private static void writeComments(string[]? comments, XmlWriter writer)
+    {
+        if (comments is null) return;
+
+        foreach (var comment in comments)
+            writer.WriteComment(comment);
     }
 
     private static string addSuffixToElementName(string elementName, object? elementValue)
@@ -163,9 +193,11 @@ public class BaseFhirXmlSerializer(ModelInspector inspector)
             case null:
                 break;  // In error situations there may be a null in a list, just don't serialize it.
             case XHtml xhtml:
+                writeComments(xhtml.Annotation<SourceComments>()?.CommentsBefore, writer);
                 writer.WriteRaw(xhtml.Value ?? "");
                 break;
             case Base complex:
+                writeComments(complex.Annotation<SourceComments>()?.CommentsBefore, writer);
                 writer.WriteStartElement(elementName, XmlNs.FHIR);
                 serializeInternal(complex, writer, filter);
                 writer.WriteEndElement();

--- a/src/Hl7.Fhir.Base/Serialization/DeserializerSettings.cs
+++ b/src/Hl7.Fhir.Base/Serialization/DeserializerSettings.cs
@@ -109,6 +109,27 @@ public record DeserializerSettings
     public bool AnnotateLineInfo { get; init; } = false;
 
     /// <summary>
+    /// Retain the comments found in the source data as <see cref="SourceComments"/> annotations on the parsed
+    /// POCOs, so <see cref="BaseFhirXmlSerializer"/> can write them out again.
+    /// </summary>
+    /// <remarks>
+    /// <para>This setting is only used by the Xml deserializers - FHIR Json has no comments.</para>
+    /// <para>Comments are annotated on the POCO for the element they precede (<see cref="SourceComments.CommentsBefore"/>),
+    /// on the POCO of the element they are the last content of (<see cref="SourceComments.ClosingComments"/>), and,
+    /// for comments trailing the root element, on the root POCO (<see cref="SourceComments.DocumentEndComments"/>).</para>
+    /// <para>Since this adds an annotation to every element that is preceded or closed by a comment, it costs
+    /// memory, which is why it is off by default.</para>
+    /// <para>When you pass in your own <see cref="System.Xml.XmlReader"/>, this setting can only do its work if
+    /// that reader reports comments: a reader created with <c>XmlReaderSettings.IgnoreComments</c> (which is what
+    /// <see cref="SerializationUtil.WrapXmlReader"/> and friends do by default) filters them out before the
+    /// deserializer can see them. The overloads that take a string handle this for you.</para>
+    /// <para>Two caveats when roundtripping: comments between a resource container (e.g. <c>contained</c>) and the
+    /// resource element within it are written back out before the container, and comments are lost when serializing
+    /// with a summary filter, since the subsetted clone that is made for it does not carry annotations.</para>
+    /// </remarks>
+    public bool RetainComments { get; init; } = false;
+
+    /// <summary>
     /// For performance reasons, validation of Xhtml again the rules specified in the FHIR
     /// specification for Narrative (http://hl7.org/fhir/narrative.html#2.4.0) is turned off by
     /// default. Set this property to any other value than <see cref="None{T}"/>

--- a/src/Hl7.Fhir.Base/Serialization/PocoDeserializationExtensions.cs
+++ b/src/Hl7.Fhir.Base/Serialization/PocoDeserializationExtensions.cs
@@ -42,7 +42,7 @@ public static class PocoDeserializationExtensions
     /// <returns>A fully initialized POCO with the data from the reader.</returns>
     public static Resource DeserializeResource(this BaseFhirXmlDeserializer deserializer, string xml)
     {
-        using var xmlReader = SerializationUtil.XmlReaderFromXmlText(xml);
+        using var xmlReader = SerializationUtil.XmlReaderFromXmlText(xml, ignoreComments: !deserializer.Settings.RetainComments);
         return deserializer.DeserializeResource(xmlReader);
     }
 
@@ -59,7 +59,7 @@ public static class PocoDeserializationExtensions
 
     public static Base DeserializeElement(this BaseFhirXmlDeserializer deserializer, Type targetType, string xml)
     {
-        using var reader = SerializationUtil.XmlReaderFromXmlText(xml);
+        using var reader = SerializationUtil.XmlReaderFromXmlText(xml, ignoreComments: !deserializer.Settings.RetainComments);
         return deserializer.DeserializeElement(targetType, reader);
     }
 
@@ -85,7 +85,7 @@ public static class PocoDeserializationExtensions
     public static T Deserialize<T>(this BaseFhirXmlDeserializer deserializer, string xml) where T : Base
 
     {
-        using var reader = SerializationUtil.XmlReaderFromXmlText(xml);
+        using var reader = SerializationUtil.XmlReaderFromXmlText(xml, ignoreComments: !deserializer.Settings.RetainComments);
         return Deserialize<T>(deserializer, reader);
     }
 
@@ -103,7 +103,7 @@ public static class PocoDeserializationExtensions
         [NotNullWhen(true)] out Resource? instance,
         out IEnumerable<CodedException> issues)
     {
-        using var xmlReader = SerializationUtil.XmlReaderFromXmlText(data);
+        using var xmlReader = SerializationUtil.XmlReaderFromXmlText(data, ignoreComments: !deserializer.Settings.RetainComments);
         return deserializer.TryDeserializeResource(xmlReader, out instance, out issues);
     }
 

--- a/src/Hl7.Fhir.Base/Serialization/PocoDeserializationExtensions.cs
+++ b/src/Hl7.Fhir.Base/Serialization/PocoDeserializationExtensions.cs
@@ -24,6 +24,11 @@ namespace Hl7.Fhir.Serialization;
 /// </summary>
 public static class PocoDeserializationExtensions
 {
+    // Comments are only reported by the reader when DeserializerSettings.RetainComments asks for them -
+    // otherwise the reader drops them before the deserializer ever sees them, same as before that setting existed.
+    private static XmlReader createReader(BaseFhirXmlDeserializer deserializer, string xml) =>
+        SerializationUtil.XmlReaderFromXmlText(xml, ignoreComments: !deserializer.Settings.RetainComments);
+
     /// <summary>
     /// Deserialize the FHIR xml from the reader and create a new POCO resource containing the data from the reader.
     /// </summary>
@@ -42,7 +47,7 @@ public static class PocoDeserializationExtensions
     /// <returns>A fully initialized POCO with the data from the reader.</returns>
     public static Resource DeserializeResource(this BaseFhirXmlDeserializer deserializer, string xml)
     {
-        using var xmlReader = SerializationUtil.XmlReaderFromXmlText(xml, ignoreComments: !deserializer.Settings.RetainComments);
+        using var xmlReader = createReader(deserializer, xml);
         return deserializer.DeserializeResource(xmlReader);
     }
 
@@ -59,7 +64,7 @@ public static class PocoDeserializationExtensions
 
     public static Base DeserializeElement(this BaseFhirXmlDeserializer deserializer, Type targetType, string xml)
     {
-        using var reader = SerializationUtil.XmlReaderFromXmlText(xml, ignoreComments: !deserializer.Settings.RetainComments);
+        using var reader = createReader(deserializer, xml);
         return deserializer.DeserializeElement(targetType, reader);
     }
 
@@ -85,7 +90,7 @@ public static class PocoDeserializationExtensions
     public static T Deserialize<T>(this BaseFhirXmlDeserializer deserializer, string xml) where T : Base
 
     {
-        using var reader = SerializationUtil.XmlReaderFromXmlText(xml, ignoreComments: !deserializer.Settings.RetainComments);
+        using var reader = createReader(deserializer, xml);
         return Deserialize<T>(deserializer, reader);
     }
 
@@ -103,7 +108,7 @@ public static class PocoDeserializationExtensions
         [NotNullWhen(true)] out Resource? instance,
         out IEnumerable<CodedException> issues)
     {
-        using var xmlReader = SerializationUtil.XmlReaderFromXmlText(data, ignoreComments: !deserializer.Settings.RetainComments);
+        using var xmlReader = createReader(deserializer, data);
         return deserializer.TryDeserializeResource(xmlReader, out instance, out issues);
     }
 

--- a/src/Hl7.Fhir.Base/Serialization/PocoDeserializerState.cs
+++ b/src/Hl7.Fhir.Base/Serialization/PocoDeserializerState.cs
@@ -19,39 +19,11 @@ internal class PocoDeserializerState
     public PathPart Path { get; internal set; } = new RootPathPart();
 
     /// <summary>
-    /// Whether comments encountered in the source data are collected, so they can be retained as
-    /// <see cref="SourceComments"/> annotations on the POCOs. See <see cref="DeserializerSettings.RetainComments"/>.
+    /// Collects the comments encountered while advancing the reader, or <c>null</c> when
+    /// <see cref="DeserializerSettings.RetainComments"/> is off, so every use of it (<c>state.Comments?.…</c>)
+    /// is a no-op in the default case.
     /// </summary>
-    public bool RetainComments { get; init; }
-
-    private List<string>? _pendingComments;
-
-    /// <summary>
-    /// Records a comment encountered while moving the reader forward.
-    /// </summary>
-    /// <remarks>Comments are buffered until a consumer takes them: which comments belong to which POCO
-    /// only becomes clear once the reader has arrived at the next node. Every buffered comment must be
-    /// taken by exactly one consumer (see <see cref="TakePendingComments"/>), otherwise it will leak
-    /// forward and end up annotated on an unrelated element.</remarks>
-    public void AddComment(string comment)
-    {
-        if (!RetainComments) return;
-
-        (_pendingComments ??= []).Add(comment);
-    }
-
-    /// <summary>
-    /// Returns the comments buffered since the previous call and clears the buffer, or <c>null</c> when
-    /// no comments were encountered.
-    /// </summary>
-    public string[]? TakePendingComments()
-    {
-        if (_pendingComments is not { Count: > 0 }) return null;
-
-        var result = _pendingComments.ToArray();
-        _pendingComments.Clear();
-        return result;
-    }
+    public SourceCommentCollector? Comments { get; init; }
 
     private readonly Stack<BaseFhirJsonDeserializer.ObjectParsingState> objectContext = new();
 

--- a/src/Hl7.Fhir.Base/Serialization/PocoDeserializerState.cs
+++ b/src/Hl7.Fhir.Base/Serialization/PocoDeserializerState.cs
@@ -18,6 +18,41 @@ internal class PocoDeserializerState
 
     public PathPart Path { get; internal set; } = new RootPathPart();
 
+    /// <summary>
+    /// Whether comments encountered in the source data are collected, so they can be retained as
+    /// <see cref="SourceComments"/> annotations on the POCOs. See <see cref="DeserializerSettings.RetainComments"/>.
+    /// </summary>
+    public bool RetainComments { get; init; }
+
+    private List<string>? _pendingComments;
+
+    /// <summary>
+    /// Records a comment encountered while moving the reader forward.
+    /// </summary>
+    /// <remarks>Comments are buffered until a consumer takes them: which comments belong to which POCO
+    /// only becomes clear once the reader has arrived at the next node. Every buffered comment must be
+    /// taken by exactly one consumer (see <see cref="TakePendingComments"/>), otherwise it will leak
+    /// forward and end up annotated on an unrelated element.</remarks>
+    public void AddComment(string comment)
+    {
+        if (!RetainComments) return;
+
+        (_pendingComments ??= []).Add(comment);
+    }
+
+    /// <summary>
+    /// Returns the comments buffered since the previous call and clears the buffer, or <c>null</c> when
+    /// no comments were encountered.
+    /// </summary>
+    public string[]? TakePendingComments()
+    {
+        if (_pendingComments is not { Count: > 0 }) return null;
+
+        var result = _pendingComments.ToArray();
+        _pendingComments.Clear();
+        return result;
+    }
+
     private readonly Stack<BaseFhirJsonDeserializer.ObjectParsingState> objectContext = new();
 
     public void EnterObjectContext() =>

--- a/src/Hl7.Fhir.Base/Serialization/SourceCommentCollector.cs
+++ b/src/Hl7.Fhir.Base/Serialization/SourceCommentCollector.cs
@@ -19,8 +19,8 @@ namespace Hl7.Fhir.Serialization;
 /// </summary>
 /// <remarks>A <see cref="PocoDeserializerState"/> only has one of these when <see cref="DeserializerSettings.RetainComments"/>
 /// is set, so every call site that touches it does so through <c>state.Comments?.…</c> and is a no-op otherwise.
-/// Every comment added here must be taken by exactly one caller (see <see cref="Take"/>) - one that
-/// is never taken leaks forward and ends up annotated on whichever element happens to take next.</remarks>
+/// Every comment added here must be consumed by exactly one caller (see <see cref="Consume"/>) - one that
+/// is never consumed leaks forward and ends up annotated on whichever element happens to consume next.</remarks>
 internal sealed class SourceCommentCollector
 {
     private List<string>? _pending;
@@ -31,7 +31,7 @@ internal sealed class SourceCommentCollector
     /// Returns the comments buffered since the previous call and clears the buffer, or <c>null</c> when
     /// no comments were encountered.
     /// </summary>
-    public string[]? Take()
+    public string[]? Consume()
     {
         if (_pending is not { Count: > 0 }) return null;
 

--- a/src/Hl7.Fhir.Base/Serialization/SourceCommentCollector.cs
+++ b/src/Hl7.Fhir.Base/Serialization/SourceCommentCollector.cs
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace Hl7.Fhir.Serialization;
+
+/// <summary>
+/// Buffers the comments encountered while advancing an <see cref="System.Xml.XmlReader"/>, so they can
+/// be attached as a <see cref="SourceComments"/> annotation once it becomes clear which element they
+/// belong to. See <see cref="DeserializerSettings.RetainComments"/>.
+/// </summary>
+/// <remarks>A <see cref="PocoDeserializerState"/> only has one of these when <see cref="DeserializerSettings.RetainComments"/>
+/// is set, so every call site that touches it does so through <c>state.Comments?.…</c> and is a no-op otherwise.
+/// Every comment added here must be taken by exactly one caller (see <see cref="Take"/>) - one that
+/// is never taken leaks forward and ends up annotated on whichever element happens to take next.</remarks>
+internal sealed class SourceCommentCollector
+{
+    private List<string>? _pending;
+
+    public void Add(string comment) => (_pending ??= []).Add(comment);
+
+    /// <summary>
+    /// Returns the comments buffered since the previous call and clears the buffer, or <c>null</c> when
+    /// no comments were encountered.
+    /// </summary>
+    public string[]? Take()
+    {
+        if (_pending is not { Count: > 0 }) return null;
+
+        var result = _pending.ToArray();
+        _pending.Clear();
+        return result;
+    }
+}

--- a/src/Hl7.Fhir.Base/Serialization/XmlReaderExtensions.cs
+++ b/src/Hl7.Fhir.Base/Serialization/XmlReaderExtensions.cs
@@ -44,12 +44,47 @@ internal static class XmlReaderExtensions
         {
             while (reader.ShouldSkipNodeType(state))
             {
+                if (reader.NodeType == XmlNodeType.Comment)
+                    state.AddComment(reader.Value);
+
                 reader.Skip();
             }
             return true;
         }
         return false;
     }
+
+    /// <summary>
+    /// Moves the reader to the next content node, like <see cref="XmlReader.MoveToContent"/> does, but collects
+    /// the comments encountered on the way into <paramref name="state"/> instead of silently skipping them.
+    /// </summary>
+    internal static void MoveToContentCapturingComments(this XmlReader reader, PocoDeserializerState state)
+    {
+        if (!state.RetainComments)
+        {
+            reader.MoveToContent();
+            return;
+        }
+
+        // Like MoveToContent(), move back to the owning element when positioned on an attribute.
+        if (reader.NodeType == XmlNodeType.Attribute)
+        {
+            reader.MoveToElement();
+            return;
+        }
+
+        // These are the node types MoveToContent() considers content and stops at. Since it skips the
+        // comments in between without reporting them, we have to walk to the next content node ourselves.
+        while (!reader.EOF && reader.NodeType is not (XmlNodeType.Element or XmlNodeType.EndElement
+                   or XmlNodeType.Text or XmlNodeType.CDATA or XmlNodeType.EntityReference or XmlNodeType.EndEntity))
+        {
+            if (reader.NodeType == XmlNodeType.Comment)
+                state.AddComment(reader.Value);
+
+            if (!reader.Read()) break;
+        }
+    }
+
     internal static bool ShouldSkipNodeType(this XmlReader reader, PocoDeserializerState state)
     {
         var nodeType = reader.NodeType;

--- a/src/Hl7.Fhir.Base/Serialization/XmlReaderExtensions.cs
+++ b/src/Hl7.Fhir.Base/Serialization/XmlReaderExtensions.cs
@@ -45,7 +45,7 @@ internal static class XmlReaderExtensions
             while (reader.ShouldSkipNodeType(state))
             {
                 if (reader.NodeType == XmlNodeType.Comment)
-                    state.AddComment(reader.Value);
+                    state.Comments?.Add(reader.Value);
 
                 reader.Skip();
             }
@@ -55,12 +55,14 @@ internal static class XmlReaderExtensions
     }
 
     /// <summary>
-    /// Moves the reader to the next content node, like <see cref="XmlReader.MoveToContent"/> does, but collects
-    /// the comments encountered on the way into <paramref name="state"/> instead of silently skipping them.
+    /// Moves the reader to the next content node, exactly like <see cref="XmlReader.MoveToContent"/> does.
     /// </summary>
-    internal static void MoveToContentCapturingComments(this XmlReader reader, PocoDeserializerState state)
+    /// <remarks>When <see cref="PocoDeserializerState.Comments"/> is set (see <see cref="DeserializerSettings.RetainComments"/>),
+    /// also collects the comments encountered on the way, which <see cref="XmlReader.MoveToContent"/> would
+    /// otherwise skip over unreported.</remarks>
+    internal static void MoveToContent(this XmlReader reader, PocoDeserializerState state)
     {
-        if (!state.RetainComments)
+        if (state.Comments is not { } comments)
         {
             reader.MoveToContent();
             return;
@@ -73,13 +75,12 @@ internal static class XmlReaderExtensions
             return;
         }
 
-        // These are the node types MoveToContent() considers content and stops at. Since it skips the
-        // comments in between without reporting them, we have to walk to the next content node ourselves.
+        // These are the node types MoveToContent() considers content and stops at.
         while (!reader.EOF && reader.NodeType is not (XmlNodeType.Element or XmlNodeType.EndElement
                    or XmlNodeType.Text or XmlNodeType.CDATA or XmlNodeType.EntityReference or XmlNodeType.EndEntity))
         {
             if (reader.NodeType == XmlNodeType.Comment)
-                state.AddComment(reader.Value);
+                comments.Add(reader.Value);
 
             if (!reader.Read()) break;
         }

--- a/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirXmlCommentsTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Serialization/FhirXmlCommentsTests.cs
@@ -1,0 +1,207 @@
+using FluentAssertions;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Hl7.Fhir.Tests;
+using Hl7.Fhir.Utility;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Hl7.Fhir.Support.Poco.Tests;
+
+[TestClass]
+public class FhirXmlCommentsTests
+{
+    private const string PATIENT_WITH_COMMENTS =
+        "<!--before root-->" +
+        "<Patient xmlns=\"http://hl7.org/fhir\">" +
+            "<!--before id-->" +
+            "<id value=\"pat1\" />" +
+            "<name>" +
+                "<family value=\"Doe\" />" +
+                "<!--closing name-->" +
+            "</name>" +
+            "<!--before second name-->" +
+            "<name>" +
+                "<family value=\"Roe\" />" +
+            "</name>" +
+            "<!--closing patient-->" +
+        "</Patient>" +
+        "<!--after root-->";
+
+    private static Patient parse(bool retainComments) =>
+        new FhirXmlDeserializer(new DeserializerSettings { RetainComments = retainComments })
+            .Deserialize<Patient>(PATIENT_WITH_COMMENTS);
+
+    private static string serialize(Base poco) =>
+        SerializationUtil.WriteXmlToString(w => new FhirXmlSerializer().Serialize(poco, w));
+
+    [TestMethod]
+    public void RetainsCommentsAsAnnotations()
+    {
+        var patient = parse(retainComments: true);
+
+        var onPatient = patient.Annotation<SourceComments>();
+        onPatient.Should().NotBeNull();
+        onPatient!.CommentsBefore.Should().Equal("before root");
+        onPatient.ClosingComments.Should().Equal("closing patient");
+        onPatient.DocumentEndComments.Should().Equal("after root");
+
+        // A comment preceding an element is annotated on the POCO for that element...
+        patient.IdElement.Annotation<SourceComments>()!.CommentsBefore.Should().Equal("before id");
+        patient.Name[1].Annotation<SourceComments>()!.CommentsBefore.Should().Equal("before second name");
+
+        // ...and a comment that is the last content of an element closes that element.
+        patient.Name[0].Annotation<SourceComments>()!.ClosingComments.Should().Equal("closing name");
+
+        // The comment closing the first name must not have leaked onto the element following it.
+        patient.Name[0].Annotation<SourceComments>()!.CommentsBefore.Should().BeNull();
+        patient.Name[1].Annotation<SourceComments>()!.ClosingComments.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void RetainedCommentsSurviveARoundtrip()
+    {
+        serialize(parse(retainComments: true)).Should().Be(PATIENT_WITH_COMMENTS);
+    }
+
+    [TestMethod]
+    public void DoesNotRetainCommentsByDefault()
+    {
+        var patient = parse(retainComments: false);
+
+        patient.Annotation<SourceComments>().Should().BeNull();
+        patient.IdElement.Annotation<SourceComments>().Should().BeNull();
+        patient.Name[0].Annotation<SourceComments>().Should().BeNull();
+
+        // Without the setting, the serialized form is unchanged from what it has always been.
+        serialize(patient).Should().Be(
+            "<Patient xmlns=\"http://hl7.org/fhir\">" +
+                "<id value=\"pat1\" />" +
+                "<name><family value=\"Doe\" /></name>" +
+                "<name><family value=\"Roe\" /></name>" +
+            "</Patient>");
+    }
+
+    [TestMethod]
+    public void WritesCommentsRetainedByTheLegacyParserToo()
+    {
+        // The serializer writes whatever SourceComments it finds, whoever put them there. The legacy
+        // ElementModel parser has always produced this annotation, so POCOs parsed that way roundtrip
+        // their comments through the new serializer as well - the same as they do through FhirXmlBuilder.
+        var poco = FhirXmlNode.Parse(PATIENT_WITH_COMMENTS).ToPoco<Patient>();
+
+        serialize(poco).Should().Be(PATIENT_WITH_COMMENTS);
+    }
+
+    [TestMethod]
+    public void RetainsEveryCommentOfTheEdgecasesFile()
+    {
+        // The hand-written cases above check placement; this checks the setting against a real file, both
+        // that it retains every comment in document order, and that it leaves the rest of the data alone.
+        var expected = File.ReadAllText(Path.Combine("TestData", "fp-test-patient.xml"));
+
+        // Ostrich, because this file deliberately contains data the validator objects to - the comments
+        // are what is under test here, not the validation.
+        var poco = new FhirXmlDeserializer(
+                new DeserializerSettings { RetainComments = true }.UsingMode(DeserializationMode.Ostrich))
+            .Deserialize<Patient>(expected);
+
+        var actual = serialize(poco);
+
+        commentsOf(actual).Should().Equal(commentsOf(expected));
+        XmlAssert.AreSame("edgecases", expected, actual, ignoreSchemaLocation: true);
+
+        static string[] commentsOf(string xml) =>
+            SerializationUtil.XDocumentFromXmlText(xml, ignoreComments: false)
+                .DescendantNodes().OfType<XComment>().Select(c => c.Value).ToArray();
+    }
+
+    [TestMethod]
+    public void RetainsCommentsThroughTheStringOverload()
+    {
+        // The overload that PocoSerializationEngine.DeserializeFromXml uses: it builds its own XmlReader,
+        // which has to be told not to drop the comments before the deserializer ever sees them.
+        var patient = (Patient)new FhirXmlDeserializer(new DeserializerSettings { RetainComments = true })
+            .DeserializeResource(PATIENT_WITH_COMMENTS);
+
+        patient.Annotation<SourceComments>()!.CommentsBefore.Should().Equal("before root");
+    }
+
+    [TestMethod]
+    public void DropsCommentsOnValuesWrittenAsAnAttribute()
+    {
+        // Extension.url is written as an attribute, but the source has it as an element, so a comment
+        // can end up annotated on a POCO that is serialized into a start tag - where a comment cannot go.
+        // Such a comment is dropped rather than corrupting the output.
+        const string xml =
+            "<Patient xmlns=\"http://hl7.org/fhir\">" +
+                "<extension>" +
+                    "<!--before url-->" +
+                    "<url value=\"http://example.org/x\" />" +
+                    "<valueString value=\"a\" />" +
+                "</extension>" +
+            "</Patient>";
+
+        var patient = new FhirXmlDeserializer(
+                new DeserializerSettings { RetainComments = true }.UsingMode(DeserializationMode.Ostrich))
+            .Deserialize<Patient>(xml);
+
+        patient.Extension[0].UrlElement.Annotation<SourceComments>()!.CommentsBefore.Should().Equal("before url");
+
+        serialize(patient).Should().Be(
+            "<Patient xmlns=\"http://hl7.org/fhir\">" +
+                "<extension url=\"http://example.org/x\">" +
+                    "<valueString value=\"a\" />" +
+                "</extension>" +
+            "</Patient>");
+    }
+
+    [TestMethod]
+    public void RetainsCommentsInNarrativeAndContainedResources()
+    {
+        const string xml =
+            "<Patient xmlns=\"http://hl7.org/fhir\">" +
+                "<text>" +
+                    "<status value=\"generated\" />" +
+                    "<!--before div-->" +
+                    "<div xmlns=\"http://www.w3.org/1999/xhtml\">Hi<!--in div--></div>" +
+                    "<!--closing text-->" +
+                "</text>" +
+                "<contained>" +
+                    "<!--before contained patient-->" +
+                    "<Patient><id value=\"c1\" /></Patient>" +
+                    "<!--after contained patient-->" +
+                "</contained>" +
+            "</Patient>";
+
+        var patient = new FhirXmlDeserializer(new DeserializerSettings { RetainComments = true })
+            .Deserialize<Patient>(xml);
+
+        patient.Text.Div.Should().Contain("<!--in div-->", because: "comments inside the narrative are part of its value");
+        patient.Text.DivElement.Annotation<SourceComments>()!.CommentsBefore.Should().Equal("before div");
+        patient.Text.Annotation<SourceComments>()!.ClosingComments.Should().Equal("closing text");
+
+        // Comments within a resource container are annotated on the resource itself, so they move out of
+        // the container when written back out. See DeserializerSettings.RetainComments.
+        var contained = patient.Contained[0];
+        contained.Annotation<SourceComments>()!.CommentsBefore.Should().Equal("before contained patient");
+        contained.Annotation<SourceComments>()!.ClosingComments.Should().Equal("after contained patient");
+
+        serialize(patient).Should().Be(
+            "<Patient xmlns=\"http://hl7.org/fhir\">" +
+                "<text>" +
+                    "<status value=\"generated\" />" +
+                    "<!--before div-->" +
+                    "<div xmlns=\"http://www.w3.org/1999/xhtml\">Hi<!--in div--></div>" +
+                    "<!--closing text-->" +
+                "</text>" +
+                "<!--before contained patient-->" +
+                "<contained>" +
+                    "<Patient><id value=\"c1\" /><!--after contained patient--></Patient>" +
+                "</contained>" +
+            "</Patient>");
+    }
+}


### PR DESCRIPTION
## Description

The POCO-based XML parser discarded the comments in the source document, where the legacy ElementModel parser retains them as a `SourceComments` annotation and `FhirXmlBuilder` writes them back out. Moving from the legacy parser to the POCO parser therefore lost every comment silently.

This adds an opt-in `DeserializerSettings.RetainComments` (default `false`, since it adds an annotation per commented element) that reuses the existing public `SourceComments` annotation, so both parsers produce the same shape.

## Related issues

Fixes #3561.