### PR TITLE
Release 6.4.0

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,11 +1,11 @@
 ## Intro:
 
-This release includes a behavioral change in parsing alongside a minor bug fix. Please read the notes below carefully before upgrading.
+This release adds opt-in retention of XML comments in the POCO-based parser. There are no breaking changes.
 
-**POCO / type system**
-- The SDK now detects incorrectly cased element and resource type names. Two new error codes are introduced: `PVAL131` (`WRONG_CASED_ELEMENT`) and `PVAL132` (`WRONG_CASED_RESOURCE_TYPE`).
+**Serialization**
+- The POCO-based XML parser can now retain the comments found in the source document. Set `DeserializerSettings.RetainComments` to `true` (the default remains `false`) and comments are attached to the parsed POCOs as `SourceComments` annotations, so that they survive a parse/serialize round-trip. See issue [#3561](https://github.com/FirelyTeam/firely-net-sdk/issues/3561).
 
-  > **Breaking change:** Parsers running in strict mode will now report errors when receiving data with incorrectly cased element or resource type names. Data that was previously silently corrected during parsing will now cause parse errors instead. Make sure your data sources use the correct casing as defined by the FHIR specification. All non-strict modes (BackwardsCompatible, Recoverable, NoOverflow, and the default) continue to bind leniently, preserving the behaviour from previous SDK versions. The exact handling of wrong-cased names in lenient modes is subject to change in future major versions of the SDK.
+  > **Behavioural note:** the XML serializer now writes any `SourceComments` annotation it encounters. Previously only POCOs produced by the legacy parser carried such annotations, so in practice nothing was written for POCOs coming from the new parser. If your code adds `SourceComments` annotations itself, those comments will now show up in serialized output.
 
-**Other fixes**
-- Fixed redundant null-checks and initialization logic in bundle link handling.
+**Dependencies**
+- Updated Fhir.Metrics, Microsoft.SourceLink.GitHub, MSTest.TestFramework and Verify.MSTest to their latest versions. NSubstitute was updated to 6.0.0 (test-only, not part of the shipped packages).

--- a/src/firely-net-sdk.props
+++ b/src/firely-net-sdk.props
@@ -6,7 +6,7 @@
 
 	<!-- Solution-wide properties for NuGet packaging -->
 	<PropertyGroup>
-		<VersionPrefix>6.3.1</VersionPrefix>
+		<VersionPrefix>6.4.0</VersionPrefix>
 		<VersionSuffix></VersionSuffix>
 		<Authors>Firely (info@fire.ly) and contributors</Authors>
 		<Company>Firely (https://fire.ly)</Company>

--- a/src/firely-net-sdk.props
+++ b/src/firely-net-sdk.props
@@ -6,7 +6,7 @@
 
 	<!-- Solution-wide properties for NuGet packaging -->
 	<PropertyGroup>
-		<VersionPrefix>6.4.0</VersionPrefix>
+		<VersionPrefix>6.4.1</VersionPrefix>
 		<VersionSuffix></VersionSuffix>
 		<Authors>Firely (info@fire.ly) and contributors</Authors>
 		<Company>Firely (https://fire.ly)</Company>
@@ -37,7 +37,7 @@
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Configurations>Debug;Release;FullDebug</Configurations>
 		<EnablePackageValidation>true</EnablePackageValidation>
-		<PackageValidationBaselineVersion>6.3.0</PackageValidationBaselineVersion>
+		<PackageValidationBaselineVersion>6.4.0</PackageValidationBaselineVersion>
 		<!-- Error	CS4014	Because this call is not awaited, execution of the current method continues before the call is completed.
 		Consider applying the 'await' operator to the result of the call.	-->
 		<WarningsAsErrors>CS4014</WarningsAsErrors>


### PR DESCRIPTION
Merges the 6.4.0 release back into `develop`.

Contains:
- the 6.4.0 release commit (version bump + release notes), tagged `v6.4.0` and published to NuGet
- `Start development cycle 6.4.1`, which sets `VersionPrefix` to 6.4.1 and moves
  `PackageValidationBaselineVersion` to 6.4.0 so API-compatibility checks baseline against the
  version just released

Without this merge `develop` keeps reporting 6.4.0 and would collide with the released version.