### PR TITLE
VONK-10132: Adapt SnapshotGenerator handling of CDSHooks logical models

### DIFF
--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/ElementMatcher.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/ElementMatcher.cs
@@ -91,17 +91,21 @@ namespace Hl7.Fhir.Specification.Snapshot
             var baseStartBM = snapNav.Bookmark();
             var diffStartBM = diffNav.Bookmark();
 
-            snapNav.MoveToFirstChild();
+            // The base element may have no children at all, e.g. a nested anonymous element in a logical
+            // model that has neither a type code nor a contentReference to expand from. In that case
+            // snapNav remains positioned on the *parent* element and every child in the differential
+            // introduces a new element.
+            var snapHasChildren = snapNav.MoveToFirstChild();
             diffNav.MoveToFirstChild();
 
-            var choiceNames = listChoiceElements(snapNav);
+            var choiceNames = snapHasChildren ? listChoiceElements(snapNav) : new List<string>();
             var result = new List<MatchInfo>();
 
             try
             {
                 do
                 {
-                    var match = matchBase(snapNav, diffNav, choiceNames);
+                    var match = snapHasChildren && matchBase(snapNav, diffNav, choiceNames);
                     if (match)
                     {
                         result.AddRange(constructMatch(snapNav, diffNav));
@@ -111,7 +115,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                         // No matching base element; this is a new element (core resource definitions)
                         // Note: this loop consumes all new diffNav elements when processing the first element from snapNav
                         // When Match is called for remaining snapNav (base) elements, all new diffNav elements will already have been merged
-                        result.Add(constructNew(snapNav, diffNav));
+                        result.Add(constructNew(snapNav, diffNav, snapHasChildren));
                     }
                 }
                 while (diffNav.MoveToNext());
@@ -490,14 +494,16 @@ namespace Hl7.Fhir.Specification.Snapshot
         }
 
         // [WMR 20160902] Represents a new element definition with no matching base element (for core resource & datatype definitions)
