### PR TITLE
Remove allocations from ClassMapping hot path

### DIFF
--- a/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
@@ -187,54 +187,35 @@ public class ClassMapping(
     // This list is created lazily. This not only improves initial startup time of
     // applications but also ensures circular references between types will not cause loops.
     private PropertyMappingCollection? _mappings;
-    private readonly object _mappingsLock = new();
+    private object? _mappingsLock;
 
-    // Note: this member - like the other lazily initialized members below, and the equivalent
-    // members in PropertyMapping and PropertyMappingCollection - deliberately does not use
-    // LazyInitializer.EnsureInitialized(). Passing that a factory allocates a delegate on *every*
-    // access, including the warm path where the value has long been initialized, and these members
-    // are read per element on the (de)serialization path. (This only applies to factories that
-    // capture state or are instance method groups: a non-capturing lambda such as () => [] is
-    // cached by the compiler in a static field, so the LazyInitializer calls elsewhere in this
-    // assembly cost nothing per access and are left alone.)
+    // Note on the `_field ?? LazyInitializer.EnsureInitialized(...)` shape of this member, the
+    // other lazily initialized members below and the equivalents in PropertyMapping and
+    // PropertyMappingCollection: calling EnsureInitialized unconditionally would allocate its
+    // factory delegate on *every* access, including the warm path where the field has long been
+    // initialized, and these members are read per element on the (de)serialization path. The
+    // null-coalescing read short-circuits that: once the field is initialized, an access is an
+    // ordinary read that allocates nothing, and the factory delegate is only created on the
+    // once-only cold path. The ordinary read is enough because the runtime guarantees that
+    // object reference stores are release stores and that data-dependent reads are ordered, so a
+    // thread observing the field non-null also observes the fully initialized object; see
+    // https://github.com/dotnet/runtime/blob/main/docs/design/specs/Memory-model.md.
     //
-    // On the warm path all of these members are a single Volatile.Read, whose acquire semantics
-    // guarantee that a caller observing the field also observes the fully constructed object on
-    // weakly ordered architectures. The cold paths differ:
-    //
-    // This member builds the mutable collection that callers may manipulate through
-    // PropertyMappings, and it runs the (possibly user-supplied) property mapper to do so. Racing
-    // threads must therefore not each run the mapper and build their own copy - the lock, taken
-    // only until the field is first published, makes initialization run exactly once.
-    //
-    // The other lazy members (CreateInstance/CreateList below, and the equivalents in
-    // PropertyMapping and PropertyMappingCollection) have idempotent factories producing values
-    // that are never mutated afterwards, so they keep LazyInitializer's lock-free semantics
-    // instead: when threads race, the factory may run more than once, but only a single result is
-    // ever published (via Interlocked.CompareExchange) and every caller receives that one
-    // instance - a duplicate run is unobservable there.
-    private PropertyMappingCollection PropertyMappingsInternal
+    // This member uses the EnsureInitialized overload with a syncLock, so that the (possibly
+    // user-supplied) property mapper building this mutable collection runs exactly once. The other
+    // lazy members have idempotent factories whose results are never mutated afterwards, so they
+    // use the lock-free overload, where racing factories may run concurrently but only a single
+    // result is ever published and handed out.
+    private PropertyMappingCollection PropertyMappingsInternal =>
+        _mappings ?? LazyInitializer.EnsureInitialized(ref _mappings, ref _mappingsLock, createPropertyMappings)!;
+
+    private PropertyMappingCollection createPropertyMappings()
     {
-        get
-        {
-            return Volatile.Read(ref _mappings) ?? createCollection();
+        var properties = propertyMapper(this).ToList();
+        if(properties.FirstOrDefault(m => m.DeclaringClass != this) is {} errorMapping)
+            throw new InvalidOperationException($"PropertyMapping '{errorMapping.Name}' is already used for another ClassMapping '{errorMapping.DeclaringClass.Name}'.");
 
-            PropertyMappingCollection createCollection()
-            {
-                lock (_mappingsLock)
-                {
-                    if (_mappings is { } existing) return existing;
-
-                    var properties = propertyMapper(this).ToList();
-                    if(properties.FirstOrDefault(m => m.DeclaringClass != this) is {} errorMapping)
-                        throw new InvalidOperationException($"PropertyMapping '{errorMapping.Name}' is already used for another ClassMapping '{errorMapping.DeclaringClass.Name}'.");
-
-                    var created = new PropertyMappingCollection(properties);
-                    Volatile.Write(ref _mappings, created);
-                    return created;
-                }
-            }
-        }
+        return new PropertyMappingCollection(properties);
     }
 
     /// <summary>
@@ -390,16 +371,10 @@ public class ClassMapping(
     /// <remarks>If not set, the default constructor for the <see cref="NativeType"/> will be used.</remarks>
     public Base CreateInstance()
     {
-        var factory = Volatile.Read(ref _factory) ?? createFactory();
+        var factory = _factory ?? LazyInitializer.EnsureInitialized(ref _factory, NativeType.BuildFactoryMethod)!;
         var newInstance = factory();
         if (newInstance is IDynamicType idt) idt.DynamicTypeName = Name;
         return (Base)newInstance;
-
-        Func<object> createFactory()
-        {
-            var created = NativeType.BuildFactoryMethod();
-            return Interlocked.CompareExchange(ref _factory, created, null) ?? created;
-        }
     }
 
     private Func<object>? _factory;
@@ -410,14 +385,8 @@ public class ClassMapping(
     /// <remarks>If not set, the default List constructor for the <see cref="NativeType"/> will be used.</remarks>
     public IList CreateList()
     {
-        var factory = Volatile.Read(ref _listFactory) ?? createFactory();
+        var factory = _listFactory ?? LazyInitializer.EnsureInitialized(ref _listFactory, NativeType.BuildListFactoryMethod)!;
         return factory();
-
-        Func<IList> createFactory()
-        {
-            var created = NativeType.BuildListFactoryMethod();
-            return Interlocked.CompareExchange(ref _listFactory, created, null) ?? created;
-        }
     }
 
     private Func<IList>? _listFactory;

--- a/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
@@ -187,6 +187,7 @@ public class ClassMapping(
     // This list is created lazily. This not only improves initial startup time of
     // applications but also ensures circular references between types will not cause loops.
     private PropertyMappingCollection? _mappings;
+    private readonly object _mappingsLock = new();
 
     // Note: this member - like the other lazily initialized members below, and the equivalent
     // members in PropertyMapping and PropertyMappingCollection - deliberately does not use
@@ -197,11 +198,21 @@ public class ClassMapping(
     // cached by the compiler in a static field, so the LazyInitializer calls elsewhere in this
     // assembly cost nothing per access and are left alone.)
     //
-    // The pattern used instead has the same semantics as LazyInitializer for reference types: the
-    // factory may run more than once when threads race, but only a single instance is ever
-    // published and every caller receives that one instance. The Volatile.Read on the fast path
-    // provides the same acquire semantics, so a caller that observes the field also observes the
-    // fully constructed object on weakly ordered architectures.
+    // On the warm path all of these members are a single Volatile.Read, whose acquire semantics
+    // guarantee that a caller observing the field also observes the fully constructed object on
+    // weakly ordered architectures. The cold paths differ:
+    //
+    // This member builds the mutable collection that callers may manipulate through
+    // PropertyMappings, and it runs the (possibly user-supplied) property mapper to do so. Racing
+    // threads must therefore not each run the mapper and build their own copy - the lock, taken
+    // only until the field is first published, makes initialization run exactly once.
+    //
+    // The other lazy members (CreateInstance/CreateList below, and the equivalents in
+    // PropertyMapping and PropertyMappingCollection) have idempotent factories producing values
+    // that are never mutated afterwards, so they keep LazyInitializer's lock-free semantics
+    // instead: when threads race, the factory may run more than once, but only a single result is
+    // ever published (via Interlocked.CompareExchange) and every caller receives that one
+    // instance - a duplicate run is unobservable there.
     private PropertyMappingCollection PropertyMappingsInternal
     {
         get
@@ -210,12 +221,18 @@ public class ClassMapping(
 
             PropertyMappingCollection createCollection()
             {
-                var properties = propertyMapper(this).ToList();
-                if(properties.FirstOrDefault(m => m.DeclaringClass != this) is {} errorMapping)
-                    throw new InvalidOperationException($"PropertyMapping '{errorMapping.Name}' is already used for another ClassMapping '{errorMapping.DeclaringClass.Name}'.");
+                lock (_mappingsLock)
+                {
+                    if (_mappings is { } existing) return existing;
 
-                var created = new PropertyMappingCollection(properties);
-                return Interlocked.CompareExchange(ref _mappings, created, null) ?? created;
+                    var properties = propertyMapper(this).ToList();
+                    if(properties.FirstOrDefault(m => m.DeclaringClass != this) is {} errorMapping)
+                        throw new InvalidOperationException($"PropertyMapping '{errorMapping.Name}' is already used for another ClassMapping '{errorMapping.DeclaringClass.Name}'.");
+
+                    var created = new PropertyMappingCollection(properties);
+                    Volatile.Write(ref _mappings, created);
+                    return created;
+                }
             }
         }
     }

--- a/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/ClassMapping.cs
@@ -188,11 +188,25 @@ public class ClassMapping(
     // applications but also ensures circular references between types will not cause loops.
     private PropertyMappingCollection? _mappings;
 
+    // Note: this member - like the other lazily initialized members below, and the equivalent
+    // members in PropertyMapping and PropertyMappingCollection - deliberately does not use
+    // LazyInitializer.EnsureInitialized(). Passing that a factory allocates a delegate on *every*
+    // access, including the warm path where the value has long been initialized, and these members
+    // are read per element on the (de)serialization path. (This only applies to factories that
+    // capture state or are instance method groups: a non-capturing lambda such as () => [] is
+    // cached by the compiler in a static field, so the LazyInitializer calls elsewhere in this
+    // assembly cost nothing per access and are left alone.)
+    //
+    // The pattern used instead has the same semantics as LazyInitializer for reference types: the
+    // factory may run more than once when threads race, but only a single instance is ever
+    // published and every caller receives that one instance. The Volatile.Read on the fast path
+    // provides the same acquire semantics, so a caller that observes the field also observes the
+    // fully constructed object on weakly ordered architectures.
     private PropertyMappingCollection PropertyMappingsInternal
     {
         get
         {
-            return LazyInitializer.EnsureInitialized(ref _mappings, createCollection)!;
+            return Volatile.Read(ref _mappings) ?? createCollection();
 
             PropertyMappingCollection createCollection()
             {
@@ -200,7 +214,8 @@ public class ClassMapping(
                 if(properties.FirstOrDefault(m => m.DeclaringClass != this) is {} errorMapping)
                     throw new InvalidOperationException($"PropertyMapping '{errorMapping.Name}' is already used for another ClassMapping '{errorMapping.DeclaringClass.Name}'.");
 
-                return new PropertyMappingCollection(properties);
+                var created = new PropertyMappingCollection(properties);
+                return Interlocked.CompareExchange(ref _mappings, created, null) ?? created;
             }
         }
     }
@@ -215,7 +230,7 @@ public class ClassMapping(
     /// property will also be present in the PropertyMappings collection. If this class has
     /// no such property, it is null.
     /// </summary>
-    public PropertyMapping? PrimitiveValueProperty => PropertyMappings.SingleOrDefault(pm => pm.RepresentsValueElement);
+    public PropertyMapping? PrimitiveValueProperty => PropertyMappingsInternal.PrimitiveValueProperty;
 
     /// <summary>
     /// This indicates that this class is representing the Patient data (and implements <see cref="IPatient"/>).
@@ -225,7 +240,7 @@ public class ClassMapping(
     /// <summary>
     /// Whether the reflected type has a member that represent a primitive value.
     /// </summary>
-    public bool HasPrimitiveValueMember => PropertyMappings.Any(pm => pm.RepresentsValueElement);
+    public bool HasPrimitiveValueMember => PropertyMappingsInternal.HasPrimitiveValueMember;
 
     /// <summary>
     /// Returns the mapping for an element of this class by its name.
@@ -358,10 +373,16 @@ public class ClassMapping(
     /// <remarks>If not set, the default constructor for the <see cref="NativeType"/> will be used.</remarks>
     public Base CreateInstance()
     {
-        var factory = LazyInitializer.EnsureInitialized(ref _factory, NativeType.BuildFactoryMethod)!;
+        var factory = Volatile.Read(ref _factory) ?? createFactory();
         var newInstance = factory();
         if (newInstance is IDynamicType idt) idt.DynamicTypeName = Name;
         return (Base)newInstance;
+
+        Func<object> createFactory()
+        {
+            var created = NativeType.BuildFactoryMethod();
+            return Interlocked.CompareExchange(ref _factory, created, null) ?? created;
+        }
     }
 
     private Func<object>? _factory;
@@ -372,8 +393,14 @@ public class ClassMapping(
     /// <remarks>If not set, the default List constructor for the <see cref="NativeType"/> will be used.</remarks>
     public IList CreateList()
     {
-        var factory = LazyInitializer.EnsureInitialized(ref _listFactory, NativeType.BuildListFactoryMethod)!;
+        var factory = Volatile.Read(ref _listFactory) ?? createFactory();
         return factory();
+
+        Func<IList> createFactory()
+        {
+            var created = NativeType.BuildListFactoryMethod();
+            return Interlocked.CompareExchange(ref _listFactory, created, null) ?? created;
+        }
     }
 
     private Func<IList>? _listFactory;

--- a/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
@@ -196,8 +196,16 @@ public class PropertyMapping : IElementDefinitionSummary
     {
         get
         {
-            LazyInitializer.EnsureInitialized(ref _fhirTypeMappings, buildFhirTypeMappings);
-            return _fhirTypeMappings!;
+            // GetInstantiableType() reads this for every element with an abstract property type
+            // while parsing, so this avoids LazyInitializer.EnsureInitialized() and the delegate it
+            // allocates per access; see the note on ClassMapping.PropertyMappingsInternal.
+            return Volatile.Read(ref _fhirTypeMappings) ?? create();
+
+            ClassMapping[] create()
+            {
+                var created = buildFhirTypeMappings();
+                return Interlocked.CompareExchange(ref _fhirTypeMappings, created, null) ?? created;
+            }
         }
     }
 

--- a/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Base/Introspection/PropertyMapping.cs
@@ -192,22 +192,12 @@ public class PropertyMapping : IElementDefinitionSummary
     /// <see cref="FhirType"/> it can distinguish between custom types that share the
     /// same (dynamic) .NET type. For mappings created by reflection, the list is resolved
     /// lazily from <see cref="FhirType"/>.</remarks>
-    public IReadOnlyList<ClassMapping> FhirTypeMappings
-    {
-        get
-        {
-            // GetInstantiableType() reads this for every element with an abstract property type
-            // while parsing, so this avoids LazyInitializer.EnsureInitialized() and the delegate it
-            // allocates per access; see the note on ClassMapping.PropertyMappingsInternal.
-            return Volatile.Read(ref _fhirTypeMappings) ?? create();
-
-            ClassMapping[] create()
-            {
-                var created = buildFhirTypeMappings();
-                return Interlocked.CompareExchange(ref _fhirTypeMappings, created, null) ?? created;
-            }
-        }
-    }
+    public IReadOnlyList<ClassMapping> FhirTypeMappings =>
+        // GetInstantiableType() reads this for every element with an abstract property type while
+        // parsing, so LazyInitializer.EnsureInitialized() - and the factory delegate it allocates
+        // per call - is only reached when the field is still null; see the note on
+        // ClassMapping.PropertyMappingsInternal.
+        _fhirTypeMappings ?? LazyInitializer.EnsureInitialized(ref _fhirTypeMappings, buildFhirTypeMappings)!;
 
     private ClassMapping[]? _fhirTypeMappings;
 

--- a/src/Hl7.Fhir.Base/Introspection/PropertyMappingCollection.cs
+++ b/src/Hl7.Fhir.Base/Introspection/PropertyMappingCollection.cs
@@ -95,37 +95,27 @@ internal class PropertyMappingCollection : ICollection<PropertyMapping>
     public IReadOnlyDictionary<string, PropertyMapping> ByName => _byName;
     private readonly ConcurrentDictionary<string, PropertyMapping> _byName = new(StringComparer.OrdinalIgnoreCase);
 
-    // The lazily computed lists below avoid LazyInitializer.EnsureInitialized() so that reading them
-    // allocates nothing; see the note on ClassMapping.PropertyMappingsInternal for the reasoning and
-    // for why this keeps LazyInitializer's semantics. All three are dropped by clearCaches() when the
-    // collection changes.
+    // The lazily computed lists below only call LazyInitializer.EnsureInitialized() when the field
+    // is still null, so that reading them on the warm path allocates nothing; see the note on
+    // ClassMapping.PropertyMappingsInternal for the reasoning. All three are dropped by
+    // clearCaches() when the collection changes.
 
     /// <summary>
     /// List of the properties, in the order of appearance.
     /// </summary>
-    public IReadOnlyList<PropertyMapping> ByOrder
-    {
-        get
-        {
-            return Volatile.Read(ref _byOrder) ?? create();
+    public IReadOnlyList<PropertyMapping> ByOrder =>
+        _byOrder ?? LazyInitializer.EnsureInitialized(ref _byOrder,
+            () => ByName.Values.OrderBy(pm => pm.Order).ToList())!;
 
-            List<PropertyMapping> create() => publish(ref _byOrder, ByName.Values.OrderBy(pm => pm.Order).ToList());
-        }
-    }
     private List<PropertyMapping>? _byOrder;
 
     /// <summary>
     /// The list of properties that represent choice elements.
     /// </summary>
-    public IReadOnlyList<PropertyMapping> ChoiceProperties
-    {
-        get
-        {
-            return Volatile.Read(ref _choice) ?? create();
+    public IReadOnlyList<PropertyMapping> ChoiceProperties =>
+        _choice ?? LazyInitializer.EnsureInitialized(ref _choice,
+            () => ByName.Values.Where(pm => pm.Choice == ChoiceType.DatatypeChoice).ToList())!;
 
-            List<PropertyMapping> create() => publish(ref _choice, ByName.Values.Where(pm => pm.Choice == ChoiceType.DatatypeChoice).ToList());
-        }
-    }
     private List<PropertyMapping>? _choice;
 
     /// <summary>
@@ -144,19 +134,11 @@ internal class PropertyMappingCollection : ICollection<PropertyMapping>
     /// </summary>
     public bool HasPrimitiveValueMember => valueElements.Count > 0;
 
-    private List<PropertyMapping> valueElements
-    {
-        get
-        {
-            return Volatile.Read(ref _valueElements) ?? create();
+    private List<PropertyMapping> valueElements =>
+        _valueElements ?? LazyInitializer.EnsureInitialized(ref _valueElements,
+            () => ByName.Values.Where(pm => pm.RepresentsValueElement).ToList())!;
 
-            List<PropertyMapping> create() => publish(ref _valueElements, ByName.Values.Where(pm => pm.RepresentsValueElement).ToList());
-        }
-    }
     private List<PropertyMapping>? _valueElements;
-
-    private static T publish<T>(ref T? location, T created) where T : class =>
-        Interlocked.CompareExchange(ref location, created, null) ?? created;
 
     IEnumerator<PropertyMapping> IEnumerable<PropertyMapping>.GetEnumerator() => _byName.Values.GetEnumerator();
 

--- a/src/Hl7.Fhir.Base/Introspection/PropertyMappingCollection.cs
+++ b/src/Hl7.Fhir.Base/Introspection/PropertyMappingCollection.cs
@@ -47,6 +47,7 @@ internal class PropertyMappingCollection : ICollection<PropertyMapping>
     {
         _byOrder = null;
         _choice = null;
+        _valueElements = null;
     }
 
     /// <summary>
@@ -74,8 +75,12 @@ internal class PropertyMappingCollection : ICollection<PropertyMapping>
     public bool Remove(PropertyMapping item)
     {
         if (!_byName.TryRemove(item.Name, out _)) return false;
-        _byOrder?.Remove(item);
-        _choice?.Remove(item);
+
+        // Note: removing `item` from the cached lists is not enough - since the name dictionary is
+        // case-insensitive, the mapping just evicted may be a *different* instance that happens to
+        // share `item`'s name, which would leave that evicted mapping behind in the caches. Drop
+        // the caches instead, so they are rebuilt from the name dictionary on the next read.
+        clearCaches();
 
         return true;
     }
@@ -90,19 +95,68 @@ internal class PropertyMappingCollection : ICollection<PropertyMapping>
     public IReadOnlyDictionary<string, PropertyMapping> ByName => _byName;
     private readonly ConcurrentDictionary<string, PropertyMapping> _byName = new(StringComparer.OrdinalIgnoreCase);
 
+    // The lazily computed lists below avoid LazyInitializer.EnsureInitialized() so that reading them
+    // allocates nothing; see the note on ClassMapping.PropertyMappingsInternal for the reasoning and
+    // for why this keeps LazyInitializer's semantics. All three are dropped by clearCaches() when the
+    // collection changes.
+
     /// <summary>
     /// List of the properties, in the order of appearance.
     /// </summary>
-    public IReadOnlyList<PropertyMapping> ByOrder => LazyInitializer.EnsureInitialized(ref _byOrder,
-        () => ByName.Values.OrderBy(pm => pm.Order).ToList())!;
+    public IReadOnlyList<PropertyMapping> ByOrder
+    {
+        get
+        {
+            return Volatile.Read(ref _byOrder) ?? create();
+
+            List<PropertyMapping> create() => publish(ref _byOrder, ByName.Values.OrderBy(pm => pm.Order).ToList());
+        }
+    }
     private List<PropertyMapping>? _byOrder;
 
     /// <summary>
     /// The list of properties that represent choice elements.
     /// </summary>
-    public IReadOnlyList<PropertyMapping> ChoiceProperties => LazyInitializer.EnsureInitialized(ref _choice,
-        () => ByName.Values.Where(pm => pm.Choice == ChoiceType.DatatypeChoice).ToList())!;
+    public IReadOnlyList<PropertyMapping> ChoiceProperties
+    {
+        get
+        {
+            return Volatile.Read(ref _choice) ?? create();
+
+            List<PropertyMapping> create() => publish(ref _choice, ByName.Values.Where(pm => pm.Choice == ChoiceType.DatatypeChoice).ToList());
+        }
+    }
     private List<PropertyMapping>? _choice;
+
+    /// <summary>
+    /// The property that represents the value of a FHIR primitive, or <c>null</c> when this
+    /// collection has no such property.
+    /// </summary>
+    /// <remarks>Determining which properties are value elements requires a scan of the collection,
+    /// and this is read for every element encountered during (de)serialization, so the scan is done
+    /// once and its (near-always empty or single-entry) result cached. Picking the single value
+    /// element out of that cached result is what still happens per read - including the throw when
+    /// a malformed mapping declares more than one value element.</remarks>
+    public PropertyMapping? PrimitiveValueProperty => valueElements.SingleOrDefault();
+
+    /// <summary>
+    /// Whether this collection contains a property that represents the value of a FHIR primitive.
+    /// </summary>
+    public bool HasPrimitiveValueMember => valueElements.Count > 0;
+
+    private List<PropertyMapping> valueElements
+    {
+        get
+        {
+            return Volatile.Read(ref _valueElements) ?? create();
+
+            List<PropertyMapping> create() => publish(ref _valueElements, ByName.Values.Where(pm => pm.RepresentsValueElement).ToList());
+        }
+    }
+    private List<PropertyMapping>? _valueElements;
+
+    private static T publish<T>(ref T? location, T created) where T : class =>
+        Interlocked.CompareExchange(ref location, created, null) ?? created;
 
     IEnumerator<PropertyMapping> IEnumerable<PropertyMapping>.GetEnumerator() => _byName.Values.GetEnumerator();
 

--- a/src/Hl7.Fhir.Support.Tests/Introspection/ClassMappingTest.cs
+++ b/src/Hl7.Fhir.Support.Tests/Introspection/ClassMappingTest.cs
@@ -163,6 +163,156 @@ namespace Hl7.Fhir.Tests.Introspection
             metaMapping.PropertyMappings.Add(profileMapping);
             metaMapping.FindMappedElementByName("profile").Should().NotBeNull();
         }
+
+        [TestMethod]
+        public void PrimitiveValuePropertyIsStableAndTracksChanges()
+        {
+            Assert.IsTrue(ClassMapping.TryCreate(ModelInspector.Base, typeof(FhirBoolean), out var mapping));
+
+            var valueProperty = mapping.PrimitiveValueProperty;
+            valueProperty.Should().NotBeNull();
+            valueProperty!.Name.Should().Be("value");
+            valueProperty.RepresentsValueElement.Should().BeTrue();
+            mapping.HasPrimitiveValueMember.Should().BeTrue();
+
+            // Repeated reads return the very same mapping (the value is computed once).
+            mapping.PrimitiveValueProperty.Should().BeSameAs(valueProperty);
+
+            // But it does follow changes made to the list of property mappings.
+            mapping.PropertyMappings.Remove(valueProperty);
+            mapping.PrimitiveValueProperty.Should().BeNull();
+            mapping.HasPrimitiveValueMember.Should().BeFalse();
+
+            mapping.PropertyMappings.Add(valueProperty);
+            mapping.PrimitiveValueProperty.Should().BeSameAs(valueProperty);
+            mapping.HasPrimitiveValueMember.Should().BeTrue();
+
+            // Classes without a value element have no primitive value property.
+            Assert.IsTrue(ClassMapping.TryCreate(ModelInspector.Base, typeof(Way), out var wayMapping));
+            wayMapping.PrimitiveValueProperty.Should().BeNull();
+            wayMapping.HasPrimitiveValueMember.Should().BeFalse();
+            wayMapping.PrimitiveValueProperty.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void CreateInstanceAndCreateListReturnNewInstances()
+        {
+            Assert.IsTrue(ClassMapping.TryCreate(ModelInspector.Base, typeof(FhirBoolean), out var mapping));
+
+            var first = mapping.CreateInstance();
+            var second = mapping.CreateInstance();
+            first.Should().BeOfType<FhirBoolean>();
+            second.Should().BeOfType<FhirBoolean>().And.NotBeSameAs(first);
+
+            var list = mapping.CreateList();
+            list.Count.Should().Be(0);
+            list.Add(first);
+            list.Count.Should().Be(1);
+
+            var otherList = mapping.CreateList();
+            otherList.Should().NotBeSameAs(list);
+            otherList.Count.Should().Be(0);
+        }
+
+        [TestMethod]
+        public void PrimitiveValuePropertyThrowsOnDuplicateValueElements()
+        {
+            // A class declaring two value elements is malformed, but PrimitiveValueProperty has
+            // always reported that by throwing, so make sure caching the scan did not swallow it.
+            var inspector = new ModelInspector(FhirRelease.STU3);
+            inspector.Import(typeof(Resource).GetTypeInfo().Assembly);
+            var stringMapping = inspector.FindClassMapping("string")!;
+
+            var twoValues = new ClassMapping(inspector, "TwoValues", typeof(DynamicDataType), cm =>
+            [
+                new PropertyMapping(cm, "value", typeof(FhirString), [stringMapping]) { RepresentsValueElement = true },
+                new PropertyMapping(cm, "alsoValue", typeof(FhirString), [stringMapping]) { RepresentsValueElement = true }
+            ]);
+
+            // HasPrimitiveValueMember answers the "is there at least one" question, and still does.
+            twoValues.HasPrimitiveValueMember.Should().BeTrue();
+
+            // Repeatedly, not just on the first (uncached) read.
+            twoValues.Invoking(m => m.PrimitiveValueProperty).Should().Throw<InvalidOperationException>();
+            twoValues.Invoking(m => m.PrimitiveValueProperty).Should().Throw<InvalidOperationException>();
+        }
+
+        [TestMethod]
+        public void PrimitiveValuePropertyIsInvalidatedByClearAndAddRange()
+        {
+            Assert.IsTrue(ClassMapping.TryCreate(ModelInspector.Base, typeof(FhirBoolean), out var mapping));
+            var valueProperty = mapping.PrimitiveValueProperty!;
+            valueProperty.Should().NotBeNull();
+
+            var mappings = (PropertyMappingCollection)mapping.PropertyMappings;
+            var all = mappings.ToList();
+
+            mappings.Clear();
+            mapping.PrimitiveValueProperty.Should().BeNull();
+            mapping.HasPrimitiveValueMember.Should().BeFalse();
+
+            mappings.AddRange(all);
+            mapping.PrimitiveValueProperty.Should().BeSameAs(valueProperty);
+            mapping.HasPrimitiveValueMember.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void RemovingAMappingByNameInvalidatesThePrimitiveValueProperty()
+        {
+            // Mappings are keyed by name (case-insensitively), so Remove() evicts whatever mapping
+            // carries the given name - which need not be the very instance passed in. Any cache of
+            // the value element has to follow that, or it hands out an evicted mapping.
+            Assert.IsTrue(ClassMapping.TryCreate(ModelInspector.Base, typeof(FhirBoolean), out var mapping));
+            var stored = mapping.PrimitiveValueProperty!;
+            stored.Should().NotBeNull();
+            stored.Name.Should().Be("value");
+
+            var sameNameOtherInstance =
+                new PropertyMapping(mapping, "VALUE", typeof(FhirBoolean), [ModelInspector.Base.FindClassMapping("boolean")!]);
+            sameNameOtherInstance.Should().NotBeSameAs(stored);
+
+            mapping.PropertyMappings.Remove(sameNameOtherInstance).Should().BeTrue();
+
+            mapping.FindMappedElementByName("value").Should().BeNull();
+            mapping.PrimitiveValueProperty.Should().BeNull();
+            mapping.HasPrimitiveValueMember.Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void LazyMembersAreSafeToReadConcurrently()
+        {
+            // Unlike GetMappingsInParrallel (which only races ClassMapping.TryCreate), this races
+            // the lazily initialized members themselves on a mapping that starts out uninitialized.
+            const int threads = 64;
+
+            Assert.IsTrue(ClassMapping.TryCreate(ModelInspector.Base, typeof(FhirBoolean), out var mapping));
+
+            var propertyMappings = new ICollection<PropertyMapping>[threads];
+            var valueProperties = new PropertyMapping[threads];
+            var instances = new Base[threads];
+            var lists = new System.Collections.IList[threads];
+
+            var result = Parallel.For(0, threads, new ParallelOptions { MaxDegreeOfParallelism = threads }, i =>
+            {
+                propertyMappings[i] = mapping.PropertyMappings;
+                valueProperties[i] = mapping.PrimitiveValueProperty!;
+                instances[i] = mapping.CreateInstance();
+                lists[i] = mapping.CreateList();
+            });
+
+            result.IsCompleted.Should().BeTrue();
+
+            // Every thread must observe the one published collection and the one value element...
+            propertyMappings.Should().AllSatisfy(pm => pm.Should().BeSameAs(propertyMappings[0]));
+            valueProperties.Should().AllSatisfy(vp => vp.Should().BeSameAs(valueProperties[0]));
+            valueProperties[0].Should().NotBeNull();
+            valueProperties[0].Name.Should().Be("value");
+
+            // ...while the factories must still hand out a fresh instance/list to each of them.
+            instances.Should().OnlyHaveUniqueItems().And.AllBeOfType<FhirBoolean>();
+            lists.Should().OnlyHaveUniqueItems();
+            lists.Should().AllSatisfy(l => l.Count.Should().Be(0));
+        }
     }
 
 

--- a/src/Hl7.Fhir.Support.Tests/Introspection/ClassMappingTest.cs
+++ b/src/Hl7.Fhir.Support.Tests/Introspection/ClassMappingTest.cs
@@ -313,6 +313,33 @@ twoValues.Invoking(m => m.PrimitiveValueProperty).Should().Throw<InvalidOperatio
             lists.Should().OnlyHaveUniqueItems();
             lists.Should().AllSatisfy(l => l.Count.Should().Be(0));
         }
+
+        [TestMethod]
+        public void PropertyMapperRunsExactlyOnceUnderConcurrentFirstAccess()
+        {
+            // The property mapper may be user-supplied and builds the mutable PropertyMappings
+            // collection, so racing threads must not each run it and build their own copy: the
+            // first access initializes it exactly once and all threads see that single result.
+            const int threads = 64;
+            var mapperRuns = 0;
+
+            var mapping = new ClassMapping(ModelInspector.Base, "test", typeof(FhirBoolean), _ =>
+            {
+                System.Threading.Interlocked.Increment(ref mapperRuns);
+                // Keep the factory busy for a while so racing threads pile up on the
+                // still-uninitialized field instead of hitting the warm path.
+                System.Threading.Thread.Sleep(50);
+                return [];
+            });
+
+            var collections = new ICollection<PropertyMapping>[threads];
+            var result = Parallel.For(0, threads, new ParallelOptions { MaxDegreeOfParallelism = threads },
+                i => collections[i] = mapping.PropertyMappings);
+
+            result.IsCompleted.Should().BeTrue();
+            mapperRuns.Should().Be(1);
+            collections.Should().AllSatisfy(c => c.Should().BeSameAs(collections[0]));
+        }
     }
 
 

--- a/src/Hl7.Fhir.Support.Tests/Introspection/ClassMappingTest.cs
+++ b/src/Hl7.Fhir.Support.Tests/Introspection/ClassMappingTest.cs
@@ -233,8 +233,8 @@ namespace Hl7.Fhir.Tests.Introspection
             twoValues.HasPrimitiveValueMember.Should().BeTrue();
 
             // Repeatedly, not just on the first (uncached) read.
-            twoValues.Invoking(m => m.PrimitiveValueProperty).Should().Throw<InvalidOperationException>();
-            twoValues.Invoking(m => m.PrimitiveValueProperty).Should().Throw<InvalidOperationException>();
+twoValues.Invoking(m => m.PrimitiveValueProperty).Should().Throw<InvalidOperationException>().WithMessage("*more than one element*");
+twoValues.Invoking(m => m.PrimitiveValueProperty).Should().Throw<InvalidOperationException>().WithMessage("*more than one element*");
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description

Two patterns in `ClassMapping`, `PropertyMappingCollection` and `PropertyMapping` cost an allocation
— and in one case a full, locked snapshot of a collection — on *every* access, while all of them sit
on the per-element path of (de)serialization. This PR removes both.

**1. `LazyInitializer.EnsureInitialized(ref field, factory)` allocates its factory on every call**,
including the warm path where the field has long been initialized. The local functions passed in
capture `this` (so the compiler cannot cache them in a static), and the method-group arguments
(`NativeType.BuildFactoryMethod`, `NativeType.BuildListFactoryMethod`, `buildFhirTypeMappings`)
allocate too — for `CreateInstance`/`CreateList`, once per element and per list created during a
parse.

Six sites are converted: `ClassMapping.PropertyMappingsInternal`, `ClassMapping.CreateInstance`,
`ClassMapping.CreateList`, `PropertyMappingCollection.ByOrder`, `PropertyMappingCollection.ChoiceProperties`
and `PropertyMapping.FhirTypeMappings` (reached via `GetInstantiableType()` for every element whose
property type is abstract). They now use:

```csharp
_field ?? LazyInitializer.EnsureInitialized(ref _field, factory)
```

The `??` short-circuits, so once the field is initialized an access is an ordinary read that never
reaches `EnsureInitialized` or the factory delegate it allocates per call; the delegate is only
created on the once-only cold path, which stays the standard BCL idiom. The ordinary read on the
warm path is safe per the documented .NET memory model
([Memory-model.md](https://github.com/dotnet/runtime/blob/main/docs/design/specs/Memory-model.md)):
object reference stores are release stores ("*Object assignment to a location potentially accessible
by other threads is a release with respect to accesses to the instance's fields/elements and
metadata*") and "*memory ordering honors data dependency*" on the reading side, so a thread that
observes the field non-null also observes the fully initialized object. The factory bodies are
unchanged, including the `DeclaringClass` validation performed when building the property mappings.
(Earlier revisions of this PR used a hand-rolled `Volatile.Read`/`Interlocked.CompareExchange`
pattern here; it was reworked to the shape above after review, for maintainability — see the review
thread.)

`ClassMapping.PropertyMappingsInternal` additionally uses the `EnsureInitialized` overload with a
`syncLock`, which double-checks under a lock so its factory runs *exactly once* (also a review
outcome): that member runs a possibly user-supplied `PropertyMapper` and builds the mutable
collection that callers manipulate through `PropertyMappings`, where a concurrently repeated factory
run would not be obviously harmless. The lock object itself is allocated on demand by
`LazyInitializer`. The other five sites use the lock-free two-argument overload: their factories are
idempotent and produce values that are never mutated afterwards, so its
publish-once-but-may-run-twice semantics are unobservable there. No deadlock exposure: building a
class's property mappings never reads another mapping's `PropertyMappings` (type resolution via
`FhirTypeMappings` is itself lazy — that is what breaks the type cycles).

**Scope — why these six and not the other eleven `LazyInitializer` calls in the assembly.** Only a
factory that captures state or is an instance method group allocates per access; a non-capturing
lambda such as `() => []` is cached by the compiler in a static field and is free. Of the remaining
eleven calls, five are non-capturing (`Base`, `DomNode`, `PocoNodeOrList` annotations/overflow), four
capture but are not on the per-element POCO parse path (`EnumMapping.PropertyMappings`,
`PropertyMapping`'s `IElementDefinitionSummary.Type`, `ElementNode.ChildDefinitions`,
`TypedElementOnSourceNode.Value`), and two (`PropertyMapping.Getter`/`Setter`) are inside a
`#if USE_GETTER_SETTER_AND_CODEGEN` that is not defined. An allocation census of the parsing workload
below confirms this empirically: the only `LazyInitializer` factories that allocate anything at all in
that workload are exactly the six converted here.

**2. `ClassMapping.PrimitiveValueProperty` re-ran a scan of the whole collection on every read.**
`PropertyMappings.SingleOrDefault(pm => pm.RepresentsValueElement)` looks like a cheap LINQ call, but
enumerating `PropertyMappingCollection` reads `ConcurrentDictionary.Values` — which takes *all* of the
dictionary's bucket locks and copies every entry into a fresh `List` inside a `ReadOnlyCollection`.
So every element parsed took a full, locked snapshot of its declaring class's property collection,
and `HasPrimitiveValueMember` (`Any`, same enumeration) took another. That was 26.8% of active thread
time in our profile, and ~93% of the lock contention at 4-way parallelism.

Both now read a list that `PropertyMappingCollection` computes once, next to the existing `ByOrder`
and `ChoiceProperties` caches and invalidated in the same places, so mutating a mapping's property
list is still reflected. `null` stays a valid, cached answer for classes without a value element, and
`SingleOrDefault` still resolves the value, so a malformed mapping with two value elements still
throws.

**3. Drive-by bug fix: `PropertyMappingCollection.Remove` left stale cache entries.** Mappings are
keyed by name *case-insensitively*, so `Remove(x)` evicts whatever mapping carries `x`'s name, which
need not be `x` itself. Updating the cached lists with `_byOrder?.Remove(x)` then removes nothing and
leaves the evicted mapping in the cache. This was already wrong for `ByOrder`/`ChoiceProperties`, and
caching the value element would have inherited it. `Remove` now calls `clearCaches()` instead, so the
lists are rebuilt from the name dictionary on the next read. Covered by a new test that fails without
this change.

## Observable behavioural deltas

No public API change and no *intended* behavioural change, but for completeness, everything that is
observably different:

* **Exception message in the duplicate case.** A (malformed) class declaring two value elements still
  throws `InvalidOperationException` from `PrimitiveValueProperty`, but the message now comes from
  `SingleOrDefault()` over the cached list ("Sequence contains more than one element") rather than
  from `SingleOrDefault(predicate)` ("…more than one matching element"). Pinned by a new test.
* **The property mapper runs exactly once.** Before this PR, racing first accesses to
  `PropertyMappings` could each run the property mapper, with only one result ever published. Now
  the mapper runs exactly once — a strictly narrower behaviour that only shows up for mappers with
  side effects.
* **Concurrent read-during-mutation of the property collection.** Previously each read of
  `PrimitiveValueProperty` took a point-in-time snapshot under the `ConcurrentDictionary`'s bucket
  locks; now it reads an unsynchronised cached list that is dropped on mutation, so a read racing a
  mutation may observe either side of it. This is exactly the guarantee `ByOrder` and
  `ChoiceProperties` have always had, and the collection was never safe for concurrent mutation anyway
  (`Add`/`AddRange`/`Clear`/`Remove` update the dictionary and clear the caches non-atomically).
* **Stale caches after `Remove` are fixed**, as described above — a behaviour change in the sense that
  a bug stopped happening.

## Related issues

Closes #3563 — ClassMapping hot paths: per-access delegate allocation and repeated
PropertyMappings snapshots during deserialization.

## Testing

Suites re-run after the change (including the review revisions):

* `Hl7.Fhir.Support.Tests` — **508 passed, 0 failed** (503 before, plus the new tests below).
* `Hl7.Fhir.Support.Poco.Tests` — **603 passed, 0 failed** (POCO JSON/XML (de)serialization).
* `Hl7.Fhir.Serialization.R4.Tests` — **16 234 passed, 0 failed**.

Seven tests added to `ClassMappingTest`, all of which exercise the changed paths directly:

| test | what it guards |
|---|---|
| `PrimitiveValuePropertyIsStableAndTracksChanges` | `FhirBoolean` → the `value` element; repeated reads return the same instance; remove/re-add is reflected; a class with no value element keeps returning `null` (the cached-`null` case) |
| `PrimitiveValuePropertyThrowsOnDuplicateValueElements` | a mapping with two value elements still throws, on the cached read as well as the first one, while `HasPrimitiveValueMember` still answers `true` |
| `PrimitiveValuePropertyIsInvalidatedByClearAndAddRange` | `Clear()` and `AddRange()` invalidate the value-element cache |
| `RemovingAMappingByNameInvalidatesThePrimitiveValueProperty` | the case-insensitive-`Remove` bug above — **fails without the `clearCaches()` fix** |
| `LazyMembersAreSafeToReadConcurrently` | 64 threads racing `PropertyMappings`, `PrimitiveValueProperty`, `CreateInstance` and `CreateList` on a freshly created, uninitialised mapping: all threads must observe the one published collection and the one value element, while the factories must still hand each of them a fresh instance/list |
| `PropertyMapperRunsExactlyOnceUnderConcurrentFirstAccess` | 64 threads racing first access against a counting property mapper: the mapper runs exactly once and every thread observes the same collection |
| `CreateInstanceAndCreateListReturnNewInstances` | the cached factories still hand out fresh instances and fresh lists |

(The existing `GetMappingsInParrallel` regression test for #556 races `ClassMapping.TryCreate` only and
never reads these members, and `CanManipulatePropertyMappingsList` checks `FindMappedElementByName`
rather than the caches — hence the new concurrency and invalidation tests.)

Additionally verified, outside the test suite:

* **Runtime allocation** on a warmed-up mapping, 200 000 iterations (re-verified after each review
  revision — the `??` short-circuit leaves the warm path at 0 B):

  | path | develop | this PR |
  |---|---|---|
  | `PropertyMappings` + `PrimitiveValueProperty` + `HasPrimitiveValueMember` + `FindMappedElementByName`, per iteration | 464 B | **0 B** |
  | `FhirTypeMappings`, per read | 64 B | **0 B** |
  | `CreateInstance`, per call | 128 B | **64 B** (just the `FhirBoolean`) |
  | `CreateList`, per call | 96 B | **32 B** (just the `List`) |

* **IL:** on `develop`, the six converted `EnsureInitialized` sites each contain an *unconditional*
  `ldftn; newobj` pair — a delegate allocated on every call — while
  `ClassMapping.PrimitiveValueProperty`/`HasPrimitiveValueMember` allocate their (non-capturing)
  predicate only once behind the usual `ldsfld; brtrue` cache, and pay per access through the calls
  underneath instead: `PropertyMappings` (one of the six delegates) plus the
  `ConcurrentDictionary.Values` snapshot. With this PR, the allocating instructions sit behind the
  `??`'s null check, on the branch that only executes while the field is still uninitialized; the
  0 B runtime figures above are the warm path's actual cost.

## Measured effect

Measured as a drop-in A/B in a downstream consumer (the Firely CQL SDK's CMS measure integration
corpus), because that is where the hot path was found. Note the caveat: the consumer pins **6.3.0**
and a `develop` build is not binary compatible with it, so the measurement uses `Hl7.Fhir.Base.dll`
built from the `v6.3.0` tag with and without this change. All three touched files are byte-identical
between `v6.3.0` and current `develop` (`git diff v6.3.0 develop --` is empty for them), and the
commit cherry-picks onto the tag with an identical diff, so the measurement carries over.

Workload: 900 measure cases, FHIR-JSON bundle deserialization **in** the loop, single-threaded (the
deserialization path is serial), 100 reps per run, medians over reps 86–100, four order-balanced
rounds.

| metric (per 900 cases) | A (6.3.0 stock) | B (+ fix) | delta | delta % |
|---|---|---|---|---|
| wall | 1635 ms | 1546 ms | −89 ms | **−5.4%** |
| cpu | 1731 ms | 1625 ms | −106 ms | **−6.2%** |
| allocated | 778.6 MB | 711.5 MB | −67.2 MB | **−8.6%** |
| allocated per case | 886.0 KB | 809.8 KB | −76.2 KB | **−8.6%** |
| gen0 collections | 47 | 43 | −4 | −8.5% |
| GC pause | 43.1 ms | 38.5 ms | −4.6 ms | −11% |
| gen1 / gen2 / lock contention | ~0 / 0 / 0 | 0 / 0 / 0 | — | — |

Round agreement:

* **Allocation and gen0 are reproducible**: −8.3% / −8.9% / −8.6% / −8.7% (allocation) and −8.5% in
  all four rounds (gen0). This is the part of the result to rely on.
* **Wall and CPU do not agree across rounds**: −15.4% / −3.2% / −0.1% / −2.0% (wall). The scatter
  tracks run order and first-run effects on this 4-core box, not the variant — round 1's stock run
  was simply a slow one (median 1769 ms against 1536–1635 ms in the other three rounds). −5.4% is
  the order-balanced mean, and it is worth exactly as much as that spread allows: the direction is
  consistent (every round favours the patch) but the magnitude is not resolved better than
  "a few percent".

  One cross-check: this A/B was run twice, before and after the first round of review revisions
  (which added the `FhirTypeMappings` conversion). Four order-balanced rounds each time, eight in
  total. Pooled wall came out at −5.40% the first time and −5.44% the second, and pooled allocation
  at −8.3% then −8.6% — the extra ~0.3 points of allocation being the `FhirTypeMappings` delegate,
  consistent with the 0.23% share the census attributed to it.


Correctness gate on the same corpus: all 900 cases across 20 measures complete with exit code 0 and
zero exceptions, both with and without the patch.

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes
      (not applicable — no public API change; see "Observable behavioural deltas" above)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj6AseHiRtRbAEN6yRzK1t)_