### PR TITLE
Fix concurrent calls into caller-supplied resolver during terminology validation/expansion

### DIFF
--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/LocalTerminologyService.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/LocalTerminologyService.cs
@@ -12,6 +12,7 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Utility;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -193,8 +194,14 @@ public class LocalTerminologyService : BaseTerminologyService
         if (cc.Coding.Count == 1)
             return await validateCodeVs(vs, cc.Coding.Single(), abstractAllowed).ConfigureAwait(false);
 
-        // Else, look for one succesful match in any of the codes in the CodeableConcept
-        var callResults = await T.Task.WhenAll(cc.Coding.Select(coding => validateCodeVs(vs, coding, abstractAllowed))).ConfigureAwait(false);
+        // Else, look for one succesful match in any of the codes in the CodeableConcept.
+        // These are run sequentially (rather than in parallel) since the caller-supplied resolver
+        // used to resolve the codings is not guaranteed to be safe for concurrent use.
+        var callResults = new List<ValidateCodeResult>();
+        foreach (var coding in cc.Coding)
+        {
+            callResults.Add(await validateCodeVs(vs, coding, abstractAllowed).ConfigureAwait(false));
+        }
         var successResult = callResults.FirstOrDefault(p => p.GetSingleValue<FhirBoolean>("result")?.Value == true);
 
         if (successResult is not null)