-        private static MatchInfo constructNew(ElementDefinitionNavigator snapNav, ElementDefinitionNavigator diffNav)
+        private static MatchInfo constructNew(ElementDefinitionNavigator snapNav, ElementDefinitionNavigator diffNav, bool snapIsOnChild = true)
         {
             // Called by Match when the current diffNav does not match any following sibling of snapNav (base)
             // This happens when merging a core definition (e.g. Patient) with a base type (e.g. Resource)
             // Return reference to *parent* element as BaseBookmark!
             // Exception: when snapNav = {} | {Resource} e.g. Resource & Element
+            // Exception: when the base element has no children at all, snapNav is already positioned
+            // on the parent element and must not be moved up another level.
             var bm = snapNav.Bookmark();
-            if (!string.IsNullOrEmpty(snapNav.ParentPath))
+            if (snapIsOnChild && !string.IsNullOrEmpty(snapNav.ParentPath))
             {
                 snapNav.MoveToParent();
             }

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotBaseComponentGenerator.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotBaseComponentGenerator.cs
@@ -24,18 +24,30 @@ namespace Hl7.Fhir.Specification.Snapshot
     partial class SnapshotGenerator
     {
         private Tasks.Task ensureSnapshotBaseComponents(StructureDefinition structureDef, bool force = false) =>
-            ensureBaseComponents(structureDef.Snapshot.Element, structureDef.BaseDefinition, force);
+            ensureBaseComponents(structureDef.Snapshot.Element, structureDef.BaseDefinition, force, structureDef.Kind);
 
         /// <summary>(Re-)generate the <see cref="ElementDefinition.Base"/> components.</summary>
         /// <param name="elements">A list of <see cref="ElementDefinition"/> instances.</param>
         /// <param name="baseProfileUrl">The canonical url of the base profile, as defined by the <see cref="StructureDefinition.BaseDefinition"/> property.</param>
         /// <param name="force">If <c>true</c>, then always (re-)generate the Base component, even if it exists.</param>
-        private async Tasks.Task ensureBaseComponents(IList<ElementDefinition> elements, string baseProfileUrl, bool force = false)
+        /// <param name="kind">The <see cref="StructureDefinition.Kind"/> of the structure that owns <paramref name="elements"/>, if known.</param>
+        private async Tasks.Task ensureBaseComponents(IList<ElementDefinition> elements, string baseProfileUrl, bool force = false, StructureDefinition.StructureDefinitionKind? kind = null)
         {
             var nav = new ElementDefinitionNavigator(elements);
             if (nav.MoveToFirstChild() && !string.IsNullOrEmpty(baseProfileUrl))
             {
                 var sd = await AsyncResolver.FindStructureDefinitionAsync(baseProfileUrl).ConfigureAwait(false);
+
+                // #3576 A logical model may derive directly from Base, which is only resolvable since R5.
+                // There is nothing to inherit from the (empty) Base definition, so silently skip; generate()
+                // already reported the unresolved base as a warning.
+                if (sd is null
+                    && kind == StructureDefinition.StructureDefinitionKind.Logical
+                    && baseProfileUrl == BASE_TYPE_CANONICAL)
+                {
+                    return;
+                }
+
                 if (await ensureSnapshot(sd, baseProfileUrl).ConfigureAwait(false))
                 {
                     var baseNav = new ElementDefinitionNavigator(sd);

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotBaseComponentGenerator.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotBaseComponentGenerator.cs
@@ -43,7 +43,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                 // already reported the unresolved base as a warning.
                 if (sd is null
                     && kind == StructureDefinition.StructureDefinitionKind.Logical
-                    && baseProfileUrl == BASE_TYPE_CANONICAL)
+                    && isBaseTypeCanonical(baseProfileUrl))
                 {
                     return;
                 }

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
@@ -303,16 +303,36 @@ namespace Hl7.Fhir.Specification.Snapshot
         /// <param name="structure">the StructureDefinition to get the base from</param>
         /// <returns>The parent of <paramref name="structure"/>, skipping the interface classes</returns>
         internal async Tasks.Task<StructureDefinition> getBaseDefinition(StructureDefinition structure)
-        {
-            if (structure?.BaseDefinition is null) return null;
+            => (await resolveBaseDefinition(structure).ConfigureAwait(false)).baseStructure;
 
-            structure = await AsyncResolver.FindStructureDefinitionAsync(structure.BaseDefinition);
-            while (structure?.GetBoolExtension(SnapshotGeneratorExtensions.STRUCTURE_DEFINITION_INTERFACE_EXT) == true)
+        /// <summary>
+        /// The canonical url of the FHIR <c>Base</c> type. Note that <c>Base</c> is only published as a
+        /// resolvable <see cref="StructureDefinition"/> since R5, even though HL7 tooling stamps this
+        /// version-independent canonical url regardless of the targeted FHIR release.
+        /// </summary>
+        private const string BASE_TYPE_CANONICAL = "http://hl7.org/fhir/StructureDefinition/Base";
+
+        /// <inheritdoc cref="getBaseDefinition(StructureDefinition)"/>
+        /// <returns>
+        /// The resolved parent of <paramref name="structure"/> and, if resolution failed, the canonical
+        /// url that could not be resolved. Note that this is not necessarily
+        /// <see cref="StructureDefinition.BaseDefinition"/> itself, as interface classes are skipped.
+        /// </returns>
+        private async Tasks.Task<(StructureDefinition baseStructure, string unresolvedCanonical)> resolveBaseDefinition(StructureDefinition structure)
+        {
+            var canonical = structure?.BaseDefinition;
+            if (canonical is null) return (null, null);
+
+            var result = await AsyncResolver.FindStructureDefinitionAsync(canonical).ConfigureAwait(false);
+            while (result?.GetBoolExtension(SnapshotGeneratorExtensions.STRUCTURE_DEFINITION_INTERFACE_EXT) == true)
             {
-                structure = await AsyncResolver.FindStructureDefinitionAsync(structure.BaseDefinition);
+                canonical = result.BaseDefinition;
+                if (canonical is null) return (null, null);
+
+                result = await AsyncResolver.FindStructureDefinitionAsync(canonical).ConfigureAwait(false);
             }
 
-            return structure;
+            return (result, result is null ? canonical : null);
         }
 
         ///// <inheritdoc cref="MergeElementDefinitionAsync(ElementDefinition, ElementDefinition, bool)" />
@@ -348,19 +368,39 @@ namespace Hl7.Fhir.Specification.Snapshot
             }
 
             ElementDefinitionNavigator nav;
+            StructureDefinition baseStructure = null;
             // StructureDefinition.SnapshotComponent snapshot = null;
             if (structure.BaseDefinition != null)
             {
-                var baseStructure = await getBaseDefinition(structure);
+                var (resolvedBase, unresolvedCanonical) = await resolveBaseDefinition(structure).ConfigureAwait(false);
 
                 // [WMR 20161208] Handle unresolved base profile
-                if (baseStructure == null)
+                if (resolvedBase == null)
                 {
-                    addIssueProfileNotFound(structure.BaseDefinition);
-                    // Fatal error...
-                    return null;
+                    // #3576 A logical model may derive directly from Base, which is only published as a
+                    // resolvable StructureDefinition since R5. As the real Base definition is empty (an
+                    // abstract root element without any children), terminating the derivation chain here
+                    // is functionally identical to resolving it. Note the narrow scope: this only applies
+                    // to logical models, and only to Base itself. Any other unresolvable base definition,
+                    // and any unresolvable base definition of a non-logical structure, remains fatal.
+                    if (structure.Kind == StructureDefinition.StructureDefinitionKind.Logical
+                        && unresolvedCanonical == BASE_TYPE_CANONICAL)
+                    {
+                        addIssueBaseTypeUnresolved(structure, unresolvedCanonical);
+                    }
+                    else
+                    {
+                        addIssueProfileNotFound(structure.BaseDefinition);
+                        // Fatal error...
+                        return null;
+                    }
                 }
 
+                baseStructure = resolvedBase;
+            }
+
+            if (baseStructure != null)
+            {
                 var baseDefinitionUrl = baseStructure.BaseDefinitionElement;
                 // [WMR 20161208] Handle missing differential
                 var location = differential.Element.Count > 0 ? differential.Element[0].Path : null;
@@ -468,7 +508,7 @@ namespace Hl7.Fhir.Specification.Snapshot
 
                 // Ensure that ElementDefinition.Base components in base StructureDef are propertly initialized
                 // [WMR 20170424] Inherit existing base components, generate if missing
-                await ensureBaseComponents(snapshot.Element, structure.BaseDefinition, false).ConfigureAwait(false);
+                await ensureBaseComponents(snapshot.Element, structure.BaseDefinition, false, structure.Kind).ConfigureAwait(false);
 
 
                 // [WMR 20170208] Moved to *AFTER* ensureBaseComponents - emits annotations...
@@ -488,7 +528,8 @@ namespace Hl7.Fhir.Specification.Snapshot
             }
             else
             {
-                // No base; input is a core resource or datatype definition
+                // No base; input is a core resource or datatype definition, or a logical model whose
+                // derivation chain terminates at the (unresolvable before R5) Base type - see #3576 above.
                 var snapshot = new StructureDefinition.SnapshotComponent();
                 nav = new ElementDefinitionNavigator(snapshot.Element, structure);
             }
@@ -645,6 +686,17 @@ namespace Hl7.Fhir.Specification.Snapshot
                 // Element has neither a name reference or a type...?
                 if (!nav.Current.IsRootElement())
                 {
+                    // Logical models may define nested anonymous ("named") elements that have neither a
+                    // type code nor a contentReference; their children are defined inline by the differential
+                    // (optionally described by the type-specifier extension). There is nothing to expand from
+                    // a base type here, but the differential children are still valid constraints.
+                    // Report success without children, so the caller merges them as new elements
+                    // instead of silently discarding the whole subtree.
+                    if (nav.StructureDefinition?.Kind == StructureDefinition.StructureDefinitionKind.Logical)
+                    {
+                        return true;
+                    }
+
                     addIssueNoTypeOrNameReference(defn);
                     return false;
                 }

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
@@ -312,6 +312,13 @@ namespace Hl7.Fhir.Specification.Snapshot
         /// </summary>
         private const string BASE_TYPE_CANONICAL = "http://hl7.org/fhir/StructureDefinition/Base";
 
+        /// <summary>
+        /// Determines whether <paramref name="canonical"/> refers to the FHIR <c>Base</c> type,
+        /// ignoring an optional <c>|version</c> suffix.
+        /// </summary>
+        private static bool isBaseTypeCanonical(string canonical)
+            => canonical is not null && new Canonical(canonical).Uri == BASE_TYPE_CANONICAL;
+
         /// <inheritdoc cref="getBaseDefinition(StructureDefinition)"/>
         /// <returns>
         /// The resolved parent of <paramref name="structure"/> and, if resolution failed, the canonical
@@ -384,7 +391,7 @@ namespace Hl7.Fhir.Specification.Snapshot
                     // to logical models, and only to Base itself. Any other unresolvable base definition,
                     // and any unresolvable base definition of a non-logical structure, remains fatal.
                     if (structure.Kind == StructureDefinition.StructureDefinitionKind.Logical
-                        && unresolvedCanonical == BASE_TYPE_CANONICAL)
+                        && isBaseTypeCanonical(unresolvedCanonical))
                     {
                         addIssueBaseTypeUnresolved(structure, unresolvedCanonical);
                     }

--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGeneratorOutcome.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGeneratorOutcome.cs
@@ -386,6 +386,24 @@ namespace Hl7.Fhir.Specification.Snapshot
             );
         }
 
+        // #3576 A logical model is allowed to derive directly from the FHIR Base type - there is no more
+        // specific ancestor in the FHIR type hierarchy for data that is neither a Resource nor a DataType.
+        // However, Base is only published as a resolvable StructureDefinition since R5, even though HL7
+        // tooling stamps this same version-independent canonical url regardless of the target release.
+        // The real Base definition is empty (an abstract root element without any children), so we can
+        // safely terminate the derivation chain there instead of failing.
+        public static readonly Issue PROFILE_BASE_TYPE_UNRESOLVED = Issue.Create(10017, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Incomplete);
+
+        internal OperationOutcome.IssueComponent addIssueBaseTypeUnresolved(StructureDefinition sd, string canonical)
+            => addIssue(
+                PROFILE_BASE_TYPE_UNRESOLVED,
+                $"The base definition '{canonical}' of logical model '{sd.Url}' could not be resolved in this FHIR release. " +
+                $"Treating Base as the terminal (empty) root of the derivation chain; the generated snapshot only contains " +
+                $"the content of the logical model itself.",
+                sd.Url,
+                canonical
+            );
+
         // [WMR 20190902] #1090 SnapshotGenerator should support logical models
         // StructureDefinition.type (1...1) is empty or missing
         // However for logical models we only need root element name, can parse from first element constraint

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -9108,6 +9108,355 @@ namespace Hl7.Fhir.Specification.Tests
         }
 
 
