### PR TITLE
Tweak dynamic type inference logic for NewPocoBuilder

### DIFF
--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.TypedElement.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.TypedElement.cs
@@ -191,17 +191,16 @@ internal partial class NewPocoBuilder
         if (node.Definition?.Type is [IStructureDefinitionSummary summary])
             return isPrimitiveType(summary)
                 ? DetermineBestPrimitiveMapping()
-                : isResource(summary.IsResource) ? ClassMapping.DynamicResource : ClassMapping.DynamicDataType;
+                : summary.IsResource || isResource(node) ? ClassMapping.DynamicResource : ClassMapping.DynamicDataType;
 
         if (node.InstanceType is { } it && isPrimitiveTypeName(it))
             return DetermineBestPrimitiveMapping();
 
-        return isResource(false) ? ClassMapping.DynamicResource : ClassMapping.DynamicDataType;
+        return isResource(node) ? ClassMapping.DynamicResource : ClassMapping.DynamicDataType;
 
-        bool isResource(bool typeIsResource) =>
-            typeIsResource
-            || node.Annotation<IResourceTypeSupplier>()?.ResourceType is not null
-            || node.Definition?.IsResource is true;
+        static bool isResource(ITypedElement node) =>
+            node.Definition?.IsResource is true
+            || node.Annotation<IResourceTypeSupplier>()?.ResourceType is not null;
 
         ClassMapping DetermineBestPrimitiveMapping()
         {

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.TypedElement.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.TypedElement.cs
@@ -139,15 +139,34 @@ internal partial class NewPocoBuilder
     /// Determines whether the type described by this summary is a primitive: in FHIR, those are the types
     /// with a "value" child, which is represented as an attribute in Xml.
     /// </summary>
+    /// <remarks>
+    /// Note that the SDK's own summaries deliberately hide that "value" child: both
+    /// <c>StructureDefinitionComplexTypeSerializationInfo.getElements()</c> and <see cref="ClassMapping"/>
+    /// filter the primitive value constraint out of <c>GetElements()</c>. So the presence of a "value"
+    /// attribute proves a type is primitive, but its absence does not prove the opposite - hence the
+    /// additional signals below.
+    /// </remarks>
     private static bool isPrimitiveType(IStructureDefinitionSummary summary)
     {
+        // A mapping for a POCO knows outright whether it has a value pseudo-property.
+        if (summary is ClassMapping cm)
+            return cm.PrimitiveValueProperty is not null;
+
+        var hasComplexChildren = false;
+
         foreach (var element in summary.GetElements())
         {
             if (element.ElementName == "value" && element.Representation == XmlRepresentation.XmlAttr)
                 return true;
+
+            // A primitive can only have the children it inherits from Element, so anything else means
+            // we are definitely looking at a complex type.
+            hasComplexChildren |= element.ElementName is not ("id" or "extension");
         }
 
-        return false;
+        // The elements told us nothing conclusive (e.g. a custom primitive with a filtered-out value
+        // constraint and no value present in the instance), so fall back to the naming heuristic.
+        return !hasComplexChildren && isPrimitiveTypeName(summary.TypeName);
     }
 
     /// <summary>

--- a/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.TypedElement.cs
+++ b/src/Hl7.Fhir.Base/ElementModel/NewPocoBuilder.TypedElement.cs
@@ -3,6 +3,7 @@
 using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
+using Hl7.Fhir.Specification;
 using System;
 using ET = Hl7.Fhir.ElementModel.Types;
 
@@ -135,17 +136,53 @@ internal partial class NewPocoBuilder
     }
 
     /// <summary>
