### PR TITLE
Fix SnapshotGenerator crash on complex type profile reference with child constraints

### DIFF
--- a/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
+++ b/src/Hl7.Fhir.Conformance/Specification/Snapshot/SnapshotGenerator.cs
@@ -1361,7 +1361,15 @@ namespace Hl7.Fhir.Specification.Snapshot
                             }
                             else
                             {
-                                if (!typeNav.JumpToNameReference(profileRef.ElementName))
+                                // [EK 20260824] #3583: The "elementName" fragment of a complex type profile reference
+                                // ("canonicalUrl#elementName") identifies a named slice within the referenced
+                                // extension's own Extension.extension slicing - not a local nameReference/contentReference.
+                                // So locate the child extension slice by SliceName, instead of by ElementId
+                                // (JumpToNameReference is for the unrelated ContentReference mechanism and cannot be reused here).
+                                if (!typeNav.MoveToFirstChild() // position on the (rebased) root element of the referenced extension
+                                    || !typeNav.MoveToChild("extension")
+                                    || !(StringComparer.Ordinal.Equals(typeNav.Current.SliceName, profileRef.ElementName)
+                                         || typeNav.MoveToNextSliceAtAnyLevel(profileRef.ElementName)))
                                 {
                                     addIssueInvalidProfileNameReference(snap.Current, profileRef.ElementName, primaryDiffTypeProfile);
                                     return false;

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Snapshot/SnapshotGeneratorTest.cs
@@ -4263,6 +4263,104 @@ namespace Hl7.Fhir.Specification.Tests
             assertIssue(issues[0], SnapshotGenerator.PROFILE_ELEMENTDEF_INVALID_PROFILE_TYPE);
         }
 
+        // [EK 20260824] #3583: A differential element with a complex type profile reference ("canonicalUrl#elementName")
+        // that also has child constraints in the differential (so mustExpandElement() is true) must correctly
+        // expand the referenced fragment ("elementName" = the sliceName of a sub-extension) and merge the child
+        // constraints on top of it. Previously this crashed with NotSupportedException, because mergeTypeProfiles
+        // used JumpToNameReference (the ContentReference/id-based lookup mechanism) instead of a SliceName lookup.
+        // Note: fixture t13 (Type Slicing) uses the same "...patient-nationality#code" reference WITHOUT child
+        // constraints, so mustExpandElement() is false there and it never hit the broken path.
+        [TestMethod]
+        public async Tasks.Task TestComplexTypeProfileReferenceWithChildConstraints()
+        {
+            var sdPatient = new StructureDefinition()
+            {
+                Type = FHIRAllTypes.Patient.GetLiteral(),
+                BaseDefinition = ModelInfo.CanonicalUriForFhirCoreType(FHIRAllTypes.Patient),
+                Name = "MyNationalityPatient",
+                Url = "http://example.org/fhir/StructureDefinition/MyNationalityPatient",
+                Derivation = StructureDefinition.TypeDerivationRule.Constraint,
+                Differential = new StructureDefinition.DifferentialComponent()
+                {
+                    Element = new List<ElementDefinition>()
+                    {
+                        new ElementDefinition("Patient.extension")
+                        {
+                            Slicing = new ElementDefinition.SlicingComponent()
+                            {
+                                Discriminator = new List<ElementDefinition.DiscriminatorComponent>()
+                                {
+                                    new ElementDefinition.DiscriminatorComponent()
+                                    { Type = ElementDefinition.DiscriminatorType.Value, Path = "url" }
+                                },
+                                Rules = ElementDefinition.SlicingRules.Open
+                            }
+                        },
+                        new ElementDefinition("Patient.extension")
+                        {
+                            SliceName = "nationality",
+                            Type = new List<ElementDefinition.TypeRefComponent>()
+                            {
+                                new ElementDefinition.TypeRefComponent()
+                                {
+                                    Code = FHIRAllTypes.Extension.GetLiteral(),
+                                    Profile = new string[] { "http://hl7.org/fhir/StructureDefinition/patient-nationality" }
+                                }
+                            }
+                        },
+                        new ElementDefinition("Patient.extension.extension")
+                        {
+                            Slicing = new ElementDefinition.SlicingComponent()
+                            {
+                                Discriminator = new List<ElementDefinition.DiscriminatorComponent>()
+                                {
+                                    new ElementDefinition.DiscriminatorComponent()
+                                    { Type = ElementDefinition.DiscriminatorType.Value, Path = "url" }
+                                },
+                                Rules = ElementDefinition.SlicingRules.Open
+                            }
+                        },
+                        new ElementDefinition("Patient.extension.extension")
+                        {
+                            SliceName = "code",
+                            Type = new List<ElementDefinition.TypeRefComponent>()
+                            {
+                                new ElementDefinition.TypeRefComponent()
+                                {
+                                    Code = FHIRAllTypes.Extension.GetLiteral(),
+                                    // Complex type profile reference including an element name fragment
+                                    Profile = new string[] { "http://hl7.org/fhir/StructureDefinition/patient-nationality#code" }
+                                }
+                            }
+                        },
+                        // Child constraint below the element carrying the complex profile reference,
+                        // so mustExpandElement() returns true and mergeTypeProfiles tries to expand the fragment
+                        new ElementDefinition("Patient.extension.extension.value[x]")
+                        {
+                            Short = "The nationality code"
+                        }
+                    }
+                }
+            };
+
+            _generator = new SnapshotGenerator(_testResolver, _settings);
+            await _generator.UpdateAsync(sdPatient);
+
+            Assert.IsTrue(sdPatient.HasSnapshot);
+            dumpOutcome(_generator.Outcome);
+            Assert.IsNull(_generator.Outcome);
+
+            sdPatient.Snapshot.Element.Dump();
+
+            var nav = ElementDefinitionNavigator.ForSnapshot(sdPatient);
+            Assert.IsTrue(nav.JumpToFirst("Patient.extension.extension"));
+            Assert.IsTrue(nav.MoveToNextSliceAtAnyLevel("code"));
+            // The child constraint from the differential (Short on value[x]) must be merged
+            // into the expanded fragment of the external extension, not just silently dropped
+            Assert.IsTrue(nav.MoveToChild("value[x]"));
+            Assert.AreEqual("The nationality code", nav.Current.Short);
+        }
+
         // [WMR 20170306] Verify that the snapshot generator determines and merges the correct base element for slices
         // * Slice entry is based on associated element in base profile with same path (and name)
         //   Slice entry inherits constraints from base element; can only further constrain


### PR DESCRIPTION
## Summary

Fixes #3583.

`mergeTypeProfiles` crashed with `NotSupportedException: Can only jump to local nameReferences, not <fragment>` when a differential element:
1. carried a complex type profile reference of the form `canonicalUrl#elementName` (e.g. `.../patient-nationality#code`), and
2. had child constraints in the differential (so the generator needed to expand the referenced fragment).

The code was resolving the `#elementName` fragment via `JumpToNameReference`, which implements a different mechanism (the `ContentReference`/local-nameReference lookup, matching by `ElementId`). A bare fragment like `"code"` was misparsed by `ProfileReference.Parse` as an absolute canonical url, tripping an `IsAbsolute` guard. Even past that guard, it could never have matched, since element ids in the rebased extension snapshot look like `Extension.extension:code`, never bare `code`.

The `#elementName` fragment actually identifies a named **slice** within the referenced extension's own `Extension.extension` slicing (see the existing code comment describing the `qicore-adverseevent-cause#certainty` case a few lines above the fix). The fix resolves it via `SliceName` instead, using the existing `MoveToChild`/`MoveToNextSliceAtAnyLevel` navigator helpers.

## Test plan

- [x] Added `TestComplexTypeProfileReferenceWithChildConstraints` (`SnapshotGeneratorTest.cs`), reproducing the crash pre-fix and asserting post-fix that the differential's child constraint is actually merged into the expanded fragment (not just that generation doesn't throw).
- [x] Full `SnapshotGenerator` test suites pass on R4, R4B, and R5 when run individually (447-448 passed, only pre-existing unrelated skips).
- [x] Investigated and ruled out apparent intermittent failures during regression testing: reproduced identically on unmodified `develop` when two test suites run concurrently on the same machine (pre-existing test-infra contention in `TestExpandAllCoreTypes`/`TestExpandCoreArtifacts`, unrelated to `mergeTypeProfiles`).

## Known follow-up (not in this PR)

The `Hl7.Fhir.STU3` shim package ships its own duplicated copy of `SnapshotGenerator.cs` (doesn't reference `Hl7.Fhir.Conformance`) with the identical bug at `src/Hl7.Fhir.STU3/Specification/Snapshot/SnapshotGenerator.cs:1170`. Left unfixed here — happy to open a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)