+        // #3576 SnapshotGenerator silently dropped the children of a logical model element that has
+        // neither a type code nor a contentReference ("named elements" style logical models, as used by
+        // e.g. the CDS Hooks logical models). The whole nested subtree disappeared from the snapshot,
+        // which made validation against such a profile vacuously succeed.
+
+        private static ElementDefinition logicalElement(string path, string typeCode = null, int? min = null, string max = null)
+        {
+            var result = new ElementDefinition(path);
+            if (min is not null) { result.Min = min; }
+            if (max is not null) { result.Max = max; }
+            if (typeCode is not null)
+            {
+                result.Type = new List<ElementDefinition.TypeRefComponent>
+                {
+                    new() { Code = typeCode }
+                };
+            }
+            return result;
+        }
+
+        private static StructureDefinition createLogicalModel(string name, string baseDefinition, params ElementDefinition[] elements)
+            => new()
+            {
+                Url = "http://example.org/fhir/StructureDefinition/" + name,
+                Name = name,
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Logical,
+                Abstract = false,
+                Derivation = StructureDefinition.TypeDerivationRule.Specialization,
+                Type = "http://example.org/fhir/StructureDefinition/" + name,
+                BaseDefinition = baseDefinition,
+                Differential = new StructureDefinition.DifferentialComponent { Element = elements.ToList() }
+            };
+
+        [TestMethod]
+        public async Tasks.Task TestLogicalModelWithAnonymousNestedElements()
+        {
+            // A logical model in the style of the CDS Hooks models: nested anonymous elements
+            // ("context", "context.draftOrders") that have no type code at all; their content is
+            // defined inline by the differential.
+            var model = createLogicalModel("CdsHookRequest", ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Element),
+                logicalElement("CdsHookRequest"),
+                logicalElement("CdsHookRequest.hook", "string", 1, "1"),
+                logicalElement("CdsHookRequest.hookInstance", "string", 1, "1"),
+                logicalElement("CdsHookRequest.context", min: 1, max: "1"),
+                logicalElement("CdsHookRequest.context.patientId", "string", 1, "1"),
+                logicalElement("CdsHookRequest.context.userId", "string", 0, "1"),
+                logicalElement("CdsHookRequest.context.draftOrders", min: 0, max: "1"),
+                logicalElement("CdsHookRequest.context.draftOrders.resourceType", "string", 1, "1")
+            );
+
+            var (_, expanded) = await generateSnapshotAndCompare(model);
+            dumpOutcome(_generator.Outcome);
+
+            Assert.IsNotNull(expanded);
+            Assert.IsTrue(expanded.HasSnapshot);
+
+            var elems = expanded.Snapshot.Element;
+            var paths = elems.Select(e => e.Path).ToList();
+
+            // Elements inherited from the base definition (Element), rebased onto the model root
+            Assert.AreEqual("CdsHookRequest", paths[0]);
+            CollectionAssert.Contains(paths, "CdsHookRequest.id");
+            CollectionAssert.Contains(paths, "CdsHookRequest.extension");
+
+            // Elements introduced by the differential, including the anonymous nested subtrees.
+            // Before the fix, everything below "CdsHookRequest.context" was silently dropped.
+            CollectionAssert.Contains(paths, "CdsHookRequest.hook");
+            CollectionAssert.Contains(paths, "CdsHookRequest.hookInstance");
+            CollectionAssert.Contains(paths, "CdsHookRequest.context");
+            CollectionAssert.Contains(paths, "CdsHookRequest.context.patientId");
+            CollectionAssert.Contains(paths, "CdsHookRequest.context.userId");
+            CollectionAssert.Contains(paths, "CdsHookRequest.context.draftOrders");
+            CollectionAssert.Contains(paths, "CdsHookRequest.context.draftOrders.resourceType");
+
+            // The nested elements are properly merged, not just copied
+            var patientId = elems.Single(e => e.Path == "CdsHookRequest.context.patientId");
+            Assert.AreEqual(1, patientId.Min);
+            Assert.AreEqual("1", patientId.Max);
+            Assert.AreEqual("string", patientId.Type.Single().Code);
+
+            // Verify sdf-8b: "All snapshot elements must have a base definition"
+            foreach (var elem in elems)
+            {
+                Assert.IsNotNull(elem.Base, $"Element '{elem.Path}' has no base component.");
+                Assert.IsNotNull(elem.Base.Path);
+            }
+
+            // The snapshot must be a proper tree, i.e. every non-root element must have a parent
+            foreach (var path in paths.Skip(1))
+            {
+                var parentPath = ElementDefinitionNavigator.GetParentPath(path);
+                CollectionAssert.Contains(paths, parentPath, $"Element '{path}' has no parent in the snapshot.");
+            }
+        }
+
+        [TestMethod]
+        public async Tasks.Task TestLogicalModelDerivedFromLogicalModel()
+        {
+            // A logical model constraining another logical model; verify that inherited elements are
+            // merged (not duplicated) and that overrides are applied.
+            var baseModel = createLogicalModel("BaseModel", ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Element),
+                logicalElement("BaseModel"),
+                logicalElement("BaseModel.name", "string", 0, "1"),
+                logicalElement("BaseModel.optional", "string", 0, "*"),
+                logicalElement("BaseModel.nested", min: 0, max: "1"),
+                logicalElement("BaseModel.nested.inner", "string", 0, "1")
+            );
+
+            var derived = new StructureDefinition
+            {
+                Url = "http://example.org/fhir/StructureDefinition/DerivedModel",
+                Name = "DerivedModel",
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Logical,
+                Abstract = false,
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Type = baseModel.Type,
+                BaseDefinition = baseModel.Url,
+                Differential = new StructureDefinition.DifferentialComponent
+                {
+                    Element = new List<ElementDefinition>
+                    {
+                        // Override an inherited element...
+                        logicalElement("BaseModel.optional", min: 1, max: "1"),
+                        // ...and an inherited element inside an anonymous nested element
+                        logicalElement("BaseModel.nested.inner", min: 1, max: "1")
+                    }
+                }
+            };
+
+            var resolver = new CachedResolver(new MultiResolver(new InMemoryResourceResolver(baseModel), _testResolver));
+            _generator = new SnapshotGenerator(resolver, _settings);
+            await _generator.UpdateAsync(derived);
+            dumpOutcome(_generator.Outcome);
+
+            Assert.IsTrue(derived.HasSnapshot);
+            var elems = derived.Snapshot.Element;
+
+            // Inherited, unconstrained
+            var name = elems.Single(e => e.Path == "BaseModel.name");
+            Assert.AreEqual(0, name.Min);
+            Assert.AreEqual("1", name.Max);
+
+            // Inherited and overridden
+            var optional = elems.Single(e => e.Path == "BaseModel.optional");
+            Assert.AreEqual(1, optional.Min);
+            Assert.AreEqual("1", optional.Max);
+            // ... but the base cardinality is still the one from the base model
+            Assert.AreEqual("*", optional.Base.Max);
+
+            // Inherited from an anonymous nested element, and overridden
+            var inner = elems.Single(e => e.Path == "BaseModel.nested.inner");
+            Assert.AreEqual(1, inner.Min);
+            Assert.AreEqual("1", inner.Max);
+            Assert.AreEqual("string", inner.Type.Single().Code);
+        }
+
+        // #3576 Regression test: the snapshot of a logical model with an anonymous nested element
+        // must not be empty, and must not lose the nested subtree.
+        [TestMethod]
+        public async Tasks.Task TestLogicalModelSnapshotIsNotEmpty()
+        {
+            var model = createLogicalModel("MinimalModel", ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Element),
+                logicalElement("MinimalModel"),
+                logicalElement("MinimalModel.wrapper", min: 1, max: "1"),
+                logicalElement("MinimalModel.wrapper.leaf", "string", 1, "1")
+            );
+
+            _generator = new SnapshotGenerator(_testResolver, _settings);
+            await _generator.UpdateAsync(model);
+            dumpOutcome(_generator.Outcome);
+
+            Assert.IsTrue(model.HasSnapshot, "Expected a non-empty snapshot for a kind=logical StructureDefinition.");
+            Assert.IsTrue(model.Snapshot.Element.Count > 0);
+
+            var leaf = model.Snapshot.Element.SingleOrDefault(e => e.Path == "MinimalModel.wrapper.leaf");
+            Assert.IsNotNull(leaf, "The child of the untyped element 'MinimalModel.wrapper' was dropped from the snapshot.");
+            Assert.AreEqual(1, leaf.Min);
+            Assert.AreEqual("1", leaf.Max);
+        }
+
+        // #3576 kind=logical StructureDefinitions are allowed to derive directly from the FHIR Base type,
+        // but Base is only published as a resolvable StructureDefinition since R5 - R4/R4B never shipped
+        // one, even though HL7 tooling stamps the same version-independent canonical url regardless of the
+        // target release (e.g. CDSHooksElement in hl7.fhir.uv.tools.r4). Since the real Base definition is
+        // empty, the snapshot generator terminates the derivation chain there with a warning, rather than
+        // failing and producing an empty snapshot.
+
+        private const string BaseTypeCanonical = "http://hl7.org/fhir/StructureDefinition/Base";
+
+        /// <summary>
+        /// Wraps another resolver, but refuses to resolve a fixed set of canonicals. Used to simulate the
+        /// R4/R4B situation - where Base is simply not published - in every FHIR release under test.
+        /// Note that in R5, Base is a real (and needed) part of the core type hierarchy: Element derives
+        /// from it. So the models used with this resolver must not depend on any core type.
+        /// </summary>
+        private sealed class BlockingResolver(IAsyncResourceResolver inner, params string[] blocked) : IAsyncResourceResolver
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            public Tasks.Task<Resource> ResolveByCanonicalUriAsync(string uri)
+                => blocked.Contains(uri) ? Tasks.Task.FromResult<Resource>(null) : inner.ResolveByCanonicalUriAsync(uri);
+
+            public Tasks.Task<Resource> ResolveByUriAsync(string uri)
+                => blocked.Contains(uri) ? Tasks.Task.FromResult<Resource>(null) : inner.ResolveByUriAsync(uri);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        /// <summary>A resolver that resolves the core types, but not <c>Base</c>.</summary>
+        private IAsyncResourceResolver resolverWithoutBaseType(params StructureDefinition[] extra)
+            => new CachedResolver(new BlockingResolver(
+                new MultiResolver(new InMemoryResourceResolver(extra), _testResolver), BaseTypeCanonical));
+
+        [TestMethod]
+        public async Tasks.Task TestLogicalModelWithUnresolvableBaseType()
+        {
+            // Note: only anonymous (untyped) elements, so that nothing needs the core type hierarchy -
+            // see the remark on BlockingResolver
+            var model = createLogicalModel("CdsHooksElement", BaseTypeCanonical,
+                logicalElement("CdsHooksElement"),
+                logicalElement("CdsHooksElement.hook", min: 1, max: "1"),
+                logicalElement("CdsHooksElement.context", min: 1, max: "1"),
+                logicalElement("CdsHooksElement.context.patientId", min: 1, max: "1")
+            );
+
+            // Note: Base is deliberately *not* resolvable through this resolver
+            _generator = new SnapshotGenerator(resolverWithoutBaseType(), _settings);
+            await _generator.UpdateAsync(model);
+            dumpOutcome(_generator.Outcome);
+
+            // Generation must succeed, with the model's own differential content
+            Assert.IsTrue(model.HasSnapshot, "Expected a snapshot, even though Base could not be resolved.");
+            var paths = model.Snapshot.Element.Select(e => e.Path).ToList();
+            CollectionAssert.AreEqual(
+                new[] { "CdsHooksElement", "CdsHooksElement.hook", "CdsHooksElement.context", "CdsHooksElement.context.patientId" },
+                paths);
+
+            var hook = model.Snapshot.Element.Single(e => e.Path == "CdsHooksElement.hook");
+            Assert.AreEqual(1, hook.Min);
+            Assert.AreEqual("1", hook.Max);
+
+            // ... and report the unresolved base as a warning, not an error
+            Assert.IsNotNull(_generator.Outcome);
+            var issue = _generator.Outcome.Issue.Single();
+            Assert.AreEqual(OperationOutcome.IssueSeverity.Warning, issue.Severity);
+            Assert.AreEqual(SnapshotGenerator.PROFILE_BASE_TYPE_UNRESOLVED.Code.ToString(), issue.Details.Coding[0].Code);
+            StringAssert.Contains(issue.Details.Text, BaseTypeCanonical);
+            StringAssert.Contains(issue.Details.Text, model.Url);
+            Assert.IsFalse(_generator.Outcome.Issue.Any(i => i.Severity == OperationOutcome.IssueSeverity.Error));
+        }
+
+        [TestMethod]
+        public async Tasks.Task TestLogicalModelDerivedFromModelWithUnresolvableBaseType()
+        {
+            // The normal shape of the CDS Hooks models: they derive from CDSHooksElement, which in turn
+            // derives from the unresolvable Base. Verify that the recursive expansion of the parent also
+            // succeeds, and that the child inherits the parent's elements.
+            var parent = createLogicalModel("CdsHooksElement", BaseTypeCanonical,
+                logicalElement("CdsHooksElement"),
+                logicalElement("CdsHooksElement.hook", min: 1, max: "1")
+            );
+
+            var child = new StructureDefinition
+            {
+                Url = "http://example.org/fhir/StructureDefinition/CdsHooksRequest",
+                Name = "CdsHooksRequest",
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.Logical,
+                Abstract = false,
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Type = parent.Type,
+                BaseDefinition = parent.Url,
+                Differential = new StructureDefinition.DifferentialComponent
+                {
+                    Element = new List<ElementDefinition>
+                    {
+                        logicalElement("CdsHooksElement.hookInstance", min: 1, max: "1")
+                    }
+                }
+            };
+
+            _generator = new SnapshotGenerator(resolverWithoutBaseType(parent), _settings);
+            await _generator.UpdateAsync(child);
+            dumpOutcome(_generator.Outcome);
+
+            Assert.IsTrue(child.HasSnapshot);
+            var paths = child.Snapshot.Element.Select(e => e.Path).ToList();
+            CollectionAssert.Contains(paths, "CdsHooksElement.hook");         // inherited from the parent
+            CollectionAssert.Contains(paths, "CdsHooksElement.hookInstance"); // introduced by the child
+
+            Assert.IsFalse(_generator.Outcome?.Issue.Any(i => i.Severity == OperationOutcome.IssueSeverity.Error) == true);
+        }
+
+        // #3576 Regression test: the special case above is narrowly scoped to (kind=logical AND Base).
+        // Any other unresolvable base definition must keep failing exactly as it did before.
+        [TestMethod]
+        public async Tasks.Task TestLogicalModelWithOtherUnresolvableBaseTypeStillFails()
+        {
+            var model = createLogicalModel("SomeModel", "http://example.org/fhir/StructureDefinition/DoesNotExist",
+                logicalElement("SomeModel"),
+                logicalElement("SomeModel.name", "string", 1, "1")
+            );
+
+            _generator = new SnapshotGenerator(resolverWithoutBaseType(), _settings);
+            await _generator.UpdateAsync(model);
+            dumpOutcome(_generator.Outcome);
+
+            Assert.IsFalse(model.HasSnapshot, "An unresolvable base definition other than Base must remain fatal.");
+            Assert.IsNotNull(_generator.Outcome);
+            Assert.IsTrue(_generator.Outcome.Issue.Any(i =>
+                i.Severity == OperationOutcome.IssueSeverity.Error &&
+                i.Details.Coding[0].Code == Issue.UNAVAILABLE_REFERENCED_PROFILE.Code.ToString()));
+        }
+
+        [TestMethod]
+        public async Tasks.Task TestNonLogicalModelWithUnresolvableBaseTypeStillFails()
+        {
+            // Same unresolvable Base, but on a complex-type: the special case must not apply here
+            var complexType = new StructureDefinition
+            {
+                Url = "http://example.org/fhir/StructureDefinition/MyComplexType",
+                Name = "MyComplexType",
+                Status = PublicationStatus.Draft,
+                Kind = StructureDefinition.StructureDefinitionKind.ComplexType,
+                Abstract = false,
+                Derivation = StructureDefinition.TypeDerivationRule.Specialization,
+                Type = "MyComplexType",
+                BaseDefinition = BaseTypeCanonical,
+                Differential = new StructureDefinition.DifferentialComponent
+                {
+                    Element = new List<ElementDefinition>
+                    {
+                        logicalElement("MyComplexType"),
+                        logicalElement("MyComplexType.name", "string", 1, "1")
+                    }
+                }
+            };
+
+            _generator = new SnapshotGenerator(resolverWithoutBaseType(), _settings);
+            await _generator.UpdateAsync(complexType);
+            dumpOutcome(_generator.Outcome);
+
+            Assert.IsFalse(complexType.HasSnapshot, "The Base special case must only apply to kind=logical.");
+            Assert.IsNotNull(_generator.Outcome);
+            Assert.IsTrue(_generator.Outcome.Issue.Any(i =>
+                i.Severity == OperationOutcome.IssueSeverity.Error &&
+                i.Details.Coding[0].Code == Issue.UNAVAILABLE_REFERENCED_PROFILE.Code.ToString()));
+        }
+
         // #1123 SnapshotGenerator - ElementDefinition.base is empty for children of contentreference
 
         [TestMethod]