+    /// Determines whether the type described by this summary is a primitive: in FHIR, those are the types
+    /// with a "value" child, which is represented as an attribute in Xml.
+    /// </summary>
+    private static bool isPrimitiveType(IStructureDefinitionSummary summary)
+    {
+        foreach (var element in summary.GetElements())
+        {
+            if (element.ElementName == "value" && element.Representation == XmlRepresentation.XmlAttr)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// In FHIR, primitive types are the only types whose name starts with a lowercase letter, so this is
+    /// used as a heuristic to recognize them when we have no definition to go on. Note that types can also
+    /// be identified by their canonical url (as is the case for logical models), which would incorrectly
+    /// trip this heuristic - those are excluded here.
+    /// </summary>
+    private static bool isPrimitiveTypeName(string typeName) =>
+        char.IsLower(typeName[0]) && !new Canonical(typeName).IsAbsolute;
+
+    /// <summary>
     /// Determine the "best" dynamic type based on the actual contents of the ITypedElement.
     /// </summary>
     private ClassMapping determineBestDynamicMappingForElement(ITypedElement node)
     {
-        if (node.Value is not null || (node.InstanceType is { } it && char.IsLower(it[0])))
+        if (node.Value is not null)
             return DetermineBestPrimitiveMapping();
 
-        if (node.Annotation<IResourceTypeSupplier>()?.ResourceType is not null || node.Definition?.IsResource is true)
-            return ClassMapping.DynamicResource;
+        // When the definition tells us the type of this element, use it to decide primitive versus complex -
+        // that beats guessing based on the shape of the type's name (which is all we can do below).
+        if (node.Definition?.Type is [IStructureDefinitionSummary summary])
+            return isPrimitiveType(summary)
+                ? DetermineBestPrimitiveMapping()
+                : isResource(summary.IsResource) ? ClassMapping.DynamicResource : ClassMapping.DynamicDataType;
 
-        return ClassMapping.DynamicDataType;
+        if (node.InstanceType is { } it && isPrimitiveTypeName(it))
+            return DetermineBestPrimitiveMapping();
+
+        return isResource(false) ? ClassMapping.DynamicResource : ClassMapping.DynamicDataType;
+
+        bool isResource(bool typeIsResource) =>
+            typeIsResource
+            || node.Annotation<IResourceTypeSupplier>()?.ResourceType is not null
+            || node.Definition?.IsResource is true;
 
         ClassMapping DetermineBestPrimitiveMapping()
         {

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/LogicalModelToPocoTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/LogicalModelToPocoTests.cs
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2025, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+using FluentAssertions;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.FhirPath;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Hl7.Fhir.Specification;
+using Hl7.FhirPath;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Hl7.Fhir.Tests.Model;
+
+/// <summary>
+/// Tests for building POCOs for types that have no compiled POCO - most notably logical models, which
+/// are identified by their canonical url rather than by a type name.
+/// </summary>
+[TestClass]
+public class LogicalModelToPocoTests
+{
+    private const string CANONICAL = "http://validationtest.org/fhir/StructureDefinition/SpikeRoot";
+
+    [TestMethod]
+    [DataRow(CANONICAL, DisplayName = "type identified by canonical url")]
+    [DataRow("SpikeRoot", DisplayName = "type identified by name")]
+    [DataRow("spikeRoot", DisplayName = "type identified by name starting with a lowercase letter")]
+    public void ComplexRootIsNotBuiltAsAPrimitive(string typeName)
+    {
+        var root = buildRoot(typeName);
+
+        // A logical model root is a complex type, so it should never end up as a DynamicPrimitive -
+        // that would make it a primitive without a value, which FhirPath treats as an empty focus.
+        root.Poco.Should().BeOfType<DynamicDataType>();
+        root.Poco.TypeName.Should().Be(typeName);
+    }
+
+    [TestMethod]
+    [DataRow(CANONICAL, DisplayName = "type identified by canonical url")]
+    [DataRow("SpikeRoot", DisplayName = "type identified by name")]
+    [DataRow("spikeRoot", DisplayName = "type identified by name starting with a lowercase letter")]
+    public void CanEvaluateFhirPathOnDynamicallyBuiltPoco(string typeName)
+    {
+        var root = buildRoot(typeName);
+        var compiler = new FhirPathCompiler();
+        var ctx = new FhirEvaluationContext();
+
+        evaluate("hook").Should().BeEquivalentTo(["order-sign"]);
+
+        // Operators and functions that propagate empty (=, !=, is, toString()) must not see the root as
+        // an empty focus
+        evaluate("hook = 'order-sign'").Should().BeEquivalentTo([true]);
+        evaluate("hook != 'order-sign'").Should().BeEquivalentTo([false]);
+        evaluate("hook is string").Should().BeEquivalentTo([true]);
+        evaluate("hook.toString() = 'order-sign'").Should().BeEquivalentTo([true]);
+        compiler.Compile("hook = 'order-sign'").IsTrue(root, ctx).Should().BeTrue();
+
+        List<object> evaluate(string expression) =>
+            compiler.Compile(expression)(root, ctx).Select(node => ((ITypedElement)node).Value).ToList();
+    }
+
+    private static PocoNode buildRoot(string typeName)
+    {
+        var sourceNode = FhirJsonNode.Parse("""{ "hook": "order-sign" }""", "SpikeRoot");
+        return sourceNode.ToTypedElement(new TestSummaryProvider(typeName), typeName).ToPocoNode();
+    }
+
+    /// <summary>
+    /// A hand-built type mapping for a logical model with a single "hook" element of type string.
+    /// </summary>
+    private class TestSummaryProvider(string rootTypeName) : IStructureDefinitionSummaryProvider
+    {
+        public IStructureDefinitionSummary Provide(string canonical) =>
+            canonical == rootTypeName ? new ComplexSummary(rootTypeName, new ElementSummary("hook", "string")) :
+            canonical == "string" ? new ComplexSummary("string", new ElementSummary("value", "System.String", XmlRepresentation.XmlAttr)) :
+            null;
+    }
+
+    private class ComplexSummary(string typeName, params IElementDefinitionSummary[] elements) : IStructureDefinitionSummary
+    {
+        public string TypeName => typeName;
+        public bool IsAbstract => false;
+        public bool IsResource => false;
+        public IReadOnlyCollection<IElementDefinitionSummary> GetElements() => elements;
+    }
+
+    private class ElementSummary(
+        string elementName,
+        string typeName,
+        XmlRepresentation representation = XmlRepresentation.XmlElement) : IElementDefinitionSummary
+    {
+        public string ElementName => elementName;
+        public bool IsCollection => false;
+        public bool IsRequired => false;
+        public bool InSummary => false;
+        public bool IsChoiceElement => false;
+        public bool IsResource => false;
+        public bool IsModifier => false;
+        public ITypeSerializationInfo[] Type => [new TypeReference(typeName)];
+        public string DefaultTypeName => null;
+        public string NonDefaultNamespace => null;
+        public XmlRepresentation Representation => representation;
+        public int Order => 0;
+    }
+
+    private class TypeReference(string referredType) : IStructureDefinitionReference
+    {
+        public string ReferredType => referredType;
+    }
+}

--- a/src/Hl7.Fhir.Support.Poco.Tests/Model/LogicalModelToPocoTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/Model/LogicalModelToPocoTests.cs
@@ -66,6 +66,43 @@ public class LogicalModelToPocoTests
             compiler.Compile(expression)(root, ctx).Select(node => ((ITypedElement)node).Value).ToList();
     }
 
+    /// <summary>
+    /// Covers how a type without a value in the instance is classified as primitive or complex, based on
+    /// what its definition tells us. Note that the SDK's real summary providers filter the primitive
+    /// "value" constraint out of <c>GetElements()</c>, so a value child proves a type is a primitive, but
+    /// its absence does not prove the opposite.
+    /// </summary>
+    [TestMethod]
+    // A value attribute in the definition is conclusive, whatever the type is called.
+    [DataRow("myCode", "value@attr", true, DisplayName = "value attribute, primitive-looking name")]
+    [DataRow("MyCode", "value@attr", true, DisplayName = "value attribute, complex-looking name")]
+    // Without it, only the children a primitive is allowed to have leave the naming heuristic to decide.
+    [DataRow("myCode", "extension", true, DisplayName = "no value attribute, primitive-looking name")]
+    [DataRow("myCode", "id,extension", true, DisplayName = "no value attribute, only inherited children")]
+    [DataRow("MyCode", "extension", false, DisplayName = "no value attribute, complex-looking name")]
+    // A child a primitive cannot have means complex, even when the name suggests otherwise.
+    [DataRow("myCode", "extension,hook", false, DisplayName = "child element beyond those of a primitive")]
+    // Logical models are identified by canonical url, which is never a primitive type name.
+    [DataRow(CANONICAL, "extension", false, DisplayName = "type identified by canonical url")]
+    public void ClassifiesValueLessTypeAsPrimitiveOrComplex(string typeName, string children, bool expectPrimitive)
+    {
+        // Extension-only (so: value-less) instances of a primitive are legal, and this is the only content
+        // all the type definitions under test have in common.
+        var sourceNode = FhirJsonNode.Parse(
+            """{ "extension": { "url": "http://example.org/ext", "valueString": "absent" } }""", typeName);
+        var elements = children.Split(',')
+            .Select(name => name.EndsWith("@attr")
+                ? new ElementSummary("value", "System.String", XmlRepresentation.XmlAttr)
+                : new ElementSummary(name, name == "extension" ? "Extension" : "string"))
+            .ToArray<IElementDefinitionSummary>();
+        var provider = new SingleTypeSummaryProvider(new ComplexSummary(typeName, elements));
+
+        var root = sourceNode.ToTypedElement(provider, typeName).ToPocoNode();
+
+        root.Poco.Should().BeOfType(expectPrimitive ? typeof(DynamicPrimitive) : typeof(DynamicDataType));
+        root.Poco.TypeName.Should().Be(typeName);
+    }
+
     private static PocoNode buildRoot(string typeName)
     {
         var sourceNode = FhirJsonNode.Parse("""{ "hook": "order-sign" }""", "SpikeRoot");
@@ -81,6 +118,15 @@ public class LogicalModelToPocoTests
             canonical == rootTypeName ? new ComplexSummary(rootTypeName, new ElementSummary("hook", "string")) :
             canonical == "string" ? new ComplexSummary("string", new ElementSummary("value", "System.String", XmlRepresentation.XmlAttr)) :
             null;
+    }
+
+    /// <summary>
+    /// A provider that knows a single hand-built type.
+    /// </summary>
+    private class SingleTypeSummaryProvider(ComplexSummary summary) : IStructureDefinitionSummaryProvider
+    {
+        public IStructureDefinitionSummary Provide(string canonical) =>
+            canonical == summary.TypeName ? summary : null;
     }
 
     private class ComplexSummary(string typeName, params IElementDefinitionSummary[] elements) : IStructureDefinitionSummary


### PR DESCRIPTION
This pull request improves the logic for determining whether a FHIR type should be treated as a primitive or complex type, especially for dynamically built POCOs such as logical models, and adds new tests to verify this behavior. The main changes are grouped below:

### Improved Type Determination Logic

* Refactored the `determineBestDynamicMappingForElement` method in `NewPocoBuilder.TypedElement.cs` to use FHIR definitions (when available) to distinguish between primitive and complex types, rather than relying solely on type name heuristics. This helps correctly handle logical models identified by canonical URLs and prevents misclassification of complex types as primitives.
* Added helper methods `isPrimitiveType` (checks for "value" child with XML attribute representation) and `isPrimitiveTypeName` (uses lowercase naming heuristic, but excludes canonical URLs) to improve primitive type detection.
* Updated imports in `NewPocoBuilder.TypedElement.cs` to include `Hl7.Fhir.Specification` for new logic.

### New Tests for Logical Model Handling

* Added a new test class `LogicalModelToPocoTests` to verify that logical model roots (identified by canonical URL or type name) are always built as complex types and not as primitives, and that FhirPath evaluation works correctly on these dynamically built POCOs.

Encountered when working with CDS hooks being parsed by legacy stack, FHIRPath of `%resource.hook` would return the value correctly, but `%resource.hook = 'order-sign'` would fail.

Poco parsers did not exhibit the issue as they go over the json property type directly rather than working with just `ISourceNode.Text`