--- a/src/Hl7.Fhir.Shims.Base/Specification/Terminology/ValueSetExpander.cs
+++ b/src/Hl7.Fhir.Shims.Base/Specification/Terminology/ValueSetExpander.cs
@@ -155,10 +155,15 @@ namespace Hl7.Fhir.Specification.Terminology
             {
                 // > valueSet(s) only: Codes are 'selected' for inclusion if they are in all the referenced value sets
                 // "all the referenced sets" means we need to calculate the intersection of the expanded valuesets.
-                var expanded = await Tasks.Task.WhenAll(
-                    conceptSet.ValueSet!.Where(vs => vs is not null)
-                        .Select(vs => expandValueSetAndFilterOnSystem(vs!))).ConfigureAwait(false);
-                var concepts = expanded.Length == 1 ? expanded.Single() : expanded.Aggregate((l, r) => l.Intersect(r, _systemAndCodeComparer));
+                // These are expanded sequentially (rather than in parallel) since the caller-supplied
+                // ValueSetSource used to resolve them is not guaranteed to be safe for concurrent use, and
+                // the recursive expansion below shares the (non-thread-safe) inclusionChain across calls.
+                var expanded = new List<IEnumerable<ValueSet.ContainsComponent>>();
+                foreach (var vs in conceptSet.ValueSet!.Where(vs => vs is not null))
+                {
+                    expanded.Add(await expandValueSetAndFilterOnSystem(vs!).ConfigureAwait(false));
+                }
+                var concepts = expanded.Count == 1 ? expanded.Single() : expanded.Aggregate((l, r) => l.Intersect(r, _systemAndCodeComparer));
 
                 addCapped(result, concepts, $"Import of valuesets '{string.Join(",", conceptSet.ValueSet!)}' would result in an expansion larger than the maximum expansion size.");
 

--- a/src/Hl7.Fhir.Specification.Shared.Tests/Terminology/LocalTerminologyServiceTests.cs
+++ b/src/Hl7.Fhir.Specification.Shared.Tests/Terminology/LocalTerminologyServiceTests.cs
@@ -6,6 +6,8 @@ using Hl7.Fhir.Specification.Terminology;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using System;
+using System.Linq;
+using System.Threading;
 using Task = System.Threading.Tasks.Task;
 
 namespace Hl7.Fhir.Specification.Tests
@@ -192,6 +194,147 @@ namespace Hl7.Fhir.Specification.Tests
 
             var ex = await expandAction.Should().ThrowAsync<FhirOperationException>();
             ex.Which.Status.Should().Be((System.Net.HttpStatusCode)422);
+        }
+
+        // Regression test for https://github.com/FirelyTeam/firely-net-sdk/issues/3582:
+        // validating a multi-coding CodeableConcept used to fan out with Task.WhenAll, so a
+        // non-thread-safe caller-supplied resolver (e.g. a scoped EF Core DbContext) could see
+        // overlapping calls from a single logical validate-code operation.
+        [TestMethod]
+        public async Task ValidateCodeVsDoesNotCallResolverConcurrentlyForMultiCodingCodeableConcept()
+        {
+            var resolver = new ConcurrencyTrackingResolver();
+            var service = new LocalTerminologyService(resolver);
+
+            var valueSet = new ValueSet
+            {
+                Url = "http://fire.ly/ValueSet/empty-vs",
+                Expansion = new ValueSet.ExpansionComponent()
+            };
+
+            var cc = new CodeableConcept();
+            cc.Coding.Add(new Coding("http://fire.ly/CodeSystem/a", "code-a"));
+            cc.Coding.Add(new Coding("http://fire.ly/CodeSystem/b", "code-b"));
+            cc.Coding.Add(new Coding("http://fire.ly/CodeSystem/c", "code-c"));
+
+            var parameters = new ValidateCodeParameters()
+                .WithValueSet(url: valueSet.Url, valueSet: valueSet)
+                .WithCodeableConcept(cc);
+
+            await service.ValueSetValidateCode(parameters);
+
+            resolver.MaxObservedConcurrency.Should().Be(1);
+        }
+
+        private class ConcurrencyTrackingResolver : IAsyncResourceResolver
+        {
+            private int _active;
+
+            public int MaxObservedConcurrency { get; private set; }
+
+            public System.Threading.Tasks.Task<Resource> ResolveByUriAsync(string uri) => throw new NotImplementedException();
+
+            public System.Threading.Tasks.Task<Resource> ResolveByCanonicalUriAsync(string uri) => throw new NotImplementedException();
+
+            public async System.Threading.Tasks.Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri)
+            {
+                var current = Interlocked.Increment(ref _active);
+                MaxObservedConcurrency = Math.Max(MaxObservedConcurrency, current);
+                try
+                {
+                    // Mimics a non-thread-safe resolver (e.g. a scoped EF Core DbContext): if this
+                    // method were ever re-entered concurrently, MaxObservedConcurrency would exceed 1.
+                    await System.Threading.Tasks.Task.Delay(20).ConfigureAwait(false);
+                    return ResolverException.NotFound();
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref _active);
+                }
+            }
+        }
+
+        // Regression test for https://github.com/FirelyTeam/firely-net-sdk/issues/3582:
+        // expanding a "grouping" value set (compose.include[].valueSet listing 2+ canonicals) used to
+        // fan out with Task.WhenAll in ValueSetExpander.processValueSetGroup, so a non-thread-safe
+        // caller-supplied resolver could see overlapping calls from a single logical expand operation.
+        [TestMethod]
+        public async Task Expand_GroupingValueSet_DoesNotCallResolverConcurrently()
+        {
+            var vsA = new ValueSet
+            {
+                Url = "http://fire.ly/ValueSet/vs-a",
+                Expansion = new ValueSet.ExpansionComponent
+                {
+                    Contains = new System.Collections.Generic.List<ValueSet.ContainsComponent>
+                    {
+                        new() { System = "http://fire.ly/CodeSystem/x", Code = "1" }
+                    }
+                }
+            };
+            var vsB = new ValueSet
+            {
+                Url = "http://fire.ly/ValueSet/vs-b",
+                Expansion = new ValueSet.ExpansionComponent
+                {
+                    Contains = new System.Collections.Generic.List<ValueSet.ContainsComponent>
+                    {
+                        new() { System = "http://fire.ly/CodeSystem/x", Code = "1" }
+                    }
+                }
+            };
+
+            var groupingVs = new ValueSet
+            {
+                Url = "http://fire.ly/ValueSet/grouping-vs",
+                Compose = new ValueSet.ComposeComponent
+                {
+                    Include = new System.Collections.Generic.List<ValueSet.ConceptSetComponent>
+                    {
+                        new() { ValueSet = new[] { vsA.Url, vsB.Url } }
+                    }
+                }
+            };
+
+            var resolver = new ConcurrencyTrackingCanonicalResolver(vsA, vsB);
+            var service = new LocalTerminologyService(resolver);
+
+            var parameters = new ExpandParameters().WithValueSet(valueSet: groupingVs);
+            await service.Expand(parameters);
+
+            resolver.MaxObservedConcurrency.Should().Be(1);
+        }
+
+        private class ConcurrencyTrackingCanonicalResolver : IAsyncResourceResolver
+        {
+            private readonly System.Collections.Generic.Dictionary<string, Resource> _resources;
+            private int _active;
+
+            public int MaxObservedConcurrency { get; private set; }
+
+            public ConcurrencyTrackingCanonicalResolver(params ValueSet[] valueSets) =>
+                _resources = valueSets.ToDictionary(vs => vs.Url, vs => (Resource)vs);
+
+            public System.Threading.Tasks.Task<Resource> ResolveByUriAsync(string uri) => throw new NotImplementedException();
+
+            public System.Threading.Tasks.Task<Resource> ResolveByCanonicalUriAsync(string uri) => throw new NotImplementedException();
+
+            public async System.Threading.Tasks.Task<ResolverResult> TryResolveByCanonicalUriAsync(string uri)
+            {
+                var current = Interlocked.Increment(ref _active);
+                MaxObservedConcurrency = Math.Max(MaxObservedConcurrency, current);
+                try
+                {
+                    // Mimics a non-thread-safe resolver: if this method were ever re-entered
+                    // concurrently, MaxObservedConcurrency would exceed 1.
+                    await System.Threading.Tasks.Task.Delay(20).ConfigureAwait(false);
+                    return _resources.TryGetValue(uri, out var resource) ? resource : ResolverException.NotFound();
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref _active);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

`LocalTerminologyService.validateCodeVs` (multi-coding `CodeableConcept`) and `ValueSetExpander.processValueSetGroup` (grouping value sets) fanned out with `Task.WhenAll`, so every branch could call back into the caller-supplied `IAsyncResourceResolver` concurrently from a single logical operation. A resolver that isn't safe for concurrent use (e.g. a scoped EF Core-backed resolver, as in Firely Server) then fails with:

```
System.InvalidOperationException: A second operation was started on this context
instance before a previous operation completed.
```

- Both fan-out sites now resolve sequentially instead of via `Task.WhenAll`.
- This also fixes the related race on the shared, non-thread-safe `inclusionChain` (`Stack<string>`) in `ValueSetExpander`, since branches no longer run concurrently.
- **Not addressed**: the adjacent defect where `ValueSetExpander` mutates the resolver-owned `ValueSet.Expansion` in place, which can still corrupt a shared cached instance (e.g. `CachedResolver`) if it's expanded concurrently from *unrelated* operations. That's a separate, more invasive fix — the issue reporter offered to split it into its own issue.

Fixes #3582

## Test plan

- [x] Added two regression tests in `LocalTerminologyServiceTests.cs` using resolvers that track re-entrancy; verified both fail against the pre-fix code (observed concurrency 3 and 2) and pass with the fix.
- [x] Build succeeds for both compilation branches that host this shared source (`Hl7.Fhir.Conformance` and `Hl7.Fhir.STU3`, via the `Hl7.Fhir.Shims.Base` shared-items project).
- [x] All non-network terminology tests pass: 36/36 (R4), 29/29 (STU3).
- [x] Grepped for other `Task.WhenAll` fan-outs over the terminology resolver — none found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)