### PR TITLE
Replace span-vs-null comparison in MatchesPrefix (CA2265)

### DIFF
--- a/src/Hl7.Fhir.Base/Utility/StringExtensions.cs
+++ b/src/Hl7.Fhir.Base/Utility/StringExtensions.cs
@@ -138,18 +138,19 @@ namespace Hl7.Fhir.Utility
         /// <param name="text"></param>
         /// <param name="prefix"></param>
         /// <returns></returns>
+        /// <remarks>An empty <paramref name="prefix"/> only matches an empty <paramref name="text"/>.
+        /// The "match everything" behaviour for a missing prefix lives on the <c>string</c> overload,
+        /// which treats a <c>null</c> prefix as "no filter".</remarks>
         public static bool MatchesPrefix(this ReadOnlySpan<char> text, ReadOnlySpan<char> prefix)
         {
             ReadOnlySpan<char> asterix = "*".AsSpan();
             bool wildcard = prefix.EndsWith(asterix); //used for value[x] elements
             if (wildcard) prefix = prefix.TrimEnd(asterix);
 
-            bool found = text.StartsWith(prefix);
-            if (!found) return false;
+            if (!text.StartsWith(prefix)) return false;
 
-            bool full = text.Length == prefix.Length;
-
-            return (prefix == null) || full || (wildcard && found);
+            // A wildcard prefix matches any longer text, otherwise the strings must be the same length.
+            return text.Length == prefix.Length || wildcard;
         }
 
         /// <summary>
@@ -158,11 +159,12 @@ namespace Hl7.Fhir.Utility
         /// is done, otherwise the full strings are compared.
         /// </summary>
         /// <param name="text"></param>
-        /// <param name="prefix"></param>
+        /// <param name="prefix">When <c>null</c>, acts as "no filter" and matches any <paramref name="text"/>.</param>
         /// <returns></returns>
         public static bool MatchesPrefix(this string text, string prefix)
         {
-            return text.AsSpan().MatchesPrefix(prefix.AsSpan());
+            // A null prefix means "no filter": callers like DomNode.Children(name = null) rely on this.
+            return prefix is null || text.AsSpan().MatchesPrefix(prefix.AsSpan());
         }
 
         public static string EnsureEndsWith(this string original, string toEndWith)

--- a/src/Hl7.Fhir.Support.Tests/Utility/StringExtensionsTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/Utility/StringExtensionsTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using Hl7.Fhir.Utility;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Hl7.Fhir.Support.Tests
+{
+    [TestClass]
+    public class StringExtensionsTests
+    {
+        [TestMethod]
+        // exact matches
+        [DataRow("value", "value", true)]
+        [DataRow("value", "valueString", false)]
+        [DataRow("valueString", "value", false)]
+        // wildcard prefixes, as used for value[x] elements
+        [DataRow("valueString", "value*", true)]
+        [DataRow("valueQuantity", "value*", true)]
+        [DataRow("value", "value*", true)]
+        [DataRow("other", "value*", false)]
+        [DataRow("anything", "*", true)]
+        // an empty prefix is not a wildcard: it only matches empty text
+        [DataRow("anything", "", false)]
+        [DataRow("", "", true)]
+        public void MatchesPrefixComparesTextToPrefix(string text, string prefix, bool expected) =>
+            text.MatchesPrefix(prefix).Should().Be(expected);
+
+        [TestMethod]
+        public void MatchesPrefixTreatsNullPrefixAsNoFilter()
+        {
+            // Callers such as DomNode.Children(string name = null) rely on a null prefix
+            // meaning "no filter", so every text must match.
+            "anything".MatchesPrefix(null).Should().BeTrue();
+            "".MatchesPrefix(null).Should().BeTrue();
+        }
+
+        [TestMethod]
+        [DataRow("value", "value", true)]
+        [DataRow("valueString", "value", false)]
+        [DataRow("valueString", "value*", true)]
+        [DataRow("anything", "", false)]
+        [DataRow("", "", true)]
+        public void MatchesPrefixOnSpansBehavesLikeTheStringOverload(string text, string prefix, bool expected) =>
+            text.AsSpan().MatchesPrefix(prefix.AsSpan()).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
Fixes #3580.

## What

`MatchesPrefix(this ReadOnlySpan<char> text, ReadOnlySpan<char> prefix)` ended with `return (prefix == null) || full || (wildcard && found);`. Comparing a span to `null` raises **CA2265**, which becomes a hard build error under `TreatWarningsAsErrors` as soon as a `net10.0` target framework is added. It was the only compile-level diagnostic in a full-solution build against net10.0.

## This is not a behaviour fix

Worth being explicit, because the analyzer makes it look like one. The comparison was **correct** — just written in a way that is easy to misread.

`ReadOnlySpan<T>.operator ==` is reference-and-length equality, and `null` converts to `default(ReadOnlySpan<char>)`. So `((string)null).AsSpan() == null` is `true`, but `"".AsSpan() == null` is `false`. The check therefore meant *"the prefix came from a null string"*, not *"the prefix is empty"* — which is exactly what callers like `DomNode.Children(string name = null)`, `FhirJsonNode`, `FhirXmlNode` and `TypedElementToSourceNodeAdapter` need, since they pass a nullable `name` where `null` means "no filter".

The fragility was that this depended on `AsSpan()` preserving null-ness and on the reader knowing that empty-span and null-span differ under `==`. Nothing documented it.

## Change

Null handling moves to the `string` overload, where it is an ordinary null check, and comes out of the span overload:

```csharp
public static bool MatchesPrefix(this string text, string prefix)
{
    // A null prefix means "no filter": callers like DomNode.Children(name = null) rely on this.
    return prefix is null || text.AsSpan().MatchesPrefix(prefix.AsSpan());
}
```

Also drops a redundancy: the method returns early when the prefix does not match, so `found` is always `true` at the `return` and `wildcard && found` is just `wildcard`.

Both overloads gained doc comments covering the null/empty distinction, which was previously undocumented.

## Compatibility

- **`string` overload — unchanged.** Verified identical across all combinations of `{"value", "valueString", "valueQuantity", "", "v"}` x `{"value", "value*", "valueString", "", "*", null, "v*"}` — 0 differences.
- **`span` overload — one edge-case delta.** Passed a `default`/null-reference span directly it previously returned `true` (match everything) and now returns `text.IsEmpty`. No caller in this repository does this — all four call sites go through the `string` overload — but it is public API, so flagging it. Happy to preserve the old behaviour explicitly if you would rather not touch the span contract at all.

## Tests

`MatchesPrefix` had **no test coverage**. Added `StringExtensionsTests` covering exact matches, `value[x]` wildcard prefixes, the empty-prefix case, the null-prefix "no filter" case, and span/string parity — 16 cases.

## Verification

- `Hl7.Fhir.Support.Tests` (new tests): 16 passed
- `Hl7.Fhir.ElementModel.R4.Tests`: 70 passed
- `Hl7.Fhir.Serialization.R4.Tests`: 16,240 passed
- `Hl7.Fhir.Base` builds clean against `net10.0` with CA2265 gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)