### PR DESCRIPTION
This pull request improves the handling of FHIR logical models that derive directly from the `Base` type, especially in versions before R5 where `Base` is not a resolvable `StructureDefinition`. The changes ensure that logical models with `Base` as their ancestor are processed gracefully, emitting a warning instead of failing, and treat `Base` as an empty root. Additional improvements were made to the element matching logic and snapshot generation to handle edge cases involving anonymous elements and missing children.

**Logical model derivation from Base:**
- Logical models that derive from the FHIR `Base` type (which is only resolvable since R5) are now handled gracefully: if `Base` cannot be resolved, a warning is issued and the snapshot generation continues, treating `Base` as an empty root. This avoids fatal errors for valid logical models in earlier FHIR versions. [[1]](diffhunk://#diff-d55d871d68510e0e2e543795373f7ab0e9437452b038423e7c881aa78a9653deR306-R335) [[2]](diffhunk://#diff-d55d871d68510e0e2e543795373f7ab0e9437452b038423e7c881aa78a9653deR371-R403) [[3]](diffhunk://#diff-c19738b4b7131d323e0cc3602783e4cf7f07fa423d9042f33aa0f8a174d4acddR389-R406) [[4]](diffhunk://#diff-60f1dfcac85ba76414a051fc6369e13f1fffbc1ec1fa000a8b0ba2d8ae3b816aL27-R50) [[5]](diffhunk://#diff-d55d871d68510e0e2e543795373f7ab0e9437452b038423e7c881aa78a9653deL471-R511) [[6]](diffhunk://#diff-d55d871d68510e0e2e543795373f7ab0e9437452b038423e7c881aa78a9653deL491-R532)

**Element matching and construction improvements:**
- The element matcher now detects when the base element has no children (such as anonymous elements in logical models), ensuring that new differential elements are correctly treated as new elements, and that the matching logic doesn't attempt to move to non-existent children. [[1]](diffhunk://#diff-6f2e8dab01f35a3fdcdef8caf2d321dd1899af8a94415c88e3f159f1fd90cea7L94-R108) [[2]](diffhunk://#diff-6f2e8dab01f35a3fdcdef8caf2d321dd1899af8a94415c88e3f159f1fd90cea7L114-R118) [[3]](diffhunk://#diff-6f2e8dab01f35a3fdcdef8caf2d321dd1899af8a94415c88e3f159f1fd90cea7L493-R506)

**Snapshot generation and expansion:**
- The snapshot generator now recognizes nested anonymous elements in logical models that have neither a type code nor a content reference, and correctly processes their children as new elements instead of discarding them.

**Codebase maintenance:**
- The `ensureBaseComponents` method now accepts and utilizes the structure kind to better handle special cases for logical models. [[1]](diffhunk://#diff-60f1dfcac85ba76414a051fc6369e13f1fffbc1ec1fa000a8b0ba2d8ae3b816aL27-R50) [[2]](diffhunk://#diff-d55d871d68510e0e2e543795373f7ab0e9437452b038423e7c881aa78a9653deL471-R511)

**Warning and issue reporting:**
- A new warning issue (`PROFILE_BASE_TYPE_UNRESOLVED`) is introduced and reported when a logical model's base cannot be resolved, providing clear feedback to users.

These changes collectively improve support for logical models, particularly in edge cases involving the FHIR `Base` type, and make the snapshot generation process more robust and user-friendly.